### PR TITLE
fix: repair mac auto update downloads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,6 @@ jobs:
             dist/*.dmg
             dist/*.zip
             dist/*.blockmap
-            dist/latest-mac.yml
 
   release_linux:
     name: Build Linux
@@ -222,6 +221,70 @@ jobs:
         with:
           path: artifacts
           merge-multiple: true
+
+      - name: Generate macOS update metadata
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          node <<'NODE'
+          const crypto = require("crypto");
+          const fs = require("fs");
+          const path = require("path");
+
+          const artifactsDir = path.join(process.cwd(), "artifacts");
+          const version = process.env.VERSION;
+          const zipNames = fs
+            .readdirSync(artifactsDir)
+            .filter(
+              (name) =>
+                name.startsWith(`hermes-desktop-${version}-`) &&
+                name.endsWith("-mac.zip"),
+            )
+            .sort((a, b) => {
+              if (a.includes("-x64-")) return -1;
+              if (b.includes("-x64-")) return 1;
+              return a.localeCompare(b);
+            });
+
+          if (
+            zipNames.length < 2 ||
+            !zipNames.some((name) => name.includes("-x64-")) ||
+            !zipNames.some((name) => name.includes("-arm64-"))
+          ) {
+            throw new Error(
+              `Expected x64 and arm64 macOS zips, found: ${zipNames.join(", ")}`,
+            );
+          }
+
+          const files = zipNames.map((name) => {
+            const filePath = path.join(artifactsDir, name);
+            return {
+              url: name,
+              sha512: crypto
+                .createHash("sha512")
+                .update(fs.readFileSync(filePath))
+                .digest("base64"),
+              size: fs.statSync(filePath).size,
+            };
+          });
+          const primary = files.find((file) => file.url.includes("-x64-")) || files[0];
+          const releaseDate = new Date().toISOString();
+          const lines = [
+            `version: ${version}`,
+            "files:",
+            ...files.flatMap((file) => [
+              `  - url: ${file.url}`,
+              `    sha512: ${file.sha512}`,
+              `    size: ${file.size}`,
+            ]),
+            `path: ${primary.url}`,
+            `sha512: ${primary.sha512}`,
+            `releaseDate: '${releaseDate}'`,
+            "",
+          ];
+
+          fs.writeFileSync(path.join(artifactsDir, "latest-mac.yml"), lines.join("\n"));
+          NODE
 
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -21,6 +21,7 @@ nsis:
   oneClick: true
   perMachine: false
 mac:
+  artifactName: ${name}-${version}-${arch}-${os}.${ext}
   icon: build/icon.icns
   entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.inherit.plist
@@ -31,7 +32,7 @@ mac:
     - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
   notarize: false
 dmg:
-  artifactName: ${name}-${version}.${ext}
+  artifactName: ${name}-${version}-${arch}.${ext}
 linux:
   target:
     - AppImage

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1149,9 +1149,15 @@ function setupUpdater(): void {
     }
   });
 
-  ipcMain.handle("download-update", () => {
-    autoUpdater.downloadUpdate();
-    return true;
+  ipcMain.handle("download-update", async () => {
+    try {
+      await autoUpdater.downloadUpdate();
+      return true;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      mainWindow?.webContents.send("update-error", message);
+      return false;
+    }
   });
 
   ipcMain.handle("install-update", () => {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -378,6 +378,7 @@ interface HermesAPI {
     callback: (info: { percent: number }) => void,
   ) => () => void;
   onUpdateDownloaded: (callback: () => void) => () => void;
+  onUpdateError: (callback: (message: string) => void) => () => void;
 
   // Menu events
   onMenuNewChat: (callback: () => void) => () => void;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -559,6 +559,13 @@ const hermesAPI = {
     return () => ipcRenderer.removeListener("update-downloaded", handler);
   },
 
+  onUpdateError: (callback: (message: string) => void): (() => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, message: unknown): void =>
+      callback(String(message));
+    ipcRenderer.on("update-error", handler);
+    return () => ipcRenderer.removeListener("update-error", handler);
+  },
+
   // Menu events (from native menu bar)
   onMenuNewChat: (callback: () => void): (() => void) => {
     const handler = (): void => callback();

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -939,6 +939,23 @@ body {
   background: var(--accent-hover);
 }
 
+.sidebar-update-btn:disabled {
+  cursor: default;
+  opacity: 0.75;
+}
+
+.sidebar-update-btn:disabled:hover {
+  background: var(--accent);
+}
+
+.sidebar-update-btn.error {
+  background: var(--error);
+}
+
+.sidebar-update-btn.error:hover {
+  background: var(--error);
+}
+
 /* Theme Switcher */
 .theme-switcher {
   display: flex;

--- a/src/renderer/src/screens/Layout/Layout.tsx
+++ b/src/renderer/src/screens/Layout/Layout.tsx
@@ -109,14 +109,17 @@ function Layout({
   // Auto-update state
   const [updateVersion, setUpdateVersion] = useState<string | null>(null);
   const [updateState, setUpdateState] = useState<
-    "available" | "downloading" | "ready" | null
+    "available" | "downloading" | "ready" | "error" | null
   >(null);
   const [downloadPercent, setDownloadPercent] = useState(0);
+  const [updateError, setUpdateError] = useState<string | null>(null);
 
   useEffect(() => {
     const cleanupAvailable = window.hermesAPI.onUpdateAvailable((info) => {
       setUpdateVersion(info.version);
       setUpdateState("available");
+      setUpdateError(null);
+      setDownloadPercent(0);
     });
     const cleanupProgress = window.hermesAPI.onUpdateDownloadProgress(
       (info) => {
@@ -125,18 +128,33 @@ function Layout({
     );
     const cleanupDownloaded = window.hermesAPI.onUpdateDownloaded(() => {
       setUpdateState("ready");
+      setUpdateError(null);
+    });
+    const cleanupError = window.hermesAPI.onUpdateError((message) => {
+      setUpdateState("error");
+      setUpdateError(message);
+      setDownloadPercent(0);
     });
     return () => {
       cleanupAvailable();
       cleanupProgress();
       cleanupDownloaded();
+      cleanupError();
     };
   }, []);
 
   async function handleUpdate(): Promise<void> {
-    if (updateState === "available") {
+    if (updateState === "available" || updateState === "error") {
+      setUpdateError(null);
+      setDownloadPercent(0);
       setUpdateState("downloading");
-      await window.hermesAPI.downloadUpdate();
+      try {
+        const ok = await window.hermesAPI.downloadUpdate();
+        if (!ok) setUpdateState("error");
+      } catch (err) {
+        setUpdateError(err instanceof Error ? err.message : String(err));
+        setUpdateState("error");
+      }
     } else if (updateState === "ready") {
       await window.hermesAPI.installUpdate();
     }
@@ -207,7 +225,14 @@ function Layout({
 
         <div className="sidebar-footer">
           {updateState && (
-            <button className="sidebar-update-btn" onClick={handleUpdate}>
+            <button
+              className={`sidebar-update-btn ${
+                updateState === "error" ? "error" : ""
+              }`}
+              onClick={handleUpdate}
+              disabled={updateState === "downloading"}
+              title={updateError ?? undefined}
+            >
               <Download size={13} />
               {updateState === "available" && (
                 <span>
@@ -221,6 +246,9 @@ function Layout({
               )}
               {updateState === "ready" && (
                 <span>{t("common.restartToUpdate")}</span>
+              )}
+              {updateState === "error" && (
+                <span>{t("common.updateFailed")}</span>
               )}
             </button>
           )}

--- a/src/shared/i18n/locales/en/common.ts
+++ b/src/shared/i18n/locales/en/common.ts
@@ -41,6 +41,7 @@ export default {
   updateAvailable: "Update v{{version}}",
   downloading: "Downloading {{percent}}%",
   restartToUpdate: "Restart to update",
+  updateFailed: "Update failed",
   errorTitle: "Something went wrong",
   errorMessage: "An unexpected error occurred.",
   tryAgain: "Try Again",

--- a/src/shared/i18n/locales/es/common.ts
+++ b/src/shared/i18n/locales/es/common.ts
@@ -41,6 +41,7 @@ export default {
   updateAvailable: "Actualizar a v{{version}}",
   downloading: "Descargando {{percent}}%",
   restartToUpdate: "Reiniciar para actualizar",
+  updateFailed: "Error al actualizar",
   errorTitle: "Algo salió mal",
   errorMessage: "Ocurrió un error inesperado.",
   tryAgain: "Intentar de nuevo",

--- a/src/shared/i18n/locales/id/common.ts
+++ b/src/shared/i18n/locales/id/common.ts
@@ -41,6 +41,7 @@ export default {
   updateAvailable: "Perbarui v{{version}}",
   downloading: "Mengunduh {{percent}}%",
   restartToUpdate: "Mulai ulang untuk memperbarui",
+  updateFailed: "Pembaruan gagal",
   errorTitle: "Terjadi kesalahan",
   errorMessage: "Terjadi kesalahan tak terduga.",
   tryAgain: "Coba Lagi",

--- a/src/shared/i18n/locales/pt-BR/common.ts
+++ b/src/shared/i18n/locales/pt-BR/common.ts
@@ -41,6 +41,7 @@ export default {
   updateAvailable: "Atualização v{{version}}",
   downloading: "Baixando {{percent}}%",
   restartToUpdate: "Reiniciar para atualizar",
+  updateFailed: "Falha ao atualizar",
   errorTitle: "Algo deu errado",
   errorMessage: "Ocorreu um erro inesperado.",
   tryAgain: "Tentar Novamente",

--- a/src/shared/i18n/locales/zh-CN/common.ts
+++ b/src/shared/i18n/locales/zh-CN/common.ts
@@ -41,6 +41,7 @@ export default {
   updateAvailable: "更新 v{{version}}",
   downloading: "下载中 {{percent}}%",
   restartToUpdate: "重启以更新",
+  updateFailed: "更新失败",
   errorTitle: "出现错误",
   errorMessage: "发生了意外错误。",
   tryAgain: "重试",


### PR DESCRIPTION
## Summary
- handle auto-updater download failures and surface update errors in the UI
- make macOS update artifacts use stable architecture-specific names
- regenerate latest-mac.yml from the actual uploaded macOS zip files during release publishing

## Verification
- npm run typecheck
- npm run build
- git diff --check
- GitNexus detect_changes: low risk, no affected processes