### PR TITLE
fix: recognize oauth profiles and authenticate desktop chat to local api server

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -222,6 +222,22 @@ export function getHermesHome(profile?: string): string {
   return profilePaths(profile).home;
 }
 
+export function getApiServerKey(profile?: string): string {
+  const candidates = [
+    getConfigValue("API_SERVER_KEY", profile),
+    profile && profile !== "default" ? getConfigValue("API_SERVER_KEY") : null,
+    readEnv(profile).API_SERVER_KEY || null,
+    profile && profile !== "default" ? readEnv().API_SERVER_KEY || null : null,
+  ];
+
+  for (const candidate of candidates) {
+    const value = String(candidate || "").trim();
+    if (value) return value;
+  }
+
+  return "";
+}
+
 // ── Platform enabled/disabled in config.yaml ────────────
 
 const SUPPORTED_PLATFORMS = ["telegram", "discord", "slack", "whatsapp", "signal"];

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -305,20 +305,34 @@ export function setPlatformEnabled(
   safeWriteFile(configFile, content);
 }
 
-// ── Credential Pool (auth.json) ──────────────────────────
+// ── Credential Pool / OAuth store (auth.json) ─────────────────────────
 
-function authFilePath(): string {
-  return join(HERMES_HOME, "auth.json");
+function getActiveProfileNameSync(): string {
+  try {
+    const activeFile = join(HERMES_HOME, "active_profile");
+    if (!existsSync(activeFile)) return "default";
+    const name = readFileSync(activeFile, "utf-8").trim();
+    return name || "default";
+  } catch {
+    return "default";
+  }
+}
+
+function authFilePath(profile?: string): string {
+  return join(profileHome(profile || getActiveProfileNameSync()), "auth.json");
 }
 
 interface CredentialEntry {
-  key: string;
-  label: string;
+  key?: string;
+  api_key?: string;
+  access_token?: string;
+  refresh_token?: string;
+  label?: string;
 }
 
-function readAuthStore(): Record<string, unknown> {
+function readAuthStore(profile?: string): Record<string, unknown> {
   try {
-    const p = authFilePath();
+    const p = authFilePath(profile);
     if (!existsSync(p)) return {};
     return JSON.parse(readFileSync(p, "utf-8"));
   } catch {
@@ -326,12 +340,14 @@ function readAuthStore(): Record<string, unknown> {
   }
 }
 
-function writeAuthStore(store: Record<string, unknown>): void {
-  safeWriteFile(authFilePath(), JSON.stringify(store, null, 2));
+function writeAuthStore(store: Record<string, unknown>, profile?: string): void {
+  safeWriteFile(authFilePath(profile), JSON.stringify(store, null, 2));
 }
 
-export function getCredentialPool(): Record<string, CredentialEntry[]> {
-  const store = readAuthStore();
+export function getCredentialPool(
+  profile?: string,
+): Record<string, CredentialEntry[]> {
+  const store = readAuthStore(profile);
   const pool = store.credential_pool;
   if (!pool || typeof pool !== "object") return {};
   return pool as Record<string, CredentialEntry[]>;
@@ -340,12 +356,60 @@ export function getCredentialPool(): Record<string, CredentialEntry[]> {
 export function setCredentialPool(
   provider: string,
   entries: CredentialEntry[],
+  profile?: string,
 ): void {
-  const store = readAuthStore();
+  const store = readAuthStore(profile);
   if (!store.credential_pool || typeof store.credential_pool !== "object") {
     store.credential_pool = {};
   }
   (store.credential_pool as Record<string, CredentialEntry[]>)[provider] =
     entries;
-  writeAuthStore(store);
+  writeAuthStore(store, profile);
+}
+
+export function hasOAuthCredentials(provider: string, profile?: string): boolean {
+  const cleanProvider = provider.trim();
+  if (!cleanProvider) return false;
+
+  const stores = [readAuthStore(profile)];
+  if (profile && profile !== "default") {
+    stores.push(readAuthStore());
+  }
+
+  for (const store of stores) {
+    const providers = store.providers;
+    if (providers && typeof providers === "object") {
+      const entry = (providers as Record<string, CredentialEntry>)[cleanProvider];
+      if (
+        entry &&
+        (String(entry.access_token || "").trim() ||
+          String(entry.refresh_token || "").trim() ||
+          String(entry.api_key || "").trim())
+      ) {
+        return true;
+      }
+    }
+
+    const pool = store.credential_pool;
+    const entries =
+      pool && typeof pool === "object"
+        ? (pool as Record<string, CredentialEntry[]>)[cleanProvider]
+        : undefined;
+    if (
+      Array.isArray(entries) &&
+      entries.some(
+        (entry) =>
+          !!(
+            entry &&
+            (String(entry.api_key || "").trim() ||
+              String(entry.access_token || "").trim() ||
+              String(entry.refresh_token || "").trim())
+          ),
+      )
+    ) {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -10,7 +10,7 @@ import {
   HERMES_SCRIPT,
   getEnhancedPath,
 } from "./installer";
-import { getModelConfig, readEnv } from "./config";
+import { getApiServerKey, getModelConfig, readEnv } from "./config";
 import { stripAnsi } from "./utils";
 
 const API_URL = "http://127.0.0.1:8642";
@@ -126,6 +126,10 @@ function sendMessageViaApi(
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
   };
+  const apiServerKey = getApiServerKey(profile);
+  if (apiServerKey) {
+    headers.Authorization = `Bearer ${apiServerKey}`;
+  }
 
   let sessionId = _resumeSessionId || "";
   let hasContent = false;
@@ -153,7 +157,7 @@ function sendMessageViaApi(
     });
     const probeReq = http.request(
       `${API_URL}/v1/chat/completions`,
-      { method: "POST", headers: { "Content-Type": "application/json" } },
+      { method: "POST", headers },
       (res) => {
         let raw = "";
         res.on("data", (d) => {

--- a/src/main/installer.ts
+++ b/src/main/installer.ts
@@ -2,7 +2,7 @@ import { spawn, execSync, execFile } from "child_process";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
-import { getModelConfig } from "./config";
+import { getModelConfig, hasOAuthCredentials } from "./config";
 import { stripAnsi } from "./utils";
 
 export const HERMES_HOME = join(homedir(), ".hermes");
@@ -41,9 +41,35 @@ export function getEnhancedPath(): string {
   return [...extra, process.env.PATH || ""].join(":");
 }
 
-export function checkInstallStatus(): InstallStatus {
+function getActiveProfileNameSync(): string {
+  try {
+    const activeFile = join(HERMES_HOME, "active_profile");
+    if (!existsSync(activeFile)) return "default";
+    const name = readFileSync(activeFile, "utf-8").trim();
+    return name || "default";
+  } catch {
+    return "default";
+  }
+}
+
+function activeEnvFile(profile: string): string {
+  return profile === "default"
+    ? HERMES_ENV_FILE
+    : join(HERMES_HOME, "profiles", profile, ".env");
+}
+
+function activeAuthFile(profile: string): string {
+  return profile === "default"
+    ? join(HERMES_HOME, "auth.json")
+    : join(HERMES_HOME, "profiles", profile, "auth.json");
+}
+
+export function checkInstallStatus(): InstallStatus & { activeProfile?: string } {
   const installed = existsSync(HERMES_PYTHON) && existsSync(HERMES_SCRIPT);
-  const configured = existsSync(HERMES_ENV_FILE);
+  const activeProfile = getActiveProfileNameSync();
+  const envFile = activeEnvFile(activeProfile);
+  const authFile = activeAuthFile(activeProfile);
+  const configured = existsSync(envFile) || existsSync(authFile);
   let hasApiKey = false;
   let verified = false;
 
@@ -66,20 +92,19 @@ export function checkInstallStatus(): InstallStatus {
     }
   }
 
-  // Local/custom providers don't need an API key
   try {
-    const mc = getModelConfig();
+    const mc = getModelConfig(activeProfile);
     const localProviders = ["custom", "lmstudio", "ollama", "vllm", "llamacpp"];
-    if (localProviders.includes(mc.provider)) {
+    if (localProviders.includes(mc.provider) || hasOAuthCredentials(mc.provider, activeProfile)) {
       hasApiKey = true;
     }
   } catch {
     /* ignore */
   }
 
-  if (!hasApiKey && configured) {
+  if (!hasApiKey && configured && existsSync(envFile)) {
     try {
-      const content = readFileSync(HERMES_ENV_FILE, "utf-8");
+      const content = readFileSync(envFile, "utf-8");
       for (const line of content.split("\n")) {
         const trimmed = line.trim();
         if (trimmed.startsWith("#")) continue;
@@ -100,7 +125,7 @@ export function checkInstallStatus(): InstallStatus {
     }
   }
 
-  return { installed, configured, hasApiKey, verified };
+  return { installed, configured, hasApiKey, verified, activeProfile };
 }
 
 // Cached version to avoid re-running the Python process


### PR DESCRIPTION
Title: fix: recognize oauth profiles and authenticate desktop chat to local api server

Summary
- treat OAuth-backed providers such as `openai-codex` as configured in the desktop install gate
- resolve `auth.json` against the active Hermes profile instead of only root `~/.hermes`
- support credential lookup from both `providers` token state and `credential_pool`
- when the local Hermes API server is protected by `API_SERVER_KEY`, send `Authorization: Bearer <API_SERVER_KEY>` from the desktop app's local API client

Problem
Hermes Desktop currently treats the installation as "configured" only when:
- a supported API key exists in `.env`, or
- the active provider is a local/custom endpoint

That blocks already-authenticated OAuth-backed Hermes setups (for example `openai-codex`) and incorrectly sends users into the API-key setup flow even though Hermes is already ready to chat.

A second issue appears even after setup passes:
- if the local Hermes API server is protected by `API_SERVER_KEY`, desktop chat requests to `http://127.0.0.1:8642` fail with `Invalid API key`

Reproduction
1. Log into Hermes CLI with an OAuth-backed provider such as `openai-codex`
2. Store the active session under a named profile (for example `~/.hermes/profiles/generic-core/auth.json`)
3. Enable the local API server with `API_SERVER_KEY`
4. Launch Hermes Desktop
5. Observe either:
   - the desktop app routes the user into setup/API-key onboarding instead of treating the install as ready, or
   - chat fails with `Invalid API key`

Expected behavior
- if the active Hermes profile already has valid OAuth credentials, Hermes Desktop should treat the install as configured and proceed normally
- if the local API server requires `API_SERVER_KEY`, Hermes Desktop should authenticate to it automatically

Root cause
- `checkInstallStatus()` in `src/main/installer.ts` only checks `.env` API keys and local providers
- auth lookup in `src/main/config.ts` only reads `~/.hermes/auth.json`, not the active profile's `auth.json`
- the local API fast-path in `src/main/hermes.ts` calls `http://127.0.0.1:8642/v1/*` without sending the configured `API_SERVER_KEY`

What changed
1. `src/main/config.ts`
- made `auth.json` path resolution profile-aware
- added `getActiveProfileNameSync()`
- updated credential pool helpers to accept an optional profile
- added `hasOAuthCredentials(provider, profile?)`
- added `getApiServerKey(profile?)`
- `hasOAuthCredentials()` checks:
  - `providers[provider].access_token`
  - `providers[provider].refresh_token`
  - `providers[provider].api_key`
  - `credential_pool[provider][].{api_key,access_token,refresh_token}`
- for named profiles, it also falls back to root `~/.hermes/auth.json`
- `getApiServerKey()` checks profile config/env first, then root config/env

2. `src/main/installer.ts`
- `checkInstallStatus()` now resolves the active profile first
- considers the active profile's `.env` and `auth.json`
- accepts OAuth-backed providers via `hasOAuthCredentials()`
- returns the active profile in the status payload for easier debugging

3. `src/main/hermes.ts`
- reads `API_SERVER_KEY` from config / env using the active profile when possible
- adds `Authorization: Bearer <API_SERVER_KEY>` on local requests to `http://127.0.0.1:8642`
- uses the same auth headers for the non-streaming probe request

Why this is safe
- existing API-key flows are unchanged
- local/custom providers still bypass API-key requirements as before
- the new logic broadens the definition of "configured" to include already-authenticated OAuth-backed providers
- API server auth is only forwarded to the local Hermes API fast-path and only when `API_SERVER_KEY` is configured
- fallback to root auth/config preserves compatibility for installs where shared state still lives under `~/.hermes`

Verification
- `npm run typecheck:node`
- `npm run typecheck`
- `npm run build`
- `npm run build:unpack`
- verified against a live machine state where:
  - active profile = `generic-core`
  - provider = `openai-codex`
  - OAuth credentials exist in `auth.json`
  - `API_SERVER_KEY` is enabled in Hermes config
  - the patched install gate evaluates to pass
  - an authenticated local request to `http://127.0.0.1:8642/v1/chat/completions` succeeds

Notes
This was validated against a local source-built macOS app bundle and the installed app was replaced with the source-built binary to confirm parity.

🤖 This PR was created by an AI coding agent
🤖 This was written by an AI coding agent