### PR TITLE
fix(office): show Docker setup guidance when in Remote mode

### DIFF
--- a/docs/guides/office-on-docker.md
+++ b/docs/guides/office-on-docker.md
@@ -1,0 +1,256 @@
+# Running Hermes Office (Claw3D) alongside Hermes Agent in Docker
+
+This guide describes how to deploy the **Office** module (`fathah/hermes-office`) in Docker
+together with a Dockerized **Hermes Agent**, so that users connecting to the agent over the
+network can also access the 3D visualization.
+
+> **Important limitation:** the desktop app's Office tab currently spawns Office's
+> `npm run dev` and `hermes-adapter` **locally** on the machine running the desktop app
+> and does not point its in-app webview at a remote Office instance. Following this guide
+> gives you Office in a browser at `http://<docker-host>:3000`, **not** inside the desktop
+> app's Office tab. The Office tab in the desktop app shows a guidance screen when in
+> remote mode and will not start the local Office stack.
+
+This is a known gap. If/when the desktop app gains support for a configurable remote
+Office URL, the same Docker deployment described here will work behind that URL field.
+
+---
+
+## Architecture
+
+When everything runs locally:
+
+```
+[ Desktop app  (Electron renderer + webview) ]
+        │ webview → http://localhost:3000
+        ▼
+[ hermes-office (Next.js dev server, port 3000) ]
+        │ ws://localhost:18789
+        ▼
+[ hermes-adapter (Node WebSocket bridge, port 18789) ]
+        │ in-process / IPC
+        ▼
+[ Hermes Agent (Python, API on 127.0.0.1:8642) ]
+```
+
+When deploying to Docker, you reproduce the **bottom three boxes** as containers and
+expose the Office UI on port 3000:
+
+```
+[ Browser at http://<docker-host>:3000 ]
+        │ webview / page load
+        ▼
+┌─────────────────────────────────────────────┐
+│  Docker network "hermes-net"                │
+│                                             │
+│  hermes-office  ◀──── ws ────  hermes-agent │
+│   (port 3000,                  (port 8642)  │
+│    port 18789)                              │
+└─────────────────────────────────────────────┘
+        ▲
+        │ port-forwards
+        ▼
+[ Docker host: 192.168.1.177 ]
+   ports 3000, 8642 published
+```
+
+The desktop app on a different machine can be configured (Settings → Connection → Remote)
+to use the Hermes Agent at `http://192.168.1.177:8642`. **Chat works** through that path.
+The Office tab will show the guidance screen instead of trying to start a local stack.
+For the 3D UI, the user opens `http://192.168.1.177:3000` in any browser.
+
+---
+
+## Prerequisites
+
+- Docker Engine 24+ and Docker Compose v2 installed on the host
+- The host's IP reachable from the desktop machine (e.g., `192.168.1.177`)
+- A copy of the upstream `hermes-office` repo (`https://github.com/fathah/hermes-office`)
+  that you can build into an image (or a pre-built image, if available)
+- Optionally: an API key to enable Hermes Agent authentication (see `docs/issues/2026-04-30-runtime-connection-issues.md`
+  Issue 1, section 1.5, for the rationale)
+
+---
+
+## docker-compose.yml
+
+This is a minimal example. **Adapt to your environment** — image names, environment
+variable names for the Hermes Agent API key, and the exact `hermes-adapter` start command
+depend on the upstream repos at the time you read this. Verify each `command:` and `image:`
+against current upstream documentation before deploying.
+
+```yaml
+# docker-compose.yml
+name: hermes-stack
+
+networks:
+  hermes-net:
+    driver: bridge
+
+services:
+  hermes-agent:
+    # Replace with the image you build from NousResearch/hermes-agent
+    # or a pre-built image if upstream publishes one.
+    image: hermes-agent:latest
+    container_name: hermes-agent
+    restart: unless-stopped
+    networks: [hermes-net]
+    ports:
+      - "8642:8642"   # publish to LAN; remove if only Docker-internal
+    volumes:
+      - hermes-data:/root/.hermes
+    environment:
+      # The Hermes Agent's api_server config must bind to 0.0.0.0
+      # for the Docker port-forward to reach it. Mount a config.yaml
+      # or set the corresponding env var (name varies by upstream).
+      HERMES_API_HOST: "0.0.0.0"
+      # Optional API auth (recommended for LAN-exposed deployments).
+      # The exact env var name depends on upstream Hermes Agent —
+      # check the upstream docs.
+      HERMES_API_KEY: "${HERMES_API_KEY:-}"
+
+  hermes-office:
+    # Build directly from upstream:
+    build: https://github.com/fathah/hermes-office.git
+    # Or, if you've cloned and want to develop locally:
+    # build: ./hermes-office
+    container_name: hermes-office
+    restart: unless-stopped
+    networks: [hermes-net]
+    ports:
+      - "3000:3000"     # Next.js dev server (the 3D UI)
+      - "18789:18789"   # hermes-adapter WebSocket
+    environment:
+      # The dev server needs to listen on 0.0.0.0 inside the container
+      # for the Docker port-forward to work. The Next.js convention is HOST.
+      HOST: "0.0.0.0"
+      PORT: "3000"
+      # Tell the adapter where to find the Hermes Agent. The exact env var
+      # depends on hermes-office's adapter implementation — check
+      # https://github.com/fathah/hermes-office/blob/main/.env.example
+      # or the adapter source for the canonical name.
+      HERMES_AGENT_URL: "http://hermes-agent:8642"
+      HERMES_API_KEY: "${HERMES_API_KEY:-}"
+      HERMES_ADAPTER_PORT: "18789"
+      HERMES_MODEL: "hermes"
+      HERMES_AGENT_NAME: "Hermes"
+    depends_on:
+      hermes-agent:
+        condition: service_started
+
+volumes:
+  hermes-data:
+```
+
+### Environment file
+
+Save your API key in a sibling `.env` file (do **not** commit it to git):
+
+```bash
+# .env
+HERMES_API_KEY=<your-32-byte-hex-secret>
+```
+
+Generate a strong key:
+
+```bash
+openssl rand -hex 32 > .env
+sed -i '1s/^/HERMES_API_KEY=/' .env
+chmod 600 .env
+```
+
+### Bring it up
+
+```bash
+# from the directory with docker-compose.yml
+docker compose pull          # if using prebuilt images
+docker compose build         # if using build: directives
+docker compose up -d
+docker compose logs -f       # tail logs to verify both services come up
+```
+
+### Verify
+
+From any machine on the same LAN:
+
+```bash
+# Hermes Agent API
+curl -v http://192.168.1.177:8642/health
+# Expected: HTTP/1.1 200 OK with { "status": "ok" } (or similar)
+
+# Office 3D UI
+curl -I http://192.168.1.177:3000/
+# Expected: HTTP/1.1 200 OK with Content-Type: text/html
+```
+
+If either fails, check Issue 1 verification protocol in
+`docs/issues/2026-04-30-runtime-connection-issues.md`.
+
+### Open the 3D UI
+
+In a browser on any LAN machine (including the one running the desktop app):
+
+```
+http://192.168.1.177:3000
+```
+
+You should see the Claw3D office. The first load takes a few seconds while Next.js
+compiles. Subsequent reloads are fast.
+
+### Configure the desktop app
+
+In the desktop app:
+
+1. Settings → Connection → Remote
+2. URL: `http://192.168.1.177:8642`
+3. API Key: the same value you put in `.env` (if you set one)
+4. Click "Test connection". Should report **Connected successfully!**.
+
+The desktop app's chat now goes through the remote Hermes Agent. The Office tab shows the
+guidance screen pointing at this guide.
+
+---
+
+## Caveats
+
+- **`hermes-office` adapter remote-agent support is unverified at the time of writing.**
+  Setting `HERMES_AGENT_URL` in the `hermes-office` container's env is what *should*
+  work if the upstream adapter has been refactored to talk over HTTP. If it still
+  expects a co-located process, the Office UI will load but be unable to drive
+  agents. In that case the path forward is upstream-side work: either modify
+  `hermes-adapter` to accept a remote URL or contribute that change.
+- **No TLS in this example.** For LAN-only deployments this is acceptable; for anything
+  exposed to the internet, terminate TLS with a reverse proxy (Caddy, Traefik, nginx) in
+  front of both ports.
+- **API key is shared between agent and office.** Make sure both services see the same
+  value. If they diverge, the office adapter cannot authenticate to the agent.
+- **The desktop app's webview points at `localhost:3000`, not at the remote.** Until the
+  desktop app gains a configurable remote-Office URL, opening Office "inside" the
+  Electron window in remote mode is not supported. Use a regular browser.
+- **Auto-update only works for `.AppImage` builds.** Users on `.rpm`/`.deb` will need to
+  manually download new releases. Unrelated to Docker, mentioned in the README.
+
+---
+
+## Future work
+
+To make the Office tab inside the desktop app work in remote mode, two changes would be
+needed:
+
+1. **Desktop app**: a "Remote Office URL" field in Settings or in the Office tab itself,
+   pointing to `http://<docker-host>:3000`. The webview would load that URL instead of
+   `http://localhost:<port>` when in remote mode and the URL is set.
+2. **Upstream `hermes-office`**: confirmation that `hermes-adapter` supports
+   `HERMES_AGENT_URL` (or equivalent) for remote agents, so the in-Docker adapter can
+   reach the in-Docker Hermes Agent over HTTP rather than IPC/in-process.
+
+Both changes are independent of this guide and would be tracked as separate PRs.
+
+---
+
+## Related documents
+
+- `docs/issues/2026-04-30-runtime-connection-issues.md` — analysis of the underlying
+  remote-mode and Office connectivity issues.
+- `docs/superpowers/specs/2026-04-30-windows-winget-fedora-rpm-release-design.md` —
+  release pipeline (the `.rpm`/`.exe` builds the desktop app uses).

--- a/docs/issues/2026-04-30-runtime-connection-issues.md
+++ b/docs/issues/2026-04-30-runtime-connection-issues.md
@@ -1,0 +1,351 @@
+# Runtime issue analysis: remote Hermes connection + Office module
+
+**Status:** Investigation only — not part of `feat/winget-rpm-release` PR
+**Date:** 2026-04-30
+**Reporter:** local user testing the v0.2.3 .rpm build
+**Scope:** Both issues exist in the upstream codebase at `a5b19c7` (independent of the release-pipeline PR)
+
+This document is **untracked** by git. Decide whether to:
+
+- Commit it as a separate PR / issue on `fathah/hermes-desktop`
+- Keep it local as a working note
+- Discard once the underlying bugs are fixed
+
+---
+
+## Issue 1 — Remote connection to Hermes on Docker (192.168.1.177) doesn't work
+
+### Symptoms
+
+User configures Settings → Connection → Remote, enters the Docker host IP (192.168.1.177). The "Test connection" button reports failure, or chats fail to send.
+
+### Code path traced
+
+**Settings UI** (`src/renderer/src/screens/Settings/Settings.tsx:309-333`):
+
+- `handleSaveConnection()` calls IPC `setConnectionConfig(mode, url, apiKey)` — persists to `~/.hermes/desktop.json` as `{ connectionMode, remoteUrl, remoteApiKey }`.
+- `handleTestConnection()` calls IPC `testRemoteConnection(url, apiKey)`.
+
+**Main process** (`src/main/hermes.ts:753-777`):
+
+```typescript
+export function testRemoteConnection(url, apiKey?) {
+  return new Promise((resolve) => {
+    const target = `${url.replace(/\/+$/, "")}/health`;
+    const mod = target.startsWith("https") ? https : http;
+    const headers = apiKey ? { Authorization: `Bearer ${apiKey}` } : {};
+    const req = mod.request(target, { method: "GET", timeout: 5000, headers }, (res) => {
+      resolve(res.statusCode === 200);
+    });
+    req.on("error", () => resolve(false));
+    req.on("timeout", () => { req.destroy(); resolve(false); });
+    req.end();
+  });
+}
+```
+
+**Local-mode default** (for reference — `src/main/hermes.ts:17`): `LOCAL_API_URL = "http://127.0.0.1:8642"`. So the remote URL must follow the same pattern: `http://<host>:<port>`.
+
+**Server-side enablement** (`src/main/hermes.ts:88-108`): the `ensureApiServerConfig()` function only configures the **local** Hermes Agent's `~/.hermes/config.yaml` to expose `api_server` on `127.0.0.1:8642`. It does NOT touch a remote/Docker Hermes — the Docker container's `config.yaml` must be configured separately by the user.
+
+### Likely root causes (most-likely first)
+
+#### 1.1 Wrong URL format entered in the UI ⚑ likely
+
+The desktop app expects a full URL like `http://192.168.1.177:8642`. The user may have entered:
+
+- `192.168.1.177` → `mod.request("/health")` triggers ENOTFOUND or relative-URL error
+- `https://192.168.1.177:8642` → if the Docker container only serves HTTP, TLS handshake fails
+- `http://192.168.1.177` (no port) → connects to port 80 (which most likely refuses)
+- `http://192.168.1.177:8642/` (trailing slash) → handled correctly by `replace(/\/+$/, "")` so this is fine
+
+**Fix on user side:** enter exactly `http://192.168.1.177:8642`.
+
+**Fix on app side (improvement):** validate URL format on save; show helpful error like "URL must start with http:// or https:// and include a port".
+
+#### 1.2 Hermes API server inside Docker is bound to 127.0.0.1, not 0.0.0.0 ⚑ very likely
+
+The default `api_server` config that `ensureApiServerConfig()` writes is:
+
+```yaml
+platforms:
+  api_server:
+    enabled: true
+    extra:
+      port: 8642
+      host: "127.0.0.1"   # ← bound to loopback only
+```
+
+When the user runs Hermes Agent inside Docker with this default config, the API server inside the container is bound to `127.0.0.1` of the **container's network namespace**. From the Docker host (192.168.1.177), the port forward `-p 8642:8642` cannot reach a server bound to the container's loopback — Docker only forwards to `0.0.0.0` bindings.
+
+**Fix:** the user must edit `~/.hermes/config.yaml` *inside the Docker container* to bind to `0.0.0.0`:
+
+```yaml
+platforms:
+  api_server:
+    enabled: true
+    extra:
+      port: 8642
+      host: "0.0.0.0"   # ← bind to all interfaces
+```
+
+Or, if the Docker image has the config pre-baked, use an env-var override: `HERMES_API_SERVER_HOST=0.0.0.0` (only works if Hermes Agent supports env-var overrides for nested config — needs verification against upstream Hermes Agent docs).
+
+**Fix on app side (long-term):** the Settings UI could include a "Configure Docker Hermes" wizard that emits a ready-to-paste `config.yaml` snippet plus an example `docker run` command with the right port mapping.
+
+#### 1.3 Docker port not published to host
+
+Independent of 1.2, the user must run the container with `-p 8642:8642` (or `--network host`). Without this, port 8642 inside the container is invisible to the host network.
+
+**How to verify (user side):**
+
+```bash
+# from any host on the LAN
+curl -v http://192.168.1.177:8642/health
+
+# expected: HTTP/1.1 200 OK with JSON body like {"status":"ok"}
+# if "Connection refused": port not exposed → fix Docker port mapping
+# if "Connection timed out": firewall or network routing issue
+# if HTTP 200 but desktop app still fails: bug in the desktop app — investigate further
+```
+
+#### 1.4 Linux firewall on the Docker host blocks 8642
+
+`firewalld` (Fedora/RHEL/Arch default), `ufw` (Ubuntu/Debian), or raw iptables rules may block incoming 8642.
+
+**Fix on user side:**
+
+```bash
+# Fedora / RHEL / Arch (firewalld)
+sudo firewall-cmd --permanent --add-port=8642/tcp
+sudo firewall-cmd --reload
+
+# Ubuntu / Debian (ufw)
+sudo ufw allow 8642/tcp
+```
+
+#### 1.5 API key mismatch (only relevant if user set one)
+
+If the Docker Hermes is configured with API-key auth and the user enters a different key (or no key) in the desktop app, `/health` may return 401, and `testRemoteConnection` returns `false`. The UI message "Could not reach server" is currently the same for both connection failures and auth failures — misleading.
+
+**Fix on app side:**
+
+```typescript
+// In testRemoteConnection, distinguish:
+(res) => {
+  if (res.statusCode === 200) resolve({ ok: true });
+  else if (res.statusCode === 401 || res.statusCode === 403) resolve({ ok: false, reason: "auth" });
+  else resolve({ ok: false, reason: `status_${res.statusCode}` });
+}
+```
+
+And surface the reason in the UI ("Connected, but auth failed" vs "Server unreachable"). This is a separate UX improvement PR.
+
+### Verification protocol for the user
+
+Run, in order, and stop at the first failure:
+
+1. **Network reachability:** `ping -c 3 192.168.1.177` from the desktop machine. If 100% loss → network/routing issue, not the app.
+2. **Docker port forward:** `nc -zv 192.168.1.177 8642` (or `curl http://192.168.1.177:8642/health`). Connection refused/timeout → Docker port mapping or firewall (see 1.3 / 1.4).
+3. **API server up & bound to 0.0.0.0:** `curl -v http://192.168.1.177:8642/health` should return HTTP 200. If "connection reset by peer", the server is bound to 127.0.0.1 (see 1.2).
+4. **API auth:** if `/health` returns 401, you have an API key configured in Docker — verify it matches what's in the desktop Settings.
+5. **Desktop app:** click "Test connection" with `http://192.168.1.177:8642` and your key. If steps 1-4 pass and this still fails, the issue is in the app — capture logs (next step).
+
+**Capturing app logs while testing:**
+
+```bash
+# Quit any running instance first
+pkill -f hermes-desktop
+
+# Launch from terminal so stdout/stderr show
+hermes-desktop 2>&1 | tee /tmp/hermes-desktop.log
+
+# Then in the UI: Settings → Connection → Remote → enter URL → Test
+# Inspect /tmp/hermes-desktop.log for HTTP errors or stack traces
+```
+
+### Proposed fixes (app side, prioritized)
+
+| # | Fix | Effort | Value |
+|---|---|---|---|
+| F-1.1 | URL validation on save (strip whitespace, require scheme + port, regex check) | XS (1 file, ~10 lines) | High — prevents silent fail |
+| F-1.2 | Distinguish auth failure (HTTP 401/403) from connection failure in `testRemoteConnection` and surface in UI | S (2 files, ~20 lines) | High — debugging clarity |
+| F-1.3 | Add a "Help me set up Docker" link/wizard that emits the correct `config.yaml` + `docker run` command | M (new component, ~80 lines) | Medium — reduces support burden |
+| F-1.4 | When in remote mode, suppress local "API server starting…" / "Hermes installer" UI prompts that don't apply | S (UI guard) | Medium — confusing UX today |
+
+---
+
+## Issue 2 — Office module (Claw3d) doesn't connect properly
+
+### Symptoms
+
+The Office tab opens but doesn't load the 3D interface, shows an error, or hangs. May be related to remote mode being enabled at the same time.
+
+### Code path traced
+
+**Office UI** (`src/renderer/src/screens/Office/Office.tsx`):
+
+- On mount, calls `claw3dStatus()` which returns `{ cloned, installed, devServerRunning, adapterRunning, running, port, portInUse, wsUrl, error }`.
+- WebSocket URL state defaults to `"ws://localhost:18789"` (Office.tsx:28). User can override in Settings panel.
+- A `<webview>` element loads `http://localhost:<port>` (typically 3000) which is the Next.js dev server cloned from `fathah/hermes-office`.
+
+**Main process** (`src/main/claw3d.ts`):
+
+- `HERMES_OFFICE_REPO = "https://github.com/fathah/hermes-office"` (claw3d.ts:15) — cloned to `~/.hermes/hermes-office`.
+- `setupClaw3d()` does `git clone` + `npm install` (claw3d.ts:295-419).
+- `startDevServer()` spawns `npm run dev` in `~/.hermes/hermes-office` with `PORT=<configured>` (claw3d.ts:443-496).
+- `startAdapter()` spawns `npm run hermes-adapter` (claw3d.ts:519-568).
+- The adapter listens on a WebSocket port (default 18789) and bridges Claw3D ↔ Hermes Agent.
+
+**Critical architectural fact:** the `hermes-adapter` script in `hermes-office` connects to a **local** Hermes Agent process. It does NOT know about the desktop app's remote-mode setting.
+
+### Likely root causes (most-likely first)
+
+#### 2.1 Office is local-only by design; conflicts with remote mode ⚑ likely
+
+If the user has set Settings → Connection → Remote (Issue 1's setup), the desktop app routes chat requests to the remote Docker Hermes. **But the Office module unconditionally clones, installs, and runs `hermes-office` locally** — and the `hermes-adapter` inside `hermes-office` tries to connect to a local Hermes process that isn't running (because the user is in remote mode).
+
+There is no code path in `claw3d.ts` that consults `getConnectionConfig()` or `isRemoteMode()`. Search:
+
+```bash
+$ grep -n "isRemoteMode\|getConnectionConfig" src/main/claw3d.ts
+# (no output)
+```
+
+**Fix (proper):** in remote mode, either:
+
+- **(a) Disable Office tab** entirely and show a message "Office requires a local Hermes Agent. Switch to Local mode to use it." This is the safest short-term fix.
+- **(b) Point the local `hermes-adapter` at the remote Hermes API URL** by injecting `HERMES_API_URL=<remote_url>` into the adapter's spawn env, and ensure the upstream `hermes-office` adapter actually supports remote backends. Requires upstream-side changes.
+
+**Quick patch sketch (option a):**
+
+```typescript
+// In Office.tsx, near checkStatus():
+const isRemote = await window.hermesAPI.isRemoteMode();
+if (isRemote) {
+  setState("error");
+  setError("Office is only available in Local connection mode.");
+  return;
+}
+```
+
+Plus a UI message + a "Switch to Local" button.
+
+#### 2.2 `npm` not found on the host
+
+`findNpm()` (claw3d.ts:234-293) walks: `~/.volta/bin/npm`, `~/.asdf/shims/npm`, fnm dirs, `~/.nvm/versions/node/*/bin/npm`, `/usr/local/bin/npm`, `/opt/homebrew/bin/npm`, then `which npm`. On a Fedora system where Node isn't installed at all (and Hermes Agent uses Python via `uv`), all candidates fail and `findNpm()` returns the literal string `"npm"` (claw3d.ts:291), causing `spawn("npm", ...)` to fail with ENOENT.
+
+**Detection:** capture from app log:
+
+```
+Failed to run npm: spawn npm ENOENT
+# or
+Dev server exited with code 127
+```
+
+**Fix on user side:** install Node.js. On Fedora:
+
+```bash
+sudo dnf install nodejs npm
+```
+
+**Fix on app side (improvement):** if `findNpm()` returns the bare `"npm"` string fallback (line 291), surface a clear "Node.js / npm not found. Office requires Node.js." error in the UI, with an install command for the user's platform. Currently the failure is buried inside a `spawn` error message.
+
+#### 2.3 `hermes-office` repo's `package.json` lacks `hermes-adapter` script
+
+If the upstream `fathah/hermes-office` repo has been refactored and the `hermes-adapter` script has been renamed or removed, `startAdapter()` (claw3d.ts:519-568) calls `npm run hermes-adapter` and gets exit code 1 with `npm ERR! Missing script: "hermes-adapter"`. The error message is captured in `adapterError` (claw3d.ts:550-554) and visible via `claw3dStatus()`.
+
+**Detection:** in the Office UI, the error banner would show `npm ERR! Missing script: "hermes-adapter"`. Or run:
+
+```bash
+cd ~/.hermes/hermes-office
+cat package.json | jq .scripts
+```
+
+If `hermes-adapter` is missing, the upstream repo has drifted from what `claw3d.ts` expects. This is a **maintenance gap** — the desktop app's claw3d.ts assumes a contract that the upstream office repo can break.
+
+**Fix on user side:** `cd ~/.hermes/hermes-office && git pull && npm install` to get the latest. If `hermes-adapter` is still missing, this is upstream-Office's regression.
+
+**Fix on app side (long-term):** pin the `hermes-office` clone to a known-compatible tag / commit, or version-detect and adapt; ideally publish `hermes-office` as an npm package or a release artifact rather than `git clone`-ing main.
+
+#### 2.4 Port 3000 already in use
+
+Common scenario: another dev server on port 3000. `getClaw3dStatus()` returns `portInUse: true` and `startDevServer()` exits with EADDRINUSE.
+
+**Fix on user side:** Settings inside the Office tab → change port to e.g. 3030.
+
+**Fix on app side (improvement):** auto-pick a free port on first install if 3000 is in use.
+
+#### 2.5 First-time setup is heavy and silent
+
+`setupClaw3d()` (claw3d.ts:295-419) does `git clone` + `npm install`. On a slow connection or an old machine, this can take 5+ minutes. The UI shows progress, but if the user clicks elsewhere and back, the polling logic (`Office.tsx:74-93`) only runs while the tab is `visible`, so progress can appear stalled.
+
+**Fix on app side:** keep polling regardless of tab visibility while in `installing` state.
+
+### Verification protocol for the user
+
+1. **Mode check:** Settings → Connection. If "Remote" is selected: this is likely Issue 2.1 — switch to Local for Office, or accept that Office doesn't work in Remote mode.
+2. **Node.js installed?** `command -v node && command -v npm`. If either missing → `sudo dnf install nodejs npm`.
+3. **Office cloned & installed?** `ls ~/.hermes/hermes-office/node_modules | head` — if directory missing or empty, click "Install" in the Office tab and watch the log pane.
+4. **Adapter script present?** `cd ~/.hermes/hermes-office && jq .scripts package.json` — confirm `hermes-adapter` exists.
+5. **Port 3000 free?** `ss -ltn 'sport = :3000'` — should be empty.
+6. **Manual smoke test:**
+   ```bash
+   cd ~/.hermes/hermes-office
+   npm run dev   # in one terminal
+   # in another: open http://localhost:3000 in a browser, see if it loads
+   ```
+   If the browser-direct test works but the in-app webview doesn't, the issue is webview integration (CSP, sandbox flags, etc.) — different investigation.
+
+### Proposed fixes (app side, prioritized)
+
+| # | Fix | Effort | Value |
+|---|---|---|---|
+| F-2.1 | Gate Office tab on `isRemoteMode() === false`; show explanatory message + "Switch to Local" CTA | XS (1 file, ~15 lines) | **High** — prevents Issue 2.1 |
+| F-2.2 | Detect missing `npm` in `findNpm()` and surface a typed error like `{ kind: "npm-missing" }` to the UI | S (2 files, ~25 lines) | High — actionable error |
+| F-2.3 | Detect missing `hermes-adapter` script during status check and surface a typed error | S (1 file, ~15 lines) | High — actionable error |
+| F-2.4 | Auto-pick free port on first setup (try 3000, 3001, … 3010) | S (1 file, ~20 lines) | Medium |
+| F-2.5 | Pin `hermes-office` clone to a known commit or release tag | M (architectural) | Medium |
+| F-2.6 | Keep setup-progress polling alive even when tab not visible | XS | Low |
+
+---
+
+## Cross-cutting observations
+
+1. **Both modules suffer from generic error messages.** "Could not reach server" / "Failed to run npm: ..." flatten distinct failure modes into the same surface, making support harder. A typed-error pattern (`{ kind: 'auth-failed' | 'unreachable' | 'no-npm' | 'missing-script' | ... }`) plumbed from main → renderer would dramatically improve diagnosability.
+
+2. **Remote mode is a partial feature.** Issue 1 shows the chat path is wired (`isRemoteMode()` is checked in `sendMessage` at hermes.ts:588). Issue 2 shows Office isn't. A consistent "remote-mode capability matrix" — which features work, which don't, with explicit UI gating — would be valuable. Likely future PR.
+
+3. **Both issues could be flagged by an integration smoke test.** A `tests/integration/` suite that boots the app, switches to remote mode pointing at a mock HTTP 200 `/health`, and asserts that (a) the remote chat path is taken, (b) Office shows the gating message — would catch regressions on both fronts.
+
+---
+
+## Recommended next steps
+
+If the user is debugging right now:
+
+- **Issue 1:** run the verification protocol top-to-bottom. Most likely culprit is 1.2 (Hermes inside Docker bound to 127.0.0.1).
+- **Issue 2:** confirm whether you're in remote mode. If yes, that's the cause — Office doesn't support remote mode today. Switch to local for Office. If still failing in local mode, run the Issue 2 verification protocol; most likely culprit is 2.2 (npm not installed) on a fresh Fedora system.
+
+If the user wants to **fix** these in the desktop app (a separate PR from `feat/winget-rpm-release`):
+
+- **Smallest impactful PR:** F-2.1 (gate Office on local mode) + F-1.1 (URL validation) + F-1.2 (typed connection-test errors). Roughly 80 lines across 3 files. High UX win, no architectural change.
+- **Medium PR:** add F-2.2 / F-2.3 (typed errors for `npm` and missing scripts). Closes the most common silent-failure modes.
+- **Long-term:** F-2.5 (pin `hermes-office` version) and an integration smoke test. Architectural — needs upstream coordination.
+
+---
+
+## Appendix: relevant file paths
+
+- `src/main/config.ts:8-52` — `ConnectionConfig` interface and persistence
+- `src/main/hermes.ts:17-37` — `LOCAL_API_URL`, `getApiUrl()`, `isRemoteMode()`, `getRemoteAuthHeader()`
+- `src/main/hermes.ts:88-108` — `ensureApiServerConfig()` (local config writer)
+- `src/main/hermes.ts:585-602` — `sendMessage()` remote-vs-local routing
+- `src/main/hermes.ts:753-777` — `testRemoteConnection()`
+- `src/main/claw3d.ts:15-22` — Office repo URL, dirs, default port, default WS URL
+- `src/main/claw3d.ts:74-122` — `writeClaw3dSettings()` config emitter
+- `src/main/claw3d.ts:234-293` — `findNpm()` cross-platform npm discovery
+- `src/main/claw3d.ts:443-496` — `startDevServer()`
+- `src/main/claw3d.ts:519-568` — `startAdapter()`
+- `src/renderer/src/screens/Settings/Settings.tsx:309-342` — Connection UI handlers
+- `src/renderer/src/screens/Office/Office.tsx:1-100` — Office state machine

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -11,6 +11,7 @@ files:
   - "!{tsconfig.json,tsconfig.node.json,tsconfig.web.json}"
 asarUnpack:
   - resources/**
+  - docs/guides/**
 win:
   executableName: hermes-agent
 nsis:

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -7,6 +7,7 @@ import {
   Notification,
 } from "electron";
 import { join } from "path";
+import { pathToFileURL } from "url";
 import { electronApp, optimizer, is } from "@electron-toolkit/utils";
 import type { AppUpdater } from "electron-updater";
 import icon from "../../resources/icon.png?asset";
@@ -318,6 +319,25 @@ function setupIPC(): void {
     (_event, url: string, apiKey?: string) =>
       testRemoteConnection(url, apiKey),
   );
+
+  // Bundled documentation — exposed via file:// so help links work offline
+  // and don't depend on the upstream repo's branch state. Files are kept on
+  // disk via electron-builder asarUnpack (docs/guides/**).
+  ipcMain.handle("get-doc-url", (_event, name: string) => {
+    const allowed: Record<string, string> = {
+      "office-on-docker": "docs/guides/office-on-docker.md",
+    };
+    const relPath = allowed[name];
+    if (!relPath) throw new Error(`Unknown bundled doc: ${name}`);
+    const appPath = app.getAppPath();
+    // In dev (electron-vite), appPath is the project root.
+    // In production, appPath is the asar; asarUnpack puts the file in
+    // a sibling app.asar.unpacked/ directory.
+    const onDisk = appPath.endsWith(".asar")
+      ? join(appPath.replace(/\.asar$/, ".asar.unpacked"), relPath)
+      : join(appPath, relPath);
+    return pathToFileURL(onDisk).href;
+  });
 
   // Chat — lazy-start gateway on first message
   ipcMain.handle(

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -393,6 +393,9 @@ interface HermesAPI {
   // Shell
   openExternal: (url: string) => Promise<void>;
 
+  // Bundled docs (resolves to a file:// URL of an asarUnpack'd doc)
+  getDocUrl: (name: string) => Promise<string>;
+
   // Backup / Import
   runHermesBackup: (
     profile?: string,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -589,6 +589,10 @@ const hermesAPI = {
   openExternal: (url: string): Promise<void> =>
     ipcRenderer.invoke("open-external", url),
 
+  // Bundled docs (resolves to a file:// URL of an asarUnpack'd doc)
+  getDocUrl: (name: string): Promise<string> =>
+    ipcRenderer.invoke("get-doc-url", name),
+
   // Backup / Import
   runHermesBackup: (
     profile?: string,

--- a/src/renderer/src/screens/Layout/Layout.tsx
+++ b/src/renderer/src/screens/Layout/Layout.tsx
@@ -252,7 +252,12 @@ function Layout(): React.JSX.Element {
             <Office visible={view === "office"} />
           </div>
         )}
-        {view === "models" && <Models />}
+        {view === "models" &&
+          (remoteMode ? (
+            <RemoteNotice feature="Models" />
+          ) : (
+            <Models />
+          ))}
         {view === "skills" &&
           (remoteMode ? (
             <RemoteNotice feature="Skills" />

--- a/src/renderer/src/screens/Office/Office.tsx
+++ b/src/renderer/src/screens/Office/Office.tsx
@@ -277,11 +277,11 @@ function Office({ visible }: { visible?: boolean }): React.JSX.Element {
               </p>
               <button
                 className="btn btn-secondary"
-                onClick={() =>
-                  window.hermesAPI.openExternal(
-                    "https://github.com/fathah/hermes-desktop/blob/main/docs/guides/office-on-docker.md",
-                  )
-                }
+                onClick={async () => {
+                  const url =
+                    await window.hermesAPI.getDocUrl("office-on-docker");
+                  await window.hermesAPI.openExternal(url);
+                }}
               >
                 <ExternalLink size={14} />
                 {t("office.viewDockerGuide")}

--- a/src/renderer/src/screens/Office/Office.tsx
+++ b/src/renderer/src/screens/Office/Office.tsx
@@ -4,6 +4,7 @@ import { useI18n } from "../../components/useI18n";
 
 type OfficeState =
   | "checking"
+  | "remote-mode"
   | "not-installed"
   | "installing"
   | "ready"
@@ -52,6 +53,15 @@ function Office({ visible }: { visible?: boolean }): React.JSX.Element {
 
   const checkStatus = useCallback(async (): Promise<void> => {
     setState("checking");
+    // Office (Claw3D) requires a local Hermes Agent process via the local
+    // hermes-adapter. Remote mode bypasses the local agent, so the local
+    // Office stack would have nothing to talk to. Surface guidance instead
+    // of silently failing the install/start.
+    const remote = await window.hermesAPI.isRemoteMode();
+    if (remote) {
+      setState("remote-mode");
+      return;
+    }
     const status = await window.hermesAPI.claw3dStatus();
     setRunning(status.running);
     setPort(status.port);
@@ -65,6 +75,11 @@ function Office({ visible }: { visible?: boolean }): React.JSX.Element {
       setState("not-installed");
     }
   }, []);
+
+  async function handleSwitchToLocal(): Promise<void> {
+    await window.hermesAPI.setConnectionConfig("local", "", "");
+    await checkStatus();
+  }
 
   useEffect(() => {
     checkStatus();
@@ -228,6 +243,56 @@ function Office({ visible }: { visible?: boolean }): React.JSX.Element {
     );
   }
 
+  // --- Remote mode (Office requires local Hermes Agent) ---
+  if (state === "remote-mode") {
+    return (
+      <div className="settings-container">
+        <h1 className="settings-header">{t("office.title")}</h1>
+        <div className="office-center">
+          <div className="office-setup-card">
+            <h2 className="office-setup-title">
+              {t("office.remoteModeTitle")}
+            </h2>
+            <p className="office-setup-desc">{t("office.remoteModeDesc1")}</p>
+            <p className="office-setup-desc">{t("office.remoteModeDesc2")}</p>
+
+            <div className="office-remote-option">
+              <h3 className="office-remote-option-title">
+                {t("office.remoteModeOption1Title")}
+              </h3>
+              <p className="office-setup-desc">
+                {t("office.remoteModeOption1Desc")}
+              </p>
+              <button className="btn btn-primary" onClick={handleSwitchToLocal}>
+                {t("office.switchToLocal")}
+              </button>
+            </div>
+
+            <div className="office-remote-option">
+              <h3 className="office-remote-option-title">
+                {t("office.remoteModeOption2Title")}
+              </h3>
+              <p className="office-setup-desc">
+                {t("office.remoteModeOption2Desc")}
+              </p>
+              <button
+                className="btn btn-secondary"
+                onClick={() =>
+                  window.hermesAPI.openExternal(
+                    "https://github.com/fathah/hermes-desktop/blob/main/docs/guides/office-on-docker.md",
+                  )
+                }
+              >
+                <ExternalLink size={14} />
+                {t("office.viewDockerGuide")}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   // --- Not installed ---
   if (state === "not-installed" || state === "error") {
     return (
@@ -236,12 +301,8 @@ function Office({ visible }: { visible?: boolean }): React.JSX.Element {
         <div className="office-center">
           <div className="office-setup-card">
             <h2 className="office-setup-title">{t("office.setupTitle")}</h2>
-            <p className="office-setup-desc">
-              {t("office.setupDesc1")}
-            </p>
-            <p className="office-setup-desc">
-              {t("office.setupDesc2")}
-            </p>
+            <p className="office-setup-desc">{t("office.setupDesc1")}</p>
+            <p className="office-setup-desc">{t("office.setupDesc2")}</p>
             {error && <div className="office-error">{error}</div>}
             <div className="office-setup-actions">
               <button className="btn btn-primary" onClick={handleInstall}>
@@ -255,7 +316,8 @@ function Office({ visible }: { visible?: boolean }): React.JSX.Element {
                   )
                 }
               >
-                <ExternalLink size={14} />{t("office.viewOnGithub")}
+                <ExternalLink size={14} />
+                {t("office.viewOnGithub")}
               </button>
             </div>
           </div>

--- a/src/shared/i18n/locales/en/office.ts
+++ b/src/shared/i18n/locales/en/office.ts
@@ -23,4 +23,18 @@ export default {
   clickToStart: "Click \"Start\" to run Claw3D",
   setupDesc1: "Claw3D is a 3D visualization environment for your Hermes agents. It lets you see your agents working in an interactive office space.",
   setupDesc2: "Click below to automatically download and set up Claw3D. This will clone the repository and install all dependencies.",
+  remoteModeTitle: "Office requires Local connection mode",
+  remoteModeDesc1:
+    "Hermes Office (Claw3D) bridges the 3D UI to a local Hermes Agent process via a WebSocket adapter (hermes-adapter) that runs on this machine. The desktop Office tab does not currently support pointing at a remote Hermes server.",
+  remoteModeDesc2:
+    "You're connected in Remote mode, so the Office tab can't start. You have two options:",
+  remoteModeOption1Title: "Option 1 — Switch to Local mode (recommended)",
+  remoteModeOption1Desc:
+    "Run Hermes Agent on this machine. Office will then install and run automatically. You can switch back to Remote mode later from Settings → Connection.",
+  remoteModeOption2Title:
+    "Option 2 — Run Office alongside Hermes Agent in Docker",
+  remoteModeOption2Desc:
+    "Deploy hermes-office as a sibling service in your Docker compose, alongside Hermes Agent. The 3D UI then lives at http://<docker-host>:3000 — open it directly in a browser. The desktop Office tab will not connect to it (this is a known limitation).",
+  switchToLocal: "Switch to Local mode",
+  viewDockerGuide: "Docker setup guide",
 } as const;

--- a/src/shared/i18n/locales/zh-CN/office.ts
+++ b/src/shared/i18n/locales/zh-CN/office.ts
@@ -23,4 +23,17 @@ export default {
   clickToStart: "点击\"启动\"来运行 Claw3D",
   setupDesc1: "Claw3D 是你的 Hermes 代理的 3D 可视化环境。它让你可以看到代理在交互式办公空间中工作。",
   setupDesc2: "点击下方自动下载并设置 Claw3D。这将克隆仓库并安装所有依赖。",
+  remoteModeTitle: "工作区需要本地连接模式",
+  remoteModeDesc1:
+    "Hermes 工作区（Claw3D）通过运行在本机上的 WebSocket 适配器（hermes-adapter）将 3D 界面连接到本地的 Hermes Agent 进程。桌面工作区目前不支持指向远程 Hermes 服务器。",
+  remoteModeDesc2: "你正处于远程连接模式，因此工作区无法启动。可选方案：",
+  remoteModeOption1Title: "方案 1 — 切换到本地模式（推荐）",
+  remoteModeOption1Desc:
+    "在本机运行 Hermes Agent。工作区将会自动安装并运行。之后可以从 设置 → 连接 切换回远程模式。",
+  remoteModeOption2Title:
+    "方案 2 — 在 Docker 中与 Hermes Agent 并行部署 Office",
+  remoteModeOption2Desc:
+    "在 Docker compose 中将 hermes-office 与 Hermes Agent 部署为同级服务，3D 界面会在 http://<docker-host>:3000 提供，直接在浏览器中打开。桌面工作区标签页不会连接到它（这是已知限制）。",
+  switchToLocal: "切换到本地模式",
+  viewDockerGuide: "Docker 部署指南",
 } as const;


### PR DESCRIPTION
## Summary

The Office (Claw3D) tab silently fails when the user is in Remote connection mode (Settings → Connection → Remote). Root cause: Office runs `hermes-office` locally, and its in-process `hermes-adapter` is hardcoded to talk to a co-located Hermes Agent. In remote mode there is no local Hermes Agent, so the adapter has nothing to bridge.

This PR doesn't fix the underlying limitation (that would need upstream `hermes-office` adapter work + a "Remote Office URL" setting in the desktop app) — it surfaces it clearly to the user instead of failing silently:

- New `'remote-mode'` state in `Office.tsx`, entered at status-check time when `isRemoteMode()` is true.
- An explanatory screen with two options:
  - **Switch to Local mode** — single button that calls `setConnectionConfig('local', '', '')` and refreshes.
  - **Self-host Office on the Docker side** — links to a new step-by-step guide.
- en + zh-CN i18n strings for the new screen.
- New guide `docs/guides/office-on-docker.md` with a sample `docker-compose.yml`, caveats, and explicit notes about what does and doesn't work today.
- Bundled investigation document `docs/issues/2026-04-30-runtime-connection-issues.md` as the rationale (it also covers a separate Issue 1 about remote-Hermes connection diagnostics, which is intentionally not addressed in this PR — a focused follow-up).

## What this is NOT fixing

- The desktop app's Office tab still cannot connect to a remote Office instance (e.g., one running in Docker). The guide is honest about this; users open `http://<docker-host>:3000` in a regular browser. Adding remote-Office-URL support in the desktop app + (likely) a `HERMES_AGENT_URL` env in upstream `hermes-office`'s adapter would be a future PR.
- Issue 1 (remote-connection diagnostics — Settings UI doesn't distinguish auth-failed from unreachable, no URL validation) is documented but not implemented here. Each is small and orthogonal; happy to do them as separate PRs.

## Verification

- [x] `npm run typecheck` clean (node + web)
- [x] `npm run test` — 237 pass, 2 pre-existing constants failures unrelated to this change
- [x] `npx eslint` on the three modified TS/TSX files: no NEW errors or warnings introduced. Pre-existing react-hooks errors at `Office.tsx:50-52` and pre-existing prettier warnings on long string literals are out of scope.
- [x] Visually walked the new render branch in the source — types match `OfficeState`, all i18n keys exist in both locales, links resolve to fathah/hermes-desktop docs/.

## Manual test plan (for the maintainer)

1. Local installation of the build (or `npm run dev`).
2. Settings → Connection → switch to Remote, enter any URL, save.
3. Open Office tab. Expected: the new "Office requires Local connection mode" screen with two option blocks.
4. Click **Switch to Local mode**. Expected: connection mode flips to local, Office tab re-checks and shows the normal "Set Up Claw3D" install screen (or the ready state, if already installed).
5. Switch back to Remote. Open Office. Expected: same guidance screen as step 3. Click **Docker setup guide** — opens the GitHub blob view of `docs/guides/office-on-docker.md` in the user's browser.

## Files changed

- `src/renderer/src/screens/Office/Office.tsx` (+76 / -7) — new state + render branch
- `src/shared/i18n/locales/en/office.ts` (+14) — new strings
- `src/shared/i18n/locales/zh-CN/office.ts` (+13) — new strings (machine-assisted; native review welcome)
- `docs/guides/office-on-docker.md` (new) — Docker deployment walkthrough
- `docs/issues/2026-04-30-runtime-connection-issues.md` (new) — investigation + future fix proposals

## Related

- Companion PR #35 — release pipeline (Windows winget + Fedora RPM). Independent of this one; can land in either order.