### PR TITLE
fix: detect Hermes auth credentials during setup

### DIFF
--- a/src/main/installer.ts
+++ b/src/main/installer.ts
@@ -15,6 +15,7 @@ export const HERMES_PYTHON = join(HERMES_VENV, "bin", "python");
 export const HERMES_SCRIPT = join(HERMES_REPO, "hermes");
 export const HERMES_ENV_FILE = join(HERMES_HOME, ".env");
 export const HERMES_CONFIG_FILE = join(HERMES_HOME, "config.yaml");
+export const HERMES_AUTH_FILE = join(HERMES_HOME, "auth.json");
 
 export interface InstallStatus {
   installed: boolean;
@@ -80,6 +81,23 @@ function resolveNvmBin(home: string): string[] {
   return [];
 }
 
+export function hasHermesAuthCredential(provider: string): boolean {
+  if (!provider || !existsSync(HERMES_AUTH_FILE)) return false;
+  try {
+    const auth = JSON.parse(readFileSync(HERMES_AUTH_FILE, "utf-8")) as {
+      active_provider?: string;
+      credential_pool?: Record<string, unknown[]>;
+      providers?: Record<string, unknown>;
+    };
+    const pool = auth.credential_pool?.[provider];
+    if (Array.isArray(pool) && pool.length > 0) return true;
+    if (auth.active_provider === provider) return true;
+    return Boolean(auth.providers?.[provider]);
+  } catch {
+    return false;
+  }
+}
+
 export function checkInstallStatus(): InstallStatus {
   // Remote mode: skip local checks entirely
   const conn = getConnectionConfig();
@@ -101,11 +119,15 @@ export function checkInstallStatus(): InstallStatus {
   let hasApiKey = false;
   const verified = installed;
 
-  // Local/custom providers don't need an API key
+  // Local/custom providers don't need an API key. OAuth-backed providers
+  // can be configured through Hermes auth.json instead of .env.
   try {
     const mc = getModelConfig();
     const localProviders = ["custom", "lmstudio", "ollama", "vllm", "llamacpp"];
-    if (localProviders.includes(mc.provider)) {
+    if (
+      localProviders.includes(mc.provider) ||
+      hasHermesAuthCredential(mc.provider)
+    ) {
       hasApiKey = true;
     }
   } catch {

--- a/tests/installer-utils.test.ts
+++ b/tests/installer-utils.test.ts
@@ -201,6 +201,62 @@ describe("Memory provider discovery", () => {
   });
 });
 
+// ─── Hermes auth credential discovery ─────────────────
+
+describe("Hermes auth credential discovery", () => {
+  async function importInstallerWithHome(
+    home: string,
+  ): Promise<typeof import("../src/main/installer")> {
+    vi.resetModules();
+    process.env.HERMES_HOME = home;
+    return await import("../src/main/installer");
+  }
+
+  afterEach(() => {
+    delete process.env.HERMES_HOME;
+    vi.resetModules();
+  });
+
+  it("detects OAuth credentials stored in auth.json credential_pool", async () => {
+    writeFileSync(
+      join(TEST_DIR, "auth.json"),
+      JSON.stringify({ credential_pool: { "openai-codex": [{ id: "acct" }] } }),
+    );
+
+    const { HERMES_AUTH_FILE, hasHermesAuthCredential } =
+      await importInstallerWithHome(TEST_DIR);
+
+    expect(HERMES_AUTH_FILE).toBe(join(TEST_DIR, "auth.json"));
+    expect(hasHermesAuthCredential("openai-codex")).toBe(true);
+    expect(hasHermesAuthCredential("anthropic")).toBe(false);
+  });
+
+  it("accepts active_provider and providers entries as configured credentials", async () => {
+    writeFileSync(
+      join(TEST_DIR, "auth.json"),
+      JSON.stringify({
+        active_provider: "openrouter",
+        providers: { anthropic: {} },
+      }),
+    );
+
+    const { hasHermesAuthCredential } = await importInstallerWithHome(TEST_DIR);
+
+    expect(hasHermesAuthCredential("openrouter")).toBe(true);
+    expect(hasHermesAuthCredential("anthropic")).toBe(true);
+    expect(hasHermesAuthCredential("openai-codex")).toBe(false);
+  });
+
+  it("returns false when auth.json is missing or malformed", async () => {
+    const missing = await importInstallerWithHome(TEST_DIR);
+    expect(missing.hasHermesAuthCredential("openai-codex")).toBe(false);
+
+    writeFileSync(join(TEST_DIR, "auth.json"), "{not-json");
+    const malformed = await importInstallerWithHome(TEST_DIR);
+    expect(malformed.hasHermesAuthCredential("openai-codex")).toBe(false);
+  });
+});
+
 // ─── Backward compatibility checks ─────────────────────
 
 describe("Backward compatibility", () => {


### PR DESCRIPTION
## Summary
- treat usable Hermes auth.json credentials as setup credentials for OAuth-backed providers
- add auth.json detection covering credential_pool, active_provider, and providers entries
- add tests for missing, malformed, and provider-specific auth.json handling

## Test Plan
- npm run typecheck
- npm test

Note: npm run lint currently fails on pre-existing repository lint issues unrelated to this change.