### PR TITLE
[codex] Use remote API for management views

### DIFF
--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -195,6 +195,9 @@ function sendMessageViaApi(
     "Content-Type": "application/json",
     ...getRemoteAuthHeader(),
   };
+  if (_resumeSessionId) {
+    headers["X-Hermes-Session-Id"] = _resumeSessionId;
+  }
 
   let sessionId = _resumeSessionId || "";
   let hasContent = false;
@@ -226,10 +229,7 @@ function sendMessageViaApi(
       probeUrl,
       {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...getRemoteAuthHeader(),
-        },
+        headers,
       },
       (res) => {
         let raw = "";
@@ -633,7 +633,7 @@ export async function sendMessage(
 
   // Remote mode: always use API, no CLI fallback
   if (isRemoteMode()) {
-    return sendMessageViaApi(message, cb, profile, resumeSessionId);
+    return sendMessageViaApi(message, cb, profile, resumeSessionId, history);
   }
 
   // Check API server availability (cache the result, re-check periodically)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -162,6 +162,31 @@ import {
   sshRunDump,
   sshDiscoverMemoryProviders,
 } from "./ssh-remote";
+import {
+  remoteAddMemoryEntry,
+  remoteCreateProfile,
+  remoteDeleteProfile,
+  remoteGatewayStatus,
+  remoteGetSessionMessages,
+  remoteGetSkillContent,
+  remoteGetToolsets,
+  remoteListCachedSessions,
+  remoteListBundledSkills,
+  remoteListInstalledSkills,
+  remoteListProfiles,
+  remoteListSessions,
+  remoteReadMemory,
+  remoteReadSoul,
+  remoteRemoveMemoryEntry,
+  remoteResetSoul,
+  remoteSearchSessions,
+  remoteSetActiveProfile,
+  remoteSetToolsetEnabled,
+  remoteUnsupported,
+  remoteUpdateMemoryEntry,
+  remoteWriteSoul,
+  remoteWriteUserProfile,
+} from "./remote-api";
 
 process.on("uncaughtException", (err) => {
   console.error("[MAIN UNCAUGHT]", err);
@@ -594,17 +619,20 @@ function setupIPC(): void {
   // Gateway
   ipcMain.handle("start-gateway", async () => {
     const conn = getConnectionConfig();
+    if (conn.mode === "remote") return remoteGatewayStatus();
     if (conn.mode === "ssh" && conn.ssh) { await sshStartGateway(conn.ssh); return true; }
     return startGateway();
   });
   ipcMain.handle("stop-gateway", async () => {
     const conn = getConnectionConfig();
+    if (conn.mode === "remote") return false;
     if (conn.mode === "ssh" && conn.ssh) { await sshStopGateway(conn.ssh); return true; }
     stopGateway(true);
     return true;
   });
   ipcMain.handle("gateway-status", () => {
     const conn = getConnectionConfig();
+    if (conn.mode === "remote") return remoteGatewayStatus();
     if (conn.mode === "ssh" && conn.ssh) return sshGatewayStatus(conn.ssh);
     return isGatewayRunning();
   });
@@ -635,12 +663,14 @@ function setupIPC(): void {
   // Sessions
   ipcMain.handle("list-sessions", (_event, limit?: number, offset?: number) => {
     const conn = getConnectionConfig();
+    if (conn.mode === "remote") return remoteListSessions(limit, offset);
     if (conn.mode === "ssh" && conn.ssh) return sshListSessions(conn.ssh, limit, offset);
     return listSessions(limit, offset);
   });
 
   ipcMain.handle("get-session-messages", (_event, sessionId: string) => {
     const conn = getConnectionConfig();
+    if (conn.mode === "remote") return remoteGetSessionMessages(sessionId);
     if (conn.mode === "ssh" && conn.ssh) return sshGetSessionMessages(conn.ssh, sessionId);
     return getSessionMessages(sessionId);
   });
@@ -648,27 +678,33 @@ function setupIPC(): void {
   // Profiles
   ipcMain.handle("list-profiles", async () => {
     const conn = getConnectionConfig();
+    if (conn.mode === "remote") return remoteListProfiles();
     if (conn.mode === "ssh" && conn.ssh) return sshListProfiles(conn.ssh);
     return listProfiles();
   });
   ipcMain.handle("create-profile", (_event, name: string, clone: boolean) => {
     const conn = getConnectionConfig();
+    if (conn.mode === "remote") return remoteCreateProfile(name, clone);
     if (conn.mode === "ssh" && conn.ssh) return sshCreateProfile(conn.ssh, name, clone);
     return createProfile(name, clone);
   });
   ipcMain.handle("delete-profile", (_event, name: string) => {
     const conn = getConnectionConfig();
+    if (conn.mode === "remote") return remoteDeleteProfile(name);
     if (conn.mode === "ssh" && conn.ssh) return sshDeleteProfile(conn.ssh, name);
     return deleteProfile(name);
   });
   ipcMain.handle("set-active-profile", (_event, name: string) => {
-    if (getConnectionConfig().mode !== "ssh") setActiveProfile(name);
+    const conn = getConnectionConfig();
+    if (conn.mode === "remote") return remoteSetActiveProfile(name);
+    if (conn.mode !== "ssh") setActiveProfile(name);
     return true;
   });
 
   // Memory
   ipcMain.handle("read-memory", (_event, profile?: string) => {
     const conn = getConnectionConfig();
+    if (conn.mode === "remote") return remoteReadMemory(profile);
     if (conn.mode === "ssh" && conn.ssh) return sshReadMemory(conn.ssh, profile);
     return readMemory(profile);
   });
@@ -676,6 +712,7 @@ function setupIPC(): void {
     "add-memory-entry",
     (_event, content: string, profile?: string) => {
       const conn = getConnectionConfig();
+      if (conn.mode === "remote") return remoteAddMemoryEntry(content, profile);
       if (conn.mode === "ssh" && conn.ssh) return sshAddMemoryEntry(conn.ssh, content, profile);
       return addMemoryEntry(content, profile);
     },
@@ -684,6 +721,7 @@ function setupIPC(): void {
     "update-memory-entry",
     (_event, index: number, content: string, profile?: string) => {
       const conn = getConnectionConfig();
+      if (conn.mode === "remote") return remoteUpdateMemoryEntry(index, content, profile);
       if (conn.mode === "ssh" && conn.ssh) return sshUpdateMemoryEntry(conn.ssh, index, content, profile);
       return updateMemoryEntry(index, content, profile);
     },
@@ -692,6 +730,7 @@ function setupIPC(): void {
     "remove-memory-entry",
     (_event, index: number, profile?: string) => {
       const conn = getConnectionConfig();
+      if (conn.mode === "remote") return remoteRemoveMemoryEntry(index, profile);
       if (conn.mode === "ssh" && conn.ssh) return sshRemoveMemoryEntry(conn.ssh, index, profile);
       return removeMemoryEntry(index, profile);
     },
@@ -700,6 +739,7 @@ function setupIPC(): void {
     "write-user-profile",
     (_event, content: string, profile?: string) => {
       const conn = getConnectionConfig();
+      if (conn.mode === "remote") return remoteWriteUserProfile(content, profile);
       if (conn.mode === "ssh" && conn.ssh) return sshWriteUserProfile(conn.ssh, content, profile);
       return writeUserProfile(content, profile);
     },
@@ -708,16 +748,19 @@ function setupIPC(): void {
   // Soul
   ipcMain.handle("read-soul", (_event, profile?: string) => {
     const conn = getConnectionConfig();
+    if (conn.mode === "remote") return remoteReadSoul(profile);
     if (conn.mode === "ssh" && conn.ssh) return sshReadSoul(conn.ssh, profile);
     return readSoul(profile);
   });
   ipcMain.handle("write-soul", (_event, content: string, profile?: string) => {
     const conn = getConnectionConfig();
+    if (conn.mode === "remote") return remoteWriteSoul(content, profile);
     if (conn.mode === "ssh" && conn.ssh) return sshWriteSoul(conn.ssh, content, profile);
     return writeSoul(content, profile);
   });
   ipcMain.handle("reset-soul", (_event, profile?: string) => {
     const conn = getConnectionConfig();
+    if (conn.mode === "remote") return remoteResetSoul(profile);
     if (conn.mode === "ssh" && conn.ssh) return sshResetSoul(conn.ssh, profile);
     return resetSoul(profile);
   });
@@ -725,6 +768,7 @@ function setupIPC(): void {
   // Tools
   ipcMain.handle("get-toolsets", (_event, profile?: string) => {
     const conn = getConnectionConfig();
+    if (conn.mode === "remote") return remoteGetToolsets(profile);
     if (conn.mode === "ssh" && conn.ssh) return sshGetToolsets(conn.ssh, profile);
     return getToolsets(profile);
   });
@@ -732,6 +776,7 @@ function setupIPC(): void {
     "set-toolset-enabled",
     (_event, key: string, enabled: boolean, profile?: string) => {
       const conn = getConnectionConfig();
+      if (conn.mode === "remote") return remoteSetToolsetEnabled(key, enabled, profile);
       if (conn.mode === "ssh" && conn.ssh) return sshSetToolsetEnabled(conn.ssh, key, enabled, profile);
       return setToolsetEnabled(key, enabled, profile);
     },
@@ -740,16 +785,19 @@ function setupIPC(): void {
   // Skills
   ipcMain.handle("list-installed-skills", (_event, profile?: string) => {
     const conn = getConnectionConfig();
+    if (conn.mode === "remote") return remoteListInstalledSkills(profile);
     if (conn.mode === "ssh" && conn.ssh) return sshListInstalledSkills(conn.ssh, profile);
     return listInstalledSkills(profile);
   });
   ipcMain.handle("list-bundled-skills", () => {
     const conn = getConnectionConfig();
+    if (conn.mode === "remote") return remoteListBundledSkills();
     if (conn.mode === "ssh" && conn.ssh) return sshListBundledSkills(conn.ssh);
     return listBundledSkills();
   });
-  ipcMain.handle("get-skill-content", (_event, skillPath: string) => {
+  ipcMain.handle("get-skill-content", (_event, skillPath: string, profile?: string) => {
     const conn = getConnectionConfig();
+    if (conn.mode === "remote") return remoteGetSkillContent(skillPath, profile);
     if (conn.mode === "ssh" && conn.ssh) return sshGetSkillContent(conn.ssh, skillPath);
     return getSkillContent(skillPath);
   });
@@ -757,12 +805,14 @@ function setupIPC(): void {
     "install-skill",
     (_event, identifier: string, _profile?: string) => {
       const conn = getConnectionConfig();
+      if (conn.mode === "remote") return remoteUnsupported("Installing skills");
       if (conn.mode === "ssh" && conn.ssh) return sshInstallSkill(conn.ssh, identifier);
       return installSkill(identifier, _profile);
     },
   );
   ipcMain.handle("uninstall-skill", (_event, name: string, _profile?: string) => {
     const conn = getConnectionConfig();
+    if (conn.mode === "remote") return remoteUnsupported("Uninstalling skills");
     if (conn.mode === "ssh" && conn.ssh) return sshUninstallSkill(conn.ssh, name);
     return uninstallSkill(name, _profile);
   });
@@ -772,12 +822,14 @@ function setupIPC(): void {
     "list-cached-sessions",
     (_event, limit?: number, offset?: number) => {
       const conn = getConnectionConfig();
+      if (conn.mode === "remote") return remoteListCachedSessions(limit, offset);
       if (conn.mode === "ssh" && conn.ssh) return sshListCachedSessions(conn.ssh, limit, offset);
       return listCachedSessions(limit, offset);
     },
   );
   ipcMain.handle("sync-session-cache", () => {
     const conn = getConnectionConfig();
+    if (conn.mode === "remote") return remoteListCachedSessions(50);
     if (conn.mode === "ssh" && conn.ssh) return sshListCachedSessions(conn.ssh, 50);
     return syncSessionCache();
   });
@@ -790,6 +842,7 @@ function setupIPC(): void {
   // Session search
   ipcMain.handle("search-sessions", (_event, query: string, limit?: number) => {
     const conn = getConnectionConfig();
+    if (conn.mode === "remote") return remoteSearchSessions(query, limit);
     if (conn.mode === "ssh" && conn.ssh) return sshSearchSessions(conn.ssh, query, limit);
     return searchSessions(query, limit);
   });

--- a/src/main/remote-api.ts
+++ b/src/main/remote-api.ts
@@ -1,0 +1,353 @@
+import { getApiUrl, getRemoteAuthHeader } from "./hermes";
+import type { MemoryInfo } from "./memory";
+import type { ProfileInfo } from "./profiles";
+import type { CachedSession } from "./session-cache";
+import type { SessionMessage, SessionSummary, SearchResult } from "./sessions";
+import type { InstalledSkill, SkillSearchResult } from "./skills";
+import type { ToolsetInfo } from "./tools";
+
+type JsonRecord = Record<string, unknown>;
+const REMOTE_CONVERSATION_SOURCE = "api_server";
+
+function withProfile(path: string, profile?: string): string {
+  if (!profile) return path;
+  const sep = path.includes("?") ? "&" : "?";
+  return `${path}${sep}profile=${encodeURIComponent(profile)}`;
+}
+
+async function remoteFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  const headers: Record<string, string> = {
+    ...getRemoteAuthHeader(),
+    ...((init.headers as Record<string, string>) || {}),
+  };
+  return fetch(`${getApiUrl()}${path}`, { ...init, headers });
+}
+
+async function remoteJson<T = JsonRecord>(
+  path: string,
+  init: RequestInit = {},
+): Promise<T> {
+  const res = await remoteFetch(path, init);
+  if (!res.ok) {
+    let message = `HTTP ${res.status}`;
+    try {
+      const body = (await res.json()) as {
+        error?: string | { message?: string };
+        detail?: string;
+      };
+      if (typeof body.error === "string") message = body.error;
+      else if (body.error?.message) message = body.error.message;
+      else if (body.detail) message = body.detail;
+    } catch {
+      // keep HTTP status fallback
+    }
+    throw new Error(message);
+  }
+  return (await res.json()) as T;
+}
+
+function postJson(path: string, body: unknown): Promise<JsonRecord> {
+  return remoteJson(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function putJson(path: string, body: unknown): Promise<JsonRecord> {
+  return remoteJson(path, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function num(value: unknown): number {
+  return typeof value === "number" ? value : 0;
+}
+
+function str(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+export async function remoteGatewayStatus(): Promise<boolean> {
+  try {
+    const body = await remoteJson<{ ok?: boolean; status?: string }>(
+      "/api/gateway/status",
+    );
+    return body.ok === true || body.status === "ok";
+  } catch {
+    return false;
+  }
+}
+
+export async function remoteListSessions(
+  limit = 30,
+  offset = 0,
+  profile?: string,
+): Promise<SessionSummary[]> {
+  const path = withProfile(
+    `/api/sessions?limit=${limit}&offset=${offset}&source=${REMOTE_CONVERSATION_SOURCE}`,
+    profile,
+  );
+  const body = await remoteJson<{ sessions?: JsonRecord[] }>(path);
+  return (body.sessions || []).map((s) => ({
+    id: str(s.id),
+    source: str(s.source),
+    startedAt: num(s.startedAt ?? s.started_at),
+    endedAt:
+      typeof (s.endedAt ?? s.ended_at) === "number"
+        ? ((s.endedAt ?? s.ended_at) as number)
+        : null,
+    messageCount: num(s.messageCount ?? s.message_count),
+    model: str(s.model),
+    title: typeof s.title === "string" ? s.title : null,
+    preview: str(s.preview),
+  }));
+}
+
+export async function remoteSearchSessions(
+  query: string,
+  limit = 20,
+  profile?: string,
+): Promise<SearchResult[]> {
+  const path = withProfile(
+    `/api/sessions/search?q=${encodeURIComponent(query)}&limit=${limit}&source=${REMOTE_CONVERSATION_SOURCE}`,
+    profile,
+  );
+  const body = await remoteJson<{ results?: JsonRecord[] }>(path);
+  return (body.results || []).map((r) => ({
+    sessionId: str(r.sessionId ?? r.session_id),
+    title: typeof r.title === "string" ? r.title : null,
+    startedAt: num(r.startedAt ?? r.started_at ?? r.session_started),
+    source: str(r.source),
+    messageCount: num(r.messageCount ?? r.message_count),
+    model: str(r.model),
+    snippet: str(r.snippet),
+  }));
+}
+
+export async function remoteListCachedSessions(
+  limit = 50,
+  offset = 0,
+  profile?: string,
+): Promise<CachedSession[]> {
+  const sessions = await remoteListSessions(limit, offset, profile);
+  return sessions.map((s) => ({
+    id: s.id,
+    title: s.title || s.preview || "New conversation",
+    startedAt: s.startedAt,
+    source: s.source,
+    messageCount: s.messageCount,
+    model: s.model,
+  }));
+}
+
+export async function remoteGetSessionMessages(
+  sessionId: string,
+  profile?: string,
+): Promise<SessionMessage[]> {
+  const path = withProfile(
+    `/api/sessions/${encodeURIComponent(sessionId)}/messages`,
+    profile,
+  );
+  const body = await remoteJson<{ messages?: JsonRecord[] }>(path);
+  return (body.messages || [])
+    .filter((m) => ["user", "assistant", "tool"].includes(str(m.role)))
+    .map((m) => ({
+      id: num(m.id),
+      role: str(m.role) as SessionMessage["role"],
+      content: str(m.content),
+      timestamp: num(m.timestamp),
+    }));
+}
+
+export async function remoteListProfiles(): Promise<ProfileInfo[]> {
+  const body = await remoteJson<{ profiles?: JsonRecord[] }>("/api/profiles");
+  return (body.profiles || []).map((p) => ({
+    name: str(p.name),
+    path: str(p.path),
+    isDefault: Boolean(p.isDefault ?? p.is_default),
+    isActive: Boolean(p.isActive ?? p.is_active),
+    model: str(p.model),
+    provider: str(p.provider),
+    hasEnv: Boolean(p.hasEnv ?? p.has_env),
+    hasSoul: Boolean(p.hasSoul ?? p.has_soul),
+    skillCount: num(p.skillCount ?? p.skill_count),
+    gatewayRunning: Boolean(p.gatewayRunning ?? p.gateway_running),
+  }));
+}
+
+export async function remoteCreateProfile(
+  name: string,
+  clone: boolean,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    await postJson("/api/profiles", { name, clone });
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: (err as Error).message };
+  }
+}
+
+export async function remoteDeleteProfile(
+  name: string,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    await remoteJson(`/api/profiles/${encodeURIComponent(name)}`, {
+      method: "DELETE",
+    });
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: (err as Error).message };
+  }
+}
+
+export async function remoteSetActiveProfile(name: string): Promise<boolean> {
+  await postJson(`/api/profiles/${encodeURIComponent(name)}/activate`, {});
+  return true;
+}
+
+export async function remoteReadMemory(profile?: string): Promise<MemoryInfo> {
+  return remoteJson<MemoryInfo>(withProfile("/api/memory", profile));
+}
+
+export async function remoteAddMemoryEntry(
+  content: string,
+  profile?: string,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    await postJson(withProfile("/api/memory/entries", profile), { content });
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: (err as Error).message };
+  }
+}
+
+export async function remoteUpdateMemoryEntry(
+  index: number,
+  content: string,
+  profile?: string,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    await putJson(withProfile(`/api/memory/entries/${index}`, profile), { content });
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: (err as Error).message };
+  }
+}
+
+export async function remoteRemoveMemoryEntry(
+  index: number,
+  profile?: string,
+): Promise<boolean> {
+  const res = await remoteFetch(withProfile(`/api/memory/entries/${index}`, profile), {
+    method: "DELETE",
+  });
+  return res.ok;
+}
+
+export async function remoteWriteUserProfile(
+  content: string,
+  profile?: string,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    await putJson(withProfile("/api/memory/user", profile), { content });
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: (err as Error).message };
+  }
+}
+
+export async function remoteReadSoul(profile?: string): Promise<string> {
+  const target = profile || "current";
+  const body = await remoteJson<{ content?: string }>(
+    `/api/profiles/${encodeURIComponent(target)}/soul`,
+  );
+  return body.content || "";
+}
+
+export async function remoteWriteSoul(
+  content: string,
+  profile?: string,
+): Promise<boolean> {
+  const target = profile || "current";
+  await putJson(`/api/profiles/${encodeURIComponent(target)}/soul`, { content });
+  return true;
+}
+
+export async function remoteResetSoul(profile?: string): Promise<string> {
+  const target = profile || "current";
+  const body = await postJson(
+    `/api/profiles/${encodeURIComponent(target)}/soul/reset`,
+    {},
+  );
+  return typeof body.content === "string" ? body.content : "";
+}
+
+export async function remoteGetToolsets(profile?: string): Promise<ToolsetInfo[]> {
+  const body = await remoteJson<{ toolsets?: JsonRecord[] }>(
+    withProfile("/api/tools/toolsets", profile),
+  );
+  return (body.toolsets || []).map((t) => ({
+    key: str(t.key ?? t.name),
+    label: str(t.label ?? t.key ?? t.name),
+    description: str(t.description),
+    enabled: Boolean(t.enabled),
+  }));
+}
+
+export async function remoteSetToolsetEnabled(
+  key: string,
+  enabled: boolean,
+  profile?: string,
+): Promise<boolean> {
+  await putJson(withProfile(`/api/tools/toolsets/${encodeURIComponent(key)}`, profile), {
+    enabled,
+  });
+  return true;
+}
+
+export async function remoteListInstalledSkills(
+  profile?: string,
+): Promise<InstalledSkill[]> {
+  const body = await remoteJson<{ skills?: JsonRecord[] }>(
+    withProfile("/api/skills/installed", profile),
+  );
+  return (body.skills || []).map((s) => ({
+    name: str(s.name ?? s.slug),
+    category: str(s.category),
+    description: str(s.description),
+    path: str(s.path),
+  }));
+}
+
+export async function remoteListBundledSkills(): Promise<SkillSearchResult[]> {
+  const body = await remoteJson<{ skills?: JsonRecord[] }>("/api/skills/bundled");
+  return (body.skills || []).map((s) => ({
+    name: str(s.name ?? s.slug),
+    description: str(s.description),
+    category: str(s.category),
+    source: str(s.source || "bundled"),
+    installed: false,
+  }));
+}
+
+export async function remoteGetSkillContent(
+  skillPath: string,
+  profile?: string,
+): Promise<string> {
+  const body = await remoteJson<{ content?: string }>(
+    withProfile(`/api/skills/content?path=${encodeURIComponent(skillPath)}`, profile),
+  );
+  return body.content || "";
+}
+
+export function remoteUnsupported(
+  feature: string,
+): { success: boolean; error: string } {
+  return {
+    success: false,
+    error: `${feature} is not supported by the remote Hermes API yet.`,
+  };
+}

--- a/src/renderer/src/screens/Chat/Chat.tsx
+++ b/src/renderer/src/screens/Chat/Chat.tsx
@@ -288,6 +288,10 @@ function Chat({
     }
   }, [messages]);
 
+  useEffect(() => {
+    setHermesSessionId(sessionId);
+  }, [sessionId]);
+
   const loadModelConfig = useCallback(async (): Promise<void> => {
     const [mc, savedModels] = await Promise.all([
       window.hermesAPI.getModelConfig(profile),

--- a/src/renderer/src/screens/Layout/Layout.tsx
+++ b/src/renderer/src/screens/Layout/Layout.tsx
@@ -221,29 +221,23 @@ function Layout(): React.JSX.Element {
             onNewChat={handleNewChat}
           />
         </div>
-        {view === "sessions" &&
-          (remoteMode ? (
-            <RemoteNotice feature="Sessions" />
-          ) : (
-            <Sessions
-              onResumeSession={handleResumeSession}
-              onNewChat={handleNewChat}
-              currentSessionId={currentSessionId}
-            />
-          ))}
-        {view === "agents" &&
-          (remoteMode ? (
-            <RemoteNotice feature="Profiles" />
-          ) : (
-            <Agents
-              activeProfile={activeProfile}
-              onSelectProfile={handleSelectProfile}
-              onChatWith={(name: string) => {
-                handleSelectProfile(name);
-                setView("chat");
-              }}
-            />
-          ))}
+        {view === "sessions" && (
+          <Sessions
+            onResumeSession={handleResumeSession}
+            onNewChat={handleNewChat}
+            currentSessionId={currentSessionId}
+          />
+        )}
+        {view === "agents" && (
+          <Agents
+            activeProfile={activeProfile}
+            onSelectProfile={handleSelectProfile}
+            onChatWith={(name: string) => {
+              handleSelectProfile(name);
+              setView("chat");
+            }}
+          />
+        )}
         {officeVisited && (
           <div
             style={{
@@ -271,37 +265,12 @@ function Layout(): React.JSX.Element {
             <Providers profile={activeProfile} visible={view === "providers"} />
           )}
         </div>
-        {view === "skills" &&
-          (remoteMode ? (
-            <RemoteNotice feature="Skills" />
-          ) : (
-            <Skills profile={activeProfile} />
-          ))}
-        {view === "soul" &&
-          (remoteMode ? (
-            <RemoteNotice feature="Persona" />
-          ) : (
-            <Soul profile={activeProfile} />
-          ))}
-        {view === "memory" &&
-          (remoteMode ? (
-            <RemoteNotice feature="Memory" />
-          ) : (
-            <Memory profile={activeProfile} />
-          ))}
-        {view === "tools" &&
-          (remoteMode ? (
-            <RemoteNotice feature="Tools" />
-          ) : (
-            <Tools profile={activeProfile} />
-          ))}
+        {view === "skills" && <Skills profile={activeProfile} />}
+        {view === "soul" && <Soul profile={activeProfile} />}
+        {view === "memory" && <Memory profile={activeProfile} />}
+        {view === "tools" && <Tools profile={activeProfile} />}
         {view === "schedules" && <Schedules profile={activeProfile} />}
-        {view === "gateway" &&
-          (remoteMode ? (
-            <RemoteNotice feature="Gateway" />
-          ) : (
-            <Gateway profile={activeProfile} />
-          ))}
+        {view === "gateway" && <Gateway profile={activeProfile} />}
         <div
           style={{
             display: view === "settings" ? "flex" : "none",


### PR DESCRIPTION
## Summary
- Adds a remote API adapter for pure HTTP remote mode.
- Routes sessions, session cache/search, profiles, memory, SOUL.md, tools, skills, and gateway status IPC handlers through Hermes Agent API endpoints when connection mode is remote.
- Keeps existing local and SSH behavior unchanged; skill install/uninstall still report unsupported until the Agent API exposes those write endpoints.

## Companion PR
Requires the Hermes Agent API surface from NousResearch/hermes-agent#23742.

## Validation
- npm run typecheck
- npm test
- npm run build
- npm run build:unpack
