### PR TITLE
feat(desktop): wire Sessions tab for remote mode

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -71,6 +71,11 @@ import {
 } from "./config";
 import { listSessions, getSessionMessages, searchSessions } from "./sessions";
 import {
+  listSessionsRemote,
+  getSessionMessagesRemote,
+  searchSessionsRemote,
+} from "./sessions-remote";
+import {
   syncSessionCache,
   listCachedSessions,
   updateSessionTitle,
@@ -434,10 +439,12 @@ function setupIPC(): void {
 
   // Sessions
   ipcMain.handle("list-sessions", (_event, limit?: number, offset?: number) => {
+    if (isRemoteMode()) return listSessionsRemote(limit, offset);
     return listSessions(limit, offset);
   });
 
   ipcMain.handle("get-session-messages", (_event, sessionId: string) => {
+    if (isRemoteMode()) return getSessionMessagesRemote(sessionId);
     return getSessionMessages(sessionId);
   });
 
@@ -531,7 +538,7 @@ function setupIPC(): void {
 
   // Session search
   ipcMain.handle("search-sessions", (_event, query: string, limit?: number) =>
-    searchSessions(query, limit),
+    isRemoteMode() ? searchSessionsRemote(query, limit) : searchSessions(query, limit),
   );
 
   // Credential Pool

--- a/src/main/sessions-remote.ts
+++ b/src/main/sessions-remote.ts
@@ -1,0 +1,89 @@
+import { getApiUrl, getRemoteAuthHeader } from "./hermes";
+import type { SessionSummary, SessionMessage, SearchResult } from "./sessions";
+
+/**
+ * Fetch all sessions from the remote API server.
+ * Returns an empty array on network errors or non-OK responses.
+ */
+export async function listSessionsRemote(
+  limit = 30,
+  offset = 0,
+): Promise<SessionSummary[]> {
+  try {
+    const base = getApiUrl();
+    const headers = getRemoteAuthHeader();
+    headers["Accept"] = "application/json";
+    const url = `${base}/api/sessions?limit=${limit}&offset=${offset}`;
+    const res = await fetch(url, { headers });
+    if (!res.ok) return [];
+    const data = (await res.json()) as Array<Record<string, unknown>>;
+    return data.map((r) => ({
+      id: String(r.id ?? ""),
+      source: String(r.source ?? ""),
+      startedAt: Number(r.started_at ?? r.startedAt ?? 0),
+      endedAt: r.ended_at != null ? Number(r.ended_at) : null,
+      messageCount: Number(r.message_count ?? r.messageCount ?? 0),
+      model: String(r.model ?? ""),
+      title: r.title != null ? String(r.title) : null,
+      preview: String(r.preview ?? ""),
+    }));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Search sessions via the remote API server.
+ * Returns an empty array on network errors or non-OK responses.
+ */
+export async function searchSessionsRemote(
+  query: string,
+  limit = 20,
+): Promise<SearchResult[]> {
+  try {
+    const base = getApiUrl();
+    const headers = getRemoteAuthHeader();
+    headers["Accept"] = "application/json";
+    const url = `${base}/api/sessions/search?q=${encodeURIComponent(query)}&limit=${limit}`;
+    const res = await fetch(url, { headers });
+    if (!res.ok) return [];
+    const data = (await res.json()) as Array<Record<string, unknown>>;
+    return data.map((r) => ({
+      sessionId: String(r.session_id ?? r.id ?? ""),
+      title: r.title != null ? String(r.title) : null,
+      startedAt: Number(r.started_at ?? r.startedAt ?? 0),
+      source: String(r.source ?? ""),
+      messageCount: Number(r.message_count ?? r.messageCount ?? 0),
+      model: String(r.model ?? ""),
+      snippet: String(r.snippet ?? ""),
+    }));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Fetch messages for a specific session from the remote API server.
+ * Returns an empty array on network errors or non-OK responses.
+ */
+export async function getSessionMessagesRemote(
+  sessionId: string,
+): Promise<SessionMessage[]> {
+  try {
+    const base = getApiUrl();
+    const headers = getRemoteAuthHeader();
+    headers["Accept"] = "application/json";
+    const url = `${base}/api/sessions/${encodeURIComponent(sessionId)}/messages`;
+    const res = await fetch(url, { headers });
+    if (!res.ok) return [];
+    const data = (await res.json()) as Array<Record<string, unknown>>;
+    return data.map((r) => ({
+      id: Number(r.id ?? 0),
+      role: (String(r.role ?? "user")) as "user" | "assistant" | "tool",
+      content: String(r.content ?? ""),
+      timestamp: Number(r.timestamp ?? 0),
+    }));
+  } catch {
+    return [];
+  }
+}

--- a/src/renderer/src/screens/Layout/Layout.tsx
+++ b/src/renderer/src/screens/Layout/Layout.tsx
@@ -221,16 +221,13 @@ function Layout(): React.JSX.Element {
             onNewChat={handleNewChat}
           />
         </div>
-        {view === "sessions" &&
-          (remoteMode ? (
-            <RemoteNotice feature="Sessions" />
-          ) : (
-            <Sessions
-              onResumeSession={handleResumeSession}
-              onNewChat={handleNewChat}
-              currentSessionId={currentSessionId}
-            />
-          ))}
+        {view === "sessions" && (
+          <Sessions
+            onResumeSession={handleResumeSession}
+            onNewChat={handleNewChat}
+            currentSessionId={currentSessionId}
+          />
+        )}
         {view === "agents" &&
           (remoteMode ? (
             <RemoteNotice feature="Profiles" />


### PR DESCRIPTION
### Summary

Wire the Sessions tab to work in remote mode by adding an HTTP client that fetches from the backend API, modifying IPC handlers to branch on `isRemoteMode()`, and removing the `RemoteNotice` gate for Sessions.

### Changes

1. **`src/main/sessions-remote.ts`** (NEW) — HTTP client that mirrors `sessions.ts` types but uses `fetch()` against the remote API server
2. **`src/main/index.ts`** — IPC handlers (`list-sessions`, `get-session-messages`, `search-sessions`) now branch on `isRemoteMode()`
3. **`Layout.tsx`** — Removed `<RemoteNotice feature="Sessions" />` so Sessions renders in both modes