### PR TITLE
fix(profiles): show profile dirs that have neither config.yaml nor .env

### DIFF
--- a/src/main/profiles.ts
+++ b/src/main/profiles.ts
@@ -135,20 +135,25 @@ export async function listProfiles(): Promise<ProfileInfo[]> {
     try {
       const dirs = await fs.readdir(PROFILES_DIR);
       const profilePromises = dirs.map(async (name) => {
+        // Skip dotfiles like .DS_Store so they don't get mistaken for profiles.
+        if (name.startsWith(".")) return null;
+
         const profilePath = join(PROFILES_DIR, name);
         const stat = await fs.stat(profilePath);
         if (!stat.isDirectory()) return null;
 
-        const hasConfig = await fileExists(join(profilePath, "config.yaml"));
-        const hasEnvFile = await fileExists(join(profilePath, ".env"));
-        if (!hasConfig && !hasEnvFile) return null;
-
-        const [config, hasSoul, skillCount, gwRunning] = await Promise.all([
-          readProfileConfig(profilePath),
-          fileExists(join(profilePath, "SOUL.md")),
-          countSkills(profilePath),
-          isGatewayRunning(profilePath),
-        ]);
+        // Any subdirectory of ~/.hermes/profiles/ is treated as a profile.
+        // We deliberately do NOT require config.yaml or .env to exist —
+        // a freshly created profile may have neither yet, and filtering on
+        // them silently hides it from the UI (issue #19).
+        const [config, hasEnvFile, hasSoul, skillCount, gwRunning] =
+          await Promise.all([
+            readProfileConfig(profilePath),
+            fileExists(join(profilePath, ".env")),
+            fileExists(join(profilePath, "SOUL.md")),
+            countSkills(profilePath),
+            isGatewayRunning(profilePath),
+          ]);
 
         return {
           name,

--- a/tests/profiles.test.ts
+++ b/tests/profiles.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { join } from "path";
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
+
+// `vi.hoisted` runs before module imports, so we can't reference imported
+// `join` / `tmpdir` here — use the bare Node modules via require, which is
+// the documented escape hatch for hoisted setup.
+const { TEST_HOME } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const path = require("path");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const os = require("os");
+  return {
+    TEST_HOME: path.join(os.tmpdir(), `hermes-profiles-test-${Date.now()}`),
+  };
+});
+
+// Mock installer module so HERMES_HOME points at our temp dir before
+// profiles.ts evaluates the `PROFILES_DIR` constant from it.
+vi.mock("../src/main/installer", () => ({
+  HERMES_HOME: TEST_HOME,
+  HERMES_PYTHON: "/usr/bin/python3",
+  HERMES_SCRIPT: "/dev/null",
+  getEnhancedPath: () => process.env.PATH || "",
+}));
+
+// Import AFTER the mock so PROFILES_DIR is resolved against TEST_HOME.
+import { listProfiles } from "../src/main/profiles";
+
+const PROFILES_DIR = join(TEST_HOME, "profiles");
+
+beforeEach(() => {
+  mkdirSync(TEST_HOME, { recursive: true });
+  mkdirSync(PROFILES_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  if (existsSync(TEST_HOME)) {
+    rmSync(TEST_HOME, { recursive: true, force: true });
+  }
+});
+
+describe("listProfiles", () => {
+  it("includes a profile directory that has neither config.yaml nor .env (issue #19)", async () => {
+    const empty = join(PROFILES_DIR, "fresh");
+    mkdirSync(empty, { recursive: true });
+
+    const profiles = await listProfiles();
+    const fresh = profiles.find((p) => p.name === "fresh");
+    expect(fresh).toBeDefined();
+    expect(fresh?.isDefault).toBe(false);
+    expect(fresh?.hasEnv).toBe(false);
+  });
+
+  it("includes a profile that has only .env", async () => {
+    const dir = join(PROFILES_DIR, "env-only");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, ".env"), "OPENAI_API_KEY=x\n");
+
+    const profiles = await listProfiles();
+    const found = profiles.find((p) => p.name === "env-only");
+    expect(found).toBeDefined();
+    expect(found?.hasEnv).toBe(true);
+  });
+
+  it("includes a profile that has only config.yaml and parses model/provider", async () => {
+    const dir = join(PROFILES_DIR, "config-only");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "config.yaml"),
+      "models:\n  default: gpt-4o\n  provider: openai\n",
+    );
+
+    const profiles = await listProfiles();
+    const found = profiles.find((p) => p.name === "config-only");
+    expect(found).toBeDefined();
+    expect(found?.model).toBe("gpt-4o");
+    expect(found?.provider).toBe("openai");
+  });
+
+  it("ignores dotfiles like .DS_Store under the profiles directory", async () => {
+    writeFileSync(join(PROFILES_DIR, ".DS_Store"), "");
+    mkdirSync(join(PROFILES_DIR, ".hidden"), { recursive: true });
+
+    const profiles = await listProfiles();
+    const dotProfiles = profiles.filter(
+      (p) => p.name.startsWith(".") || p.name === ".DS_Store",
+    );
+    expect(dotProfiles).toHaveLength(0);
+  });
+
+  it("ignores files (non-directories) under the profiles directory", async () => {
+    writeFileSync(join(PROFILES_DIR, "stray.txt"), "stray");
+
+    const profiles = await listProfiles();
+    expect(profiles.find((p) => p.name === "stray.txt")).toBeUndefined();
+  });
+
+  it("returns the default profile even when ~/.hermes/profiles/ is empty", async () => {
+    const profiles = await listProfiles();
+    expect(profiles.find((p) => p.isDefault)).toBeDefined();
+  });
+
+  it("marks the active profile correctly", async () => {
+    const dir = join(PROFILES_DIR, "work");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(TEST_HOME, "active_profile"), "work\n");
+
+    const profiles = await listProfiles();
+    const work = profiles.find((p) => p.name === "work");
+    const def = profiles.find((p) => p.isDefault);
+    expect(work?.isActive).toBe(true);
+    expect(def?.isActive).toBe(false);
+  });
+});


### PR DESCRIPTION
### What

\`listProfiles()\` filtered out any subdirectory of \`~/.hermes/profiles/\` that didn't have either \`config.yaml\` or \`.env\`. Newly created profiles often have neither file yet — for example, when the user plans to add a Nous subscription to the profile rather than an API key, no \`.env\` is needed.

These profiles existed on disk and were visible to the CLI, but were silently hidden from the desktop **Profiles** tab.

### Why

From the issue (#19):

> I created a new profile, and although it exists on the command line (I set it up with a different provider, after creating it with the UI), it does not show up in the WebUI after creation or after UI restart.
>
> To give this some context, I added this new profile to be able to use the CLI to add my Nous subscription to the profile (not API key) as this is not yet supported by the UI.

The user couldn't see their own profile in the desktop UI even though the profile directory was right there on disk.

### Change

\`src/main/profiles.ts\`:

- Removed the \`if (!hasConfig && !hasEnvFile) return null;\` guard inside the per-directory mapper. Any subdirectory of \`~/.hermes/profiles/\` is now treated as a profile.
- Added a small guard to skip dotfiles (e.g. \`.DS_Store\`) so they don't appear as ghost profiles in the UI.

### Tests

Adds \`tests/profiles.test.ts\` with 7 cases:

1. **Issue #19 regression**: a profile dir with neither \`config.yaml\` nor \`.env\` is now returned.
2. A profile with only \`.env\` is returned with \`hasEnv: true\`.
3. A profile with only \`config.yaml\` is returned and its \`model\` / \`provider\` are parsed.
4. \`.DS_Store\` and other dotfiles are skipped.
5. Stray files (non-directories) under \`~/.hermes/profiles/\` are skipped.
6. The default profile is always returned even when the profiles dir is empty.
7. The active profile is correctly marked via \`~/.hermes/active_profile\`.

\`\`\`
$ npx vitest run tests/profiles.test.ts
 Test Files  1 passed (1)
      Tests  7 passed (7)
\`\`\`

\`npm run typecheck\` passes. \`npm run lint\` shows no new errors or warnings introduced by this PR (8 pre-existing prettier warnings in surrounding code in \`profiles.ts\` are untouched).

### Notes

- No backward-compat shim is needed — the prior behavior was the bug (silently hidden profiles), and the new behavior is strictly more inclusive.
- The 2 unrelated test failures in \`tests/constants.test.ts\` exist on \`upstream/main\` already and are not introduced by this PR.

Fixes #19