### PR TITLE
fix: hide Windows subprocess consoles

### DIFF
--- a/src/main/cronjobs.ts
+++ b/src/main/cronjobs.ts
@@ -5,6 +5,7 @@ import { execFile } from "child_process";
 import { HERMES_HOME, HERMES_PYTHON, hermesCliArgs } from "./installer";
 import { profileHome } from "./utils";
 import { isRemoteMode, getApiUrl, getRemoteAuthHeader } from "./hermes";
+import { HIDDEN_SUBPROCESS_OPTIONS } from "./process-options";
 
 export interface CronJob {
   id: string;
@@ -152,7 +153,11 @@ function runCronCommand(
     execFile(
       HERMES_PYTHON,
       cliArgs,
-      { cwd: join(HERMES_HOME, "hermes-agent"), timeout: 15000 },
+      {
+        cwd: join(HERMES_HOME, "hermes-agent"),
+        timeout: 15000,
+        ...HIDDEN_SUBPROCESS_OPTIONS,
+      },
       (err, stdout, stderr) => {
         if (err) {
           resolve({

--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -15,6 +15,7 @@ import { getModelConfig, readEnv, getConnectionConfig } from "./config";
 import { getSshTunnelUrl, isSshTunnelActive, isSshTunnelHealthy, startSshTunnel } from "./ssh-tunnel";
 import { stripAnsi } from "./utils";
 import { readModels } from "./models";
+import { HIDDEN_SUBPROCESS_OPTIONS } from "./process-options";
 
 const LOCAL_API_URL = "http://127.0.0.1:8642";
 
@@ -561,6 +562,7 @@ function sendMessageViaCli(
     cwd: HERMES_REPO,
     env,
     stdio: ["ignore", "pipe", "pipe"],
+    ...HIDDEN_SUBPROCESS_OPTIONS,
   });
 
   let hasOutput = false;
@@ -741,6 +743,7 @@ export function startGateway(profile?: string): boolean {
     env: gatewayEnv,
     stdio: "ignore",
     detached: true,
+    ...HIDDEN_SUBPROCESS_OPTIONS,
   });
 
   gatewayProcess.unref();

--- a/src/main/installer.ts
+++ b/src/main/installer.ts
@@ -14,6 +14,7 @@ import { getModelConfig, getConnectionConfig } from "./config";
 import { profileHome, stripAnsi } from "./utils";
 import { setupAskpass, AskpassHandle } from "./askpass";
 import { precacheSudoCredentials } from "./sudoCreds";
+import { HIDDEN_SUBPROCESS_OPTIONS } from "./process-options";
 
 const IS_WINDOWS = process.platform === "win32";
 
@@ -235,6 +236,7 @@ export async function verifyInstall(): Promise<boolean> {
           HERMES_HOME,
         },
         timeout: 15000,
+        ...HIDDEN_SUBPROCESS_OPTIONS,
       },
       (error) => {
         const ok = !error;
@@ -277,6 +279,7 @@ export async function getHermesVersion(): Promise<string | null> {
           HERMES_HOME,
         },
         timeout: 15000,
+        ...HIDDEN_SUBPROCESS_OPTIONS,
       },
       (error, stdout) => {
         _versionFetching = false;
@@ -310,6 +313,7 @@ export function runHermesDoctor(): string {
       },
       stdio: ["ignore", "pipe", "pipe"],
       timeout: 30000,
+      ...HIDDEN_SUBPROCESS_OPTIONS,
     });
     return stripAnsi(output.toString());
   } catch (err) {
@@ -369,6 +373,7 @@ export async function runClawMigrate(
         TERM: "dumb",
       },
       stdio: ["ignore", "pipe", "pipe"],
+      ...HIDDEN_SUBPROCESS_OPTIONS,
     });
 
     proc.stdout?.on("data", (data: Buffer) => {
@@ -426,6 +431,7 @@ export async function runHermesUpdate(
         TERM: "dumb",
       },
       stdio: ["ignore", "pipe", "pipe"],
+      ...HIDDEN_SUBPROCESS_OPTIONS,
     });
 
     proc.stdout?.on("data", (data: Buffer) => {
@@ -603,6 +609,7 @@ export async function runInstall(
           ...(askpass?.env ?? {}),
         },
         stdio: ["ignore", "pipe", "pipe"],
+        ...HIDDEN_SUBPROCESS_OPTIONS,
       });
 
       proc.stdout?.on("data", (data: Buffer) => {
@@ -741,7 +748,7 @@ async function runInstallWindows(emit: (t: string) => void): Promise<void> {
           NO_COLOR: "1",
         },
         stdio: ["ignore", "pipe", "pipe"],
-        windowsHide: true,
+        ...HIDDEN_SUBPROCESS_OPTIONS,
       },
     );
 
@@ -823,6 +830,7 @@ export async function runHermesBackup(
           TERM: "dumb",
         },
         timeout: 120000,
+        ...HIDDEN_SUBPROCESS_OPTIONS,
       },
       (error, stdout, stderr) => {
         if (error) {
@@ -871,6 +879,7 @@ export async function runHermesImport(
           TERM: "dumb",
         },
         timeout: 120000,
+        ...HIDDEN_SUBPROCESS_OPTIONS,
       },
       (error, _stdout, stderr) => {
         if (error) {
@@ -908,6 +917,7 @@ export function runHermesDump(): Promise<string> {
           TERM: "dumb",
         },
         timeout: 30000,
+        ...HIDDEN_SUBPROCESS_OPTIONS,
       },
       (error, stdout, stderr) => {
         if (error) {

--- a/src/main/process-options.ts
+++ b/src/main/process-options.ts
@@ -1,0 +1,7 @@
+export const HIDDEN_SUBPROCESS_OPTIONS = { windowsHide: true } as const;
+
+export function hiddenSubprocessOptions<T extends object>(
+  options: T,
+): T & typeof HIDDEN_SUBPROCESS_OPTIONS {
+  return { ...options, ...HIDDEN_SUBPROCESS_OPTIONS };
+}

--- a/src/main/profiles.ts
+++ b/src/main/profiles.ts
@@ -14,6 +14,7 @@ import {
   isValidProfileName,
   PROFILE_NAME_ERROR,
 } from "./utils";
+import { HIDDEN_SUBPROCESS_OPTIONS } from "./process-options";
 
 const PROFILES_DIR = join(HERMES_HOME, "profiles");
 
@@ -217,6 +218,7 @@ export function createProfile(
       },
       stdio: "pipe",
       timeout: 15000,
+      ...HIDDEN_SUBPROCESS_OPTIONS,
     });
     return { success: true };
   } catch (err) {
@@ -250,6 +252,7 @@ export function deleteProfile(name: string): {
         },
         stdio: "pipe",
         timeout: 15000,
+        ...HIDDEN_SUBPROCESS_OPTIONS,
       },
     );
     return { success: true };
@@ -276,6 +279,7 @@ export function setActiveProfile(name: string): void {
       },
       stdio: "pipe",
       timeout: 10000,
+      ...HIDDEN_SUBPROCESS_OPTIONS,
     });
   } catch {
     // ignore

--- a/src/main/skills.ts
+++ b/src/main/skills.ts
@@ -10,6 +10,7 @@ import {
   getEnhancedPath,
 } from "./installer";
 import { profileHome } from "./utils";
+import { HIDDEN_SUBPROCESS_OPTIONS } from "./process-options";
 
 export interface InstalledSkill {
   name: string;
@@ -148,6 +149,7 @@ export function searchSkills(query: string): SkillSearchResult[] {
         },
         stdio: ["ignore", "pipe", "pipe"],
         timeout: 30000,
+        ...HIDDEN_SUBPROCESS_OPTIONS,
       },
     );
 
@@ -253,6 +255,7 @@ export function installSkill(
       },
       stdio: "pipe",
       timeout: 60000,
+      ...HIDDEN_SUBPROCESS_OPTIONS,
     });
     return { success: true };
   } catch (err) {
@@ -282,6 +285,7 @@ export function uninstallSkill(
       },
       stdio: "pipe",
       timeout: 30000,
+      ...HIDDEN_SUBPROCESS_OPTIONS,
     });
     return { success: true };
   } catch (err) {

--- a/src/main/ssh-remote.ts
+++ b/src/main/ssh-remote.ts
@@ -18,6 +18,7 @@ import type { SavedModel } from "./models";
 import type { MemoryProviderInfo } from "./installer";
 import { t } from "../shared/i18n";
 import { getAppLocale } from "./locale";
+import { HIDDEN_SUBPROCESS_OPTIONS } from "./process-options";
 
 // ── SSH exec core ────────────────────────────────────────────────────────────
 
@@ -38,6 +39,7 @@ export function sshExec(config: SshConfig, command: string, stdin?: string, time
   return new Promise((resolve, reject) => {
     const child = spawn("ssh", [...buildExecArgs(config), command], {
       stdio: ["pipe", "pipe", "pipe"],
+      ...HIDDEN_SUBPROCESS_OPTIONS,
     });
     let stdout = "";
     let stderr = "";

--- a/src/main/ssh-tunnel.ts
+++ b/src/main/ssh-tunnel.ts
@@ -4,6 +4,7 @@ import { join } from "path";
 import net from "net";
 import http from "http";
 import { buildSshControlOptions } from "./ssh-options";
+import { HIDDEN_SUBPROCESS_OPTIONS } from "./process-options";
 
 export interface SshConfig {
   host: string;
@@ -127,6 +128,7 @@ export async function startSshTunnel(config: SshConfig): Promise<void> {
   tunnelProcess = spawn("ssh", buildSshArgs(config, localPort), {
     stdio: "ignore",
     detached: false,
+    ...HIDDEN_SUBPROCESS_OPTIONS,
   });
 
   tunnelProcess.on("exit", () => {
@@ -169,7 +171,10 @@ export function testSshConnection(config: SshConfig): Promise<boolean> {
   return findFreePort(config.localPort || 19642)
     .then((localPort) => new Promise<boolean>((resolve) => {
       const args = buildSshArgs(config, localPort);
-      const proc = spawn("ssh", args, { stdio: "ignore" });
+      const proc = spawn("ssh", args, {
+        stdio: "ignore",
+        ...HIDDEN_SUBPROCESS_OPTIONS,
+      });
 
       let done = false;
       const finish = (result: boolean): void => {

--- a/tests/process-options.test.ts
+++ b/tests/process-options.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { hiddenSubprocessOptions } from "../src/main/process-options";
+
+describe("hiddenSubprocessOptions", () => {
+  it("forces child process console windows to stay hidden", () => {
+    const options = hiddenSubprocessOptions({
+      cwd: "C:\\work",
+      timeout: 1000,
+      windowsHide: false,
+    });
+
+    expect(options).toEqual({
+      cwd: "C:\\work",
+      timeout: 1000,
+      windowsHide: true,
+    });
+  });
+
+  it("does not mutate the caller's options object", () => {
+    const original = { stdio: "ignore" as const };
+
+    const options = hiddenSubprocessOptions(original);
+
+    expect(original).toEqual({ stdio: "ignore" });
+    expect(options).toEqual({ stdio: "ignore", windowsHide: true });
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes Windows command prompt windows briefly flashing and stealing focus while Hermes Desktop is working.

The issue happens when the Electron main process launches child processes without `windowsHide: true`. On Windows, those subprocesses can briefly create visible console windows, interrupting typing or focus in other applications.

## What Changed

- Added a shared Desktop subprocess helper in `src/main/process-options.ts`.
- The helper forces `windowsHide: true` while preserving all existing child process options.
- Applied the hidden subprocess option to Desktop-launched processes for:
  - Hermes Python CLI calls
  - Hermes gateway startup
  - installer / update / doctor / version checks
  - backup / import / dump commands
  - cron commands
  - profile commands
  - skill install/search/uninstall commands
  - SSH tunnel and SSH remote subprocesses
- Added unit tests for the helper to verify:
  - it always enables hidden Windows subprocess windows
  - it does not mutate the caller's original options object

## Scope

This PR is intentionally scoped to Hermes Desktop only.

It does not modify Hermes Agent's internal Python subprocess behavior. The reported issue was reproduced and fixed at the Desktop subprocess-launch layer.

## Manual Verification

Tested on Windows with Hermes Desktop running normal agent work.

Before this fix:
- command prompt windows flashed repeatedly
- the flashing windows stole focus
- typing in other apps was interrupted

After this fix:
- subprocess windows no longer flash
- focus is not stolen
- Hermes continues working normally

## Test Plan

- [x] `npx vitest run tests/process-options.test.ts`
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] `npx eslint --no-cache src/main/process-options.ts tests/process-options.test.ts src/main/cronjobs.ts src/main/hermes.ts src/main/installer.ts src/main/profiles.ts src/main/skills.ts src/main/ssh-remote.ts src/main/ssh-tunnel.ts`
  - 0 errors
  - existing Prettier warnings remain
- [x] `npm test`
- [x] `npm run build`
- [x] Manual Windows runtime verification
