### PR TITLE
refactor(main): robust profile path resolution with validation

### DIFF
--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -15,14 +15,23 @@ export function stripAnsi(str: string): string {
 }
 
 /**
+ * Validate that a profile name contains only alphanumeric characters,
+ * underscores, or dashes. Prevents path traversal via the profile parameter.
+ */
+export function isValidProfileName(name: string): boolean {
+  return /^[a-zA-Z0-9_-]+$/.test(name);
+}
+
+/**
  * Resolve the home directory for a given profile.
  * 'default' or undefined maps to ~/.hermes; named profiles
  * live under ~/.hermes/profiles/<name>.
  */
 export function profileHome(profile?: string): string {
-  return profile && profile !== "default"
-    ? join(HERMES_HOME, "profiles", profile)
-    : HERMES_HOME;
+  if (profile && profile !== "default" && isValidProfileName(profile)) {
+    return join(HERMES_HOME, "profiles", profile);
+  }
+  return HERMES_HOME;
 }
 
 /**


### PR DESCRIPTION
Secures the profile home directory resolution by validating the profile name against a whitelist of allowed characters. Currently, the `profileHome` function joins paths directly with the user-supplied `profile` string, which could lead to path traversal if malicious input is passed through the IPC layer.

Validation logic restricts names to alphanumeric characters, underscores, and dashes. This change ensures that any attempts to use navigation characters like `..` or absolute paths will safely fallback to the default home directory instead of resolving to an unintended location on the filesystem.

Verified the fix by testing both valid and invalid profile strings. Standard names like 'work' or 'personal' resolve correctly, while strings containing traversal sequences are now effectively blocked. Also confirmed that the default profile resolution remains unaffected.