### PR TITLE
fix(office): allow vertical scroll on ready state

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -4330,7 +4330,7 @@ body {
   display: flex;
   flex-direction: column;
   height: 100%;
-  overflow: hidden;
+  overflow-y: auto;
 }
 
 .office-toolbar {


### PR DESCRIPTION
The Office page's "ready" state container uses `overflow: hidden`, which blocks scrolling when content exceeds the viewport. Users can't reach the "Run locally" section or anything below the fold.

One-line fix: changed `.office-ready` from `overflow: hidden` to `overflow-y: auto`, matching the pattern used by Settings, Tools, and Schedules containers.

The reporter also noted low-contrast text (dark gray on charcoal). That's a theme-level issue with `--text-muted: #8e8e8e` on dark backgrounds (~3.7:1 ratio, below WCAG AA 4.5:1) — affects the whole app, not just Office. Separate issue if worth addressing.

Fixes #72
