### PR TITLE
fix(skills): drop --yes from uninstall args

### DIFF
--- a/src/main/skills.ts
+++ b/src/main/skills.ts
@@ -267,7 +267,7 @@ export function uninstallSkill(
   profile?: string,
 ): { success: boolean; error?: string } {
   try {
-    const args = [HERMES_SCRIPT, "skills", "uninstall", name, "--yes"];
+    const args = [HERMES_SCRIPT, "skills", "uninstall", name];
     if (profile && profile !== "default") {
       args.splice(1, 0, "-p", profile);
     }


### PR DESCRIPTION
uninstallSkill passes `--yes` to `hermes skills uninstall`, but the runtime parser dropped that flag — call errors with `unrecognized arguments: --yes`. Install path keeps it (still supported).

Closes #33