### PR TITLE
fix(renderer): skip verifyInstall() in remote-mode connections

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -64,7 +64,13 @@ function App(): React.JSX.Element {
 
     // Lazy deep-verify in the background after the UI is up. If the
     // install is broken, surface the warning then — don't block startup.
-    if (next === "main" || next === "setup") {
+    //
+    // Skip for remote-mode connections: verifyInstall() probes the LOCAL
+    // Python + script paths (HERMES_PYTHON / HERMES_SCRIPT in installer.ts),
+    // which don't exist on machines that only use a remote backend. Without
+    // this guard the user is bounced back to Welcome with an "installBroken"
+    // error immediately after a successful remote connect. (#47, #41, #30)
+    if ((next === "main" || next === "setup") && conn.mode !== "remote") {
       window.hermesAPI.verifyInstall().then((ok) => {
         if (!ok) {
           setInstallError(t("errors.installBroken"));


### PR DESCRIPTION
## Summary

Closes #47, also relevant to #41 and #30.

The lazy-fired `verifyInstall()` in `App.tsx` runs after a successful initial connection check, regardless of mode. `verifyInstall()` in `installer.ts` probes the LOCAL Python + script paths (`HERMES_PYTHON` / `HERMES_SCRIPT`), which don't exist on machines that only use a remote backend.

Result: a user with a healthy remote backend connects → sees the main UI for a moment → gets bounced to the Welcome screen with the "installBroken" error. The behavior persists across reinstalls because it isn't an install problem.

## Reproduction

- Windows v0.3.1
- Remote Hermes Agent reachable (verified via `curl http://gateway:8642/health` → 200)
- CORS configured (`cors_origins: '*'`)
- Set `connectionMode: remote` and a working `remoteUrl` in desktop.json
- Launch the app → main loads briefly → bounces back to Welcome with `errors.installBroken`

## Fix

Single-line guard: only run the lazy `verifyInstall()` when `conn.mode !== "remote"`. The initial mode-aware check in `runInstallCheck()` already handles remote-mode correctly via `testRemoteConnection()`; the lazy verify is redundant when we're not using a local install.

## Test plan

- [x] Local-mode flow unchanged: `verifyInstall()` still runs after successful local launch
- [x] Remote-mode flow no longer triggers the broken-install error after a successful `testRemoteConnection`
- [ ] Verify in CI that the existing test suite still passes

## Risk

Low. The lazy `verifyInstall()` was always a redundant check in remote mode (the screen had already been gated by `testRemoteConnection` upstream in the same function). The patch only suppresses a probe that returns false-but-meaningless on remote-mode machines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)