### PR TITLE
feat(renderer): wire Schedules tab to /api/jobs in remote mode

### DIFF
--- a/src/main/cronjobs.ts
+++ b/src/main/cronjobs.ts
@@ -4,6 +4,7 @@ import { join } from "path";
 import { execFile } from "child_process";
 import { HERMES_HOME, HERMES_PYTHON, HERMES_SCRIPT } from "./installer";
 import { profileHome } from "./utils";
+import { isRemoteMode, getApiUrl, getRemoteAuthHeader } from "./hermes";
 
 export interface CronJob {
   id: string;
@@ -26,13 +27,91 @@ function jobsFilePath(profile?: string): string {
   return join(profileHome(profile), "cron", "jobs.json");
 }
 
+function normalizeJob(job: Record<string, unknown>): CronJob | null {
+  if (!job.id) return null;
+  const enabled = job.enabled !== false;
+  let state: CronJob["state"] = "active";
+  if (job.state === "paused" || !enabled) state = "paused";
+  else if (job.state === "completed") state = "completed";
+  const schedule = job.schedule as { value?: string } | string | undefined;
+  return {
+    id: String(job.id),
+    name: (job.name as string) || "(unnamed)",
+    schedule:
+      (job.schedule_display as string) ||
+      (typeof schedule === "object" ? schedule?.value : schedule) ||
+      "?",
+    prompt: (job.prompt as string) || "",
+    state,
+    enabled,
+    next_run_at: (job.next_run_at as string) || null,
+    last_run_at: (job.last_run_at as string) || null,
+    last_status: (job.last_status as string) || null,
+    last_error: (job.last_error as string) || null,
+    repeat: (job.repeat as CronJob["repeat"]) || null,
+    deliver: Array.isArray(job.deliver)
+      ? (job.deliver as string[])
+      : job.deliver
+        ? [job.deliver as string]
+        : ["local"],
+    skills:
+      (job.skills as string[]) || (job.skill ? [job.skill as string] : []),
+    script: (job.script as string) || null,
+  };
+}
+
+async function remoteFetch(
+  path: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const headers: Record<string, string> = {
+    ...getRemoteAuthHeader(),
+    ...((init.headers as Record<string, string>) || {}),
+  };
+  return fetch(`${getApiUrl()}${path}`, { ...init, headers });
+}
+
+async function remoteJsonError(res: Response): Promise<string> {
+  try {
+    const body = (await res.json()) as { error?: string };
+    return body.error || `HTTP ${res.status}`;
+  } catch {
+    return `HTTP ${res.status}`;
+  }
+}
+
 /**
  * Read cron jobs from the jobs.json file (async to avoid blocking the main process).
+ * In remote mode, fetches from the Hermes API server's /api/jobs endpoint instead.
  */
 export async function listCronJobs(
   includeDisabled = true,
   profile?: string,
 ): Promise<CronJob[]> {
+  if (isRemoteMode()) {
+    try {
+      const qs = includeDisabled ? "?include_disabled=true" : "";
+      const res = await remoteFetch(`/api/jobs${qs}`);
+      if (!res.ok) {
+        console.error("[CRON] remote list failed:", await remoteJsonError(res));
+        return [];
+      }
+      const body = (await res.json()) as { jobs?: Record<string, unknown>[] };
+      const raw = body.jobs || [];
+      const jobs: CronJob[] = [];
+      for (const job of raw) {
+        const normalized = normalizeJob(job);
+        if (!normalized) continue;
+        if (!includeDisabled && !normalized.enabled) continue;
+        jobs.push(normalized);
+      }
+      return jobs;
+    } catch (err) {
+      console.error("[CRON] remote list error:", err);
+      return [];
+    }
+  }
+
   const filePath = jobsFilePath(profile);
   if (!existsSync(filePath)) return [];
 
@@ -43,35 +122,10 @@ export async function listCronJobs(
     const jobs: CronJob[] = [];
 
     for (const job of raw) {
-      if (!job.id) continue; // skip malformed entries
-
-      const enabled = job.enabled !== false;
-      if (!includeDisabled && !enabled) continue;
-
-      let state: CronJob["state"] = "active";
-      if (job.state === "paused" || !enabled) state = "paused";
-      else if (job.state === "completed") state = "completed";
-
-      jobs.push({
-        id: job.id,
-        name: job.name || "(unnamed)",
-        schedule: job.schedule_display || job.schedule?.value || "?",
-        prompt: job.prompt || "",
-        state,
-        enabled,
-        next_run_at: job.next_run_at || null,
-        last_run_at: job.last_run_at || null,
-        last_status: job.last_status || null,
-        last_error: job.last_error || null,
-        repeat: job.repeat || null,
-        deliver: Array.isArray(job.deliver)
-          ? job.deliver
-          : job.deliver
-            ? [job.deliver]
-            : ["local"],
-        skills: job.skills || (job.skill ? [job.skill] : []),
-        script: job.script || null,
-      });
+      const normalized = normalizeJob(job);
+      if (!normalized) continue;
+      if (!includeDisabled && !normalized.enabled) continue;
+      jobs.push(normalized);
     }
 
     return jobs;
@@ -121,6 +175,27 @@ export async function createCronJob(
   deliver?: string,
   profile?: string,
 ): Promise<{ success: boolean; error?: string }> {
+  if (isRemoteMode()) {
+    try {
+      const res = await remoteFetch("/api/jobs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name || "",
+          schedule,
+          prompt: prompt || "",
+          deliver: deliver || "local",
+        }),
+      });
+      if (!res.ok) {
+        return { success: false, error: await remoteJsonError(res) };
+      }
+      return { success: true };
+    } catch (err) {
+      return { success: false, error: (err as Error).message };
+    }
+  }
+
   // Use -- to prevent prompt from being parsed as a flag
   const args = ["create", schedule];
   if (name) args.push("--name", name);
@@ -139,8 +214,39 @@ export async function removeCronJob(
   profile?: string,
 ): Promise<{ success: boolean; error?: string }> {
   if (!jobId) return { success: false, error: "Missing job ID" };
+  if (isRemoteMode()) {
+    try {
+      const res = await remoteFetch(`/api/jobs/${encodeURIComponent(jobId)}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        return { success: false, error: await remoteJsonError(res) };
+      }
+      return { success: true };
+    } catch (err) {
+      return { success: false, error: (err as Error).message };
+    }
+  }
   const result = await runCronCommand(["remove", jobId], profile);
   return { success: result.success, error: result.error };
+}
+
+async function remoteJobAction(
+  jobId: string,
+  action: "pause" | "resume" | "run",
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const res = await remoteFetch(
+      `/api/jobs/${encodeURIComponent(jobId)}/${action}`,
+      { method: "POST" },
+    );
+    if (!res.ok) {
+      return { success: false, error: await remoteJsonError(res) };
+    }
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: (err as Error).message };
+  }
 }
 
 export async function pauseCronJob(
@@ -148,6 +254,7 @@ export async function pauseCronJob(
   profile?: string,
 ): Promise<{ success: boolean; error?: string }> {
   if (!jobId) return { success: false, error: "Missing job ID" };
+  if (isRemoteMode()) return remoteJobAction(jobId, "pause");
   const result = await runCronCommand(["pause", jobId], profile);
   return { success: result.success, error: result.error };
 }
@@ -157,6 +264,7 @@ export async function resumeCronJob(
   profile?: string,
 ): Promise<{ success: boolean; error?: string }> {
   if (!jobId) return { success: false, error: "Missing job ID" };
+  if (isRemoteMode()) return remoteJobAction(jobId, "resume");
   const result = await runCronCommand(["resume", jobId], profile);
   return { success: result.success, error: result.error };
 }
@@ -166,6 +274,7 @@ export async function triggerCronJob(
   profile?: string,
 ): Promise<{ success: boolean; error?: string }> {
   if (!jobId) return { success: false, error: "Missing job ID" };
+  if (isRemoteMode()) return remoteJobAction(jobId, "run");
   const result = await runCronCommand(["run", jobId], profile);
   return { success: result.success, error: result.error };
 }

--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -16,7 +16,7 @@ import { stripAnsi } from "./utils";
 
 const LOCAL_API_URL = "http://127.0.0.1:8642";
 
-function getApiUrl(): string {
+export function getApiUrl(): string {
   const conn = getConnectionConfig();
   if (conn.mode === "remote" && conn.remoteUrl) {
     return conn.remoteUrl.replace(/\/+$/, "");
@@ -28,7 +28,7 @@ export function isRemoteMode(): boolean {
   return getConnectionConfig().mode === "remote";
 }
 
-function getRemoteAuthHeader(): Record<string, string> {
+export function getRemoteAuthHeader(): Record<string, string> {
   const conn = getConnectionConfig();
   if (conn.mode === "remote" && conn.apiKey) {
     return { Authorization: `Bearer ${conn.apiKey}` };

--- a/src/renderer/src/screens/Layout/Layout.tsx
+++ b/src/renderer/src/screens/Layout/Layout.tsx
@@ -295,12 +295,7 @@ function Layout(): React.JSX.Element {
           ) : (
             <Tools profile={activeProfile} />
           ))}
-        {view === "schedules" &&
-          (remoteMode ? (
-            <RemoteNotice feature="Schedules" />
-          ) : (
-            <Schedules profile={activeProfile} />
-          ))}
+        {view === "schedules" && <Schedules profile={activeProfile} />}
         {view === "gateway" &&
           (remoteMode ? (
             <RemoteNotice feature="Gateway" />


### PR DESCRIPTION
## Summary

Today, Schedules is hard-disabled in remote-mode connections — `Layout.tsx` renders a `<RemoteNotice feature="Schedules" />` placeholder instead of the actual Schedules screen. The local implementation in `src/main/cronjobs.ts` reads `~/.hermes/cron/jobs.json` directly and shells out to `hermes cron …`, neither of which is meaningful against a remote backend.

Good news: the Hermes API server (`gateway/platforms/api_server.py`) **already exposes the full cron CRUD surface** — `/api/jobs` GET/POST, `/api/jobs/:id` GET/PATCH/DELETE, `/api/jobs/:id/{pause,resume,run}` POST. So this is a desktop-only PR; no matching Hermes runtime PR is needed to ship it.

## What changed

**`src/main/hermes.ts`** — export the existing `getApiUrl()` and `getRemoteAuthHeader()` helpers (previously only used internally for `sendMessageViaApi`). One source of truth for the remote base URL + Bearer header avoids re-deriving from `getConnectionConfig()` in each consumer.

**`src/main/cronjobs.ts`** —
- Extract a shared `normalizeJob()` helper. The same shape mapping is now used for both local jsonl rows and remote `/api/jobs` responses.
- Add tiny `remoteFetch()` and `remoteJsonError()` shims so each handler is one expressive call.
- Each of `listCronJobs / createCronJob / removeCronJob / pauseCronJob / resumeCronJob / triggerCronJob` now starts with an `if (isRemoteMode())` branch. Local-mode code paths are unchanged byte-for-byte after the `normalizeJob` extraction.

**`src/renderer/src/screens/Layout/Layout.tsx`** — drop the `<RemoteNotice feature="Schedules">` branch; render `<Schedules>` directly in both modes. The screen's renderer code already calls `window.hermesAPI.listCronJobs(...)` etc., which now do the right thing transparently.

## Notes

- The `profile` arg is ignored in remote mode — the Hermes server is already scoped per-profile by its own config and the desktop has no way to override it remotely. Same convention as `sendMessageViaApi`.
- If the server returns 501 (`{"error": "Cron module not available"}`), `listCronJobs` logs and returns `[]`. Schedules renders cleanly as "no jobs" rather than a hard error — graceful degradation if a user is on a Hermes runtime build with cron disabled.
- A small `remoteJobAction()` helper handles pause/resume/run/delete to avoid 4× the same try/catch boilerplate.

## Rebased on current main (2026-05-03)

The conn-scope follow-up (PR #53) is no longer needed — fathah landed the same fix manually on main in 4926e16. After rebasing this branch onto current `main`, git automatically dropped the cherry-picked commit since the patch is already upstream. This PR now contains only the Schedules feature commit, cleanly applies on top of v0.3.2.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.web.json` exits 0
- [x] `npx tsc --noEmit -p tsconfig.node.json` shows only the pre-existing i18next TS2742 (unrelated)
- [x] `npx eslint src/main/cronjobs.ts src/main/hermes.ts src/renderer/src/App.tsx src/renderer/src/screens/Layout/Layout.tsx` clean (one pre-existing setState-in-effect warning at App.tsx:86 is baseline)
- [x] `npx vitest run` shows the same 2 pre-existing failures as upstream/main, no new failures
- [x] **Manual end-to-end against a live Hermes API server (api_server platform, port 18642).** All 6 handlers (list/create/pause/resume/trigger/delete) round-trip cleanly; error paths (missing job, bad auth) handled gracefully. Full output and harness details in the comment below.