### PR TITLE
security: validate environment variable writes

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -54,6 +54,7 @@ export function setConnectionConfig(config: ConnectionConfig): void {
 // ── In-memory cache with TTL ─────────────────────────────
 const CACHE_TTL = 5000; // 5 seconds
 const _cache = new Map<string, { data: unknown; ts: number }>();
+const ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 function getCached<T>(key: string): T | undefined {
   const entry = _cache.get(key);
@@ -126,6 +127,8 @@ export function setEnvValue(
   value: string,
   profile?: string,
 ): void {
+  validateEnvEntry(key, value);
+
   const { envFile } = profilePaths(profile);
   invalidateCache(`env:${profile || "default"}`);
 
@@ -152,6 +155,18 @@ export function setEnvValue(
   }
 
   safeWriteFile(envFile, lines.join("\n"));
+}
+
+export function validateEnvEntry(key: string, value: string): void {
+  if (!ENV_KEY_RE.test(key)) {
+    throw new Error(
+      "Invalid environment variable name. Use letters, numbers, and underscores, and do not start with a number.",
+    );
+  }
+
+  if (/[\0\r\n]/.test(value)) {
+    throw new Error("Environment variable values must be single-line strings.");
+  }
 }
 
 export function getConfigValue(key: string, profile?: string): string | null {
@@ -194,7 +209,11 @@ export function getModelConfig(profile?: string): {
   baseUrl: string;
 } {
   const cacheKey = `mc:${profile || "default"}`;
-  const cached = getCached<{ provider: string; model: string; baseUrl: string }>(cacheKey);
+  const cached = getCached<{
+    provider: string;
+    model: string;
+    baseUrl: string;
+  }>(cacheKey);
   if (cached) return cached;
 
   const { configFile } = profilePaths(profile);
@@ -272,7 +291,13 @@ export function getHermesHome(profile?: string): string {
 
 // ── Platform enabled/disabled in config.yaml ────────────
 
-const SUPPORTED_PLATFORMS = ["telegram", "discord", "slack", "whatsapp", "signal"];
+const SUPPORTED_PLATFORMS = [
+  "telegram",
+  "discord",
+  "slack",
+  "whatsapp",
+  "signal",
+];
 
 export function getPlatformEnabled(profile?: string): Record<string, boolean> {
   const { configFile } = profilePaths(profile);

--- a/tests/env-validation.test.ts
+++ b/tests/env-validation.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+let testHome: string;
+
+async function loadConfigModule(): Promise<
+  typeof import("../src/main/config")
+> {
+  vi.resetModules();
+  vi.stubEnv("HERMES_HOME", testHome);
+  return await import("../src/main/config");
+}
+
+function readEnvFile(): string {
+  return readFileSync(join(testHome, ".env"), "utf-8");
+}
+
+describe("environment variable write validation", () => {
+  beforeEach(() => {
+    testHome = mkdtempSync(join(tmpdir(), "hermes-env-validation-"));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    rmSync(testHome, { recursive: true, force: true });
+  });
+
+  it("accepts standard environment variable names and single-line values", async () => {
+    const { readEnv, setEnvValue } = await loadConfigModule();
+
+    setEnvValue("OPENAI_API_KEY", "sk-valid");
+    setEnvValue("_CUSTOM_TOKEN_2", "token=value=with=equals");
+
+    expect(readEnv()).toEqual({
+      OPENAI_API_KEY: "sk-valid",
+      _CUSTOM_TOKEN_2: "token=value=with=equals",
+    });
+    expect(readEnvFile()).toContain("OPENAI_API_KEY=sk-valid");
+  });
+
+  it("rejects malformed environment variable names", async () => {
+    const { setEnvValue } = await loadConfigModule();
+
+    expect(() => setEnvValue("1TOKEN", "value")).toThrow(
+      /Invalid environment variable name/,
+    );
+    expect(() => setEnvValue("BAD-KEY", "value")).toThrow(
+      /Invalid environment variable name/,
+    );
+    expect(() => setEnvValue("KEY\nINJECTED", "value")).toThrow(
+      /Invalid environment variable name/,
+    );
+    expect(existsSync(join(testHome, ".env"))).toBe(false);
+  });
+
+  it("rejects newline and NUL characters before rewriting .env", async () => {
+    const { setEnvValue } = await loadConfigModule();
+
+    setEnvValue("SAFE_KEY", "original");
+
+    expect(() => setEnvValue("SAFE_KEY", "next\nINJECTED=value")).toThrow(
+      /single-line/,
+    );
+    expect(() => setEnvValue("SAFE_KEY", "next\rINJECTED=value")).toThrow(
+      /single-line/,
+    );
+    expect(() => setEnvValue("SAFE_KEY", "next\0INJECTED=value")).toThrow(
+      /single-line/,
+    );
+
+    expect(readEnvFile()).toBe("SAFE_KEY=original\n");
+  });
+});


### PR DESCRIPTION
Reject malformed environment variable names before writing profile .env files. Only conventional env identifiers are accepted: letters, numbers, and underscores, with a non-numeric first character.

Reject newline, carriage return, and NUL characters in env values so a renderer-originated set-env call cannot inject additional .env entries or corrupt the file format.

Keep existing valid values compatible, including values that contain equals signs, and validate before any file rewrite so rejected updates leave the existing .env unchanged.

Adds regression coverage for valid env writes, malformed names, newline injection, carriage-return injection, and NUL injection.

Verified with: npm test -- env-validation.test.ts ipc-handlers.test.ts constants.test.ts; npx eslint src/main/config.ts tests/env-validation.test.ts; npm run typecheck; npm run build; npx vitest run --testTimeout 60000.