### PR TITLE
fix: refresh session list when Sessions view becomes visible

### DIFF
--- a/src/renderer/src/screens/Layout/Layout.tsx
+++ b/src/renderer/src/screens/Layout/Layout.tsx
@@ -260,6 +260,7 @@ function Layout({
                 onResumeSession={handleResumeSession}
                 onNewChat={handleNewChat}
                 currentSessionId={currentSessionId}
+                visible={view === "sessions"}
               />
             )}
           </div>

--- a/src/renderer/src/screens/Sessions/Sessions.tsx
+++ b/src/renderer/src/screens/Sessions/Sessions.tsx
@@ -25,6 +25,7 @@ interface SessionsProps {
   onResumeSession: (sessionId: string) => void;
   onNewChat: () => void;
   currentSessionId: string | null;
+  visible: boolean;
 }
 
 function formatTime(ts: number): string {
@@ -151,6 +152,7 @@ function Sessions({
   onResumeSession,
   onNewChat,
   currentSessionId,
+  visible,
 }: SessionsProps): React.JSX.Element {
   const { t } = useI18n();
   const [sessions, setSessions] = useState<CachedSession[]>([]);
@@ -176,6 +178,16 @@ function Sessions({
   useEffect(() => {
     loadSessions();
   }, [loadSessions]);
+
+  // Refresh sessions whenever the Sessions view becomes visible.
+  // This ensures new sessions created in the Chat view (via "+")
+  // appear immediately when the user navigates back to Sessions,
+  // and also fixes stale sessions list after clearing search.
+  useEffect(() => {
+    if (visible) {
+      loadSessions();
+    }
+  }, [visible, loadSessions]);
 
   useEffect(() => {
     if (searchTimer.current) clearTimeout(searchTimer.current);


### PR DESCRIPTION
## Problem

Two related bugs in the Sessions screen:

1. **New sessions not appearing**: Clicking the "+" button in the chat view creates a new conversation and sends messages, but the resulting session never appears in the Sessions list until the app is restarted.

2. **Search clear shows stale data**: After searching sessions and clearing the search query, the regular session list reverts to the stale data loaded at mount time — any sessions created since the initial load are invisible.

**Root cause**: The `Sessions` component loads session data only once, on initial mount (`useEffect` with empty deps). It has no mechanism to refresh when the user navigates back to the Sessions view.

## Fix

Added a `visible` prop to the `Sessions` component, following the same pattern already used by `Providers`, `Office`, and `Kanban` screens in the same codebase. When the Sessions view becomes visible (i.e. the user navigates to it from the sidebar), the session cache is re-synced and the list refreshes immediately.

**Changes:**
- `src/renderer/src/screens/Sessions/Sessions.tsx`: Added `visible` prop + `useEffect` that calls `loadSessions()` when `visible` becomes true
- `src/renderer/src/screens/Layout/Layout.tsx`: Pass `visible={view === "sessions"}` to the `Sessions` component

**Why this works for both bugs:**
- Bug 1: After creating a new chat session and sending messages, navigating to the Sessions tab triggers a fresh sync from the DB → new session appears immediately.
- Bug 2: After clearing search, the regular sessions view is shown — and since navigating to the Sessions tab now refreshes the data, the list is always up to date.

No polling, no event listeners, no IPC changes needed.