### PR TITLE
[codex] Fix Windows SSH tunnel multiplexing

### DIFF
--- a/src/main/ssh-options.ts
+++ b/src/main/ssh-options.ts
@@ -1,0 +1,21 @@
+export function buildSshControlOptions(platform = process.platform): string[] {
+  if (platform === "win32") {
+    return [
+      "-o",
+      "ControlMaster=no",
+      "-o",
+      "ControlPath=none",
+      "-o",
+      "ControlPersist=no",
+    ];
+  }
+
+  return [
+    "-o",
+    "ControlMaster=auto",
+    "-o",
+    "ControlPath=~/.ssh/cm-hermes-%r@%h:%p",
+    "-o",
+    "ControlPersist=60s",
+  ];
+}

--- a/src/main/ssh-remote.ts
+++ b/src/main/ssh-remote.ts
@@ -8,6 +8,7 @@ import { spawn } from "child_process";
 import { homedir } from "os";
 import { join } from "path";
 import type { SshConfig } from "./ssh-tunnel";
+import { buildSshControlOptions } from "./ssh-options";
 import type { InstalledSkill, SkillSearchResult } from "./skills";
 import type { MemoryInfo } from "./memory";
 import type { SessionSummary, SessionMessage, SearchResult } from "./sessions";
@@ -26,9 +27,7 @@ function buildExecArgs(config: SshConfig): string[] {
     "-o", "BatchMode=yes",
     "-o", "StrictHostKeyChecking=accept-new",
     "-o", "ConnectTimeout=15",
-    "-o", "ControlMaster=auto",
-    "-o", "ControlPath=~/.ssh/cm-hermes-%r@%h:%p",
-    "-o", "ControlPersist=60s",
+    ...buildSshControlOptions(),
     "-i", keyPath,
     "-p", String(config.port || 22),
     `${config.username}@${config.host}`,

--- a/src/main/ssh-tunnel.ts
+++ b/src/main/ssh-tunnel.ts
@@ -3,6 +3,7 @@ import { homedir } from "os";
 import { join } from "path";
 import net from "net";
 import http from "http";
+import { buildSshControlOptions } from "./ssh-options";
 
 export interface SshConfig {
   host: string;
@@ -108,9 +109,7 @@ function buildSshArgs(config: SshConfig, localPort: number): string[] {
     "-i", keyPath,
     "-o", "StrictHostKeyChecking=accept-new",
     "-o", "BatchMode=yes",
-    "-o", "ControlMaster=auto",
-    "-o", "ControlPath=~/.ssh/cm-hermes-%r@%h:%p",
-    "-o", "ControlPersist=60s",
+    ...buildSshControlOptions(),
     "-o", "ExitOnForwardFailure=yes",
     "-o", "ServerAliveInterval=30",
     "-o", "ServerAliveCountMax=3",

--- a/tests/ssh-options.test.ts
+++ b/tests/ssh-options.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { buildSshControlOptions } from "../src/main/ssh-options";
+
+describe("ssh control options", () => {
+  it("disables SSH multiplexing on Windows", () => {
+    expect(buildSshControlOptions("win32")).toEqual([
+      "-o",
+      "ControlMaster=no",
+      "-o",
+      "ControlPath=none",
+      "-o",
+      "ControlPersist=no",
+    ]);
+  });
+
+  it("keeps SSH multiplexing enabled on non-Windows platforms", () => {
+    expect(buildSshControlOptions("linux")).toEqual([
+      "-o",
+      "ControlMaster=auto",
+      "-o",
+      "ControlPath=~/.ssh/cm-hermes-%r@%h:%p",
+      "-o",
+      "ControlPersist=60s",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes SSH tunnel startup on Windows by disabling OpenSSH connection multiplexing options (`ControlMaster`, `ControlPath`, and `ControlPersist`) for `win32`.

Windows OpenSSH can fail with these control socket options, causing Hermes Desktop to report `SSH tunnel not ready after 12000ms`. Non-Windows platforms keep the existing multiplexing behavior.

## Testing

- `npm test -- tests/ssh-options.test.ts tests/ssh-remote.test.ts`

Note: `npm run typecheck` currently fails on an unrelated existing error in `src/main/models.ts` importing `profilePaths` from `./utils`.
