### PR TITLE
fix(chat): ignore IME composition enter

### DIFF
--- a/src/renderer/src/screens/Chat/Chat.tsx
+++ b/src/renderer/src/screens/Chat/Chat.tsx
@@ -16,6 +16,7 @@ import {
   Slash,
   Zap,
 } from "lucide-react";
+import { isImeComposing } from "./keyboard";
 
 // ── Slash Commands ──────────────────────────────────────
 
@@ -558,7 +559,11 @@ function Chat({
     }
   }
 
-  function handleKeyDown(e: React.KeyboardEvent): void {
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>): void {
+    if (isImeComposing(e)) {
+      return;
+    }
+
     // Slash menu keyboard navigation
     if (slashMenuOpen && filteredSlashCommands.length > 0) {
       if (e.key === "ArrowDown") {
@@ -907,7 +912,9 @@ function Chat({
               <Zap size={14} />
             </button>
             <div className="chat-fast-popover">
-              <strong>{fastMode ? t("chat.fastModeOn") : t("chat.fastMode")}</strong>
+              <strong>
+                {fastMode ? t("chat.fastModeOn") : t("chat.fastMode")}
+              </strong>
               <span>
                 {fastMode
                   ? t("chat.fastModeActive")

--- a/src/renderer/src/screens/Chat/keyboard.test.ts
+++ b/src/renderer/src/screens/Chat/keyboard.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { isImeComposing } from "./keyboard";
+
+describe("chat keyboard helpers", () => {
+  it("detects active IME composition from the native event", () => {
+    expect(
+      isImeComposing({
+        nativeEvent: { isComposing: true },
+      }),
+    ).toBe(true);
+  });
+
+  it("detects IME process key events", () => {
+    expect(
+      isImeComposing({
+        keyCode: 229,
+        nativeEvent: { isComposing: false },
+      }),
+    ).toBe(true);
+  });
+
+  it("does not treat regular key events as composing", () => {
+    expect(
+      isImeComposing({
+        keyCode: 13,
+        nativeEvent: { isComposing: false },
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/renderer/src/screens/Chat/keyboard.ts
+++ b/src/renderer/src/screens/Chat/keyboard.ts
@@ -1,0 +1,10 @@
+interface ImeKeyEvent {
+  keyCode?: number;
+  nativeEvent: {
+    isComposing?: boolean;
+  };
+}
+
+export function isImeComposing(event: ImeKeyEvent): boolean {
+  return Boolean(event.nativeEvent.isComposing || event.keyCode === 229);
+}


### PR DESCRIPTION
## Summary
- skip chat key handling while an IME composition event is active
- treat keyCode 229 as an IME process key fallback
- add unit coverage for the composition helper

Fixes #106

## Testing
- `npm ci`
- `npm run typecheck`
- `npx eslint src/renderer/src/screens/Chat/Chat.tsx src/renderer/src/screens/Chat/keyboard.ts src/renderer/src/screens/Chat/keyboard.test.ts`
- `npx prettier --check src/renderer/src/screens/Chat/Chat.tsx src/renderer/src/screens/Chat/keyboard.ts src/renderer/src/screens/Chat/keyboard.test.ts`
- `npx vitest run src/renderer/src/screens/Chat/keyboard.test.ts`

Note: `npm test` currently reaches 268/269 passing locally after rebuilding better-sqlite3 for Node; the remaining existing `tests/session-cache-sync.test.ts` large-cache test times out at Vitest's 5s limit and is unrelated to this chat input change.