### PR TITLE
feat: Add auto-connect feature to Gateway settings

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -73,6 +73,17 @@ export function setConnectionConfig(config: ConnectionConfig): void {
   writeDesktopConfig(data);
 }
 
+export function getAutoConnect(): boolean {
+  const data = readDesktopConfig();
+  return data.autoConnect === true;
+}
+
+export function setAutoConnect(enabled: boolean): void {
+  const data = readDesktopConfig();
+  data.autoConnect = enabled;
+  writeDesktopConfig(data);
+}
+
 // ── In-memory cache with TTL ─────────────────────────────
 const CACHE_TTL = 5000; // 5 seconds
 const _cache = new Map<string, { data: unknown; ts: number }>();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -78,6 +78,8 @@ import {
   setConnectionConfig,
   getPlatformEnabled,
   setPlatformEnabled,
+  getAutoConnect,
+  setAutoConnect,
 } from "./config";
 import { listSessions, getSessionMessages, searchSessions } from "./sessions";
 import {
@@ -684,6 +686,13 @@ function setupIPC(): void {
     },
   );
 
+  // Auto-connect toggle
+  ipcMain.handle("get-autoconnect", () => getAutoConnect());
+  ipcMain.handle("set-autoconnect", (_event, enabled: boolean) => {
+    setAutoConnect(enabled);
+    return true;
+  });
+
   // Sessions
   ipcMain.handle("list-sessions", (_event, limit?: number, offset?: number) => {
     const conn = getConnectionConfig();
@@ -1181,6 +1190,16 @@ app.whenReady().then(() => {
   setupIPC();
   createWindow();
   setupUpdater();
+
+  // Reconnect loop: restart local gateway if autoconnect is enabled and it went offline
+  setInterval(async () => {
+    const conn = getConnectionConfig();
+    if (conn.mode !== "local") return;
+    if (!getAutoConnect()) return;
+    if (!isGatewayRunning()) {
+      await startGateway();
+    }
+  }, 30000);
 
   // Auto-start SSH tunnel if configured
   const conn = getConnectionConfig();

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -132,6 +132,8 @@ interface HermesAPI {
   startGateway: () => Promise<boolean>;
   stopGateway: () => Promise<boolean>;
   gatewayStatus: () => Promise<boolean>;
+  getAutoConnect: () => Promise<boolean>;
+  setAutoConnect: (enabled: boolean) => Promise<boolean>;
 
   // Platform toggles
   getPlatformEnabled: (profile?: string) => Promise<Record<string, boolean>>;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -231,6 +231,9 @@ const hermesAPI = {
   startGateway: (): Promise<boolean> => ipcRenderer.invoke("start-gateway"),
   stopGateway: (): Promise<boolean> => ipcRenderer.invoke("stop-gateway"),
   gatewayStatus: (): Promise<boolean> => ipcRenderer.invoke("gateway-status"),
+  getAutoConnect: (): Promise<boolean> => ipcRenderer.invoke("get-autoconnect"),
+  setAutoConnect: (enabled: boolean): Promise<boolean> =>
+    ipcRenderer.invoke("set-autoconnect", enabled),
 
   // Platform toggles
   getPlatformEnabled: (profile?: string): Promise<Record<string, boolean>> =>

--- a/src/renderer/src/screens/Gateway/Gateway.tsx
+++ b/src/renderer/src/screens/Gateway/Gateway.tsx
@@ -5,6 +5,7 @@ import { useI18n } from "../../components/useI18n";
 function Gateway({ profile }: { profile?: string }): React.JSX.Element {
   const { t } = useI18n();
   const [gatewayRunning, setGatewayRunning] = useState(false);
+  const [autoConnect, setAutoConnectState] = useState(false);
   const [env, setEnv] = useState<Record<string, string>>({});
   const [platformEnabled, setPlatformEnabled] = useState<
     Record<string, boolean>
@@ -21,6 +22,8 @@ function Gateway({ profile }: { profile?: string }): React.JSX.Element {
     setGatewayRunning(gwStatus);
     const platforms = await window.hermesAPI.getPlatformEnabled(profile);
     setPlatformEnabled(platforms);
+    const ac = await window.hermesAPI.getAutoConnect();
+    setAutoConnectState(ac);
   }, [profile]);
 
   useEffect(() => {
@@ -35,6 +38,12 @@ function Gateway({ profile }: { profile?: string }): React.JSX.Element {
     }, 10000);
     return () => clearInterval(interval);
   }, []);
+
+  async function toggleAutoConnect(): Promise<void> {
+    const next = !autoConnect;
+    setAutoConnectState(next);
+    await window.hermesAPI.setAutoConnect(next);
+  }
 
   async function toggleGateway(): Promise<void> {
     if (gatewayStatusTimeoutRef.current) {
@@ -128,6 +137,20 @@ function Gateway({ profile }: { profile?: string }): React.JSX.Element {
             </button>
           </div>
           <div className="settings-field-hint">{t("gateway.gatewayHint")}</div>
+        </div>
+        <div className="settings-field">
+          <label className="settings-field-label">{t("gateway.autoConnect")}</label>
+          <div className="settings-gateway-row">
+            <label className="tools-toggle">
+              <input
+                type="checkbox"
+                checked={autoConnect}
+                onChange={toggleAutoConnect}
+              />
+              <span className="tools-toggle-track" />
+            </label>
+          </div>
+          <div className="settings-field-hint">{t("gateway.autoConnectHint")}</div>
         </div>
       </div>
 

--- a/src/shared/i18n/locales/en/gateway.ts
+++ b/src/shared/i18n/locales/en/gateway.ts
@@ -7,4 +7,7 @@ export default {
   stopped: "Stopped",
   gatewayHint:
     "Connects Hermes to Telegram, Discord, Slack, and other platforms",
+  autoConnect: "Auto-reconnect",
+  autoConnectHint:
+    "Automatically restart the gateway if it goes offline",
 } as const;


### PR DESCRIPTION
Introduce an option to automatically restart the local gateway if it disconnects. This enhances user experience by maintaining continuous connectivity without manual intervention.
