### PR TITLE
fix: point Help menu links to canonical NousResearch/hermes-agent repo

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -760,13 +760,17 @@ function buildMenu(): void {
         {
           label: "Hermes Agent on GitHub",
           click: (): void => {
-            shell.openExternal("https://github.com/fathah/Hermes-Agent");
+            shell.openExternal(
+              "https://github.com/NousResearch/hermes-agent",
+            );
           },
         },
         {
           label: "Report an Issue",
           click: (): void => {
-            shell.openExternal("https://github.com/fathah/Hermes-Agent/issues");
+            shell.openExternal(
+              "https://github.com/NousResearch/hermes-agent/issues",
+            );
           },
         },
       ],


### PR DESCRIPTION
## Summary

The two Help menu items in the Application menu — "Hermes Agent on GitHub" and "Report an Issue" — pointed to `https://github.com/fathah/Hermes-Agent` (note the capital H, which GitHub case-insensitively redirects to `fathah/hermes-agent`, a fork of the canonical repo).

Per `README.md`, the canonical upstream of the agent is `https://github.com/NousResearch/hermes-agent`. Users opening "Hermes Agent on GitHub" expect to land on the source-of-truth repo where releases, issues, and core discussion happen — not on a fork.

This PR repoints both links to the canonical upstream.

## Why this is a separate PR

This change is orthogonal to ongoing work on the desktop app (release pipeline #35, Office remote-mode guidance #36). It's a 6-line typo-class fix, easy to review and merge independently.

## Verification

- [x] `npm run typecheck` clean
- [x] Both URLs resolve to existing repos (`gh api repos/NousResearch/hermes-agent` returns the canonical repo with `fork: false`).

## Files changed

- `src/main/index.ts` (+6 / -2) — both `shell.openExternal` calls updated.