### PR TITLE
fix: clean up process lifecycle on quit and gateway stop

### DIFF
--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -1,5 +1,5 @@
 import { ChildProcess, spawn } from "child_process";
-import { existsSync, readFileSync, appendFileSync } from "fs";
+import { existsSync, readFileSync, appendFileSync, unlinkSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import http from "http";
@@ -717,6 +717,17 @@ export function stopGateway(force = false): void {
       process.kill(pid, "SIGTERM");
     } catch {
       // already dead
+    }
+  }
+  // Always clear the PID file once we've signalled it. Leaving a stale PID
+  // around means the next isGatewayRunning() / stopGateway() call can hit
+  // an unrelated process that the OS has since assigned the same PID.
+  const pidFile = join(HERMES_HOME, "gateway.pid");
+  if (existsSync(pidFile)) {
+    try {
+      unlinkSync(pidFile);
+    } catch {
+      // best-effort; will be overwritten on next gateway start
     }
   }
   gatewayStartedByApp = false;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -868,6 +868,10 @@ app.on("window-all-closed", () => {
 
 app.on("before-quit", () => {
   stopHealthPolling();
+  if (currentChatAbort) {
+    currentChatAbort();
+    currentChatAbort = null;
+  }
   stopGateway();
   stopClaw3d();
 });


### PR DESCRIPTION
## Summary

Two related process-lifecycle bugs found while reviewing the main process. Both are about leaked / stale process state that persists across the app's lifecycle.

### Bug 1 — Chat process orphaned on app quit (`src/main/index.ts`)

The \`before-quit\` handler stops the gateway and claw3d, but does **not** abort an in-flight chat:

\`\`\`ts
// before
app.on(\"before-quit\", () =&gt; {
  stopHealthPolling();
  stopGateway();
  stopClaw3d();
});
\`\`\`

\`sendMessageViaCli\` spawns a non-detached Hermes Python child and exposes \`abort()\` via \`currentChatAbort\`. When the user quits while a response is still streaming, that child is left running. \`stopGateway()\` only kills the gateway, not the per-message worker.

**Fix:** call \`currentChatAbort()\` before the other shutdown steps so the streaming worker gets SIGTERM (and SIGKILL after 3s if needed, per the existing abort handler).

### Bug 2 — Stale \`gateway.pid\` file (\`src/main/hermes.ts\`)

\`stopGateway()\` signals the recorded PID but never unlinks the PID file:

\`\`\`ts
const pid = readPidFile();
if (pid) {
  try { process.kill(pid, \"SIGTERM\"); } catch { /* already dead */ }
}
// pid file remains on disk
\`\`\`

Once the OS recycles that PID for an **unrelated** process, two follow-on hazards appear:

- \`isGatewayRunning()\` returns \`true\` because \`process.kill(pid, 0)\` succeeds against the unrelated process — the UI then shows the gateway as up when it is not.
- A subsequent \`stopGateway(true)\` will SIGTERM that unrelated process, killing whatever now happens to own the recycled PID. On macOS / Linux this is a real footgun on long-running sessions.

**Fix:** always \`unlinkSync\` the PID file after signalling. The cleanup is best-effort; the file is rewritten on the next \`startGateway()\`. \`existsSync\` + \`unlinkSync\` are already in the same dep set this file uses.

## Diff

\`\`\`
src/main/hermes.ts | 13 ++++++++++++-
src/main/index.ts  |  4 ++++
2 files changed, 16 insertions(+), 1 deletion(-)
\`\`\`

## Test plan

- [x] Reproduced bug 1 by quitting the app via Cmd+Q while a long response is streaming. Before fix: \`ps aux | grep hermes\` shows the python child still running. After fix: it terminates.
- [x] Reproduced bug 2 conceptually: confirmed \`stopGateway()\` exits without removing \`~/.hermes/gateway.pid\`. After fix: the file is removed.
- [x] No new dependencies. Pure stdlib (\`fs.unlinkSync\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)