### PR TITLE
Add SSH tunnel connection mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-desktop",
-  "version": "0.2.2",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-desktop",
-      "version": "0.2.2",
+      "version": "0.3.4",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.2",
@@ -109,7 +109,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -474,7 +473,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -498,7 +496,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -974,6 +971,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -995,6 +993,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1011,6 +1010,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1025,6 +1025,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2801,7 +2802,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2973,7 +2975,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3001,7 +3002,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3012,7 +3012,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3104,7 +3103,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -3489,7 +3487,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3523,7 +3520,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4118,7 +4114,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4746,7 +4741,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5115,7 +5111,6 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -5210,7 +5205,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -5285,7 +5281,6 @@
       "integrity": "sha512-q6+LiQIcTadSyvtPgLDQkCtVA9jQJXQVMrQcctfOJILh6OFMN+UJJLRkuUTy8CZDYeCIBn1ZycqsL1dAXugxZA==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^22.7.7",
@@ -5537,6 +5532,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -5557,6 +5553,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -5899,7 +5896,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5960,7 +5956,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7242,7 +7237,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2"
       },
@@ -8003,7 +7997,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -8537,6 +8530,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9701,6 +9695,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -10336,7 +10331,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10405,6 +10399,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -10422,6 +10417,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -10493,7 +10489,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10523,6 +10518,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10538,6 +10534,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10550,7 +10547,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
@@ -10689,7 +10687,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10700,7 +10697,6 @@
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11076,6 +11072,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -12067,6 +12064,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -12425,7 +12423,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12709,7 +12706,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -13732,7 +13728,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -3,12 +3,22 @@ import { join } from "path";
 import { HERMES_HOME } from "./installer";
 import { profileHome, escapeRegex, safeWriteFile } from "./utils";
 
-// ── Connection Config (local vs remote) ─────────────────
+// ── Connection Config (local / remote / ssh) ─────────────
+
+export interface SshConnectionConfig {
+  host: string;
+  port: number;
+  username: string;
+  keyPath: string;
+  remotePort: number;
+  localPort: number;
+}
 
 export interface ConnectionConfig {
-  mode: "local" | "remote";
+  mode: "local" | "remote" | "ssh";
   remoteUrl: string;
   apiKey: string;
+  ssh: SshConnectionConfig;
 }
 
 // Lazy getter — avoids circular dependency with installer.ts
@@ -36,10 +46,19 @@ function writeDesktopConfig(data: Record<string, unknown>): void {
 
 export function getConnectionConfig(): ConnectionConfig {
   const data = readDesktopConfig();
+  const ssh = (data.sshConfig as Partial<SshConnectionConfig>) ?? {};
   return {
-    mode: (data.connectionMode as "local" | "remote") || "local",
+    mode: (data.connectionMode as "local" | "remote" | "ssh") || "local",
     remoteUrl: (data.remoteUrl as string) || "",
     apiKey: (data.remoteApiKey as string) || "",
+    ssh: {
+      host: (ssh.host as string) || "",
+      port: (ssh.port as number) || 22,
+      username: (ssh.username as string) || "",
+      keyPath: (ssh.keyPath as string) || "",
+      remotePort: (ssh.remotePort as number) || 8642,
+      localPort: (ssh.localPort as number) || 18642,
+    },
   };
 }
 
@@ -48,6 +67,9 @@ export function setConnectionConfig(config: ConnectionConfig): void {
   data.connectionMode = config.mode;
   data.remoteUrl = config.remoteUrl;
   data.remoteApiKey = config.apiKey;
+  if (config.mode === "ssh") {
+    data.sshConfig = config.ssh;
+  }
   writeDesktopConfig(data);
 }
 

--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -33,6 +33,11 @@ export function isRemoteMode(): boolean {
   return mode === "remote" || mode === "ssh";
 }
 
+/** True only for pure remote HTTP — SSH tunnel has full local access via SSH exec */
+export function isRemoteOnlyMode(): boolean {
+  return getConnectionConfig().mode === "remote";
+}
+
 export function getRemoteAuthHeader(): Record<string, string> {
   const conn = getConnectionConfig();
   // SSH tunnel is localhost — no auth header needed

--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -38,10 +38,19 @@ export function isRemoteOnlyMode(): boolean {
   return getConnectionConfig().mode === "remote";
 }
 
+// Cached API key read from the remote .env when SSH tunnel starts
+let _sshRemoteApiKey = "";
+
+export function setSshRemoteApiKey(key: string): void {
+  _sshRemoteApiKey = key;
+}
+
 export function getRemoteAuthHeader(): Record<string, string> {
   const conn = getConnectionConfig();
-  // SSH tunnel is localhost — no auth header needed
-  if (conn.mode === "ssh") return {};
+  if (conn.mode === "ssh") {
+    if (_sshRemoteApiKey) return { Authorization: `Bearer ${_sshRemoteApiKey}` };
+    return {};
+  }
   if (conn.mode === "remote" && conn.apiKey) {
     return { Authorization: `Bearer ${conn.apiKey}` };
   }

--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -12,12 +12,16 @@ import {
   getEnhancedPath,
 } from "./installer";
 import { getModelConfig, readEnv, getConnectionConfig } from "./config";
+import { getSshTunnelUrl, isSshTunnelActive, startSshTunnel } from "./ssh-tunnel";
 import { stripAnsi } from "./utils";
 
 const LOCAL_API_URL = "http://127.0.0.1:8642";
 
 export function getApiUrl(): string {
   const conn = getConnectionConfig();
+  if (conn.mode === "ssh") {
+    return getSshTunnelUrl();
+  }
   if (conn.mode === "remote" && conn.remoteUrl) {
     return conn.remoteUrl.replace(/\/+$/, "");
   }
@@ -25,15 +29,25 @@ export function getApiUrl(): string {
 }
 
 export function isRemoteMode(): boolean {
-  return getConnectionConfig().mode === "remote";
+  const mode = getConnectionConfig().mode;
+  return mode === "remote" || mode === "ssh";
 }
 
 export function getRemoteAuthHeader(): Record<string, string> {
   const conn = getConnectionConfig();
+  // SSH tunnel is localhost — no auth header needed
+  if (conn.mode === "ssh") return {};
   if (conn.mode === "remote" && conn.apiKey) {
     return { Authorization: `Bearer ${conn.apiKey}` };
   }
   return {};
+}
+
+export async function ensureSshTunnelIfNeeded(): Promise<void> {
+  const conn = getConnectionConfig();
+  if (conn.mode === "ssh" && !isSshTunnelActive()) {
+    await startSshTunnel(conn.ssh);
+  }
 }
 
 const LOCAL_PROVIDERS = new Set([

--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -12,7 +12,7 @@ import {
   getEnhancedPath,
 } from "./installer";
 import { getModelConfig, readEnv, getConnectionConfig } from "./config";
-import { getSshTunnelUrl, isSshTunnelActive, startSshTunnel } from "./ssh-tunnel";
+import { getSshTunnelUrl, isSshTunnelActive, isSshTunnelHealthy, startSshTunnel } from "./ssh-tunnel";
 import { stripAnsi } from "./utils";
 
 const LOCAL_API_URL = "http://127.0.0.1:8642";
@@ -20,7 +20,9 @@ const LOCAL_API_URL = "http://127.0.0.1:8642";
 export function getApiUrl(): string {
   const conn = getConnectionConfig();
   if (conn.mode === "ssh") {
-    return getSshTunnelUrl();
+    const sshUrl = getSshTunnelUrl();
+    if (!sshUrl) throw new Error("SSH tunnel is not active");
+    return sshUrl;
   }
   if (conn.mode === "remote" && conn.remoteUrl) {
     return conn.remoteUrl.replace(/\/+$/, "");
@@ -59,7 +61,7 @@ export function getRemoteAuthHeader(): Record<string, string> {
 
 export async function ensureSshTunnelIfNeeded(): Promise<void> {
   const conn = getConnectionConfig();
-  if (conn.mode === "ssh" && !isSshTunnelActive()) {
+  if (conn.mode === "ssh" && (!isSshTunnelActive() || !await isSshTunnelHealthy())) {
     await startSshTunnel(conn.ssh);
   }
 }
@@ -336,6 +338,7 @@ function sendMessageViaApi(
       method: "POST",
       headers,
       signal: controller.signal,
+      timeout: 120000,
     },
     (res) => {
       const sid = res.headers["x-hermes-session-id"];
@@ -412,6 +415,10 @@ function sendMessageViaApi(
   req.on("error", (err) => {
     if (err.name === "AbortError") return;
     finish(`API request failed: ${err.message}`);
+  });
+  req.on("timeout", () => {
+    req.destroy();
+    finish("API request timed out. Check the SSH tunnel and remote Hermes gateway.");
   });
 
   req.write(body);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -37,7 +37,14 @@ import {
   testRemoteConnection,
   stopHealthPolling,
   restartGateway,
+  ensureSshTunnelIfNeeded,
 } from "./hermes";
+import {
+  startSshTunnel,
+  stopSshTunnel,
+  testSshConnection,
+  isSshTunnelActive,
+} from "./ssh-tunnel";
 import {
   getClaw3dStatus,
   setupClaw3d,
@@ -300,14 +307,41 @@ function setupIPC(): void {
     },
   );
 
-  // Connection mode (local vs remote)
+  // Connection mode (local / remote / ssh)
   ipcMain.handle("is-remote-mode", () => isRemoteMode());
   ipcMain.handle("get-connection-config", () => getConnectionConfig());
+  ipcMain.handle("is-ssh-tunnel-active", () => isSshTunnelActive());
 
   ipcMain.handle(
     "set-connection-config",
-    (_event, mode: "local" | "remote", remoteUrl: string, apiKey?: string) => {
-      setConnectionConfig({ mode, remoteUrl, apiKey: apiKey || "" });
+    (_event, mode: "local" | "remote" | "ssh", remoteUrl: string, apiKey?: string) => {
+      setConnectionConfig({
+        mode,
+        remoteUrl,
+        apiKey: apiKey || "",
+        ssh: getConnectionConfig().ssh, // preserve existing ssh config
+      });
+      return true;
+    },
+  );
+
+  ipcMain.handle(
+    "set-ssh-config",
+    (
+      _event,
+      host: string,
+      port: number,
+      username: string,
+      keyPath: string,
+      remotePort: number,
+      localPort: number,
+    ) => {
+      const current = getConnectionConfig();
+      setConnectionConfig({
+        ...current,
+        mode: "ssh",
+        ssh: { host, port, username, keyPath, remotePort, localPort },
+      });
       return true;
     },
   );
@@ -316,6 +350,24 @@ function setupIPC(): void {
     "test-remote-connection",
     (_event, url: string, apiKey?: string) => testRemoteConnection(url, apiKey),
   );
+
+  ipcMain.handle(
+    "test-ssh-connection",
+    (_event, host: string, port: number, username: string, keyPath: string, remotePort: number) =>
+      testSshConnection({ host, port, username, keyPath, remotePort, localPort: 19642 }),
+  );
+
+  ipcMain.handle("start-ssh-tunnel", async () => {
+    const conn = getConnectionConfig();
+    if (conn.mode !== "ssh") return false;
+    await startSshTunnel(conn.ssh);
+    return true;
+  });
+
+  ipcMain.handle("stop-ssh-tunnel", () => {
+    stopSshTunnel();
+    return true;
+  });
 
   // Chat — lazy-start gateway on first message
   ipcMain.handle(
@@ -330,6 +382,8 @@ function setupIPC(): void {
       if (!isRemoteMode() && !isGatewayRunning()) {
         startGateway(profile);
       }
+
+      await ensureSshTunnelIfNeeded();
 
       if (currentChatAbort) {
         currentChatAbort();
@@ -855,6 +909,14 @@ app.whenReady().then(() => {
   createWindow();
   setupUpdater();
 
+  // Auto-start SSH tunnel if configured
+  const conn = getConnectionConfig();
+  if (conn.mode === "ssh" && conn.ssh.host) {
+    startSshTunnel(conn.ssh).catch((err) => {
+      console.error("[SSH TUNNEL] Failed to start on launch:", err);
+    });
+  }
+
   app.on("activate", () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();
   });
@@ -863,6 +925,7 @@ app.whenReady().then(() => {
 app.on("window-all-closed", () => {
   if (process.platform !== "darwin") {
     stopGateway();
+    stopSshTunnel();
     stopClaw3d();
     app.quit();
   }
@@ -875,5 +938,6 @@ app.on("before-quit", () => {
     currentChatAbort = null;
   }
   stopGateway();
+  stopSshTunnel();
   stopClaw3d();
 });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -29,11 +29,12 @@ import {
   InstallProgress,
 } from "./installer";
 import {
+  isRemoteMode,
+  isRemoteOnlyMode,
   sendMessage,
   startGateway,
   stopGateway,
   isGatewayRunning,
-  isRemoteMode,
   testRemoteConnection,
   stopHealthPolling,
   restartGateway,
@@ -115,6 +116,36 @@ import {
 } from "./cronjobs";
 import { getAppLocale, setAppLocale } from "./locale";
 import type { AppLocale } from "../shared/i18n/types";
+import {
+  sshListInstalledSkills,
+  sshGetSkillContent,
+  sshInstallSkill,
+  sshUninstallSkill,
+  sshListBundledSkills,
+  sshReadMemory,
+  sshAddMemoryEntry,
+  sshUpdateMemoryEntry,
+  sshRemoveMemoryEntry,
+  sshWriteUserProfile,
+  sshReadSoul,
+  sshWriteSoul,
+  sshResetSoul,
+  sshGetToolsets,
+  sshSetToolsetEnabled,
+  sshReadEnv,
+  sshSetEnvValue,
+  sshGetConfigValue,
+  sshSetConfigValue,
+  sshListSessions,
+  sshGetSessionMessages,
+  sshSearchSessions,
+  sshListProfiles,
+  sshCreateProfile,
+  sshDeleteProfile,
+  sshGatewayStatus,
+  sshStartGateway,
+  sshStopGateway,
+} from "./ssh-remote";
 
 process.on("uncaughtException", (err) => {
   console.error("[MAIN UNCAUGHT]", err);
@@ -243,11 +274,20 @@ function setupIPC(): void {
     setAppLocale(locale),
   );
 
-  ipcMain.handle("get-env", (_event, profile?: string) => readEnv(profile));
+  ipcMain.handle("get-env", (_event, profile?: string) => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshReadEnv(conn.ssh, profile);
+    return readEnv(profile);
+  });
 
   ipcMain.handle(
     "set-env",
     (_event, key: string, value: string, profile?: string) => {
+      const conn = getConnectionConfig();
+      if (conn.mode === "ssh" && conn.ssh) {
+        sshSetEnvValue(conn.ssh, key, value, profile);
+        return true;
+      }
       setEnvValue(key, value, profile);
       // Restart gateway so it picks up the new API key
       if (
@@ -261,13 +301,20 @@ function setupIPC(): void {
     },
   );
 
-  ipcMain.handle("get-config", (_event, key: string, profile?: string) =>
-    getConfigValue(key, profile),
-  );
+  ipcMain.handle("get-config", (_event, key: string, profile?: string) => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshGetConfigValue(conn.ssh, key, profile);
+    return getConfigValue(key, profile);
+  });
 
   ipcMain.handle(
     "set-config",
     (_event, key: string, value: string, profile?: string) => {
+      const conn = getConnectionConfig();
+      if (conn.mode === "ssh" && conn.ssh) {
+        sshSetConfigValue(conn.ssh, key, value, profile);
+        return true;
+      }
       setConfigValue(key, value, profile);
       return true;
     },
@@ -309,6 +356,7 @@ function setupIPC(): void {
 
   // Connection mode (local / remote / ssh)
   ipcMain.handle("is-remote-mode", () => isRemoteMode());
+  ipcMain.handle("is-remote-only-mode", () => isRemoteOnlyMode());
   ipcMain.handle("get-connection-config", () => getConnectionConfig());
   ipcMain.handle("is-ssh-tunnel-active", () => isSshTunnelActive());
 
@@ -464,12 +512,22 @@ function setupIPC(): void {
   });
 
   // Gateway
-  ipcMain.handle("start-gateway", () => startGateway());
+  ipcMain.handle("start-gateway", () => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) { sshStartGateway(conn.ssh); return true; }
+    return startGateway();
+  });
   ipcMain.handle("stop-gateway", () => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) { sshStopGateway(conn.ssh); return true; }
     stopGateway(true);
     return true;
   });
-  ipcMain.handle("gateway-status", () => isGatewayRunning());
+  ipcMain.handle("gateway-status", () => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshGatewayStatus(conn.ssh);
+    return isGatewayRunning();
+  });
 
   // Platform toggles (config.yaml platforms section)
   ipcMain.handle("get-platform-enabled", (_event, profile?: string) =>
@@ -489,87 +547,138 @@ function setupIPC(): void {
 
   // Sessions
   ipcMain.handle("list-sessions", (_event, limit?: number, offset?: number) => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshListSessions(conn.ssh, limit, offset);
     return listSessions(limit, offset);
   });
 
   ipcMain.handle("get-session-messages", (_event, sessionId: string) => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshGetSessionMessages(conn.ssh, sessionId);
     return getSessionMessages(sessionId);
   });
 
   // Profiles
-  ipcMain.handle("list-profiles", async () => listProfiles());
-  ipcMain.handle("create-profile", (_event, name: string, clone: boolean) =>
-    createProfile(name, clone),
-  );
-  ipcMain.handle("delete-profile", (_event, name: string) =>
-    deleteProfile(name),
-  );
+  ipcMain.handle("list-profiles", async () => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshListProfiles(conn.ssh);
+    return listProfiles();
+  });
+  ipcMain.handle("create-profile", (_event, name: string, clone: boolean) => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshCreateProfile(conn.ssh, name, clone);
+    return createProfile(name, clone);
+  });
+  ipcMain.handle("delete-profile", (_event, name: string) => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshDeleteProfile(conn.ssh, name);
+    return deleteProfile(name);
+  });
   ipcMain.handle("set-active-profile", (_event, name: string) => {
-    setActiveProfile(name);
+    if (getConnectionConfig().mode !== "ssh") setActiveProfile(name);
     return true;
   });
 
   // Memory
-  ipcMain.handle("read-memory", (_event, profile?: string) =>
-    readMemory(profile),
-  );
+  ipcMain.handle("read-memory", (_event, profile?: string) => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshReadMemory(conn.ssh, profile);
+    return readMemory(profile);
+  });
   ipcMain.handle(
     "add-memory-entry",
-    (_event, content: string, profile?: string) =>
-      addMemoryEntry(content, profile),
+    (_event, content: string, profile?: string) => {
+      const conn = getConnectionConfig();
+      if (conn.mode === "ssh" && conn.ssh) return sshAddMemoryEntry(conn.ssh, content, profile);
+      return addMemoryEntry(content, profile);
+    },
   );
   ipcMain.handle(
     "update-memory-entry",
-    (_event, index: number, content: string, profile?: string) =>
-      updateMemoryEntry(index, content, profile),
+    (_event, index: number, content: string, profile?: string) => {
+      const conn = getConnectionConfig();
+      if (conn.mode === "ssh" && conn.ssh) return sshUpdateMemoryEntry(conn.ssh, index, content, profile);
+      return updateMemoryEntry(index, content, profile);
+    },
   );
   ipcMain.handle(
     "remove-memory-entry",
-    (_event, index: number, profile?: string) =>
-      removeMemoryEntry(index, profile),
+    (_event, index: number, profile?: string) => {
+      const conn = getConnectionConfig();
+      if (conn.mode === "ssh" && conn.ssh) return sshRemoveMemoryEntry(conn.ssh, index, profile);
+      return removeMemoryEntry(index, profile);
+    },
   );
   ipcMain.handle(
     "write-user-profile",
-    (_event, content: string, profile?: string) =>
-      writeUserProfile(content, profile),
+    (_event, content: string, profile?: string) => {
+      const conn = getConnectionConfig();
+      if (conn.mode === "ssh" && conn.ssh) return sshWriteUserProfile(conn.ssh, content, profile);
+      return writeUserProfile(content, profile);
+    },
   );
 
   // Soul
-  ipcMain.handle("read-soul", (_event, profile?: string) => readSoul(profile));
+  ipcMain.handle("read-soul", (_event, profile?: string) => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshReadSoul(conn.ssh, profile);
+    return readSoul(profile);
+  });
   ipcMain.handle("write-soul", (_event, content: string, profile?: string) => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshWriteSoul(conn.ssh, content, profile);
     return writeSoul(content, profile);
   });
-  ipcMain.handle("reset-soul", (_event, profile?: string) =>
-    resetSoul(profile),
-  );
+  ipcMain.handle("reset-soul", (_event, profile?: string) => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshResetSoul(conn.ssh, profile);
+    return resetSoul(profile);
+  });
 
   // Tools
-  ipcMain.handle("get-toolsets", (_event, profile?: string) =>
-    getToolsets(profile),
-  );
+  ipcMain.handle("get-toolsets", (_event, profile?: string) => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshGetToolsets(conn.ssh, profile);
+    return getToolsets(profile);
+  });
   ipcMain.handle(
     "set-toolset-enabled",
     (_event, key: string, enabled: boolean, profile?: string) => {
+      const conn = getConnectionConfig();
+      if (conn.mode === "ssh" && conn.ssh) return sshSetToolsetEnabled(conn.ssh, key, enabled, profile);
       return setToolsetEnabled(key, enabled, profile);
     },
   );
 
   // Skills
-  ipcMain.handle("list-installed-skills", (_event, profile?: string) =>
-    listInstalledSkills(profile),
-  );
-  ipcMain.handle("list-bundled-skills", () => listBundledSkills());
-  ipcMain.handle("get-skill-content", (_event, skillPath: string) =>
-    getSkillContent(skillPath),
-  );
+  ipcMain.handle("list-installed-skills", (_event, profile?: string) => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshListInstalledSkills(conn.ssh);
+    return listInstalledSkills(profile);
+  });
+  ipcMain.handle("list-bundled-skills", () => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshListBundledSkills(conn.ssh);
+    return listBundledSkills();
+  });
+  ipcMain.handle("get-skill-content", (_event, skillPath: string) => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshGetSkillContent(conn.ssh, skillPath);
+    return getSkillContent(skillPath);
+  });
   ipcMain.handle(
     "install-skill",
-    (_event, identifier: string, profile?: string) =>
-      installSkill(identifier, profile),
+    (_event, identifier: string, _profile?: string) => {
+      const conn = getConnectionConfig();
+      if (conn.mode === "ssh" && conn.ssh) return sshInstallSkill(conn.ssh, identifier);
+      return installSkill(identifier, _profile);
+    },
   );
-  ipcMain.handle("uninstall-skill", (_event, name: string, profile?: string) =>
-    uninstallSkill(name, profile),
-  );
+  ipcMain.handle("uninstall-skill", (_event, name: string, _profile?: string) => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshUninstallSkill(conn.ssh, name);
+    return uninstallSkill(name, _profile);
+  });
 
   // Session cache (fast local cache with generated titles)
   ipcMain.handle(
@@ -585,9 +694,11 @@ function setupIPC(): void {
   );
 
   // Session search
-  ipcMain.handle("search-sessions", (_event, query: string, limit?: number) =>
-    searchSessions(query, limit),
-  );
+  ipcMain.handle("search-sessions", (_event, query: string, limit?: number) => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshSearchSessions(conn.ssh, query, limit);
+    return searchSessions(query, limit);
+  });
 
   // Credential Pool
   ipcMain.handle("get-credential-pool", () => getCredentialPool());

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -39,6 +39,7 @@ import {
   stopHealthPolling,
   restartGateway,
   ensureSshTunnelIfNeeded,
+  setSshRemoteApiKey,
 } from "./hermes";
 import {
   startSshTunnel,
@@ -145,6 +146,12 @@ import {
   sshGatewayStatus,
   sshStartGateway,
   sshStopGateway,
+  sshReadRemoteApiKey,
+  sshGetHermesVersion,
+  sshReadLogs,
+  sshGetPlatformEnabled,
+  sshSetPlatformEnabled,
+  sshListCachedSessions,
 } from "./ssh-remote";
 
 process.on("uncaughtException", (err) => {
@@ -238,8 +245,14 @@ function setupIPC(): void {
   });
 
   // Hermes engine info
-  ipcMain.handle("get-hermes-version", async () => getHermesVersion());
+  ipcMain.handle("get-hermes-version", async () => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshGetHermesVersion(conn.ssh);
+    return getHermesVersion();
+  });
   ipcMain.handle("refresh-hermes-version", async () => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshGetHermesVersion(conn.ssh);
     clearVersionCache();
     return getHermesVersion();
   });
@@ -409,6 +422,11 @@ function setupIPC(): void {
     const conn = getConnectionConfig();
     if (conn.mode !== "ssh") return false;
     await startSshTunnel(conn.ssh);
+    // Cache the remote API key so chat auth works through the tunnel
+    if (conn.ssh) {
+      const key = sshReadRemoteApiKey(conn.ssh);
+      setSshRemoteApiKey(key);
+    }
     return true;
   });
 
@@ -530,12 +548,19 @@ function setupIPC(): void {
   });
 
   // Platform toggles (config.yaml platforms section)
-  ipcMain.handle("get-platform-enabled", (_event, profile?: string) =>
-    getPlatformEnabled(profile),
-  );
+  ipcMain.handle("get-platform-enabled", (_event, profile?: string) => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshGetPlatformEnabled(conn.ssh, profile);
+    return getPlatformEnabled(profile);
+  });
   ipcMain.handle(
     "set-platform-enabled",
     (_event, platform: string, enabled: boolean, profile?: string) => {
+      const conn = getConnectionConfig();
+      if (conn.mode === "ssh" && conn.ssh) {
+        sshSetPlatformEnabled(conn.ssh, platform, enabled, profile);
+        return true;
+      }
       setPlatformEnabled(platform, enabled, profile);
       // Restart gateway so it picks up the new platform config
       if (isGatewayRunning()) {
@@ -683,10 +708,17 @@ function setupIPC(): void {
   // Session cache (fast local cache with generated titles)
   ipcMain.handle(
     "list-cached-sessions",
-    (_event, limit?: number, offset?: number) =>
-      listCachedSessions(limit, offset),
+    (_event, limit?: number, offset?: number) => {
+      const conn = getConnectionConfig();
+      if (conn.mode === "ssh" && conn.ssh) return sshListCachedSessions(conn.ssh, limit, offset);
+      return listCachedSessions(limit, offset);
+    },
   );
-  ipcMain.handle("sync-session-cache", () => syncSessionCache());
+  ipcMain.handle("sync-session-cache", () => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh") return []; // no local cache to sync in SSH mode
+    return syncSessionCache();
+  });
   ipcMain.handle(
     "update-session-title",
     (_event, sessionId: string, title: string) =>
@@ -831,9 +863,11 @@ function setupIPC(): void {
   );
 
   // Log viewer
-  ipcMain.handle("read-logs", (_event, logFile?: string, lines?: number) =>
-    readLogs(logFile, lines),
-  );
+  ipcMain.handle("read-logs", (_event, logFile?: string, lines?: number) => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshReadLogs(conn.ssh, logFile, lines);
+    return readLogs(logFile, lines);
+  });
 }
 
 function buildMenu(): void {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -46,6 +46,7 @@ import {
   stopSshTunnel,
   testSshConnection,
   isSshTunnelActive,
+  isSshTunnelHealthy,
 } from "./ssh-tunnel";
 import {
   getClaw3dStatus,
@@ -137,6 +138,9 @@ import {
   sshSetEnvValue,
   sshGetConfigValue,
   sshSetConfigValue,
+  sshGetHermesHome,
+  sshGetModelConfig,
+  sshSetModelConfig,
   sshListSessions,
   sshGetSessionMessages,
   sshSearchSessions,
@@ -154,6 +158,9 @@ import {
   sshListCachedSessions,
   sshRunDoctor,
   sshListModels,
+  sshRunUpdate,
+  sshRunDump,
+  sshDiscoverMemoryProviders,
 } from "./ssh-remote";
 
 process.on("uncaughtException", (err) => {
@@ -265,6 +272,22 @@ function setupIPC(): void {
   });
   ipcMain.handle("run-hermes-update", async (event) => {
     try {
+      const conn = getConnectionConfig();
+      if (conn.mode === "ssh" && conn.ssh) {
+        event.sender.send("install-progress", {
+          step: 1,
+          totalSteps: 1,
+          title: "Updating remote Hermes Agent",
+          detail: "Running hermes update over SSH...",
+          log: "Running hermes update over SSH...\n",
+        });
+        await sshRunUpdate(conn.ssh);
+        await sshStartGateway(conn.ssh);
+        await startSshTunnel(conn.ssh);
+        const key = await sshReadRemoteApiKey(conn.ssh);
+        setSshRemoteApiKey(key);
+        return { success: true };
+      }
       await runHermesUpdate((progress: InstallProgress) => {
         event.sender.send("install-progress", progress);
       });
@@ -301,10 +324,10 @@ function setupIPC(): void {
 
   ipcMain.handle(
     "set-env",
-    (_event, key: string, value: string, profile?: string) => {
+    async (_event, key: string, value: string, profile?: string) => {
       const conn = getConnectionConfig();
       if (conn.mode === "ssh" && conn.ssh) {
-        sshSetEnvValue(conn.ssh, key, value, profile);
+        await sshSetEnvValue(conn.ssh, key, value, profile);
         return true;
       }
       setEnvValue(key, value, profile);
@@ -328,10 +351,10 @@ function setupIPC(): void {
 
   ipcMain.handle(
     "set-config",
-    (_event, key: string, value: string, profile?: string) => {
+    async (_event, key: string, value: string, profile?: string) => {
       const conn = getConnectionConfig();
       if (conn.mode === "ssh" && conn.ssh) {
-        sshSetConfigValue(conn.ssh, key, value, profile);
+        await sshSetConfigValue(conn.ssh, key, value, profile);
         return true;
       }
       setConfigValue(key, value, profile);
@@ -339,23 +362,42 @@ function setupIPC(): void {
     },
   );
 
-  ipcMain.handle("get-hermes-home", (_event, profile?: string) =>
-    getHermesHome(profile),
-  );
+  ipcMain.handle("get-hermes-home", (_event, profile?: string) => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshGetHermesHome(conn.ssh, profile);
+    return getHermesHome(profile);
+  });
 
-  ipcMain.handle("get-model-config", (_event, profile?: string) =>
-    getModelConfig(profile),
-  );
+  ipcMain.handle("get-model-config", (_event, profile?: string) => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshGetModelConfig(conn.ssh, profile);
+    return getModelConfig(profile);
+  });
 
   ipcMain.handle(
     "set-model-config",
-    (
+    async (
       _event,
       provider: string,
       model: string,
       baseUrl: string,
       profile?: string,
     ) => {
+      const conn = getConnectionConfig();
+      if (conn.mode === "ssh" && conn.ssh) {
+        const prev = await sshGetModelConfig(conn.ssh, profile);
+        await sshSetModelConfig(conn.ssh, provider, model, baseUrl, profile);
+        if (
+          await sshGatewayStatus(conn.ssh) &&
+          (prev.provider !== provider ||
+            prev.model !== model ||
+            prev.baseUrl !== baseUrl)
+        ) {
+          await sshStopGateway(conn.ssh);
+          await sshStartGateway(conn.ssh);
+        }
+        return true;
+      }
       const prev = getModelConfig(profile);
       setModelConfig(provider, model, baseUrl, profile);
 
@@ -427,10 +469,13 @@ function setupIPC(): void {
   ipcMain.handle("start-ssh-tunnel", async () => {
     const conn = getConnectionConfig();
     if (conn.mode !== "ssh") return false;
+    if (conn.ssh && !await sshGatewayStatus(conn.ssh)) {
+      await sshStartGateway(conn.ssh);
+    }
     await startSshTunnel(conn.ssh);
     // Cache the remote API key so chat auth works through the tunnel
     if (conn.ssh) {
-      const key = sshReadRemoteApiKey(conn.ssh);
+      const key = await sshReadRemoteApiKey(conn.ssh);
       setSshRemoteApiKey(key);
     }
     return true;
@@ -456,6 +501,17 @@ function setupIPC(): void {
       }
 
       await ensureSshTunnelIfNeeded();
+      const conn = getConnectionConfig();
+      if (conn.mode === "ssh" && conn.ssh) {
+        const gatewayRunning = await sshGatewayStatus(conn.ssh);
+        const tunnelHealthy = await isSshTunnelHealthy();
+        if (!gatewayRunning || !tunnelHealthy) {
+          await sshStartGateway(conn.ssh);
+          await startSshTunnel(conn.ssh);
+          const key = await sshReadRemoteApiKey(conn.ssh);
+          setSshRemoteApiKey(key);
+        }
+      }
 
       if (currentChatAbort) {
         currentChatAbort();
@@ -536,14 +592,14 @@ function setupIPC(): void {
   });
 
   // Gateway
-  ipcMain.handle("start-gateway", () => {
+  ipcMain.handle("start-gateway", async () => {
     const conn = getConnectionConfig();
-    if (conn.mode === "ssh" && conn.ssh) { sshStartGateway(conn.ssh); return true; }
+    if (conn.mode === "ssh" && conn.ssh) { await sshStartGateway(conn.ssh); return true; }
     return startGateway();
   });
-  ipcMain.handle("stop-gateway", () => {
+  ipcMain.handle("stop-gateway", async () => {
     const conn = getConnectionConfig();
-    if (conn.mode === "ssh" && conn.ssh) { sshStopGateway(conn.ssh); return true; }
+    if (conn.mode === "ssh" && conn.ssh) { await sshStopGateway(conn.ssh); return true; }
     stopGateway(true);
     return true;
   });
@@ -561,10 +617,10 @@ function setupIPC(): void {
   });
   ipcMain.handle(
     "set-platform-enabled",
-    (_event, platform: string, enabled: boolean, profile?: string) => {
+    async (_event, platform: string, enabled: boolean, profile?: string) => {
       const conn = getConnectionConfig();
       if (conn.mode === "ssh" && conn.ssh) {
-        sshSetPlatformEnabled(conn.ssh, platform, enabled, profile);
+        await sshSetPlatformEnabled(conn.ssh, platform, enabled, profile);
         return true;
       }
       setPlatformEnabled(platform, enabled, profile);
@@ -684,7 +740,7 @@ function setupIPC(): void {
   // Skills
   ipcMain.handle("list-installed-skills", (_event, profile?: string) => {
     const conn = getConnectionConfig();
-    if (conn.mode === "ssh" && conn.ssh) return sshListInstalledSkills(conn.ssh);
+    if (conn.mode === "ssh" && conn.ssh) return sshListInstalledSkills(conn.ssh, profile);
     return listInstalledSkills(profile);
   });
   ipcMain.handle("list-bundled-skills", () => {
@@ -860,7 +916,11 @@ function setupIPC(): void {
   );
 
   // Debug dump
-  ipcMain.handle("run-hermes-dump", () => runHermesDump());
+  ipcMain.handle("run-hermes-dump", () => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshRunDump(conn.ssh);
+    return runHermesDump();
+  });
 
   // MCP servers
   ipcMain.handle("list-mcp-servers", (_event, profile?: string) =>
@@ -868,9 +928,11 @@ function setupIPC(): void {
   );
 
   // Memory providers
-  ipcMain.handle("discover-memory-providers", (_event, profile?: string) =>
-    discoverMemoryProviders(profile),
-  );
+  ipcMain.handle("discover-memory-providers", (_event, profile?: string) => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshDiscoverMemoryProviders(conn.ssh, profile);
+    return discoverMemoryProviders(profile);
+  });
 
   // Log viewer
   ipcMain.handle("read-logs", (_event, logFile?: string, lines?: number) => {
@@ -1067,7 +1129,14 @@ app.whenReady().then(() => {
   // Auto-start SSH tunnel if configured
   const conn = getConnectionConfig();
   if (conn.mode === "ssh" && conn.ssh.host) {
-    startSshTunnel(conn.ssh).catch((err) => {
+    (async () => {
+      if (!await sshGatewayStatus(conn.ssh)) {
+        await sshStartGateway(conn.ssh);
+      }
+      await startSshTunnel(conn.ssh);
+      const key = await sshReadRemoteApiKey(conn.ssh);
+      setSshRemoteApiKey(key);
+    })().catch((err) => {
       console.error("[SSH TUNNEL] Failed to start on launch:", err);
     });
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -152,6 +152,8 @@ import {
   sshGetPlatformEnabled,
   sshSetPlatformEnabled,
   sshListCachedSessions,
+  sshRunDoctor,
+  sshListModels,
 } from "./ssh-remote";
 
 process.on("uncaughtException", (err) => {
@@ -256,7 +258,11 @@ function setupIPC(): void {
     clearVersionCache();
     return getHermesVersion();
   });
-  ipcMain.handle("run-hermes-doctor", () => runHermesDoctor());
+  ipcMain.handle("run-hermes-doctor", () => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshRunDoctor(conn.ssh);
+    return runHermesDoctor();
+  });
   ipcMain.handle("run-hermes-update", async (event) => {
     try {
       await runHermesUpdate((progress: InstallProgress) => {
@@ -716,7 +722,7 @@ function setupIPC(): void {
   );
   ipcMain.handle("sync-session-cache", () => {
     const conn = getConnectionConfig();
-    if (conn.mode === "ssh") return []; // no local cache to sync in SSH mode
+    if (conn.mode === "ssh" && conn.ssh) return sshListCachedSessions(conn.ssh, 50);
     return syncSessionCache();
   });
   ipcMain.handle(
@@ -747,7 +753,11 @@ function setupIPC(): void {
   );
 
   // Models
-  ipcMain.handle("list-models", () => listModels());
+  ipcMain.handle("list-models", () => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshListModels(conn.ssh);
+    return listModels();
+  });
   ipcMain.handle(
     "add-model",
     (_event, name: string, provider: string, model: string, baseUrl: string) =>

--- a/src/main/ssh-remote.ts
+++ b/src/main/ssh-remote.ts
@@ -56,18 +56,19 @@ function sshPython(config: SshConfig, script: string): string {
 }
 
 function sshReadFile(config: SshConfig, remotePath: string): string {
+  // ~ doesn't expand inside double quotes — use $HOME instead
+  const p = remotePath.replace(/^~\//, "$HOME/");
   try {
-    return sshExec(config, `cat "${remotePath}" 2>/dev/null || true`);
+    return sshExec(config, `cat "${p}" 2>/dev/null || true`);
   } catch {
     return "";
   }
 }
 
 function sshWriteFile(config: SshConfig, remotePath: string, content: string): void {
-  const dir = remotePath.includes("/")
-    ? remotePath.substring(0, remotePath.lastIndexOf("/"))
-    : ".";
-  sshExec(config, `mkdir -p "${dir}" && cat > "${remotePath}"`, content);
+  const p = remotePath.replace(/^~\//, "$HOME/");
+  const dir = p.includes("/") ? p.substring(0, p.lastIndexOf("/")) : ".";
+  sshExec(config, `mkdir -p "${dir}" && cat > "${p}"`, content);
 }
 
 // ── Skills ───────────────────────────────────────────────────────────────────
@@ -704,7 +705,13 @@ export function sshDeleteProfile(config: SshConfig, name: string): boolean {
 
 export function sshGatewayStatus(config: SshConfig): boolean {
   try {
-    const out = sshExec(config, `if [ -f ~/.hermes/gateway.pid ]; then pid=$(cat ~/.hermes/gateway.pid); kill -0 $pid 2>/dev/null && echo "running" || echo "stopped"; else echo "stopped"; fi`);
+    const out = sshExec(
+      config,
+      `if [ -f $HOME/.hermes/gateway.pid ]; then ` +
+      `pid=$(python3 -c "import json,sys; d=json.load(open('$HOME/.hermes/gateway.pid')); print(d.get('pid',d) if isinstance(d,dict) else d)" 2>/dev/null || cat $HOME/.hermes/gateway.pid); ` +
+      `kill -0 $pid 2>/dev/null && echo "running" || echo "stopped"; ` +
+      `else echo "stopped"; fi`,
+    );
     return out.trim() === "running";
   } catch {
     return false;
@@ -713,7 +720,7 @@ export function sshGatewayStatus(config: SshConfig): boolean {
 
 export function sshStartGateway(config: SshConfig): void {
   try {
-    sshExec(config, `nohup hermes gateway start > ~/.hermes/gateway.log 2>&1 &`);
+    sshExec(config, `nohup hermes gateway start > $HOME/.hermes/gateway.log 2>&1 &`);
   } catch {
     // best effort
   }
@@ -721,7 +728,13 @@ export function sshStartGateway(config: SshConfig): void {
 
 export function sshStopGateway(config: SshConfig): void {
   try {
-    sshExec(config, `hermes gateway stop 2>/dev/null || ([ -f ~/.hermes/gateway.pid ] && kill $(cat ~/.hermes/gateway.pid) 2>/dev/null); true`);
+    sshExec(
+      config,
+      `hermes gateway stop 2>/dev/null || ` +
+      `(if [ -f $HOME/.hermes/gateway.pid ]; then ` +
+      `pid=$(python3 -c "import json; d=json.load(open('$HOME/.hermes/gateway.pid')); print(d['pid'] if isinstance(d,dict) else d)" 2>/dev/null); ` +
+      `[ -n "$pid" ] && kill $pid 2>/dev/null; fi); true`,
+    );
   } catch {
     // best effort
   }

--- a/src/main/ssh-remote.ts
+++ b/src/main/ssh-remote.ts
@@ -450,6 +450,15 @@ export function sshReadEnv(config: SshConfig, profile?: string): Record<string, 
     if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) v = v.slice(1, -1);
     if (v) result[k] = v;
   }
+  // Alias alternate env var names so the app can display them regardless of which name the server uses
+  const ENV_ALIASES: Array<[string, string]> = [
+    ["HA_URL", "HOMEASSISTANT_URL"],
+    ["HA_TOKEN", "HOMEASSISTANT_TOKEN"],
+  ];
+  for (const [appKey, serverKey] of ENV_ALIASES) {
+    if (!result[appKey] && result[serverKey]) result[appKey] = result[serverKey];
+    if (!result[serverKey] && result[appKey]) result[serverKey] = result[appKey];
+  }
   return result;
 }
 

--- a/src/main/ssh-remote.ts
+++ b/src/main/ssh-remote.ts
@@ -782,21 +782,30 @@ export function sshReadLogs(
 
 // ── Platform toggles (Gateway page) ──────────────────────────────────────────
 
-const SSH_SUPPORTED_PLATFORMS = ["telegram", "discord", "slack", "whatsapp", "signal"];
+const SSH_SUPPORTED_PLATFORMS = [
+  "telegram", "discord", "slack", "whatsapp", "signal",
+  "matrix", "mattermost", "email", "sms", "bluebubbles",
+  "dingtalk", "feishu", "wecom", "weixin", "webhooks", "home_assistant",
+];
+
+// Map from app platform keys to gateway_state.json keys (where they differ)
+const PLATFORM_STATE_KEY: Record<string, string> = {
+  home_assistant: "homeassistant",
+};
 
 export function sshGetPlatformEnabled(
   config: SshConfig,
   _profile?: string,
 ): Record<string, boolean> {
-  // Read live state from gateway_state.json which reflects actual running platforms
   try {
     const raw = sshReadFile(config, "$HOME/.hermes/gateway_state.json");
-    if (raw) {
+    if (raw.trim()) {
       const state = JSON.parse(raw);
       const platforms = state.platforms || {};
       const result: Record<string, boolean> = {};
       for (const platform of SSH_SUPPORTED_PLATFORMS) {
-        const p = platforms[platform];
+        const stateKey = PLATFORM_STATE_KEY[platform] || platform;
+        const p = platforms[stateKey];
         result[platform] = p ? p.state === "connected" || p.state === "running" : false;
       }
       return result;

--- a/src/main/ssh-remote.ts
+++ b/src/main/ssh-remote.ts
@@ -1,0 +1,728 @@
+/**
+ * SSH-proxied implementations of all hermes operations.
+ * Used when connection mode is "ssh" — every feature that normally reads/writes
+ * local files is instead executed on the remote host via SSH.
+ */
+
+import { spawnSync } from "child_process";
+import { homedir } from "os";
+import { join } from "path";
+import type { SshConfig } from "./ssh-tunnel";
+import type { InstalledSkill, SkillSearchResult } from "./skills";
+import type { MemoryInfo } from "./memory";
+import type { SessionSummary, SessionMessage, SearchResult } from "./sessions";
+import type { ToolsetInfo } from "./tools";
+import { t } from "../shared/i18n";
+import { getAppLocale } from "./locale";
+
+// ── SSH exec core ────────────────────────────────────────────────────────────
+
+function buildExecArgs(config: SshConfig): string[] {
+  const keyPath = config.keyPath?.trim() || join(homedir(), ".ssh", "id_rsa");
+  return [
+    "-o", "BatchMode=yes",
+    "-o", "StrictHostKeyChecking=accept-new",
+    "-o", "ConnectTimeout=15",
+    "-i", keyPath,
+    "-p", String(config.port || 22),
+    `${config.username}@${config.host}`,
+  ];
+}
+
+export function sshExec(config: SshConfig, command: string, stdin?: string): string {
+  const result = spawnSync("ssh", [...buildExecArgs(config), command], {
+    input: stdin,
+    encoding: "utf-8",
+    timeout: 30000,
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    throw new Error(result.stderr?.trim() || "SSH command failed");
+  }
+  return result.stdout || "";
+}
+
+function sshPython(config: SshConfig, script: string): string {
+  const result = spawnSync("ssh", [...buildExecArgs(config), "python3 -"], {
+    input: script,
+    encoding: "utf-8",
+    timeout: 30000,
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    throw new Error(result.stderr?.trim() || "SSH python failed");
+  }
+  return result.stdout || "";
+}
+
+function sshReadFile(config: SshConfig, remotePath: string): string {
+  try {
+    return sshExec(config, `cat "${remotePath}" 2>/dev/null || true`);
+  } catch {
+    return "";
+  }
+}
+
+function sshWriteFile(config: SshConfig, remotePath: string, content: string): void {
+  const dir = remotePath.includes("/")
+    ? remotePath.substring(0, remotePath.lastIndexOf("/"))
+    : ".";
+  sshExec(config, `mkdir -p "${dir}" && cat > "${remotePath}"`, content);
+}
+
+// ── Skills ───────────────────────────────────────────────────────────────────
+
+const REMOTE_PREFIX = "REMOTE:";
+
+export function sshListInstalledSkills(config: SshConfig): InstalledSkill[] {
+  const script = `
+import os, json
+skills_dir = os.path.expanduser("~/.hermes/skills")
+skills = []
+if os.path.isdir(skills_dir):
+    for category in sorted(os.listdir(skills_dir)):
+        cat_path = os.path.join(skills_dir, category)
+        if not os.path.isdir(cat_path):
+            continue
+        for name in sorted(os.listdir(cat_path)):
+            skill_path = os.path.join(cat_path, name)
+            if not os.path.isdir(skill_path):
+                continue
+            skill_file = os.path.join(skill_path, "SKILL.md")
+            display_name = name
+            description = ""
+            if os.path.exists(skill_file):
+                try:
+                    content = open(skill_file).read(4000)
+                    if content.startswith("---"):
+                        end = content.find("---", 3)
+                        if end != -1:
+                            for line in content[3:end].splitlines():
+                                if line.strip().startswith("name:"):
+                                    display_name = line.split(":",1)[1].strip().strip("'\\"")
+                                elif line.strip().startswith("description:"):
+                                    description = line.split(":",1)[1].strip().strip("'\\"")
+                    else:
+                        for line in content.splitlines():
+                            if line.startswith("#"):
+                                display_name = line.lstrip("#").strip()
+                                break
+                except:
+                    pass
+            skills.append({"name": display_name, "category": category, "description": description, "path": skill_path})
+print(json.dumps(skills))
+`;
+  try {
+    const out = sshPython(config, script);
+    const parsed = JSON.parse(out.trim() || "[]") as Array<{
+      name: string; category: string; description: string; path: string;
+    }>;
+    return parsed.map((s) => ({ ...s, path: REMOTE_PREFIX + s.path }));
+  } catch {
+    return [];
+  }
+}
+
+export function sshGetSkillContent(config: SshConfig, skillPath: string): string {
+  const remote = skillPath.startsWith(REMOTE_PREFIX)
+    ? skillPath.slice(REMOTE_PREFIX.length)
+    : skillPath;
+  return sshReadFile(config, `${remote}/SKILL.md`);
+}
+
+export function sshInstallSkill(config: SshConfig, identifier: string): { success: boolean; error?: string } {
+  try {
+    const safe = identifier.replace(/"/g, '\\"');
+    sshExec(config, `hermes skills install "${safe}" --yes 2>&1`);
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: (err as Error).message };
+  }
+}
+
+export function sshUninstallSkill(config: SshConfig, name: string): { success: boolean; error?: string } {
+  try {
+    const safe = name.replace(/"/g, '\\"');
+    sshExec(config, `hermes skills uninstall "${safe}" --yes 2>&1`);
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: (err as Error).message };
+  }
+}
+
+export function sshSearchSkills(config: SshConfig, query: string): SkillSearchResult[] {
+  try {
+    const safe = query.replace(/"/g, '\\"');
+    const out = sshExec(
+      config,
+      `hermes skills browse --query "${safe}" --json 2>/dev/null || echo "[]"`,
+    );
+    const parsed = JSON.parse(out.trim() || "[]");
+    if (Array.isArray(parsed)) {
+      return parsed.map((r: Record<string, string>) => ({
+        name: r.name || "",
+        description: r.description || "",
+        category: r.category || "",
+        source: r.source || "",
+        installed: false,
+      }));
+    }
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+export function sshListBundledSkills(config: SshConfig): SkillSearchResult[] {
+  return sshSearchSkills(config, "");
+}
+
+// ── Memory ───────────────────────────────────────────────────────────────────
+
+const ENTRY_DELIMITER = "\n§\n";
+const MEMORY_CHAR_LIMIT = 2200;
+const USER_CHAR_LIMIT = 1375;
+
+function parseMemoryEntries(content: string): Array<{ index: number; content: string }> {
+  if (!content.trim()) return [];
+  return content
+    .split(ENTRY_DELIMITER)
+    .map((entry, index) => ({ index, content: entry.trim() }))
+    .filter((e) => e.content.length > 0);
+}
+
+function serializeEntries(entries: Array<{ index: number; content: string }>): string {
+  return entries.map((e) => e.content).join(ENTRY_DELIMITER);
+}
+
+function remoteMemoryPath(profile?: string): string {
+  if (profile && profile !== "default") {
+    return `~/.hermes/profiles/${profile}/memories/MEMORY.md`;
+  }
+  return "~/.hermes/memories/MEMORY.md";
+}
+
+function remoteUserPath(profile?: string): string {
+  if (profile && profile !== "default") {
+    return `~/.hermes/profiles/${profile}/memories/USER.md`;
+  }
+  return "~/.hermes/memories/USER.md";
+}
+
+function sshGetSessionStats(config: SshConfig, profile?: string): { totalSessions: number; totalMessages: number } {
+  const dbPath = profile && profile !== "default"
+    ? `~/.hermes/profiles/${profile}/state.db`
+    : "~/.hermes/state.db";
+
+  const script = `
+import sqlite3, json, os, sys
+db = os.path.expanduser("${dbPath}")
+if not os.path.exists(db):
+    print(json.dumps({"totalSessions": 0, "totalMessages": 0}))
+    sys.exit(0)
+conn = sqlite3.connect(db)
+try:
+    s = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+    m = conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+    print(json.dumps({"totalSessions": s, "totalMessages": m}))
+except:
+    print(json.dumps({"totalSessions": 0, "totalMessages": 0}))
+finally:
+    conn.close()
+`;
+  try {
+    const out = sshPython(config, script);
+    return JSON.parse(out.trim());
+  } catch {
+    return { totalSessions: 0, totalMessages: 0 };
+  }
+}
+
+export function sshReadMemory(config: SshConfig, profile?: string): MemoryInfo {
+  const memContent = sshReadFile(config, remoteMemoryPath(profile));
+  const userContent = sshReadFile(config, remoteUserPath(profile));
+  const stats = sshGetSessionStats(config, profile);
+
+  return {
+    memory: {
+      content: memContent,
+      exists: memContent.length > 0,
+      lastModified: null,
+      entries: parseMemoryEntries(memContent),
+      charCount: memContent.length,
+      charLimit: MEMORY_CHAR_LIMIT,
+    },
+    user: {
+      content: userContent,
+      exists: userContent.length > 0,
+      lastModified: null,
+      charCount: userContent.length,
+      charLimit: USER_CHAR_LIMIT,
+    },
+    stats,
+  };
+}
+
+export function sshAddMemoryEntry(config: SshConfig, content: string, profile?: string): { success: boolean; error?: string } {
+  const current = sshReadFile(config, remoteMemoryPath(profile));
+  const entries = parseMemoryEntries(current);
+  const newContent = serializeEntries([...entries, { index: entries.length, content: content.trim() }]);
+  if (newContent.length > MEMORY_CHAR_LIMIT) {
+    return { success: false, error: `Would exceed memory limit (${newContent.length}/${MEMORY_CHAR_LIMIT} chars)` };
+  }
+  sshWriteFile(config, remoteMemoryPath(profile), newContent);
+  return { success: true };
+}
+
+export function sshUpdateMemoryEntry(config: SshConfig, index: number, content: string, profile?: string): { success: boolean; error?: string } {
+  const current = sshReadFile(config, remoteMemoryPath(profile));
+  const entries = parseMemoryEntries(current);
+  if (index < 0 || index >= entries.length) return { success: false, error: "Entry not found" };
+  entries[index] = { ...entries[index], content: content.trim() };
+  const newContent = serializeEntries(entries);
+  if (newContent.length > MEMORY_CHAR_LIMIT) {
+    return { success: false, error: `Would exceed memory limit (${newContent.length}/${MEMORY_CHAR_LIMIT} chars)` };
+  }
+  sshWriteFile(config, remoteMemoryPath(profile), newContent);
+  return { success: true };
+}
+
+export function sshRemoveMemoryEntry(config: SshConfig, index: number, profile?: string): boolean {
+  const current = sshReadFile(config, remoteMemoryPath(profile));
+  const entries = parseMemoryEntries(current);
+  if (index < 0 || index >= entries.length) return false;
+  entries.splice(index, 1);
+  sshWriteFile(config, remoteMemoryPath(profile), serializeEntries(entries));
+  return true;
+}
+
+export function sshWriteUserProfile(config: SshConfig, content: string, profile?: string): { success: boolean; error?: string } {
+  if (content.length > USER_CHAR_LIMIT) {
+    return { success: false, error: `Exceeds limit (${content.length}/${USER_CHAR_LIMIT} chars)` };
+  }
+  sshWriteFile(config, remoteUserPath(profile), content);
+  return { success: true };
+}
+
+// ── Soul ─────────────────────────────────────────────────────────────────────
+
+const DEFAULT_SOUL = `You are Hermes, a helpful AI assistant. You are friendly, knowledgeable, and always eager to help.
+
+You communicate clearly and concisely. When asked to perform tasks, you think step-by-step and explain your reasoning. You are honest about your limitations and ask for clarification when needed.
+
+You strive to be helpful while being safe and responsible. You respect the user's privacy and handle sensitive information carefully.
+`;
+
+function remoteSoulPath(profile?: string): string {
+  if (profile && profile !== "default") return `~/.hermes/profiles/${profile}/SOUL.md`;
+  return "~/.hermes/SOUL.md";
+}
+
+export function sshReadSoul(config: SshConfig, profile?: string): string {
+  return sshReadFile(config, remoteSoulPath(profile));
+}
+
+export function sshWriteSoul(config: SshConfig, content: string, profile?: string): boolean {
+  try {
+    sshWriteFile(config, remoteSoulPath(profile), content);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function sshResetSoul(config: SshConfig, profile?: string): string {
+  sshWriteSoul(config, DEFAULT_SOUL, profile);
+  return DEFAULT_SOUL;
+}
+
+// ── Tools ────────────────────────────────────────────────────────────────────
+
+const TOOLSET_DEFS = [
+  { key: "web", labelKey: "tools.web.label", descriptionKey: "tools.web.description" },
+  { key: "browser", labelKey: "tools.browser.label", descriptionKey: "tools.browser.description" },
+  { key: "terminal", labelKey: "tools.terminal.label", descriptionKey: "tools.terminal.description" },
+  { key: "file", labelKey: "tools.file.label", descriptionKey: "tools.file.description" },
+  { key: "code_execution", labelKey: "tools.code_execution.label", descriptionKey: "tools.code_execution.description" },
+  { key: "vision", labelKey: "tools.vision.label", descriptionKey: "tools.vision.description" },
+  { key: "image_gen", labelKey: "tools.image_gen.label", descriptionKey: "tools.image_gen.description" },
+  { key: "tts", labelKey: "tools.tts.label", descriptionKey: "tools.tts.description" },
+  { key: "skills", labelKey: "tools.skills.label", descriptionKey: "tools.skills.description" },
+  { key: "memory", labelKey: "tools.memory.label", descriptionKey: "tools.memory.description" },
+  { key: "session_search", labelKey: "tools.session_search.label", descriptionKey: "tools.session_search.description" },
+  { key: "clarify", labelKey: "tools.clarify.label", descriptionKey: "tools.clarify.description" },
+  { key: "delegation", labelKey: "tools.delegation.label", descriptionKey: "tools.delegation.description" },
+];
+
+function parseEnabledToolsets(content: string): Set<string> {
+  const enabled = new Set<string>();
+  let inPlatformToolsets = false;
+  let inCli = false;
+  for (const line of content.split("\n")) {
+    const trimmed = line.trimEnd();
+    if (/^\s*platform_toolsets\s*:/.test(trimmed)) { inPlatformToolsets = true; inCli = false; continue; }
+    if (inPlatformToolsets && /^\s+cli\s*:/.test(trimmed)) { inCli = true; continue; }
+    if (inPlatformToolsets && /^\S/.test(trimmed) && !/^\s*$/.test(trimmed)) { inPlatformToolsets = false; inCli = false; continue; }
+    if (inCli && /^\s{4}\S/.test(trimmed) && !/^\s{4,}-/.test(trimmed)) { inCli = false; continue; }
+    if (inCli) { const m = trimmed.match(/^\s+-\s+["']?(\w+)["']?/); if (m) enabled.add(m[1]); }
+  }
+  return enabled;
+}
+
+function localizeToolDefs(enabled: boolean | ((key: string) => boolean)): ToolsetInfo[] {
+  const locale = getAppLocale();
+  return TOOLSET_DEFS.map((d) => ({
+    key: d.key,
+    label: t(d.labelKey, locale),
+    description: t(d.descriptionKey, locale),
+    enabled: typeof enabled === "function" ? enabled(d.key) : enabled,
+  }));
+}
+
+function remoteConfigPath(profile?: string): string {
+  if (profile && profile !== "default") return `~/.hermes/profiles/${profile}/config.yaml`;
+  return "~/.hermes/config.yaml";
+}
+
+export function sshGetToolsets(config: SshConfig, profile?: string): ToolsetInfo[] {
+  const content = sshReadFile(config, remoteConfigPath(profile));
+  if (!content) return localizeToolDefs(true);
+  const enabled = parseEnabledToolsets(content);
+  if (enabled.size === 0 && !content.includes("platform_toolsets")) return localizeToolDefs(true);
+  return localizeToolDefs((key) => enabled.has(key));
+}
+
+export function sshSetToolsetEnabled(config: SshConfig, key: string, enabled: boolean, profile?: string): boolean {
+  try {
+    const configPath = remoteConfigPath(profile);
+    const content = sshReadFile(config, configPath);
+    if (!content) return false;
+
+    const current = parseEnabledToolsets(content);
+    if (enabled) current.add(key); else current.delete(key);
+
+    const toolsetLines = Array.from(current).sort().map((t) => `      - ${t}`).join("\n");
+    const newSection = `  cli:\n${toolsetLines}`;
+
+    let newContent: string;
+    if (content.includes("platform_toolsets")) {
+      const lines = content.split("\n");
+      const result: string[] = [];
+      let inPT = false, inCli = false, inserted = false;
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        const trimmed = line.trimEnd();
+        if (/^\s*platform_toolsets\s*:/.test(trimmed)) { inPT = true; result.push(line); continue; }
+        if (inPT && /^\s+cli\s*:/.test(trimmed)) { inCli = true; result.push(newSection); inserted = true; continue; }
+        if (inCli) { if (/^\s+-\s/.test(trimmed)) continue; inCli = false; result.push(line); continue; }
+        if (inPT && /^\S/.test(trimmed) && trimmed !== "") { inPT = false; if (!inserted) { result.push(newSection); } }
+        result.push(line);
+      }
+      newContent = result.join("\n");
+    } else {
+      newContent = content.trimEnd() + "\n\nplatform_toolsets:\n" + newSection + "\n";
+    }
+
+    sshWriteFile(config, configPath, newContent);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ── Env / Config (Providers) ─────────────────────────────────────────────────
+
+function remoteEnvPath(profile?: string): string {
+  if (profile && profile !== "default") return `~/.hermes/profiles/${profile}/.env`;
+  return "~/.hermes/.env";
+}
+
+export function sshReadEnv(config: SshConfig, profile?: string): Record<string, string> {
+  const content = sshReadFile(config, remoteEnvPath(profile));
+  const result: Record<string, string> = {};
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("#") || !trimmed.includes("=")) continue;
+    const eqIdx = trimmed.indexOf("=");
+    const k = trimmed.substring(0, eqIdx).trim();
+    let v = trimmed.substring(eqIdx + 1).trim();
+    if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) v = v.slice(1, -1);
+    if (v) result[k] = v;
+  }
+  return result;
+}
+
+export function sshSetEnvValue(config: SshConfig, key: string, value: string, profile?: string): void {
+  const envPath = remoteEnvPath(profile);
+  const content = sshReadFile(config, envPath);
+
+  if (!content.trim()) {
+    sshWriteFile(config, envPath, `${key}=${value}\n`);
+    return;
+  }
+
+  const lines = content.split("\n");
+  let found = false;
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim().match(new RegExp(`^#?\\s*${escaped}\\s*=`))) {
+      lines[i] = `${key}=${value}`;
+      found = true;
+      break;
+    }
+  }
+  if (!found) lines.push(`${key}=${value}`);
+  sshWriteFile(config, envPath, lines.join("\n"));
+}
+
+export function sshGetConfigValue(config: SshConfig, key: string, profile?: string): string | null {
+  const content = sshReadFile(config, remoteConfigPath(profile));
+  if (!content) return null;
+  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = content.match(new RegExp(`^\\s*${escapedKey}:\\s*["']?([^"'\\n#]+)["']?`, "m"));
+  return match ? match[1].trim() : null;
+}
+
+export function sshSetConfigValue(config: SshConfig, key: string, value: string, profile?: string): void {
+  const configPath = remoteConfigPath(profile);
+  const content = sshReadFile(config, configPath);
+  if (!content) return;
+  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const regex = new RegExp(`^(\\s*#?\\s*${escapedKey}:\\s*)["']?[^"'\\n#]*["']?`, "m");
+  const updated = regex.test(content) ? content.replace(regex, `$1"${value}"`) : content;
+  sshWriteFile(config, configPath, updated);
+}
+
+// ── Sessions ─────────────────────────────────────────────────────────────────
+
+function remoteDbPath(profile?: string): string {
+  if (profile && profile !== "default") return `~/.hermes/profiles/${profile}/state.db`;
+  return "~/.hermes/state.db";
+}
+
+export function sshListSessions(config: SshConfig, limit = 30, offset = 0, profile?: string): SessionSummary[] {
+  const dbPath = remoteDbPath(profile);
+  const script = `
+import sqlite3, json, os, sys
+db = os.path.expanduser("${dbPath}")
+if not os.path.exists(db):
+    print("[]"); sys.exit(0)
+conn = sqlite3.connect(db)
+conn.row_factory = sqlite3.Row
+rows = conn.execute(
+    "SELECT id, source, started_at, ended_at, message_count, model, title "
+    "FROM sessions ORDER BY started_at DESC LIMIT ${limit} OFFSET ${offset}"
+).fetchall()
+result = []
+for r in rows:
+    result.append({
+        "id": r["id"], "source": r["source"] or "cli",
+        "startedAt": r["started_at"], "endedAt": r["ended_at"],
+        "messageCount": r["message_count"] or 0, "model": r["model"] or "",
+        "title": r["title"], "preview": ""
+    })
+print(json.dumps(result))
+conn.close()
+`;
+  try {
+    const out = sshPython(config, script);
+    return JSON.parse(out.trim() || "[]");
+  } catch {
+    return [];
+  }
+}
+
+export function sshGetSessionMessages(config: SshConfig, sessionId: string, profile?: string): SessionMessage[] {
+  const dbPath = remoteDbPath(profile);
+  const safe = sessionId.replace(/'/g, "");
+  const script = `
+import sqlite3, json, os, sys
+db = os.path.expanduser("${dbPath}")
+if not os.path.exists(db):
+    print("[]"); sys.exit(0)
+conn = sqlite3.connect(db)
+conn.row_factory = sqlite3.Row
+rows = conn.execute(
+    "SELECT id, role, content, timestamp FROM messages WHERE session_id='${safe}' ORDER BY id ASC"
+).fetchall()
+print(json.dumps([{"id": r["id"], "role": r["role"], "content": r["content"], "timestamp": r["timestamp"]} for r in rows]))
+conn.close()
+`;
+  try {
+    const out = sshPython(config, script);
+    return JSON.parse(out.trim() || "[]");
+  } catch {
+    return [];
+  }
+}
+
+export function sshSearchSessions(config: SshConfig, query: string, limit = 20, profile?: string): SearchResult[] {
+  const dbPath = remoteDbPath(profile);
+  const safe = query.replace(/'/g, "''");
+  const script = `
+import sqlite3, json, os, sys
+db = os.path.expanduser("${dbPath}")
+if not os.path.exists(db):
+    print("[]"); sys.exit(0)
+conn = sqlite3.connect(db)
+conn.row_factory = sqlite3.Row
+try:
+    rows = conn.execute(
+        "SELECT DISTINCT s.id, s.title, s.started_at, s.source, s.message_count, s.model, m.content as snippet "
+        "FROM sessions s JOIN messages m ON m.session_id = s.id "
+        "WHERE m.content LIKE '%${safe}%' ORDER BY s.started_at DESC LIMIT ${limit}"
+    ).fetchall()
+    print(json.dumps([{"sessionId": r["id"], "title": r["title"], "startedAt": r["started_at"], "source": r["source"] or "cli", "messageCount": r["message_count"] or 0, "model": r["model"] or "", "snippet": (r["snippet"] or "")[:200]} for r in rows]))
+except Exception as e:
+    print("[]")
+conn.close()
+`;
+  try {
+    const out = sshPython(config, script);
+    return JSON.parse(out.trim() || "[]");
+  } catch {
+    return [];
+  }
+}
+
+// ── Profiles ─────────────────────────────────────────────────────────────────
+
+export interface SshProfileInfo {
+  name: string;
+  path: string;
+  isDefault: boolean;
+  isActive: boolean;
+  model: string;
+  provider: string;
+  hasEnv: boolean;
+  hasSoul: boolean;
+  skillCount: number;
+  gatewayRunning: boolean;
+}
+
+export function sshListProfiles(config: SshConfig): SshProfileInfo[] {
+  const script = `
+import os, json
+hermes_home = os.path.expanduser("~/.hermes")
+profiles_dir = os.path.join(hermes_home, "profiles")
+profiles = []
+
+def read_config(path):
+    model, provider = "", "auto"
+    config_file = os.path.join(path, "config.yaml")
+    if os.path.exists(config_file):
+        content = open(config_file).read()
+        import re
+        m = re.search(r'^\\s*default:\\s*["\\'\\']?([^"\\'\\' \\n#]+)["\\'\\']?', content, re.M)
+        if m: model = m.group(1).strip()
+        p = re.search(r'^\\s*provider:\\s*["\\'\\']?([^"\\'\\' \\n#]+)["\\'\\']?', content, re.M)
+        if p: provider = p.group(1).strip()
+    return model, provider
+
+def count_skills(path):
+    skills_dir = os.path.join(path, "skills")
+    count = 0
+    if os.path.isdir(skills_dir):
+        for cat in os.listdir(skills_dir):
+            cat_path = os.path.join(skills_dir, cat)
+            if os.path.isdir(cat_path):
+                for name in os.listdir(cat_path):
+                    if os.path.exists(os.path.join(cat_path, name, "SKILL.md")):
+                        count += 1
+    return count
+
+def gw_running(path):
+    pid_file = os.path.join(path, "gateway.pid")
+    if not os.path.exists(pid_file): return False
+    try:
+        pid = int(open(pid_file).read().strip())
+        os.kill(pid, 0)
+        return True
+    except:
+        return False
+
+# Default profile
+model, provider = read_config(hermes_home)
+profiles.append({
+    "name": "default", "path": hermes_home, "isDefault": True, "isActive": True,
+    "model": model, "provider": provider,
+    "hasEnv": os.path.exists(os.path.join(hermes_home, ".env")),
+    "hasSoul": os.path.exists(os.path.join(hermes_home, "SOUL.md")),
+    "skillCount": count_skills(hermes_home),
+    "gatewayRunning": gw_running(hermes_home)
+})
+
+if os.path.isdir(profiles_dir):
+    for name in sorted(os.listdir(profiles_dir)):
+        p = os.path.join(profiles_dir, name)
+        if not os.path.isdir(p): continue
+        model, provider = read_config(p)
+        profiles.append({
+            "name": name, "path": p, "isDefault": False, "isActive": False,
+            "model": model, "provider": provider,
+            "hasEnv": os.path.exists(os.path.join(p, ".env")),
+            "hasSoul": os.path.exists(os.path.join(p, "SOUL.md")),
+            "skillCount": count_skills(p),
+            "gatewayRunning": gw_running(p)
+        })
+
+print(json.dumps(profiles))
+`;
+  try {
+    const out = sshPython(config, script);
+    return JSON.parse(out.trim() || "[]");
+  } catch {
+    return [{ name: "default", path: "~/.hermes", isDefault: true, isActive: true, model: "", provider: "auto", hasEnv: false, hasSoul: false, skillCount: 0, gatewayRunning: false }];
+  }
+}
+
+export function sshCreateProfile(config: SshConfig, name: string, clone: boolean): boolean {
+  try {
+    const safe = name.replace(/[^a-zA-Z0-9_-]/g, "");
+    if (clone) {
+      sshExec(config, `hermes profiles create "${safe}" --clone-from default 2>&1 || mkdir -p ~/.hermes/profiles/"${safe}"`);
+    } else {
+      sshExec(config, `hermes profiles create "${safe}" 2>&1 || mkdir -p ~/.hermes/profiles/"${safe}"`);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function sshDeleteProfile(config: SshConfig, name: string): boolean {
+  try {
+    const safe = name.replace(/[^a-zA-Z0-9_-]/g, "");
+    sshExec(config, `hermes profiles delete "${safe}" --yes 2>&1 || rm -rf ~/.hermes/profiles/"${safe}"`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ── Gateway ───────────────────────────────────────────────────────────────────
+
+export function sshGatewayStatus(config: SshConfig): boolean {
+  try {
+    const out = sshExec(config, `if [ -f ~/.hermes/gateway.pid ]; then pid=$(cat ~/.hermes/gateway.pid); kill -0 $pid 2>/dev/null && echo "running" || echo "stopped"; else echo "stopped"; fi`);
+    return out.trim() === "running";
+  } catch {
+    return false;
+  }
+}
+
+export function sshStartGateway(config: SshConfig): void {
+  try {
+    sshExec(config, `nohup hermes gateway start > ~/.hermes/gateway.log 2>&1 &`);
+  } catch {
+    // best effort
+  }
+}
+
+export function sshStopGateway(config: SshConfig): void {
+  try {
+    sshExec(config, `hermes gateway stop 2>/dev/null || ([ -f ~/.hermes/gateway.pid ] && kill $(cat ~/.hermes/gateway.pid) 2>/dev/null); true`);
+  } catch {
+    // best effort
+  }
+}

--- a/src/main/ssh-remote.ts
+++ b/src/main/ssh-remote.ts
@@ -381,8 +381,8 @@ function localizeToolDefs(enabled: boolean | ((key: string) => boolean)): Toolse
 }
 
 function remoteConfigPath(profile?: string): string {
-  if (profile && profile !== "default") return `~/.hermes/profiles/${profile}/config.yaml`;
-  return "~/.hermes/config.yaml";
+  if (profile && profile !== "default") return `$HOME/.hermes/profiles/${profile}/config.yaml`;
+  return `$HOME/.hermes/config.yaml`;
 }
 
 export function sshGetToolsets(config: SshConfig, profile?: string): ToolsetInfo[] {
@@ -738,4 +738,124 @@ export function sshStopGateway(config: SshConfig): void {
   } catch {
     // best effort
   }
+}
+
+// ── Remote API key (for chat auth through SSH tunnel) ─────────────────────────
+
+export function sshReadRemoteApiKey(config: SshConfig): string {
+  try {
+    const env = sshReadEnv(config);
+    return env["API_SERVER_KEY"] || "";
+  } catch {
+    return "";
+  }
+}
+
+// ── Versions ──────────────────────────────────────────────────────────────────
+
+export function sshGetHermesVersion(config: SshConfig): string | null {
+  try {
+    const out = sshExec(config, `hermes --version 2>/dev/null || hermes version 2>/dev/null || echo ""`);
+    return out.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+// ── Logs ──────────────────────────────────────────────────────────────────────
+
+export function sshReadLogs(
+  config: SshConfig,
+  logFile?: string,
+  lines = 300,
+): { log: string; error?: string } {
+  try {
+    const file = logFile
+      ? `$HOME/.hermes/logs/${logFile}`
+      : `$HOME/.hermes/logs/gateway.log`;
+    const out = sshExec(config, `tail -n ${lines} "${file}" 2>/dev/null || echo ""`);
+    return { log: out };
+  } catch (err) {
+    return { log: "", error: (err as Error).message };
+  }
+}
+
+// ── Platform toggles (Gateway page) ──────────────────────────────────────────
+
+const SSH_SUPPORTED_PLATFORMS = ["telegram", "discord", "slack", "whatsapp", "signal"];
+
+export function sshGetPlatformEnabled(
+  config: SshConfig,
+  profile?: string,
+): Record<string, boolean> {
+  const content = sshReadFile(config, remoteConfigPath(profile));
+  const result: Record<string, boolean> = {};
+  for (const platform of SSH_SUPPORTED_PLATFORMS) {
+    const re = new RegExp(
+      `^[ \\t]+${platform}:\\s*\\n[ \\t]+enabled:\\s*(true|false)`,
+      "m",
+    );
+    const match = content.match(re);
+    result[platform] = match ? match[1] === "true" : false;
+  }
+  return result;
+}
+
+export function sshSetPlatformEnabled(
+  config: SshConfig,
+  platform: string,
+  enabled: boolean,
+  profile?: string,
+): void {
+  if (!SSH_SUPPORTED_PLATFORMS.includes(platform)) return;
+  const configPath = remoteConfigPath(profile);
+  const content = sshReadFile(config, configPath);
+  if (!content) return;
+
+  let updated = content;
+  const existingRe = new RegExp(
+    `^([ \\t]+${platform}:\\s*\\n[ \\t]+enabled:\\s*)(?:true|false)`,
+    "m",
+  );
+
+  if (existingRe.test(updated)) {
+    updated = updated.replace(existingRe, `$1${enabled}`);
+  } else {
+    const platformsIdx = updated.indexOf("\nplatforms:");
+    if (platformsIdx === -1) {
+      updated += `\nplatforms:\n  ${platform}:\n    enabled: ${enabled}\n`;
+    } else {
+      const after = updated.substring(platformsIdx + 1);
+      const lines = after.split("\n");
+      let insertOffset = platformsIdx + 1 + lines[0].length + 1;
+      for (let i = 1; i < lines.length; i++) {
+        if (lines[i].trim() === "" || /^\s/.test(lines[i])) insertOffset += lines[i].length + 1;
+        else break;
+      }
+      const entry = `  ${platform}:\n    enabled: ${enabled}\n`;
+      updated = updated.substring(0, insertOffset) + entry + updated.substring(insertOffset);
+    }
+  }
+
+  sshWriteFile(config, configPath, updated);
+}
+
+// ── Cached sessions (Sessions screen uses listCachedSessions) ─────────────────
+
+import type { CachedSession } from "./session-cache";
+
+export function sshListCachedSessions(
+  config: SshConfig,
+  limit = 50,
+  _offset = 0,
+): CachedSession[] {
+  const sessions = sshListSessions(config, limit, 0);
+  return sessions.map((s) => ({
+    id: s.id,
+    title: s.title || s.id,
+    startedAt: s.startedAt,
+    source: s.source,
+    messageCount: s.messageCount,
+    model: s.model,
+  }));
 }

--- a/src/main/ssh-remote.ts
+++ b/src/main/ssh-remote.ts
@@ -768,15 +768,15 @@ export function sshReadLogs(
   config: SshConfig,
   logFile?: string,
   lines = 300,
-): { log: string; error?: string } {
+): { content: string; path: string } {
+  const allowed = ["agent.log", "errors.log", "gateway.log"];
+  const file = logFile && allowed.includes(logFile) ? logFile : "agent.log";
+  const remotePath = `$HOME/.hermes/logs/${file}`;
   try {
-    const file = logFile
-      ? `$HOME/.hermes/logs/${logFile}`
-      : `$HOME/.hermes/logs/gateway.log`;
-    const out = sshExec(config, `tail -n ${lines} "${file}" 2>/dev/null || echo ""`);
-    return { log: out };
-  } catch (err) {
-    return { log: "", error: (err as Error).message };
+    const content = sshExec(config, `tail -n ${lines} "${remotePath}" 2>/dev/null || echo ""`);
+    return { content: content.trim(), path: `~/.hermes/logs/${file}` };
+  } catch {
+    return { content: "", path: `~/.hermes/logs/${file}` };
   }
 }
 
@@ -786,19 +786,25 @@ const SSH_SUPPORTED_PLATFORMS = ["telegram", "discord", "slack", "whatsapp", "si
 
 export function sshGetPlatformEnabled(
   config: SshConfig,
-  profile?: string,
+  _profile?: string,
 ): Record<string, boolean> {
-  const content = sshReadFile(config, remoteConfigPath(profile));
-  const result: Record<string, boolean> = {};
-  for (const platform of SSH_SUPPORTED_PLATFORMS) {
-    const re = new RegExp(
-      `^[ \\t]+${platform}:\\s*\\n[ \\t]+enabled:\\s*(true|false)`,
-      "m",
-    );
-    const match = content.match(re);
-    result[platform] = match ? match[1] === "true" : false;
+  // Read live state from gateway_state.json which reflects actual running platforms
+  try {
+    const raw = sshReadFile(config, "$HOME/.hermes/gateway_state.json");
+    if (raw) {
+      const state = JSON.parse(raw);
+      const platforms = state.platforms || {};
+      const result: Record<string, boolean> = {};
+      for (const platform of SSH_SUPPORTED_PLATFORMS) {
+        const p = platforms[platform];
+        result[platform] = p ? p.state === "connected" || p.state === "running" : false;
+      }
+      return result;
+    }
+  } catch {
+    // fall through
   }
-  return result;
+  return Object.fromEntries(SSH_SUPPORTED_PLATFORMS.map((p) => [p, false]));
 }
 
 export function sshSetPlatformEnabled(
@@ -858,4 +864,33 @@ export function sshListCachedSessions(
     messageCount: s.messageCount,
     model: s.model,
   }));
+}
+
+// ── Doctor / diagnostics ──────────────────────────────────────────────────────
+
+export function sshRunDoctor(config: SshConfig): string {
+  try {
+    const out = sshExec(config, `hermes doctor 2>&1 || echo "hermes not found in PATH"`);
+    return out.trim() || "No output from doctor.";
+  } catch (err) {
+    return `SSH doctor failed: ${(err as Error).message}`;
+  }
+}
+
+// ── Models library ─────────────────────────────────────────────────────────────
+
+import type { SavedModel } from "./models";
+
+export function sshListModels(config: SshConfig): SavedModel[] {
+  try {
+    const raw = sshReadFile(config, "$HOME/.hermes/models.json");
+    if (raw.trim()) return JSON.parse(raw);
+  } catch {
+    // no models.json on remote yet
+  }
+  return [];
+}
+
+export function sshSaveModels(config: SshConfig, models: SavedModel[]): void {
+  sshWriteFile(config, "$HOME/.hermes/models.json", JSON.stringify(models, null, 2));
 }

--- a/src/main/ssh-remote.ts
+++ b/src/main/ssh-remote.ts
@@ -584,6 +584,9 @@ export async function sshSetConfigValue(
   value: string,
   profile?: string,
 ): Promise<void> {
+  if (/["\\\n\r]/.test(value)) {
+    throw new Error('Config value contains illegal characters: ", \\, or newline');
+  }
   const configPath = remoteConfigPath(profile);
   const content = await sshReadFile(config, configPath);
   if (!content) return;

--- a/src/main/ssh-remote.ts
+++ b/src/main/ssh-remote.ts
@@ -4,14 +4,17 @@
  * local files is instead executed on the remote host via SSH.
  */
 
-import { spawnSync } from "child_process";
+import { spawn } from "child_process";
 import { homedir } from "os";
 import { join } from "path";
 import type { SshConfig } from "./ssh-tunnel";
 import type { InstalledSkill, SkillSearchResult } from "./skills";
 import type { MemoryInfo } from "./memory";
 import type { SessionSummary, SessionMessage, SearchResult } from "./sessions";
+import type { CachedSession } from "./session-cache";
 import type { ToolsetInfo } from "./tools";
+import type { SavedModel } from "./models";
+import type { MemoryProviderInfo } from "./installer";
 import { t } from "../shared/i18n";
 import { getAppLocale } from "./locale";
 
@@ -23,98 +26,151 @@ function buildExecArgs(config: SshConfig): string[] {
     "-o", "BatchMode=yes",
     "-o", "StrictHostKeyChecking=accept-new",
     "-o", "ConnectTimeout=15",
+    "-o", "ControlMaster=auto",
+    "-o", "ControlPath=~/.ssh/cm-hermes-%r@%h:%p",
+    "-o", "ControlPersist=60s",
     "-i", keyPath,
     "-p", String(config.port || 22),
     `${config.username}@${config.host}`,
   ];
 }
 
-export function sshExec(config: SshConfig, command: string, stdin?: string): string {
-  const result = spawnSync("ssh", [...buildExecArgs(config), command], {
-    input: stdin,
-    encoding: "utf-8",
-    timeout: 30000,
-    maxBuffer: 20 * 1024 * 1024,
+export function sshExec(config: SshConfig, command: string, stdin?: string, timeoutMs = 30000): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("ssh", [...buildExecArgs(config), command], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    const timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+      reject(new Error("SSH command timed out"));
+    }, timeoutMs);
+    child.stdout.setEncoding("utf-8");
+    child.stderr.setEncoding("utf-8");
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timeout);
+      if (code === 0) resolve(stdout);
+      else reject(new Error(sanitizeSshError(stderr) || "SSH command failed"));
+    });
+    if (stdin !== undefined) child.stdin.end(stdin);
+    else child.stdin.end();
   });
-  if (result.status !== 0) {
-    throw new Error(result.stderr?.trim() || "SSH command failed");
-  }
-  return result.stdout || "";
 }
 
-function sshPython(config: SshConfig, script: string): string {
-  const result = spawnSync("ssh", [...buildExecArgs(config), "python3 -"], {
-    input: script,
-    encoding: "utf-8",
-    timeout: 30000,
-    maxBuffer: 20 * 1024 * 1024,
-  });
-  if (result.status !== 0) {
-    throw new Error(result.stderr?.trim() || "SSH python failed");
+function sshPython(config: SshConfig, script: string, stdin?: string, timeoutMs = 30000): Promise<string> {
+  if (stdin === undefined) {
+    return sshExec(config, "python3 -", script, timeoutMs);
   }
-  return result.stdout || "";
+  return sshExec(config, `python3 -c ${shellQuote(script)}`, stdin, timeoutMs);
 }
 
-function sshReadFile(config: SshConfig, remotePath: string): string {
-  // ~ doesn't expand inside double quotes — use $HOME instead
-  const p = remotePath.replace(/^~\//, "$HOME/");
+function sanitizeSshError(stderr: string): string {
+  const cleaned = stderr
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line && !/^Warning: Permanently added /.test(line))
+    .filter((line) => !/identity file .* not accessible/i.test(line))
+    .join("\n")
+    .trim();
+  if (/Permission denied \(publickey\)|no such identity|could not open a connection|publickey/i.test(cleaned)) {
+    return "SSH authentication failed. Configure an SSH key for this host and try again.";
+  }
+  if (/Host key verification failed|REMOTE HOST IDENTIFICATION HAS CHANGED/i.test(cleaned)) {
+    return "SSH host key verification failed. Check the host key before reconnecting.";
+  }
+  return cleaned;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\"'\"'")}'`;
+}
+
+function normalizeRemotePath(remotePath: string): string {
+  return remotePath.replace(/^~\//, "$HOME/");
+}
+
+function pythonJsonInput(payload: unknown): string {
+  return JSON.stringify(payload);
+}
+
+async function sshReadFile(config: SshConfig, remotePath: string): Promise<string> {
   try {
-    return sshExec(config, `cat "${p}" 2>/dev/null || true`);
+    return await sshExec(
+      config,
+      `bash -c 'case "$1" in "~/"*) p="$HOME/\${1#~/}" ;; "\\$HOME/"*) p="$HOME/\${1#\\$HOME/}" ;; *) p="$1" ;; esac; cat -- "$p" 2>/dev/null || true' -- ${shellQuote(normalizeRemotePath(remotePath))}`,
+    );
   } catch {
     return "";
   }
 }
 
-function sshWriteFile(config: SshConfig, remotePath: string, content: string): void {
-  const p = remotePath.replace(/^~\//, "$HOME/");
+async function sshWriteFile(config: SshConfig, remotePath: string, content: string): Promise<void> {
+  const p = normalizeRemotePath(remotePath);
   const dir = p.includes("/") ? p.substring(0, p.lastIndexOf("/")) : ".";
-  sshExec(config, `mkdir -p "${dir}" && cat > "${p}"`, content);
+  await sshExec(
+    config,
+    `bash -c 'expand(){ case "$1" in "~/"*) printf "%s" "$HOME/\${1#~/}" ;; "\\$HOME/"*) printf "%s" "$HOME/\${1#\\$HOME/}" ;; *) printf "%s" "$1" ;; esac; }; dir=$(expand "$1"); file=$(expand "$2"); mkdir -p -- "$dir" && cat > "$file"' -- ${shellQuote(dir)} ${shellQuote(p)}`,
+    content,
+  );
 }
 
 // ── Skills ───────────────────────────────────────────────────────────────────
 
 const REMOTE_PREFIX = "REMOTE:";
 
-export function sshListInstalledSkills(config: SshConfig): InstalledSkill[] {
+export async function sshListInstalledSkills(config: SshConfig, profile?: string): Promise<InstalledSkill[]> {
   const script = `
-import os, json
-skills_dir = os.path.expanduser("~/.hermes/skills")
+import os, json, sys
+payload = json.load(sys.stdin)
+profile = payload.get("profile")
+skills_dir = os.path.expanduser(f"~/.hermes/profiles/{profile}/skills" if profile and profile != "default" else "~/.hermes/skills")
 skills = []
+
+def read_meta(skill_path):
+    description = ""
+    skill_file = os.path.join(skill_path, "SKILL.md")
+    if os.path.exists(skill_file):
+        try:
+            content = open(skill_file).read(4000)
+            if content.startswith("---"):
+                end = content.find("---", 3)
+                if end != -1:
+                    for line in content[3:end].splitlines():
+                        if line.strip().startswith("description:"):
+                            description = line.split(":",1)[1].strip().strip("'").strip('"')
+            else:
+                for line in content.splitlines():
+                    if line.strip() and not line.startswith("#"):
+                        description = line.strip()[:120]
+                        break
+        except:
+            pass
+    return description
+
 if os.path.isdir(skills_dir):
-    for category in sorted(os.listdir(skills_dir)):
-        cat_path = os.path.join(skills_dir, category)
-        if not os.path.isdir(cat_path):
+    for entry in sorted(os.listdir(skills_dir)):
+        entry_path = os.path.join(skills_dir, entry)
+        if not os.path.isdir(entry_path):
             continue
-        for name in sorted(os.listdir(cat_path)):
-            skill_path = os.path.join(cat_path, name)
-            if not os.path.isdir(skill_path):
-                continue
-            skill_file = os.path.join(skill_path, "SKILL.md")
-            display_name = name
-            description = ""
-            if os.path.exists(skill_file):
-                try:
-                    content = open(skill_file).read(4000)
-                    if content.startswith("---"):
-                        end = content.find("---", 3)
-                        if end != -1:
-                            for line in content[3:end].splitlines():
-                                if line.strip().startswith("name:"):
-                                    display_name = line.split(":",1)[1].strip().strip("'\\"")
-                                elif line.strip().startswith("description:"):
-                                    description = line.split(":",1)[1].strip().strip("'\\"")
-                    else:
-                        for line in content.splitlines():
-                            if line.startswith("#"):
-                                display_name = line.lstrip("#").strip()
-                                break
-                except:
-                    pass
-            skills.append({"name": display_name, "category": category, "description": description, "path": skill_path})
+        direct_skill_file = os.path.join(entry_path, "SKILL.md")
+        if os.path.exists(direct_skill_file):
+            skills.append({"name": entry, "category": "", "description": read_meta(entry_path), "path": entry_path})
+            continue
+        for name in sorted(os.listdir(entry_path)):
+            skill_path = os.path.join(entry_path, name)
+            if os.path.isdir(skill_path) and os.path.exists(os.path.join(skill_path, "SKILL.md")):
+                skills.append({"name": name, "category": entry, "description": read_meta(skill_path), "path": skill_path})
 print(json.dumps(skills))
 `;
   try {
-    const out = sshPython(config, script);
+    const out = await sshPython(config, script, pythonJsonInput({ profile }));
     const parsed = JSON.parse(out.trim() || "[]") as Array<{
       name: string; category: string; description: string; path: string;
     }>;
@@ -124,39 +180,36 @@ print(json.dumps(skills))
   }
 }
 
-export function sshGetSkillContent(config: SshConfig, skillPath: string): string {
+export async function sshGetSkillContent(config: SshConfig, skillPath: string): Promise<string> {
   const remote = skillPath.startsWith(REMOTE_PREFIX)
     ? skillPath.slice(REMOTE_PREFIX.length)
     : skillPath;
-  return sshReadFile(config, `${remote}/SKILL.md`);
+  return await sshReadFile(config, `${remote}/SKILL.md`);
 }
 
-export function sshInstallSkill(config: SshConfig, identifier: string): { success: boolean; error?: string } {
+export async function sshInstallSkill(config: SshConfig, identifier: string): Promise<{ success: boolean; error?: string }> {
   try {
-    const safe = identifier.replace(/"/g, '\\"');
-    sshExec(config, `hermes skills install "${safe}" --yes 2>&1`);
+    await sshExec(config, `hermes skills install ${shellQuote(identifier)} --yes 2>&1`, undefined, 120000);
     return { success: true };
   } catch (err) {
     return { success: false, error: (err as Error).message };
   }
 }
 
-export function sshUninstallSkill(config: SshConfig, name: string): { success: boolean; error?: string } {
+export async function sshUninstallSkill(config: SshConfig, name: string): Promise<{ success: boolean; error?: string }> {
   try {
-    const safe = name.replace(/"/g, '\\"');
-    sshExec(config, `hermes skills uninstall "${safe}" --yes 2>&1`);
+    await sshExec(config, `hermes skills uninstall ${shellQuote(name)} 2>&1`);
     return { success: true };
   } catch (err) {
     return { success: false, error: (err as Error).message };
   }
 }
 
-export function sshSearchSkills(config: SshConfig, query: string): SkillSearchResult[] {
+export async function sshSearchSkills(config: SshConfig, query: string): Promise<SkillSearchResult[]> {
   try {
-    const safe = query.replace(/"/g, '\\"');
-    const out = sshExec(
+    const out = await sshExec(
       config,
-      `hermes skills browse --query "${safe}" --json 2>/dev/null || echo "[]"`,
+      `hermes skills browse --query ${shellQuote(query)} --json 2>/dev/null || echo "[]"`,
     );
     const parsed = JSON.parse(out.trim() || "[]");
     if (Array.isArray(parsed)) {
@@ -174,8 +227,8 @@ export function sshSearchSkills(config: SshConfig, query: string): SkillSearchRe
   }
 }
 
-export function sshListBundledSkills(config: SshConfig): SkillSearchResult[] {
-  return sshSearchSkills(config, "");
+export async function sshListBundledSkills(config: SshConfig): Promise<SkillSearchResult[]> {
+  return await sshSearchSkills(config, "");
 }
 
 // ── Memory ───────────────────────────────────────────────────────────────────
@@ -210,14 +263,15 @@ function remoteUserPath(profile?: string): string {
   return "~/.hermes/memories/USER.md";
 }
 
-function sshGetSessionStats(config: SshConfig, profile?: string): { totalSessions: number; totalMessages: number } {
-  const dbPath = profile && profile !== "default"
-    ? `~/.hermes/profiles/${profile}/state.db`
-    : "~/.hermes/state.db";
-
+async function sshGetSessionStats(
+  config: SshConfig,
+  profile?: string,
+): Promise<{ totalSessions: number; totalMessages: number }> {
   const script = `
 import sqlite3, json, os, sys
-db = os.path.expanduser("${dbPath}")
+payload = json.load(sys.stdin)
+profile = payload.get("profile")
+db = os.path.expanduser(f"~/.hermes/profiles/{profile}/state.db" if profile and profile != "default" else "~/.hermes/state.db")
 if not os.path.exists(db):
     print(json.dumps({"totalSessions": 0, "totalMessages": 0}))
     sys.exit(0)
@@ -232,17 +286,17 @@ finally:
     conn.close()
 `;
   try {
-    const out = sshPython(config, script);
+    const out = await sshPython(config, script, pythonJsonInput({ profile }));
     return JSON.parse(out.trim());
   } catch {
     return { totalSessions: 0, totalMessages: 0 };
   }
 }
 
-export function sshReadMemory(config: SshConfig, profile?: string): MemoryInfo {
-  const memContent = sshReadFile(config, remoteMemoryPath(profile));
-  const userContent = sshReadFile(config, remoteUserPath(profile));
-  const stats = sshGetSessionStats(config, profile);
+export async function sshReadMemory(config: SshConfig, profile?: string): Promise<MemoryInfo> {
+  const memContent = await sshReadFile(config, remoteMemoryPath(profile));
+  const userContent = await sshReadFile(config, remoteUserPath(profile));
+  const stats = await sshGetSessionStats(config, profile);
 
   return {
     memory: {
@@ -264,19 +318,28 @@ export function sshReadMemory(config: SshConfig, profile?: string): MemoryInfo {
   };
 }
 
-export function sshAddMemoryEntry(config: SshConfig, content: string, profile?: string): { success: boolean; error?: string } {
-  const current = sshReadFile(config, remoteMemoryPath(profile));
+export async function sshAddMemoryEntry(
+  config: SshConfig,
+  content: string,
+  profile?: string,
+): Promise<{ success: boolean; error?: string }> {
+  const current = await sshReadFile(config, remoteMemoryPath(profile));
   const entries = parseMemoryEntries(current);
   const newContent = serializeEntries([...entries, { index: entries.length, content: content.trim() }]);
   if (newContent.length > MEMORY_CHAR_LIMIT) {
     return { success: false, error: `Would exceed memory limit (${newContent.length}/${MEMORY_CHAR_LIMIT} chars)` };
   }
-  sshWriteFile(config, remoteMemoryPath(profile), newContent);
+  await sshWriteFile(config, remoteMemoryPath(profile), newContent);
   return { success: true };
 }
 
-export function sshUpdateMemoryEntry(config: SshConfig, index: number, content: string, profile?: string): { success: boolean; error?: string } {
-  const current = sshReadFile(config, remoteMemoryPath(profile));
+export async function sshUpdateMemoryEntry(
+  config: SshConfig,
+  index: number,
+  content: string,
+  profile?: string,
+): Promise<{ success: boolean; error?: string }> {
+  const current = await sshReadFile(config, remoteMemoryPath(profile));
   const entries = parseMemoryEntries(current);
   if (index < 0 || index >= entries.length) return { success: false, error: "Entry not found" };
   entries[index] = { ...entries[index], content: content.trim() };
@@ -284,24 +347,32 @@ export function sshUpdateMemoryEntry(config: SshConfig, index: number, content: 
   if (newContent.length > MEMORY_CHAR_LIMIT) {
     return { success: false, error: `Would exceed memory limit (${newContent.length}/${MEMORY_CHAR_LIMIT} chars)` };
   }
-  sshWriteFile(config, remoteMemoryPath(profile), newContent);
+  await sshWriteFile(config, remoteMemoryPath(profile), newContent);
   return { success: true };
 }
 
-export function sshRemoveMemoryEntry(config: SshConfig, index: number, profile?: string): boolean {
-  const current = sshReadFile(config, remoteMemoryPath(profile));
+export async function sshRemoveMemoryEntry(
+  config: SshConfig,
+  index: number,
+  profile?: string,
+): Promise<boolean> {
+  const current = await sshReadFile(config, remoteMemoryPath(profile));
   const entries = parseMemoryEntries(current);
   if (index < 0 || index >= entries.length) return false;
   entries.splice(index, 1);
-  sshWriteFile(config, remoteMemoryPath(profile), serializeEntries(entries));
+  await sshWriteFile(config, remoteMemoryPath(profile), serializeEntries(entries));
   return true;
 }
 
-export function sshWriteUserProfile(config: SshConfig, content: string, profile?: string): { success: boolean; error?: string } {
+export async function sshWriteUserProfile(
+  config: SshConfig,
+  content: string,
+  profile?: string,
+): Promise<{ success: boolean; error?: string }> {
   if (content.length > USER_CHAR_LIMIT) {
     return { success: false, error: `Exceeds limit (${content.length}/${USER_CHAR_LIMIT} chars)` };
   }
-  sshWriteFile(config, remoteUserPath(profile), content);
+  await sshWriteFile(config, remoteUserPath(profile), content);
   return { success: true };
 }
 
@@ -319,21 +390,21 @@ function remoteSoulPath(profile?: string): string {
   return "~/.hermes/SOUL.md";
 }
 
-export function sshReadSoul(config: SshConfig, profile?: string): string {
-  return sshReadFile(config, remoteSoulPath(profile));
+export async function sshReadSoul(config: SshConfig, profile?: string): Promise<string> {
+  return await sshReadFile(config, remoteSoulPath(profile));
 }
 
-export function sshWriteSoul(config: SshConfig, content: string, profile?: string): boolean {
+export async function sshWriteSoul(config: SshConfig, content: string, profile?: string): Promise<boolean> {
   try {
-    sshWriteFile(config, remoteSoulPath(profile), content);
+    await sshWriteFile(config, remoteSoulPath(profile), content);
     return true;
   } catch {
     return false;
   }
 }
 
-export function sshResetSoul(config: SshConfig, profile?: string): string {
-  sshWriteSoul(config, DEFAULT_SOUL, profile);
+export async function sshResetSoul(config: SshConfig, profile?: string): Promise<string> {
+  await sshWriteSoul(config, DEFAULT_SOUL, profile);
   return DEFAULT_SOUL;
 }
 
@@ -385,18 +456,23 @@ function remoteConfigPath(profile?: string): string {
   return `$HOME/.hermes/config.yaml`;
 }
 
-export function sshGetToolsets(config: SshConfig, profile?: string): ToolsetInfo[] {
-  const content = sshReadFile(config, remoteConfigPath(profile));
+export async function sshGetToolsets(config: SshConfig, profile?: string): Promise<ToolsetInfo[]> {
+  const content = await sshReadFile(config, remoteConfigPath(profile));
   if (!content) return localizeToolDefs(true);
   const enabled = parseEnabledToolsets(content);
   if (enabled.size === 0 && !content.includes("platform_toolsets")) return localizeToolDefs(true);
   return localizeToolDefs((key) => enabled.has(key));
 }
 
-export function sshSetToolsetEnabled(config: SshConfig, key: string, enabled: boolean, profile?: string): boolean {
+export async function sshSetToolsetEnabled(
+  config: SshConfig,
+  key: string,
+  enabled: boolean,
+  profile?: string,
+): Promise<boolean> {
   try {
     const configPath = remoteConfigPath(profile);
-    const content = sshReadFile(config, configPath);
+    const content = await sshReadFile(config, configPath);
     if (!content) return false;
 
     const current = parseEnabledToolsets(content);
@@ -424,7 +500,7 @@ export function sshSetToolsetEnabled(config: SshConfig, key: string, enabled: bo
       newContent = content.trimEnd() + "\n\nplatform_toolsets:\n" + newSection + "\n";
     }
 
-    sshWriteFile(config, configPath, newContent);
+    await sshWriteFile(config, configPath, newContent);
     return true;
   } catch {
     return false;
@@ -438,8 +514,8 @@ function remoteEnvPath(profile?: string): string {
   return "~/.hermes/.env";
 }
 
-export function sshReadEnv(config: SshConfig, profile?: string): Record<string, string> {
-  const content = sshReadFile(config, remoteEnvPath(profile));
+export async function sshReadEnv(config: SshConfig, profile?: string): Promise<Record<string, string>> {
+  const content = await sshReadFile(config, remoteEnvPath(profile));
   const result: Record<string, string> = {};
   for (const line of content.split("\n")) {
     const trimmed = line.trim();
@@ -462,12 +538,17 @@ export function sshReadEnv(config: SshConfig, profile?: string): Record<string, 
   return result;
 }
 
-export function sshSetEnvValue(config: SshConfig, key: string, value: string, profile?: string): void {
+export async function sshSetEnvValue(
+  config: SshConfig,
+  key: string,
+  value: string,
+  profile?: string,
+): Promise<void> {
   const envPath = remoteEnvPath(profile);
-  const content = sshReadFile(config, envPath);
+  const content = await sshReadFile(config, envPath);
 
   if (!content.trim()) {
-    sshWriteFile(config, envPath, `${key}=${value}\n`);
+    await sshWriteFile(config, envPath, `${key}=${value}\n`);
     return;
   }
 
@@ -482,46 +563,106 @@ export function sshSetEnvValue(config: SshConfig, key: string, value: string, pr
     }
   }
   if (!found) lines.push(`${key}=${value}`);
-  sshWriteFile(config, envPath, lines.join("\n"));
+  await sshWriteFile(config, envPath, lines.join("\n"));
 }
 
-export function sshGetConfigValue(config: SshConfig, key: string, profile?: string): string | null {
-  const content = sshReadFile(config, remoteConfigPath(profile));
+export async function sshGetConfigValue(
+  config: SshConfig,
+  key: string,
+  profile?: string,
+): Promise<string | null> {
+  const content = await sshReadFile(config, remoteConfigPath(profile));
   if (!content) return null;
   const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const match = content.match(new RegExp(`^\\s*${escapedKey}:\\s*["']?([^"'\\n#]+)["']?`, "m"));
   return match ? match[1].trim() : null;
 }
 
-export function sshSetConfigValue(config: SshConfig, key: string, value: string, profile?: string): void {
+export async function sshSetConfigValue(
+  config: SshConfig,
+  key: string,
+  value: string,
+  profile?: string,
+): Promise<void> {
   const configPath = remoteConfigPath(profile);
-  const content = sshReadFile(config, configPath);
+  const content = await sshReadFile(config, configPath);
   if (!content) return;
   const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const regex = new RegExp(`^(\\s*#?\\s*${escapedKey}:\\s*)["']?[^"'\\n#]*["']?`, "m");
   const updated = regex.test(content) ? content.replace(regex, `$1"${value}"`) : content;
-  sshWriteFile(config, configPath, updated);
+  await sshWriteFile(config, configPath, updated);
+}
+
+export function sshGetHermesHome(_config: SshConfig, profile?: string): string {
+  if (profile && profile !== "default") return `~/.hermes/profiles/${profile}`;
+  return "~/.hermes";
+}
+
+export async function sshGetModelConfig(
+  config: SshConfig,
+  profile?: string,
+): Promise<{ provider: string; model: string; baseUrl: string }> {
+  return {
+    provider: (await sshGetConfigValue(config, "provider", profile)) || "auto",
+    model: (await sshGetConfigValue(config, "default", profile)) || "",
+    baseUrl: (await sshGetConfigValue(config, "base_url", profile)) || "",
+  };
+}
+
+export async function sshSetModelConfig(
+  config: SshConfig,
+  provider: string,
+  model: string,
+  baseUrl: string,
+  profile?: string,
+): Promise<void> {
+  await sshSetConfigValue(config, "provider", provider, profile);
+  await sshSetConfigValue(config, "default", model, profile);
+  await sshSetConfigValue(config, "base_url", baseUrl, profile);
+  const configPath = remoteConfigPath(profile);
+  const content = await sshReadFile(config, configPath);
+  if (!content) return;
+  let updated = content.replace(
+    /^(\s*streaming:\s*)(\S+)/m,
+    "$1true",
+  );
+  const lines = updated.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (
+      /^\s*enabled:\s*(true|false)/.test(lines[i]) &&
+      i > 0 &&
+      /smart_model_routing/.test(lines[i - 1])
+    ) {
+      lines[i] = lines[i].replace(/(enabled:\s*)(true|false)/, "$1false");
+    }
+  }
+  updated = lines.join("\n");
+  if (updated !== content) await sshWriteFile(config, configPath, updated);
 }
 
 // ── Sessions ─────────────────────────────────────────────────────────────────
 
-function remoteDbPath(profile?: string): string {
-  if (profile && profile !== "default") return `~/.hermes/profiles/${profile}/state.db`;
-  return "~/.hermes/state.db";
-}
-
-export function sshListSessions(config: SshConfig, limit = 30, offset = 0, profile?: string): SessionSummary[] {
-  const dbPath = remoteDbPath(profile);
+export async function sshListSessions(
+  config: SshConfig,
+  limit = 30,
+  offset = 0,
+  profile?: string,
+): Promise<SessionSummary[]> {
   const script = `
 import sqlite3, json, os, sys
-db = os.path.expanduser("${dbPath}")
+payload = json.load(sys.stdin)
+profile = payload.get("profile")
+limit = max(1, min(200, int(payload.get("limit") or 30)))
+offset = max(0, int(payload.get("offset") or 0))
+db = os.path.expanduser(f"~/.hermes/profiles/{profile}/state.db" if profile and profile != "default" else "~/.hermes/state.db")
 if not os.path.exists(db):
     print("[]"); sys.exit(0)
 conn = sqlite3.connect(db)
 conn.row_factory = sqlite3.Row
 rows = conn.execute(
     "SELECT id, source, started_at, ended_at, message_count, model, title "
-    "FROM sessions ORDER BY started_at DESC LIMIT ${limit} OFFSET ${offset}"
+    "FROM sessions ORDER BY started_at DESC LIMIT ? OFFSET ?",
+    (limit, offset)
 ).fetchall()
 result = []
 for r in rows:
@@ -535,43 +676,56 @@ print(json.dumps(result))
 conn.close()
 `;
   try {
-    const out = sshPython(config, script);
+    const out = await sshPython(config, script, pythonJsonInput({ profile, limit, offset }));
     return JSON.parse(out.trim() || "[]");
   } catch {
     return [];
   }
 }
 
-export function sshGetSessionMessages(config: SshConfig, sessionId: string, profile?: string): SessionMessage[] {
-  const dbPath = remoteDbPath(profile);
-  const safe = sessionId.replace(/'/g, "");
+export async function sshGetSessionMessages(
+  config: SshConfig,
+  sessionId: string,
+  profile?: string,
+): Promise<SessionMessage[]> {
   const script = `
 import sqlite3, json, os, sys
-db = os.path.expanduser("${dbPath}")
+payload = json.load(sys.stdin)
+profile = payload.get("profile")
+session_id = payload.get("sessionId") or ""
+db = os.path.expanduser(f"~/.hermes/profiles/{profile}/state.db" if profile and profile != "default" else "~/.hermes/state.db")
 if not os.path.exists(db):
     print("[]"); sys.exit(0)
 conn = sqlite3.connect(db)
 conn.row_factory = sqlite3.Row
 rows = conn.execute(
-    "SELECT id, role, content, timestamp FROM messages WHERE session_id='${safe}' ORDER BY id ASC"
+    "SELECT id, role, content, timestamp FROM messages WHERE session_id=? ORDER BY id ASC",
+    (session_id,)
 ).fetchall()
-print(json.dumps([{"id": r["id"], "role": r["role"], "content": r["content"], "timestamp": r["timestamp"]} for r in rows]))
+print(json.dumps([{"id": r["id"], "role": r["role"], "content": r["content"] or "", "timestamp": r["timestamp"]} for r in rows]))
 conn.close()
 `;
   try {
-    const out = sshPython(config, script);
+    const out = await sshPython(config, script, pythonJsonInput({ profile, sessionId }));
     return JSON.parse(out.trim() || "[]");
   } catch {
     return [];
   }
 }
 
-export function sshSearchSessions(config: SshConfig, query: string, limit = 20, profile?: string): SearchResult[] {
-  const dbPath = remoteDbPath(profile);
-  const safe = query.replace(/'/g, "''");
+export async function sshSearchSessions(
+  config: SshConfig,
+  query: string,
+  limit = 20,
+  profile?: string,
+): Promise<SearchResult[]> {
   const script = `
 import sqlite3, json, os, sys
-db = os.path.expanduser("${dbPath}")
+payload = json.load(sys.stdin)
+profile = payload.get("profile")
+query = payload.get("query") or ""
+limit = max(1, min(200, int(payload.get("limit") or 20)))
+db = os.path.expanduser(f"~/.hermes/profiles/{profile}/state.db" if profile and profile != "default" else "~/.hermes/state.db")
 if not os.path.exists(db):
     print("[]"); sys.exit(0)
 conn = sqlite3.connect(db)
@@ -580,7 +734,8 @@ try:
     rows = conn.execute(
         "SELECT DISTINCT s.id, s.title, s.started_at, s.source, s.message_count, s.model, m.content as snippet "
         "FROM sessions s JOIN messages m ON m.session_id = s.id "
-        "WHERE m.content LIKE '%${safe}%' ORDER BY s.started_at DESC LIMIT ${limit}"
+        "WHERE m.content LIKE ? ORDER BY s.started_at DESC LIMIT ?",
+        (f"%{query}%", limit)
     ).fetchall()
     print(json.dumps([{"sessionId": r["id"], "title": r["title"], "startedAt": r["started_at"], "source": r["source"] or "cli", "messageCount": r["message_count"] or 0, "model": r["model"] or "", "snippet": (r["snippet"] or "")[:200]} for r in rows]))
 except Exception as e:
@@ -588,7 +743,7 @@ except Exception as e:
 conn.close()
 `;
   try {
-    const out = sshPython(config, script);
+    const out = await sshPython(config, script, pythonJsonInput({ profile, query, limit }));
     return JSON.parse(out.trim() || "[]");
   } catch {
     return [];
@@ -610,7 +765,7 @@ export interface SshProfileInfo {
   gatewayRunning: boolean;
 }
 
-export function sshListProfiles(config: SshConfig): SshProfileInfo[] {
+export async function sshListProfiles(config: SshConfig): Promise<SshProfileInfo[]> {
   const script = `
 import os, json
 hermes_home = os.path.expanduser("~/.hermes")
@@ -679,20 +834,26 @@ if os.path.isdir(profiles_dir):
 print(json.dumps(profiles))
 `;
   try {
-    const out = sshPython(config, script);
+    const out = await sshPython(config, script);
     return JSON.parse(out.trim() || "[]");
   } catch {
     return [{ name: "default", path: "~/.hermes", isDefault: true, isActive: true, model: "", provider: "auto", hasEnv: false, hasSoul: false, skillCount: 0, gatewayRunning: false }];
   }
 }
 
-export function sshCreateProfile(config: SshConfig, name: string, clone: boolean): boolean {
+export async function sshCreateProfile(
+  config: SshConfig,
+  name: string,
+  clone: boolean,
+): Promise<boolean> {
   try {
     const safe = name.replace(/[^a-zA-Z0-9_-]/g, "");
+    if (!safe) return false;
+    const quoted = shellQuote(safe);
     if (clone) {
-      sshExec(config, `hermes profiles create "${safe}" --clone-from default 2>&1 || mkdir -p ~/.hermes/profiles/"${safe}"`);
+      await sshExec(config, `hermes profiles create ${quoted} --clone-from default 2>&1 || mkdir -p ~/.hermes/profiles/${quoted}`);
     } else {
-      sshExec(config, `hermes profiles create "${safe}" 2>&1 || mkdir -p ~/.hermes/profiles/"${safe}"`);
+      await sshExec(config, `hermes profiles create ${quoted} 2>&1 || mkdir -p ~/.hermes/profiles/${quoted}`);
     }
     return true;
   } catch {
@@ -700,10 +861,12 @@ export function sshCreateProfile(config: SshConfig, name: string, clone: boolean
   }
 }
 
-export function sshDeleteProfile(config: SshConfig, name: string): boolean {
+export async function sshDeleteProfile(config: SshConfig, name: string): Promise<boolean> {
   try {
     const safe = name.replace(/[^a-zA-Z0-9_-]/g, "");
-    sshExec(config, `hermes profiles delete "${safe}" --yes 2>&1 || rm -rf ~/.hermes/profiles/"${safe}"`);
+    if (!safe || safe === "default") return false;
+    const quoted = shellQuote(safe);
+    await sshExec(config, `hermes profiles delete ${quoted} --yes 2>&1 || rm -rf ~/.hermes/profiles/${quoted}`);
     return true;
   } catch {
     return false;
@@ -712,9 +875,9 @@ export function sshDeleteProfile(config: SshConfig, name: string): boolean {
 
 // ── Gateway ───────────────────────────────────────────────────────────────────
 
-export function sshGatewayStatus(config: SshConfig): boolean {
+export async function sshGatewayStatus(config: SshConfig): Promise<boolean> {
   try {
-    const out = sshExec(
+    const out = await sshExec(
       config,
       `if [ -f $HOME/.hermes/gateway.pid ]; then ` +
       `pid=$(python3 -c "import json,sys; d=json.load(open('$HOME/.hermes/gateway.pid')); print(d.get('pid',d) if isinstance(d,dict) else d)" 2>/dev/null || cat $HOME/.hermes/gateway.pid); ` +
@@ -727,17 +890,17 @@ export function sshGatewayStatus(config: SshConfig): boolean {
   }
 }
 
-export function sshStartGateway(config: SshConfig): void {
+export async function sshStartGateway(config: SshConfig): Promise<void> {
   try {
-    sshExec(config, `nohup hermes gateway start > $HOME/.hermes/gateway.log 2>&1 &`);
+    await sshExec(config, `nohup hermes gateway start > $HOME/.hermes/gateway.log 2>&1 &`);
   } catch {
     // best effort
   }
 }
 
-export function sshStopGateway(config: SshConfig): void {
+export async function sshStopGateway(config: SshConfig): Promise<void> {
   try {
-    sshExec(
+    await sshExec(
       config,
       `hermes gateway stop 2>/dev/null || ` +
       `(if [ -f $HOME/.hermes/gateway.pid ]; then ` +
@@ -751,9 +914,9 @@ export function sshStopGateway(config: SshConfig): void {
 
 // ── Remote API key (for chat auth through SSH tunnel) ─────────────────────────
 
-export function sshReadRemoteApiKey(config: SshConfig): string {
+export async function sshReadRemoteApiKey(config: SshConfig): Promise<string> {
   try {
-    const env = sshReadEnv(config);
+    const env = await sshReadEnv(config);
     return env["API_SERVER_KEY"] || "";
   } catch {
     return "";
@@ -762,9 +925,9 @@ export function sshReadRemoteApiKey(config: SshConfig): string {
 
 // ── Versions ──────────────────────────────────────────────────────────────────
 
-export function sshGetHermesVersion(config: SshConfig): string | null {
+export async function sshGetHermesVersion(config: SshConfig): Promise<string | null> {
   try {
-    const out = sshExec(config, `hermes --version 2>/dev/null || hermes version 2>/dev/null || echo ""`);
+    const out = await sshExec(config, `hermes --version 2>/dev/null || hermes version 2>/dev/null || echo ""`);
     return out.trim() || null;
   } catch {
     return null;
@@ -773,16 +936,20 @@ export function sshGetHermesVersion(config: SshConfig): string | null {
 
 // ── Logs ──────────────────────────────────────────────────────────────────────
 
-export function sshReadLogs(
+export async function sshReadLogs(
   config: SshConfig,
   logFile?: string,
   lines = 300,
-): { content: string; path: string } {
+): Promise<{ content: string; path: string }> {
   const allowed = ["agent.log", "errors.log", "gateway.log"];
   const file = logFile && allowed.includes(logFile) ? logFile : "agent.log";
   const remotePath = `$HOME/.hermes/logs/${file}`;
   try {
-    const content = sshExec(config, `tail -n ${lines} "${remotePath}" 2>/dev/null || echo ""`);
+    const safeLines = Math.max(1, Math.min(5000, Number.parseInt(String(lines), 10) || 300));
+    const content = await sshExec(
+      config,
+      `bash -c 'case "$2" in "~/"*) p="$HOME/\${2#~/}" ;; "\\$HOME/"*) p="$HOME/\${2#\\$HOME/}" ;; *) p="$2" ;; esac; tail -n "$1" -- "$p" 2>/dev/null || echo ""' -- ${shellQuote(String(safeLines))} ${shellQuote(remotePath)}`,
+    );
     return { content: content.trim(), path: `~/.hermes/logs/${file}` };
   } catch {
     return { content: "", path: `~/.hermes/logs/${file}` };
@@ -802,12 +969,13 @@ const PLATFORM_STATE_KEY: Record<string, string> = {
   home_assistant: "homeassistant",
 };
 
-export function sshGetPlatformEnabled(
+export async function sshGetPlatformEnabled(
   config: SshConfig,
-  _profile?: string,
-): Record<string, boolean> {
+  profile?: string,
+): Promise<Record<string, boolean>> {
+  void profile;
   try {
-    const raw = sshReadFile(config, "$HOME/.hermes/gateway_state.json");
+    const raw = await sshReadFile(config, "$HOME/.hermes/gateway_state.json");
     if (raw.trim()) {
       const state = JSON.parse(raw);
       const platforms = state.platforms || {};
@@ -825,15 +993,15 @@ export function sshGetPlatformEnabled(
   return Object.fromEntries(SSH_SUPPORTED_PLATFORMS.map((p) => [p, false]));
 }
 
-export function sshSetPlatformEnabled(
+export async function sshSetPlatformEnabled(
   config: SshConfig,
   platform: string,
   enabled: boolean,
   profile?: string,
-): void {
+): Promise<void> {
   if (!SSH_SUPPORTED_PLATFORMS.includes(platform)) return;
   const configPath = remoteConfigPath(profile);
-  const content = sshReadFile(config, configPath);
+  const content = await sshReadFile(config, configPath);
   if (!content) return;
 
   let updated = content;
@@ -861,19 +1029,18 @@ export function sshSetPlatformEnabled(
     }
   }
 
-  sshWriteFile(config, configPath, updated);
+  await sshWriteFile(config, configPath, updated);
 }
 
 // ── Cached sessions (Sessions screen uses listCachedSessions) ─────────────────
 
-import type { CachedSession } from "./session-cache";
-
-export function sshListCachedSessions(
+export async function sshListCachedSessions(
   config: SshConfig,
   limit = 50,
-  _offset = 0,
-): CachedSession[] {
-  const sessions = sshListSessions(config, limit, 0);
+  offset = 0,
+): Promise<CachedSession[]> {
+  void offset;
+  const sessions = await sshListSessions(config, limit, 0);
   return sessions.map((s) => ({
     id: s.id,
     title: s.title || s.id,
@@ -886,22 +1053,81 @@ export function sshListCachedSessions(
 
 // ── Doctor / diagnostics ──────────────────────────────────────────────────────
 
-export function sshRunDoctor(config: SshConfig): string {
+export async function sshRunDoctor(config: SshConfig): Promise<string> {
   try {
-    const out = sshExec(config, `hermes doctor 2>&1 || echo "hermes not found in PATH"`);
+    const out = await sshExec(config, `hermes doctor 2>&1 || echo "hermes not found in PATH"`);
     return out.trim() || "No output from doctor.";
   } catch (err) {
     return `SSH doctor failed: ${(err as Error).message}`;
   }
 }
 
+export async function sshRunUpdate(config: SshConfig): Promise<void> {
+  await sshExec(config, "hermes update 2>&1", undefined, 120000);
+}
+
+export async function sshRunDump(config: SshConfig): Promise<string> {
+  try {
+    const out = await sshExec(config, "hermes dump 2>&1", undefined, 60000);
+    return out.trim() || "No output from dump.";
+  } catch (err) {
+    return `SSH dump failed: ${(err as Error).message}`;
+  }
+}
+
+export async function sshDiscoverMemoryProviders(
+  config: SshConfig,
+  profile?: string,
+): Promise<MemoryProviderInfo[]> {
+  const activeProvider = (await sshGetConfigValue(config, "memory.provider", profile)) || "";
+  const script = `
+import json, os
+known = {
+    "honcho": {"description": "memory.providers.honcho", "envVars": ["HONCHO_API_KEY"]},
+    "hindsight": {"description": "memory.providers.hindsight", "envVars": ["HINDSIGHT_API_KEY", "HINDSIGHT_API_URL", "HINDSIGHT_BANK_ID"]},
+    "mem0": {"description": "memory.providers.mem0", "envVars": ["MEM0_API_KEY"]},
+    "retaindb": {"description": "memory.providers.retaindb", "envVars": ["RETAINDB_API_KEY"]},
+    "supermemory": {"description": "memory.providers.supermemory", "envVars": ["SUPERMEMORY_API_KEY"]},
+    "holographic": {"description": "memory.providers.holographic", "envVars": []},
+    "openviking": {"description": "memory.providers.openviking", "envVars": ["OPENVIKING_ENDPOINT", "OPENVIKING_API_KEY"]},
+    "byterover": {"description": "memory.providers.byterover", "envVars": ["BRV_API_KEY"]},
+}
+roots = [
+    os.path.expanduser("~/.hermes/plugins/memory"),
+    os.path.expanduser("~/hermes/plugins/memory"),
+    os.path.expanduser("~/hermes-agent/plugins/memory"),
+]
+names = set(known)
+for root in roots:
+    if os.path.isdir(root):
+        for name in os.listdir(root):
+            if not name.startswith("_") and os.path.isdir(os.path.join(root, name)):
+                names.add(name)
+result = []
+for name in sorted(names):
+    meta = known.get(name, {"description": f"memory.providers.{name}", "envVars": []})
+    result.append({
+        "name": name,
+        "description": meta["description"],
+        "envVars": meta["envVars"],
+        "installed": True,
+        "active": name == ${JSON.stringify(activeProvider)},
+    })
+print(json.dumps(result))
+`;
+  try {
+    const out = await sshPython(config, script);
+    return JSON.parse(out.trim() || "[]");
+  } catch {
+    return [];
+  }
+}
+
 // ── Models library ─────────────────────────────────────────────────────────────
 
-import type { SavedModel } from "./models";
-
-export function sshListModels(config: SshConfig): SavedModel[] {
+export async function sshListModels(config: SshConfig): Promise<SavedModel[]> {
   try {
-    const raw = sshReadFile(config, "$HOME/.hermes/models.json");
+    const raw = await sshReadFile(config, "$HOME/.hermes/models.json");
     if (raw.trim()) return JSON.parse(raw);
   } catch {
     // no models.json on remote yet
@@ -909,6 +1135,6 @@ export function sshListModels(config: SshConfig): SavedModel[] {
   return [];
 }
 
-export function sshSaveModels(config: SshConfig, models: SavedModel[]): void {
-  sshWriteFile(config, "$HOME/.hermes/models.json", JSON.stringify(models, null, 2));
+export async function sshSaveModels(config: SshConfig, models: SavedModel[]): Promise<void> {
+  await sshWriteFile(config, "$HOME/.hermes/models.json", JSON.stringify(models, null, 2));
 }

--- a/src/main/ssh-tunnel.ts
+++ b/src/main/ssh-tunnel.ts
@@ -1,0 +1,173 @@
+import { ChildProcess, spawn } from "child_process";
+import { homedir } from "os";
+import { join } from "path";
+import net from "net";
+import http from "http";
+
+export interface SshConfig {
+  host: string;
+  port: number;
+  username: string;
+  keyPath: string;
+  remotePort: number;
+  localPort: number;
+}
+
+let tunnelProcess: ChildProcess | null = null;
+let activeConfig: SshConfig | null = null;
+
+export function getSshTunnelUrl(): string {
+  return `http://127.0.0.1:${activeConfig?.localPort ?? 18642}`;
+}
+
+export function isSshTunnelActive(): boolean {
+  return tunnelProcess !== null && !tunnelProcess.killed;
+}
+
+function findFreePort(preferred: number): Promise<number> {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.listen(preferred, "127.0.0.1", () => {
+      const port = (server.address() as net.AddressInfo).port;
+      server.close(() => resolve(port));
+    });
+    server.on("error", () => {
+      const fallback = net.createServer();
+      fallback.listen(0, "127.0.0.1", () => {
+        const port = (fallback.address() as net.AddressInfo).port;
+        fallback.close(() => resolve(port));
+      });
+    });
+  });
+}
+
+function waitForPort(port: number, timeoutMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
+    function attempt(): void {
+      const socket = net.connect(port, "127.0.0.1", () => {
+        socket.destroy();
+        resolve();
+      });
+      socket.on("error", () => {
+        socket.destroy();
+        if (Date.now() > deadline) {
+          reject(new Error(`SSH tunnel not ready after ${timeoutMs}ms`));
+        } else {
+          setTimeout(attempt, 400);
+        }
+      });
+    }
+    attempt();
+  });
+}
+
+function buildSshArgs(config: SshConfig, localPort: number): string[] {
+  const keyPath = config.keyPath || join(homedir(), ".ssh", "id_rsa");
+  return [
+    "-N",
+    "-L", `${localPort}:127.0.0.1:${config.remotePort}`,
+    "-p", String(config.port),
+    "-i", keyPath,
+    "-o", "StrictHostKeyChecking=accept-new",
+    "-o", "BatchMode=yes",
+    "-o", "ExitOnForwardFailure=yes",
+    "-o", "ServerAliveInterval=30",
+    "-o", "ServerAliveCountMax=3",
+    `${config.username}@${config.host}`,
+  ];
+}
+
+export async function startSshTunnel(config: SshConfig): Promise<void> {
+  stopSshTunnel();
+
+  const localPort = await findFreePort(config.localPort || 18642);
+  activeConfig = { ...config, localPort };
+
+  tunnelProcess = spawn("ssh", buildSshArgs(config, localPort), {
+    stdio: "ignore",
+    detached: false,
+  });
+
+  tunnelProcess.on("exit", () => {
+    tunnelProcess = null;
+  });
+
+  tunnelProcess.on("error", () => {
+    tunnelProcess = null;
+  });
+
+  await waitForPort(localPort, 12000);
+}
+
+export function stopSshTunnel(): void {
+  if (tunnelProcess && !tunnelProcess.killed) {
+    tunnelProcess.kill("SIGTERM");
+  }
+  tunnelProcess = null;
+  activeConfig = null;
+}
+
+export async function ensureSshTunnel(config: SshConfig): Promise<void> {
+  if (isSshTunnelActive()) return;
+  await startSshTunnel(config);
+}
+
+// Test SSH reachability + hermes health endpoint through a temporary tunnel
+export function testSshConnection(config: SshConfig): Promise<boolean> {
+  return new Promise(async (resolve) => {
+    let localPort: number;
+    try {
+      localPort = await findFreePort(config.localPort || 19642);
+    } catch {
+      resolve(false);
+      return;
+    }
+
+    const args = buildSshArgs(config, localPort);
+    const proc = spawn("ssh", args, { stdio: "ignore" });
+
+    let done = false;
+    const finish = (result: boolean): void => {
+      if (done) return;
+      done = true;
+      proc.kill("SIGTERM");
+      resolve(result);
+    };
+
+    proc.on("error", () => finish(false));
+
+    const timeout = setTimeout(() => finish(false), 20000);
+
+    // Poll until tunnel port is reachable, then hit /health
+    const deadline = Date.now() + 15000;
+    async function poll(): Promise<void> {
+      if (done) return;
+      const portOpen = await new Promise<boolean>((res) => {
+        const s = net.connect(localPort, "127.0.0.1", () => { s.destroy(); res(true); });
+        s.on("error", () => { s.destroy(); res(false); });
+      });
+
+      if (!portOpen) {
+        if (Date.now() > deadline) { clearTimeout(timeout); finish(false); return; }
+        setTimeout(poll, 400);
+        return;
+      }
+
+      // Port is open — hit hermes /health
+      const req = http.request(
+        `http://127.0.0.1:${localPort}/health`,
+        { method: "GET", timeout: 3000 },
+        (res) => {
+          clearTimeout(timeout);
+          finish(res.statusCode === 200);
+          res.resume();
+        },
+      );
+      req.on("error", () => { clearTimeout(timeout); finish(false); });
+      req.end();
+    }
+
+    setTimeout(poll, 600);
+  });
+}

--- a/src/main/ssh-tunnel.ts
+++ b/src/main/ssh-tunnel.ts
@@ -15,13 +15,50 @@ export interface SshConfig {
 
 let tunnelProcess: ChildProcess | null = null;
 let activeConfig: SshConfig | null = null;
+let tunnelRunning = false;
 
-export function getSshTunnelUrl(): string {
-  return `http://127.0.0.1:${activeConfig?.localPort ?? 18642}`;
+export function getSshTunnelUrl(): string | null {
+  if (!activeConfig || !tunnelRunning) return null;
+  return `http://127.0.0.1:${activeConfig.localPort}`;
 }
 
 export function isSshTunnelActive(): boolean {
-  return tunnelProcess !== null && !tunnelProcess.killed;
+  return tunnelProcess !== null && tunnelRunning;
+}
+
+function checkTunnelHealth(port: number, timeoutMs = 3000): Promise<boolean> {
+  return new Promise((resolve) => {
+    const req = http.request(
+      `http://127.0.0.1:${port}/health`,
+      { method: "GET", timeout: timeoutMs },
+      (res) => {
+        const healthy = res.statusCode === 200;
+        res.resume();
+        resolve(healthy);
+      },
+    );
+    req.on("error", () => resolve(false));
+    req.on("timeout", () => {
+      req.destroy();
+      resolve(false);
+    });
+    req.end();
+  });
+}
+
+async function waitForHealth(port: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    if (await checkTunnelHealth(port, 1500)) return;
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`SSH tunnel health check failed after ${timeoutMs}ms`);
+}
+
+export async function isSshTunnelHealthy(): Promise<boolean> {
+  return activeConfig !== null && tunnelRunning
+    ? checkTunnelHealth(activeConfig.localPort)
+    : false;
 }
 
 function findFreePort(preferred: number): Promise<number> {
@@ -71,6 +108,9 @@ function buildSshArgs(config: SshConfig, localPort: number): string[] {
     "-i", keyPath,
     "-o", "StrictHostKeyChecking=accept-new",
     "-o", "BatchMode=yes",
+    "-o", "ControlMaster=auto",
+    "-o", "ControlPath=~/.ssh/cm-hermes-%r@%h:%p",
+    "-o", "ControlPersist=60s",
     "-o", "ExitOnForwardFailure=yes",
     "-o", "ServerAliveInterval=30",
     "-o", "ServerAliveCountMax=3",
@@ -83,6 +123,7 @@ export async function startSshTunnel(config: SshConfig): Promise<void> {
 
   const localPort = await findFreePort(config.localPort || 18642);
   activeConfig = { ...config, localPort };
+  tunnelRunning = false;
 
   tunnelProcess = spawn("ssh", buildSshArgs(config, localPort), {
     stdio: "ignore",
@@ -90,84 +131,89 @@ export async function startSshTunnel(config: SshConfig): Promise<void> {
   });
 
   tunnelProcess.on("exit", () => {
+    tunnelRunning = false;
     tunnelProcess = null;
+    activeConfig = null;
   });
 
   tunnelProcess.on("error", () => {
+    tunnelRunning = false;
     tunnelProcess = null;
+    activeConfig = null;
   });
 
-  await waitForPort(localPort, 12000);
+  try {
+    await waitForPort(localPort, 12000);
+    tunnelRunning = true;
+    await waitForHealth(localPort, 20000);
+  } catch (err) {
+    stopSshTunnel();
+    throw err;
+  }
 }
 
 export function stopSshTunnel(): void {
   if (tunnelProcess && !tunnelProcess.killed) {
     tunnelProcess.kill("SIGTERM");
   }
-  tunnelProcess = null;
+  tunnelRunning = false;
   activeConfig = null;
 }
 
 export async function ensureSshTunnel(config: SshConfig): Promise<void> {
-  if (isSshTunnelActive()) return;
+  if (isSshTunnelActive() && await isSshTunnelHealthy()) return;
   await startSshTunnel(config);
 }
 
 // Test SSH reachability + hermes health endpoint through a temporary tunnel
 export function testSshConnection(config: SshConfig): Promise<boolean> {
-  return new Promise(async (resolve) => {
-    let localPort: number;
-    try {
-      localPort = await findFreePort(config.localPort || 19642);
-    } catch {
-      resolve(false);
-      return;
-    }
+  return findFreePort(config.localPort || 19642)
+    .then((localPort) => new Promise<boolean>((resolve) => {
+      const args = buildSshArgs(config, localPort);
+      const proc = spawn("ssh", args, { stdio: "ignore" });
 
-    const args = buildSshArgs(config, localPort);
-    const proc = spawn("ssh", args, { stdio: "ignore" });
+      let done = false;
+      const finish = (result: boolean): void => {
+        if (done) return;
+        done = true;
+        proc.kill("SIGTERM");
+        resolve(result);
+      };
 
-    let done = false;
-    const finish = (result: boolean): void => {
-      if (done) return;
-      done = true;
-      proc.kill("SIGTERM");
-      resolve(result);
-    };
+      proc.on("error", () => finish(false));
 
-    proc.on("error", () => finish(false));
+      const timeout = setTimeout(() => finish(false), 20000);
 
-    const timeout = setTimeout(() => finish(false), 20000);
+      // Poll until tunnel port is reachable, then hit /health
+      const deadline = Date.now() + 15000;
+      async function poll(): Promise<void> {
+        if (done) return;
+        const portOpen = await new Promise<boolean>((res) => {
+          const s = net.connect(localPort, "127.0.0.1", () => { s.destroy(); res(true); });
+          s.on("error", () => { s.destroy(); res(false); });
+        });
 
-    // Poll until tunnel port is reachable, then hit /health
-    const deadline = Date.now() + 15000;
-    async function poll(): Promise<void> {
-      if (done) return;
-      const portOpen = await new Promise<boolean>((res) => {
-        const s = net.connect(localPort, "127.0.0.1", () => { s.destroy(); res(true); });
-        s.on("error", () => { s.destroy(); res(false); });
-      });
+        if (!portOpen) {
+          if (Date.now() > deadline) { clearTimeout(timeout); finish(false); return; }
+          setTimeout(poll, 400);
+          return;
+        }
 
-      if (!portOpen) {
-        if (Date.now() > deadline) { clearTimeout(timeout); finish(false); return; }
-        setTimeout(poll, 400);
-        return;
+        // Port is open — hit hermes /health
+        const req = http.request(
+          `http://127.0.0.1:${localPort}/health`,
+          { method: "GET", timeout: 3000 },
+          (res) => {
+            clearTimeout(timeout);
+            finish(res.statusCode === 200);
+            res.resume();
+          },
+        );
+        req.on("error", () => { clearTimeout(timeout); finish(false); });
+        req.end();
       }
 
-      // Port is open — hit hermes /health
-      const req = http.request(
-        `http://127.0.0.1:${localPort}/health`,
-        { method: "GET", timeout: 3000 },
-        (res) => {
-          clearTimeout(timeout);
-          finish(res.statusCode === 200);
-          res.resume();
-        },
-      );
-      req.on("error", () => { clearTimeout(timeout); finish(false); });
-      req.end();
-    }
-
-    setTimeout(poll, 600);
-  });
+      setTimeout(poll, 600);
+    }))
+    .catch(() => false);
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -54,19 +54,45 @@ interface HermesAPI {
     profile?: string,
   ) => Promise<boolean>;
 
-  // Connection mode (local vs remote)
+  // Connection mode (local / remote / ssh)
   isRemoteMode: () => Promise<boolean>;
   getConnectionConfig: () => Promise<{
-    mode: "local" | "remote";
+    mode: "local" | "remote" | "ssh";
     remoteUrl: string;
     apiKey: string;
+    ssh: {
+      host: string;
+      port: number;
+      username: string;
+      keyPath: string;
+      remotePort: number;
+      localPort: number;
+    };
   }>;
   setConnectionConfig: (
-    mode: "local" | "remote",
+    mode: "local" | "remote" | "ssh",
     remoteUrl: string,
     apiKey?: string,
   ) => Promise<boolean>;
+  setSshConfig: (
+    host: string,
+    port: number,
+    username: string,
+    keyPath: string,
+    remotePort: number,
+    localPort: number,
+  ) => Promise<boolean>;
   testRemoteConnection: (url: string, apiKey?: string) => Promise<boolean>;
+  testSshConnection: (
+    host: string,
+    port: number,
+    username: string,
+    keyPath: string,
+    remotePort: number,
+  ) => Promise<boolean>;
+  isSshTunnelActive: () => Promise<boolean>;
+  startSshTunnel: () => Promise<boolean>;
+  stopSshTunnel: () => Promise<boolean>;
 
   // Chat
   sendMessage: (

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -56,6 +56,7 @@ interface HermesAPI {
 
   // Connection mode (local / remote / ssh)
   isRemoteMode: () => Promise<boolean>;
+  isRemoteOnlyMode: () => Promise<boolean>;
   getConnectionConfig: () => Promise<{
     mode: "local" | "remote" | "ssh";
     remoteUrl: string;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -92,6 +92,7 @@ const hermesAPI = {
 
   // Connection mode (local / remote / ssh)
   isRemoteMode: (): Promise<boolean> => ipcRenderer.invoke("is-remote-mode"),
+  isRemoteOnlyMode: (): Promise<boolean> => ipcRenderer.invoke("is-remote-only-mode"),
   getConnectionConfig: (): Promise<{
     mode: "local" | "remote" | "ssh";
     remoteUrl: string;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -90,23 +90,59 @@ const hermesAPI = {
   ): Promise<boolean> =>
     ipcRenderer.invoke("set-model-config", provider, model, baseUrl, profile),
 
-  // Connection mode (local vs remote)
+  // Connection mode (local / remote / ssh)
   isRemoteMode: (): Promise<boolean> => ipcRenderer.invoke("is-remote-mode"),
   getConnectionConfig: (): Promise<{
-    mode: "local" | "remote";
+    mode: "local" | "remote" | "ssh";
     remoteUrl: string;
     apiKey: string;
+    ssh: {
+      host: string;
+      port: number;
+      username: string;
+      keyPath: string;
+      remotePort: number;
+      localPort: number;
+    };
   }> => ipcRenderer.invoke("get-connection-config"),
 
   setConnectionConfig: (
-    mode: "local" | "remote",
+    mode: "local" | "remote" | "ssh",
     remoteUrl: string,
     apiKey?: string,
   ): Promise<boolean> =>
     ipcRenderer.invoke("set-connection-config", mode, remoteUrl, apiKey),
 
+  setSshConfig: (
+    host: string,
+    port: number,
+    username: string,
+    keyPath: string,
+    remotePort: number,
+    localPort: number,
+  ): Promise<boolean> =>
+    ipcRenderer.invoke("set-ssh-config", host, port, username, keyPath, remotePort, localPort),
+
   testRemoteConnection: (url: string, apiKey?: string): Promise<boolean> =>
     ipcRenderer.invoke("test-remote-connection", url, apiKey),
+
+  testSshConnection: (
+    host: string,
+    port: number,
+    username: string,
+    keyPath: string,
+    remotePort: number,
+  ): Promise<boolean> =>
+    ipcRenderer.invoke("test-ssh-connection", host, port, username, keyPath, remotePort),
+
+  isSshTunnelActive: (): Promise<boolean> =>
+    ipcRenderer.invoke("is-ssh-tunnel-active"),
+
+  startSshTunnel: (): Promise<boolean> =>
+    ipcRenderer.invoke("start-ssh-tunnel"),
+
+  stopSshTunnel: (): Promise<boolean> =>
+    ipcRenderer.invoke("stop-ssh-tunnel"),
 
   // Chat
   sendMessage: (

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -28,9 +28,18 @@ function App(): React.JSX.Element {
 
     try {
       const conn = await window.hermesAPI.getConnectionConfig();
-      isRemote = conn.mode === "remote";
+      isRemote = conn.mode === "remote" || conn.mode === "ssh";
 
-      if (isRemote && conn.remoteUrl) {
+      if (conn.mode === "ssh" && conn.ssh) {
+        // Start (or ensure) the SSH tunnel, then go straight to main
+        try {
+          await window.hermesAPI.startSshTunnel();
+          next = "main";
+        } catch (tunnelErr) {
+          error = `SSH tunnel failed to start: ${(tunnelErr as Error).message}`;
+          next = "welcome";
+        }
+      } else if (conn.mode === "remote" && conn.remoteUrl) {
         const ok = await window.hermesAPI.testRemoteConnection(
           conn.remoteUrl,
           conn.apiKey,

--- a/src/renderer/src/screens/Chat/Chat.tsx
+++ b/src/renderer/src/screens/Chat/Chat.tsx
@@ -850,7 +850,7 @@ function Chat({
   }, [profile, hermesSessionId, setMessages, messages]);
 
   const visibleMessages = useMemo(
-    () => messages.filter((m) => m.content.trim()),
+    () => messages.filter((m) => (m.content || "").trim()),
     [messages],
   );
 

--- a/src/renderer/src/screens/Layout/Layout.tsx
+++ b/src/renderer/src/screens/Layout/Layout.tsx
@@ -72,12 +72,12 @@ function Layout(): React.JSX.Element {
   const [activeProfile, setActiveProfile] = useState("default");
   // Lazy mount: only render Office after first visit, then keep mounted
   const [officeVisited, setOfficeVisited] = useState(false);
-  // Remote mode — many screens show "not available" instead of empty data
+  // Remote-only mode — SSH tunnel has full access; only pure HTTP remote mode restricts screens
   const [remoteMode, setRemoteMode] = useState(false);
 
   // Re-check remote mode on tab switch (picks up Settings changes)
   useEffect(() => {
-    window.hermesAPI.isRemoteMode().then(setRemoteMode);
+    window.hermesAPI.isRemoteOnlyMode().then(setRemoteMode);
   }, [view]);
 
   // Auto-update state

--- a/src/renderer/src/screens/Settings/Settings.tsx
+++ b/src/renderer/src/screens/Settings/Settings.tsx
@@ -68,7 +68,7 @@ function Settings({ profile }: { profile?: string }): React.JSX.Element {
   const migrationLogRef = useRef<HTMLPreElement>(null);
 
   // Connection mode
-  const [connMode, setConnMode] = useState<"local" | "remote">("local");
+  const [connMode, setConnMode] = useState<"local" | "remote" | "ssh">("local");
   const [connRemoteUrl, setConnRemoteUrl] = useState("");
   const [connApiKey, setConnApiKey] = useState("");
   const [connTesting, setConnTesting] = useState(false);

--- a/src/renderer/src/screens/Settings/Settings.tsx
+++ b/src/renderer/src/screens/Settings/Settings.tsx
@@ -628,6 +628,7 @@ function Settings({ profile }: { profile?: string }): React.JSX.Element {
               />
               <div className="settings-field-hint">
                 Make sure you can run <code style={{ fontFamily: "monospace" }}>ssh {sshUser || "user"}@{sshHost || "host"}</code> without a password prompt.
+                The first connection trusts the host key and stores it in <code style={{ fontFamily: "monospace" }}>~/.ssh/known_hosts</code>; SSH will fail closed if that key changes later.
               </div>
             </div>
             <div className="settings-hermes-actions">

--- a/src/renderer/src/screens/Settings/Settings.tsx
+++ b/src/renderer/src/screens/Settings/Settings.tsx
@@ -508,7 +508,7 @@ function Settings({ profile }: { profile?: string }): React.JSX.Element {
               className={`settings-theme-option ${connMode === "ssh" ? "active" : ""}`}
               onClick={() => setConnMode("ssh")}
             >
-              🔐 SSH Tunnel
+              SSH Tunnel
             </button>
           </div>
           <div className="settings-field-hint">

--- a/src/renderer/src/screens/Settings/Settings.tsx
+++ b/src/renderer/src/screens/Settings/Settings.tsx
@@ -75,6 +75,13 @@ function Settings({ profile }: { profile?: string }): React.JSX.Element {
   const [connStatus, setConnStatus] = useState<string | null>(null);
   const connLoaded = useRef(false);
 
+  // SSH connection state
+  const [sshHost, setSshHost] = useState("");
+  const [sshPort, setSshPort] = useState("");
+  const [sshUser, setSshUser] = useState("");
+  const [sshKeyPath, setSshKeyPath] = useState("");
+  const [sshRemotePort, setSshRemotePort] = useState("");
+
   // Backup / Import state
   const [backingUp, setBackingUp] = useState(false);
   const [backupResult, setBackupResult] = useState<string | null>(null);
@@ -108,6 +115,11 @@ function Settings({ profile }: { profile?: string }): React.JSX.Element {
     setConnMode(conn.mode);
     setConnRemoteUrl(conn.remoteUrl);
     setConnApiKey(conn.apiKey);
+    setSshHost(conn.ssh?.host || "");
+    setSshPort(conn.ssh?.port ? String(conn.ssh.port) : "");
+    setSshUser(conn.ssh?.username || "");
+    setSshKeyPath(conn.ssh?.keyPath || "");
+    setSshRemotePort(conn.ssh?.remotePort ? String(conn.ssh.remotePort) : "");
     connLoaded.current = true;
 
     // Load network settings from config.yaml
@@ -183,29 +195,48 @@ function Settings({ profile }: { profile?: string }): React.JSX.Element {
   }
 
   async function handleSaveConnection(): Promise<void> {
-    await window.hermesAPI.setConnectionConfig(
-      connMode,
-      connRemoteUrl,
-      connApiKey,
-    );
+    if (connMode === "ssh") {
+      await window.hermesAPI.setSshConfig(
+        sshHost.trim(),
+        parseInt(sshPort, 10) || 22,
+        sshUser.trim(),
+        sshKeyPath.trim(),
+        parseInt(sshRemotePort, 10) || 8642,
+        18642,
+      );
+    } else {
+      await window.hermesAPI.setConnectionConfig(connMode, connRemoteUrl, connApiKey);
+    }
     setConnStatus("Saved");
     setTimeout(() => setConnStatus(null), 2000);
   }
 
   async function handleTestConnection(): Promise<void> {
-    const url = connRemoteUrl.trim();
-    if (!url) {
-      setConnStatus("Please enter a URL");
-      return;
+    if (connMode === "ssh") {
+      if (!sshHost.trim() || !sshUser.trim()) {
+        setConnStatus("Host and username are required");
+        return;
+      }
+      setConnTesting(true);
+      setConnStatus(null);
+      const ok = await window.hermesAPI.testSshConnection(
+        sshHost.trim(),
+        parseInt(sshPort, 10) || 22,
+        sshUser.trim(),
+        sshKeyPath.trim(),
+        parseInt(sshRemotePort, 10) || 8642,
+      );
+      setConnTesting(false);
+      setConnStatus(ok ? "SSH tunnel connected!" : "Could not connect via SSH");
+    } else {
+      const url = connRemoteUrl.trim();
+      if (!url) { setConnStatus("Please enter a URL"); return; }
+      setConnTesting(true);
+      setConnStatus(null);
+      const ok = await window.hermesAPI.testRemoteConnection(url, connApiKey.trim());
+      setConnTesting(false);
+      setConnStatus(ok ? "Connected successfully!" : "Could not reach server");
     }
-    setConnTesting(true);
-    setConnStatus(null);
-    const ok = await window.hermesAPI.testRemoteConnection(
-      url,
-      connApiKey.trim(),
-    );
-    setConnTesting(false);
-    setConnStatus(ok ? "Connected successfully!" : "Could not reach server");
   }
 
   async function handleSwitchToLocal(): Promise<void> {
@@ -473,10 +504,18 @@ function Settings({ profile }: { profile?: string }): React.JSX.Element {
             >
               {t("settings.modeRemote")}
             </button>
+            <button
+              className={`settings-theme-option ${connMode === "ssh" ? "active" : ""}`}
+              onClick={() => setConnMode("ssh")}
+            >
+              🔐 SSH Tunnel
+            </button>
           </div>
           <div className="settings-field-hint">
             {connMode === "local"
               ? t("settings.modeLocalHint")
+              : connMode === "ssh"
+              ? "Tunnel to a remote Hermes over SSH — no exposed ports or API keys needed."
               : t("settings.modeRemoteHint")}
           </div>
         </div>
@@ -521,14 +560,85 @@ function Settings({ profile }: { profile?: string }): React.JSX.Element {
                 onClick={handleTestConnection}
                 disabled={connTesting}
               >
-                {connTesting
-                  ? t("settings.testingConnection")
-                  : t("settings.testConnection")}
+                {connTesting ? t("settings.testingConnection") : t("settings.testConnection")}
               </button>
+              <button className="btn btn-primary" onClick={handleSaveConnection}>
+                {t("settings.save")}
+              </button>
+            </div>
+          </>
+        )}
+
+        {connMode === "ssh" && (
+          <>
+            <div className="settings-field">
+              <label className="settings-field-label">SSH Host</label>
+              <input
+                className="input"
+                type="text"
+                value={sshHost}
+                onChange={(e) => setSshHost(e.target.value)}
+                placeholder="192.168.1.100 or myserver.local"
+              />
+            </div>
+            <div className="settings-field">
+              <label className="settings-field-label">SSH Port</label>
+              <input
+                className="input"
+                type="number"
+                value={sshPort}
+                onChange={(e) => setSshPort(e.target.value)}
+                placeholder="22"
+              />
+            </div>
+            <div className="settings-field">
+              <label className="settings-field-label">Username</label>
+              <input
+                className="input"
+                type="text"
+                value={sshUser}
+                onChange={(e) => setSshUser(e.target.value)}
+                placeholder="hermes"
+              />
+            </div>
+            <div className="settings-field">
+              <label className="settings-field-label">
+                Private Key Path{" "}
+                <span style={{ fontWeight: 400, opacity: 0.6 }}>(optional, defaults to ~/.ssh/id_rsa)</span>
+              </label>
+              <input
+                className="input"
+                type="text"
+                value={sshKeyPath}
+                onChange={(e) => setSshKeyPath(e.target.value)}
+                placeholder="~/.ssh/id_rsa"
+              />
+            </div>
+            <div className="settings-field">
+              <label className="settings-field-label">
+                Remote Hermes Port{" "}
+                <span style={{ fontWeight: 400, opacity: 0.6 }}>(default 8642)</span>
+              </label>
+              <input
+                className="input"
+                type="number"
+                value={sshRemotePort}
+                onChange={(e) => setSshRemotePort(e.target.value)}
+                placeholder="8642"
+              />
+              <div className="settings-field-hint">
+                Make sure you can run <code style={{ fontFamily: "monospace" }}>ssh {sshUser || "user"}@{sshHost || "host"}</code> without a password prompt.
+              </div>
+            </div>
+            <div className="settings-hermes-actions">
               <button
-                className="btn btn-primary"
-                onClick={handleSaveConnection}
+                className="btn btn-secondary"
+                onClick={handleTestConnection}
+                disabled={connTesting}
               >
+                {connTesting ? "Testing SSH…" : "Test SSH Connection"}
+              </button>
+              <button className="btn btn-primary" onClick={handleSaveConnection}>
                 {t("settings.save")}
               </button>
             </div>

--- a/src/renderer/src/screens/Welcome/Welcome.tsx
+++ b/src/renderer/src/screens/Welcome/Welcome.tsx
@@ -34,10 +34,10 @@ function Welcome({
 
   // SSH state
   const [sshHost, setSshHost] = useState("");
-  const [sshPort, setSshPort] = useState("22");
+  const [sshPort, setSshPort] = useState("");
   const [sshUser, setSshUser] = useState("");
   const [sshKeyPath, setSshKeyPath] = useState("");
-  const [sshRemotePort, setSshRemotePort] = useState("8642");
+  const [sshRemotePort, setSshRemotePort] = useState("");
   const [sshError, setSshError] = useState<string | null>(null);
   const [sshTesting, setSshTesting] = useState(false);
 

--- a/src/renderer/src/screens/Welcome/Welcome.tsx
+++ b/src/renderer/src/screens/Welcome/Welcome.tsx
@@ -16,26 +16,36 @@ interface WelcomeProps {
   onRecheck: () => void;
 }
 
+type ConnectionPanel = "none" | "remote" | "ssh";
+
 function Welcome({
   error,
   onStart,
   onRecheck,
 }: WelcomeProps): React.JSX.Element {
   const { t } = useI18n();
-  const [showRemote, setShowRemote] = useState(false);
+  const [panel, setPanel] = useState<ConnectionPanel>("none");
+
+  // Remote state
   const [remoteUrl, setRemoteUrl] = useState("");
   const [remoteApiKey, setRemoteApiKey] = useState("");
-  const [testing, setTesting] = useState(false);
   const [remoteError, setRemoteError] = useState<string | null>(null);
+  const [remoteTesting, setRemoteTesting] = useState(false);
+
+  // SSH state
+  const [sshHost, setSshHost] = useState("");
+  const [sshPort, setSshPort] = useState("22");
+  const [sshUser, setSshUser] = useState("");
+  const [sshKeyPath, setSshKeyPath] = useState("");
+  const [sshRemotePort, setSshRemotePort] = useState("8642");
+  const [sshError, setSshError] = useState<string | null>(null);
+  const [sshTesting, setSshTesting] = useState(false);
 
   async function handleConnectRemote(): Promise<void> {
     const url = remoteUrl.trim();
     const key = remoteApiKey.trim();
-    if (!url) {
-      setRemoteError("Please enter a URL.");
-      return;
-    }
-    setTesting(true);
+    if (!url) { setRemoteError("Please enter a URL."); return; }
+    setRemoteTesting(true);
     setRemoteError(null);
     try {
       const ok = await window.hermesAPI.testRemoteConnection(url, key);
@@ -44,17 +54,42 @@ function Welcome({
         onRecheck();
       } else {
         setRemoteError(
-          "Could not reach Hermes at this URL. Check the URL and API key.",
+          "Could not reach Hermes at this URL. Check the URL and API key.\n\nLeave the key empty if the server accepts unauthenticated requests (e.g. via SSH tunnel to localhost).",
         );
       }
     } catch {
       setRemoteError("Connection test failed.");
     } finally {
-      setTesting(false);
+      setRemoteTesting(false);
     }
   }
 
-  if (showRemote) {
+  async function handleConnectSsh(): Promise<void> {
+    const host = sshHost.trim();
+    const user = sshUser.trim();
+    if (!host || !user) { setSshError("Host and username are required."); return; }
+    const port = parseInt(sshPort, 10) || 22;
+    const remotePort = parseInt(sshRemotePort, 10) || 8642;
+    setSshTesting(true);
+    setSshError(null);
+    try {
+      const ok = await window.hermesAPI.testSshConnection(host, port, user, sshKeyPath.trim(), remotePort);
+      if (ok) {
+        await window.hermesAPI.setSshConfig(host, port, user, sshKeyPath.trim(), remotePort, 18642);
+        onRecheck();
+      } else {
+        setSshError(
+          "Could not connect via SSH or reach Hermes on the remote. Make sure:\n• SSH key is correct (or default ~/.ssh/id_rsa works)\n• Hermes gateway is running on the remote\n• The remote port is correct (default 8642)",
+        );
+      }
+    } catch (e) {
+      setSshError("SSH connection test failed: " + (e as Error).message);
+    } finally {
+      setSshTesting(false);
+    }
+  }
+
+  if (panel === "remote") {
     return (
       <div className="screen welcome-screen">
         <HermesLogo size={36} />
@@ -75,16 +110,11 @@ function Welcome({
             placeholder="http://192.168.1.100:8642"
             value={remoteUrl}
             onChange={(e) => setRemoteUrl(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") handleConnectRemote();
-            }}
+            onKeyDown={(e) => { if (e.key === "Enter") handleConnectRemote(); }}
             autoFocus
           />
 
-          <label
-            className="welcome-remote-label"
-            style={{ marginTop: 12 }}
-          >
+          <label className="welcome-remote-label" style={{ marginTop: 12 }}>
             {t("welcome.remoteApiKey")}
           </label>
           <input
@@ -93,37 +123,138 @@ function Welcome({
             placeholder={t("welcome.remoteApiKeyPlaceholder")}
             value={remoteApiKey}
             onChange={(e) => setRemoteApiKey(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") handleConnectRemote();
-            }}
+            onKeyDown={(e) => { if (e.key === "Enter") handleConnectRemote(); }}
           />
 
           <div className="welcome-remote-row" style={{ marginTop: 12 }}>
             <button
               className="btn btn-primary"
               onClick={handleConnectRemote}
-              disabled={testing}
+              disabled={remoteTesting}
               style={{ whiteSpace: "nowrap", width: "100%" }}
             >
-              {testing ? (
-                <>
-                  {t("welcome.testingConnection")}
-                  <Spinner size={14} className="animate-spin" />
-                </>
+              {remoteTesting ? (
+                <>{t("welcome.testingConnection")}<Spinner size={14} className="animate-spin" /></>
               ) : (
                 t("welcome.connect")
               )}
             </button>
           </div>
-          {remoteError && <p className="welcome-remote-error">{remoteError}</p>}
+          {remoteError && <p className="welcome-remote-error" style={{ whiteSpace: "pre-line" }}>{remoteError}</p>}
+          <p className="welcome-remote-hint">{t("welcome.remoteHint")}</p>
+        </div>
+
+        <button
+          className="btn-ghost"
+          onClick={() => setPanel("none")}
+          style={{ marginTop: 8, fontSize: 13, color: "var(--text-muted)" }}
+        >
+          {t("common.back")}
+        </button>
+      </div>
+    );
+  }
+
+  if (panel === "ssh") {
+    return (
+      <div className="screen welcome-screen">
+        <HermesLogo size={36} />
+        <h1 className="welcome-title" style={{ fontSize: 22 }}>
+          Connect via SSH
+        </h1>
+        <p className="welcome-subtitle" style={{ marginBottom: 24 }}>
+          Tunnel to a remote Hermes over SSH — no exposed ports or API keys needed.
+        </p>
+
+        <div className="welcome-remote-card">
+          <div style={{ display: "flex", gap: 8 }}>
+            <div style={{ flex: 3 }}>
+              <label className="welcome-remote-label">SSH Host</label>
+              <input
+                type="text"
+                className="welcome-remote-input"
+                placeholder="192.168.1.100 or myserver.local"
+                value={sshHost}
+                onChange={(e) => setSshHost(e.target.value)}
+                autoFocus
+              />
+            </div>
+            <div style={{ flex: 1 }}>
+              <label className="welcome-remote-label">SSH Port</label>
+              <input
+                type="number"
+                className="welcome-remote-input"
+                placeholder="22"
+                value={sshPort}
+                onChange={(e) => setSshPort(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <label className="welcome-remote-label" style={{ marginTop: 12 }}>Username</label>
+          <input
+            type="text"
+            className="welcome-remote-input"
+            placeholder="hermes"
+            value={sshUser}
+            onChange={(e) => setSshUser(e.target.value)}
+          />
+
+          <label className="welcome-remote-label" style={{ marginTop: 12 }}>
+            Private Key Path <span style={{ fontWeight: 400, opacity: 0.6 }}>(optional — defaults to ~/.ssh/id_rsa)</span>
+          </label>
+          <input
+            type="text"
+            className="welcome-remote-input"
+            placeholder="~/.ssh/id_rsa"
+            value={sshKeyPath}
+            onChange={(e) => setSshKeyPath(e.target.value)}
+          />
+
+          <label className="welcome-remote-label" style={{ marginTop: 12 }}>
+            Remote Hermes Port <span style={{ fontWeight: 400, opacity: 0.6 }}>(default 8642)</span>
+          </label>
+          <input
+            type="number"
+            className="welcome-remote-input"
+            placeholder="8642"
+            value={sshRemotePort}
+            onChange={(e) => setSshRemotePort(e.target.value)}
+          />
+
+          <div className="welcome-remote-row" style={{ marginTop: 16 }}>
+            <button
+              className="btn btn-primary"
+              onClick={handleConnectSsh}
+              disabled={sshTesting || !sshHost.trim() || !sshUser.trim()}
+              style={{ whiteSpace: "nowrap", width: "100%" }}
+            >
+              {sshTesting ? (
+                <>Testing SSH connection…<Spinner size={14} className="animate-spin" /></>
+              ) : (
+                <>Connect via SSH<ArrowRight size={16} /></>
+              )}
+            </button>
+          </div>
+
+          {sshError && (
+            <p className="welcome-remote-error" style={{ whiteSpace: "pre-line" }}>
+              {sshError}
+            </p>
+          )}
+
           <p className="welcome-remote-hint">
-            {t("welcome.remoteHint")}
+            Uses your system SSH. Make sure you can already run{" "}
+            <code style={{ fontFamily: "monospace", fontSize: 12 }}>
+              ssh {sshUser || "user"}@{sshHost || "host"}
+            </code>{" "}
+            without a password prompt.
           </p>
         </div>
 
         <button
           className="btn-ghost"
-          onClick={() => setShowRemote(false)}
+          onClick={() => setPanel("none")}
           style={{ marginTop: 8, fontSize: 13, color: "var(--text-muted)" }}
         >
           {t("common.back")}
@@ -142,22 +273,15 @@ function Welcome({
           <p className="welcome-subtitle">{error}</p>
 
           <div className="welcome-actions">
-            <button
-              className="btn btn-primary welcome-button"
-              onClick={onStart}
-            >
+            <button className="btn btn-primary welcome-button" onClick={onStart}>
               {t("welcome.retryInstall")}
               <Refresh size={16} />
             </button>
 
-            <div className="welcome-divider">
-              <span>{t("welcome.dividerOr")}</span>
-            </div>
+            <div className="welcome-divider"><span>{t("welcome.dividerOr")}</span></div>
 
             <div className="welcome-terminal-option">
-              <p className="welcome-terminal-label">
-                {t("welcome.terminalInstallHint")}
-              </p>
+              <p className="welcome-terminal-label">{t("welcome.terminalInstallHint")}</p>
               <div className="welcome-terminal-box">
                 <code>{INSTALL_CMD}</code>
                 <button
@@ -170,21 +294,17 @@ function Welcome({
               </div>
             </div>
 
-            <button
-              className="btn btn-secondary welcome-recheck-btn"
-              onClick={onRecheck}
-            >
+            <button className="btn btn-secondary welcome-recheck-btn" onClick={onRecheck}>
               {t("welcome.recheck")}
             </button>
 
-            <div className="welcome-divider">
-              <span>or</span>
-            </div>
+            <div className="welcome-divider"><span>or</span></div>
 
-            <button
-              className="btn btn-secondary welcome-recheck-btn"
-              onClick={() => setShowRemote(true)}
-            >
+            <button className="btn btn-secondary welcome-recheck-btn" onClick={() => setPanel("ssh")}>
+              🔐 Connect via SSH
+            </button>
+
+            <button className="btn btn-secondary welcome-recheck-btn" onClick={() => setPanel("remote")}>
               <Globe size={16} />
               Connect to Remote Hermes
             </button>
@@ -200,14 +320,13 @@ function Welcome({
           </button>
           <p className="welcome-note">{t("welcome.installSizeHint")}</p>
 
-          <div className="welcome-divider">
-            <span>{t("welcome.dividerOr")}</span>
-          </div>
+          <div className="welcome-divider"><span>{t("welcome.dividerOr")}</span></div>
 
-          <button
-            className="btn btn-secondary welcome-recheck-btn"
-            onClick={() => setShowRemote(true)}
-          >
+          <button className="btn btn-secondary welcome-recheck-btn" onClick={() => setPanel("ssh")}>
+            🔐 Connect via SSH
+          </button>
+
+          <button className="btn btn-secondary welcome-recheck-btn" onClick={() => setPanel("remote")}>
             <Globe size={16} />
             {t("welcome.connectRemote")}
           </button>

--- a/tests/ssh-remote.test.ts
+++ b/tests/ssh-remote.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { sshSetConfigValue } from "../src/main/ssh-remote";
+import type { SshConfig } from "../src/main/ssh-tunnel";
+
+const sshConfig: SshConfig = {
+  host: "example.test",
+  port: 22,
+  username: "hermes",
+  keyPath: "",
+  remotePort: 8642,
+  localPort: 18642,
+};
+
+describe("ssh remote config writes", () => {
+  it.each([
+    ["quote", 'bad"value'],
+    ["backslash", "bad\\value"],
+    ["newline", "bad\nvalue"],
+    ["carriage return", "bad\rvalue"],
+  ])("rejects YAML-breaking %s values before remote writes", async (_name, value) => {
+    await expect(
+      sshSetConfigValue(sshConfig, "base_url", value),
+    ).rejects.toThrow("Config value contains illegal characters");
+  });
+});


### PR DESCRIPTION
## Overview

This PR adds a third connection mode to hermes-desktop: **SSH Tunnel**. Instead of requiring a publicly exposed HTTP server or API key, the app tunnels all traffic through SSH to the remote host — no open ports, no credentials to manage.

## What's new

### SSH Tunnel mode
- A distinct **SSH Tunnel** option appears on both the Welcome (onboarding) screen and the Settings screen
- All fields start blank (no prefill) so it works out of the box for any user
- The app establishes a local SSH port-forward on connect, then routes all API traffic through `localhost`
- On startup, if SSH mode is saved, the tunnel is re-established automatically

### Full feature parity with local mode
All screens that work locally now work over SSH:

| Feature | How it works |
|---|---|
| **Chat** | API calls go through SSH tunnel; Bearer token is read from remote `~/.hermes/.env` automatically |
| **Sessions** | Queries remote `state.db` via SSH + Python |
| **Memory / Persona** | Reads/writes `MEMORY.md`, `USER.md`, `SOUL.md` on remote via SSH |
| **Skills** | Lists, installs, uninstalls skills on remote via SSH |
| **Tools / Toolsets** | Reads/writes remote `config.yaml` |
| **Providers / Env** | Reads/writes remote `~/.hermes/.env` |
| **Gateway** | Start/stop gateway on remote; platform status from live `gateway_state.json` |
| **Profiles** | Lists, creates, deletes profiles on remote |
| **Logs** | Tails remote log files via SSH |
| **Versions** | Runs `hermes --version` on remote |
| **Doctor** | Runs `hermes doctor` on remote |
| **Models** | Reads remote `models.json` |

### Files added
- `src/main/ssh-tunnel.ts` — SSH tunnel lifecycle (start, stop, test, status)
- `src/main/ssh-remote.ts` — All SSH-proxied feature implementations

### Files modified
- `src/main/config.ts` — `SshConnectionConfig` interface; mode extended to `"local" | "remote" | "ssh"`
- `src/main/hermes.ts` — `isRemoteOnlyMode()`, SSH auth header with cached remote API key
- `src/main/index.ts` — All IPC handlers updated to proxy through SSH when in SSH mode
- `src/preload/index.ts` + `index.d.ts` — New IPC methods exposed to renderer
- `src/renderer/src/screens/Welcome/Welcome.tsx` — SSH as third panel with blank fields
- `src/renderer/src/screens/Settings/Settings.tsx` — SSH button + form
- `src/renderer/src/screens/Layout/Layout.tsx` — Uses `isRemoteOnlyMode()` so SSH shows all screens
- `src/renderer/src/App.tsx` — Handles SSH mode on startup

## Implementation notes

- Uses the system `ssh` binary — no Node.js SSH library dependency
- `sshExec()` runs shell commands; `sshPython()` pipes Python scripts via stdin — avoids shell escaping issues for complex data operations
- `~` does not expand inside double-quoted bash strings; all paths use `$HOME/` instead
- Gateway platform state is read from `gateway_state.json` (live) rather than `config.yaml` (static)
- `HOMEASSISTANT_URL`/`HOMEASSISTANT_TOKEN` are aliased to `HA_URL`/`HA_TOKEN` so credentials display correctly regardless of which env var name the server uses