### PR TITLE
feat: auto-load custom_providers from config.yaml into model library

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -264,6 +264,12 @@ export function setModelConfig(
   const baseUrlRegex = /^(\s*base_url:\s*)["']?[^"'\n#]*["']?/m;
   if (baseUrlRegex.test(content)) {
     content = content.replace(baseUrlRegex, `$1"${baseUrl}"`);
+  } else if (baseUrl && provider !== "auto") {
+    // Append base_url line after the provider line in the model section
+    content = content.replace(
+      /^(\s*provider:\s*"[^"]*"\s*\n)/m,
+      `$1  base_url: "${baseUrl}"\n`
+    );
   }
 
   // Disable smart_model_routing

--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -14,6 +14,7 @@ import {
 import { getModelConfig, readEnv, getConnectionConfig } from "./config";
 import { getSshTunnelUrl, isSshTunnelActive, isSshTunnelHealthy, startSshTunnel } from "./ssh-tunnel";
 import { stripAnsi } from "./utils";
+import { readModels } from "./models";
 
 const LOCAL_API_URL = "http://127.0.0.1:8642";
 
@@ -499,8 +500,20 @@ function sendMessageViaCli(
 
   const isCustomEndpoint = LOCAL_PROVIDERS.has(mc.provider);
   if (isCustomEndpoint && mc.baseUrl) {
-    env.HERMES_INFERENCE_PROVIDER = "custom";
-    env.OPENAI_BASE_URL = mc.baseUrl.replace(/\/+$/, "");
+    // Check if this model has an explicit apiMode from custom_providers
+    let modelApiMode: string | null = null;
+    try {
+      const modelEntry = readModels().find(m => m.baseUrl === mc.baseUrl && m.model === mc.model);
+      if (modelEntry) modelApiMode = modelEntry.apiMode || null;
+    } catch { /* ignore */ }
+    const isAnthropicProtocol = modelApiMode === "anthropic_messages";
+    if (isAnthropicProtocol) {
+      env.HERMES_INFERENCE_PROVIDER = "anthropic";
+      env.ANTHROPIC_BASE_URL = mc.baseUrl.replace(/\/+$/, "");
+    } else {
+      env.HERMES_INFERENCE_PROVIDER = "custom";
+      env.OPENAI_BASE_URL = mc.baseUrl.replace(/\/+$/, "");
+    }
 
     // Resolve the right API key: check URL-specific key first, then OPENAI_API_KEY
     let resolvedKey = "";
@@ -511,21 +524,35 @@ function sendMessageViaCli(
       }
     }
     if (!resolvedKey) {
-      resolvedKey =
-        profileEnv.CUSTOM_API_KEY ||
-        env.CUSTOM_API_KEY ||
-        profileEnv.OPENAI_API_KEY ||
-        env.OPENAI_API_KEY ||
-        "";
+      // Try custom provider auto-generated key from models.json
+      try {
+        const models = readModels();
+        const matching = models.find(m => m.baseUrl === mc.baseUrl);
+        if (matching) {
+          const envKey2 = "CUSTOM_PROVIDER_" + matching.name.replace(/[^A-Za-z0-9]/g, "_").toUpperCase() + "_KEY";
+          resolvedKey = profileEnv[envKey2] || env[envKey2] || "";
+        }
+      } catch { /* ignore */ }
+      if (!resolvedKey) {
+        resolvedKey =
+          profileEnv.CUSTOM_API_KEY ||
+          env.CUSTOM_API_KEY ||
+          profileEnv.OPENAI_API_KEY ||
+          env.OPENAI_API_KEY ||
+          "";
+      }
     }
     // Local servers (localhost/127.0.0.1) don't need a real key
     if (!resolvedKey && /localhost|127\.0\.0\.1/i.test(mc.baseUrl)) {
       resolvedKey = "no-key-required";
     }
-    env.OPENAI_API_KEY = resolvedKey || "no-key-required";
+    if (isAnthropicProtocol) {
+      env.ANTHROPIC_API_KEY = resolvedKey || "no-key-required";
+    } else {
+      env.OPENAI_API_KEY = resolvedKey || "no-key-required";
+    }
 
     delete env.OPENROUTER_API_KEY;
-    delete env.ANTHROPIC_API_KEY;
     delete env.ANTHROPIC_TOKEN;
     delete env.OPENROUTER_BASE_URL;
   }

--- a/src/main/models.ts
+++ b/src/main/models.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { randomUUID } from "crypto";
 import { HERMES_HOME } from "./installer";
-import { safeWriteFile } from "./utils";
+import { safeWriteFile, profilePaths } from "./utils";
 import DEFAULT_MODELS from "./default-models";
 
 const MODELS_FILE = join(HERMES_HOME, "models.json");
@@ -13,10 +13,11 @@ export interface SavedModel {
   provider: string;
   model: string;
   baseUrl: string;
+  apiMode?: string | null;
   createdAt: number;
 }
 
-function readModels(): SavedModel[] {
+export function readModels(): SavedModel[] {
   try {
     if (!existsSync(MODELS_FILE)) return [];
     return JSON.parse(readFileSync(MODELS_FILE, "utf-8"));
@@ -29,7 +30,51 @@ function writeModels(models: SavedModel[]): void {
   safeWriteFile(MODELS_FILE, JSON.stringify(models, null, 2));
 }
 
-function seedDefaults(): SavedModel[] {
+interface CustomProviderEntry {
+  name: string;
+  provider: string;
+  model: string;
+  baseUrl: string;
+  apiKey?: string;
+  apiMode?: string;
+}
+
+function loadCustomProviders(profile?: string): CustomProviderEntry[] {
+  const { configFile } = profilePaths(profile);
+  if (!existsSync(configFile)) return [];
+  const content = readFileSync(configFile, "utf-8");
+  const result: CustomProviderEntry[] = [];
+  const lines = content.split("\n");
+  let inCustom = false;
+  let current: CustomProviderEntry | null = null;
+  for (const line of lines) {
+    if (/^\s*custom_providers\s*:/.test(line)) { inCustom = true; continue; }
+    if (inCustom) {
+      if (/^\s*-\s*name\s*:/.test(line)) {
+        if (current && current.model && current.baseUrl) result.push(current);
+        const m = line.match(/name\s*:\s*["']?([^"'\n#]+)["']?/);
+        current = { name: (m ? m[1].trim() : "Custom"), provider: "custom", model: "", baseUrl: "" };
+      } else if (current) {
+        const bm = line.match(/base_url\s*:\s*["']?([^"'\n#]+)["']?/);
+        if (bm) current.baseUrl = bm[1].trim();
+        const mm = line.match(/^\s*model\s*:\s*["']?([^"'\n#]+)["']?/);
+        if (mm) current.model = mm[1].trim();
+        const am = line.match(/api_key\s*:\s*["']?([^"'\n#]+)["']?/);
+        if (am) current.apiKey = am[1].trim();
+        const apim = line.match(/api_mode\s*:\s*["']?([^"'\n#]+)["']?/);
+        if (apim) current.apiMode = apim[1].trim();
+      }
+      if (/^[a-z]/.test(line) && !/^\s/.test(line) && !/^\s*-\s*name/.test(line)) {
+        if (current && current.model && current.baseUrl) result.push(current);
+        inCustom = false; current = null;
+      }
+    }
+  }
+  if (current && current.model && current.baseUrl) result.push(current);
+  return result;
+}
+
+function seedDefaults(profile?: string): SavedModel[] {
   const models: SavedModel[] = DEFAULT_MODELS.map((m) => ({
     id: randomUUID(),
     name: m.name,
@@ -38,6 +83,32 @@ function seedDefaults(): SavedModel[] {
     baseUrl: m.baseUrl,
     createdAt: Date.now(),
   }));
+  try {
+    const { envFile } = profilePaths(profile);
+    const cpModels = loadCustomProviders(profile);
+    for (const cp of cpModels) {
+      models.push({
+        id: randomUUID(),
+        name: cp.name,
+        provider: cp.provider,
+        model: cp.model,
+        baseUrl: cp.baseUrl,
+        apiMode: cp.apiMode || null,
+        createdAt: Date.now(),
+      });
+      if (cp.apiKey) {
+        try {
+          let envContent = existsSync(envFile) ? readFileSync(envFile, "utf-8") : "";
+          const envKey = "CUSTOM_PROVIDER_" + cp.name.replace(/[^A-Za-z0-9]/g, "_").toUpperCase() + "_KEY";
+          const keyRegex = new RegExp("^" + envKey.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "=.*$", "m");
+          if (!keyRegex.test(envContent)) {
+            envContent = envContent.trimEnd() + "\n" + envKey + "=" + cp.apiKey + "\n";
+            safeWriteFile(envFile, envContent);
+          }
+        } catch { /* best-effort */ }
+      }
+    }
+  } catch (e) { console.error("Failed to load custom providers:", e); }
   writeModels(models);
   return models;
 }


### PR DESCRIPTION
- Add loadCustomProviders() to parse custom_providers YAML section
- Modify seedDefaults() to merge custom providers with apiKey sync
- Fix setModelConfig() to add base_url when missing for custom models
- Add apiMode support for Anthropic protocol custom providers
- Add custom provider key resolution via CUSTOM_PROVIDER_X_KEY env vars

Fixes: #138