### PR TITLE
fix(renderer): hoist isRemote flag out of try block (follow-up to #49)

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -24,9 +24,11 @@ function App(): React.JSX.Element {
     const startedAt = Date.now();
     let next: Screen = "welcome";
     let error: string | null = null;
+    let isRemote = false;
 
     try {
       const conn = await window.hermesAPI.getConnectionConfig();
+      isRemote = conn.mode === "remote";
 
       if (conn.mode === "remote" && conn.remoteUrl) {
         const ok = await window.hermesAPI.testRemoteConnection(
@@ -70,7 +72,7 @@ function App(): React.JSX.Element {
     // which don't exist on machines that only use a remote backend. Without
     // this guard the user is bounced back to Welcome with an "installBroken"
     // error immediately after a successful remote connect. (#47, #41, #30)
-    if ((next === "main" || next === "setup") && conn.mode !== "remote") {
+    if ((next === "main" || next === "setup") && !isRemote) {
       window.hermesAPI.verifyInstall().then((ok) => {
         if (!ok) {
           setInstallError(t("errors.installBroken"));


### PR DESCRIPTION
## Summary

Tiny follow-up to merged PR #49 — that PR added a `conn.mode !== "remote"` guard to the lazy `verifyInstall()` call in `App.tsx`, but `conn` is declared inside the try block on line 29 and the guard on line 73 references it after the block exits.

`npx tsc --noEmit -p tsconfig.web.json` on a clean main checkout fails with:

```
src/renderer/src/App.tsx(73,50): error TS2304: Cannot find name 'conn'.
```

That breaks `npm run build` (which runs `typecheck` first) for everyone who clones main.

## Fix

Hoist a small `isRemote: boolean` flag out of the try block, set it inside, and reuse it on line 75. Behavior is identical to #49's intent — skip `verifyInstall()` in remote mode — but the flag is in scope where it's used.

```diff
+    let isRemote = false;
     try {
       const conn = await window.hermesAPI.getConnectionConfig();
+      isRemote = conn.mode === "remote";
       ...
     }
     ...
-    if ((next === "main" || next === "setup") && conn.mode !== "remote") {
+    if ((next === "main" || next === "setup") && !isRemote) {
```

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.web.json` exits 0
- [x] `npx tsc --noEmit -p tsconfig.node.json` exits with only the pre-existing i18next TS2742 warning (unrelated)
- [x] `npm run build` (would have failed on main) now proceeds past the typecheck step
- [x] Vitest suite has the same 2 pre-existing failures as baseline `upstream/main`, no new failures

Sorry for the miss — thanks for the merge.