### PR TITLE
docs: hierarchical AGENTS.md tree + upstream runtime-kernel proposal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,98 @@
+<!-- Generated: 2026-05-15 | Updated: 2026-05-15 -->
+
+# hermes-desktop
+
+## Purpose
+
+Hermes Desktop is a native cross-platform Electron application that installs, configures, and runs the [Hermes Agent](https://github.com/NousResearch/hermes-agent) self-improving AI assistant. It provides a GUI for chat, sessions, profiles, memory, skills, tools, scheduling, messaging gateways, and Claw3d Office. It supports both **local** (spawns Hermes at `127.0.0.1:8642`) and **remote** (connects to a remote Hermes API server) modes with SSE streaming.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `package.json` | npm scripts, dependencies. Main entry: `out/main/index.js` |
+| `electron.vite.config.ts` | Electron-Vite config — main externalizes `better-sqlite3`, preload has 2 entry points (index + askpass), renderer aliases `@renderer` |
+| `electron-builder.yml` | Cross-platform packaging config (mac dmg, win nsis, linux AppImage/deb/rpm/snap); GitHub release publisher |
+| `tsconfig.json` / `tsconfig.node.json` / `tsconfig.web.json` | Split TS configs — `node` covers main+preload, `web` covers renderer |
+| `eslint.config.mjs` | Flat ESLint config using Electron Toolkit presets |
+| `vitest.config.ts` | Vitest test runner configuration |
+| `dev-app-update.yml` | electron-updater dev override |
+| `skills-lock.json` | Locked versions of bundled Hermes skills |
+| `README.md` / `README.zh-CN.md` | Project overview (English + Simplified Chinese) |
+| `CONTRIBUTING.md` / `CONTRIBUTING.zh-CN.md` | Contribution guidelines |
+| `LICENSE` | MIT license |
+
+## Subdirectories
+
+| Directory | Purpose |
+|-----------|---------|
+| `src/` | Application source — main, preload, renderer, shared (see `src/AGENTS.md`) |
+| `tests/` | Vitest test suites for main-process and preload logic (see `tests/AGENTS.md`) |
+| `build/` | Packaging assets — icons, mac entitlements, winget templates (see `build/AGENTS.md`) |
+| `scripts/` | Build-time scripts — winget manifest generator (see `scripts/AGENTS.md`) |
+| `resources/` | Runtime resources bundled into asar (icon.png) |
+| `docs/` | Long-form planning docs and design specs (see `docs/AGENTS.md`) |
+| `.github/` | CI/CD — release workflow that builds all platforms |
+| `.agents/` / `.claude/` / `.omc/` | Local AI-agent tooling skills + session state (NOT project code) |
+
+## For AI Agents
+
+### Working In This Directory
+
+- This is an **Electron** app with three process boundaries: **main** (Node, has `nodeIntegration`), **preload** (bridge using `contextIsolation`), and **renderer** (React 19, sandboxed). Never cross these boundaries directly — always add an IPC handler in `src/main/index.ts` and expose it via `src/preload/index.ts`.
+- Persistent state lives in `~/.hermes/` (Hermes Agent owns this; the desktop app reads/writes config + state.db).
+- Local SQLite session storage uses `better-sqlite3` — it is externalized from the main bundle (see `electron.vite.config.ts`).
+- The renderer uses Tailwind CSS 4 + React 19 with the `@renderer` import alias.
+- Two TypeScript projects (`tsconfig.node.json` for main/preload, `tsconfig.web.json` for renderer) — typecheck both before pushing.
+
+### Testing Requirements
+
+```bash
+npm run lint                # ESLint cache enabled
+npm run typecheck           # Both node + web tsconfig projects
+npm run test                # Vitest, single run
+npm run test:watch          # Watch mode during dev
+```
+
+All three must pass with exit 0 before commit.
+
+### Common Patterns
+
+- IPC: `ipcMain.handle("namespace:action", ...)` in main, exposed via `contextBridge.exposeInMainWorld("api", { ... })` in preload, consumed as `window.api.x()` in renderer with types in `src/preload/index.d.ts`.
+- SSE streaming: parse with `src/main/sse-parser.ts` (has matching unit tests).
+- Slash commands and constants are duplicated between renderer (`src/renderer/src/constants.ts`) and i18n locales — keep them in sync.
+- Always read `src/preload/index.d.ts` before adding a new renderer-side `window.api.*` call.
+
+### Build & Release
+
+- `npm run build` → typecheck + electron-vite build (produces `out/`).
+- Platform packaging via `npm run build:mac|win|linux|rpm` — runs electron-builder, signed builds only happen in CI.
+- Release pipeline: `.github/workflows/release.yml` produces dmg, exe, AppImage, deb, rpm, snap on tag push.
+- macOS notarization is required (`notarize: true` in builder config); credentials live in CI secrets.
+
+## Dependencies
+
+### External (runtime)
+
+- **Electron 39** — desktop shell
+- **React 19** + **react-dom** — UI
+- **TypeScript 5.9** — type safety across processes
+- **Tailwind CSS 4** — utility-first styling
+- **Vite 7** + **electron-vite 5** — dev/build tooling
+- **better-sqlite3 12** — local FTS5 session history
+- **electron-updater 6** — in-app auto-update
+- **i18next 25** + **react-i18next** — i18n
+- **react-markdown** + **remark-gfm** + **react-syntax-highlighter** — chat rendering
+- **lucide-react** — icons
+
+### External (dev)
+
+- Vitest 4 + Testing Library — unit/integration tests
+- electron-builder 26 — packaging
+- ESLint 9 + Prettier 3 — linting/formatting
+
+### Upstream Project
+
+- **Hermes Agent** (https://github.com/NousResearch/hermes-agent) — the actual agent runtime the desktop app installs and orchestrates.
+
+<!-- MANUAL: Custom project notes can be added below this line; the auto-generator preserves them. -->

--- a/build/AGENTS.md
+++ b/build/AGENTS.md
@@ -1,0 +1,57 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-05-15 | Updated: 2026-05-15 -->
+
+# build
+
+## Purpose
+
+Packaging assets consumed by `electron-builder` and the release workflow. Holds platform icons, mac entitlements, the `afterPack` hook, and winget manifest templates.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `afterPack.js` | electron-builder `afterPack` hook — runs after each platform package is assembled |
+| `icon.icns` | macOS app icon (815 KB) |
+| `icon.ico` | Windows app icon (68 KB) |
+| `icon.png` | Linux app icon (180 KB) |
+| `entitlements.mac.plist` | macOS hardened-runtime entitlements |
+| `entitlements.mac.inherit.plist` | Entitlements inherited by helper processes |
+
+## Subdirectories
+
+| Directory | Purpose |
+|-----------|---------|
+| `winget/` | Microsoft winget manifest templates (Installer / Locale / Version YAML) used by `scripts/generate-winget-manifests.mjs` |
+
+## For AI Agents
+
+### Working In This Directory
+
+- Icons here are the **shipped** assets. Source icons live elsewhere; do not edit `.icns` / `.ico` / `.png` directly without regenerating from a master.
+- `afterPack.js` runs once per platform per build — keep it idempotent and fast. It is a Node CommonJS module.
+- macOS entitlements changes require re-notarization. Do not weaken these without explicit approval — they gate the hardened runtime build.
+- The winget templates are interpolated by `scripts/generate-winget-manifests.mjs`; placeholder format must stay in sync with that script.
+
+### Testing Requirements
+
+- `tests/winget-generator.test.ts` validates that template substitution still produces valid manifests.
+- No unit tests for `afterPack.js` itself — manually verify by running `npm run build:unpack` and inspecting the output.
+
+### Common Patterns
+
+- electron-builder reads `electron-builder.yml` at the repo root, which references this directory via `directories.buildResources: build`.
+
+## Dependencies
+
+### Internal
+
+- `electron-builder.yml` (repo root) — declares `buildResources: build`
+- `scripts/generate-winget-manifests.mjs` — consumes `winget/*.template.yaml`
+- `package.json` — version field is interpolated into winget manifests
+
+### External
+
+- electron-builder
+
+<!-- MANUAL: -->

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,43 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-05-15 | Updated: 2026-05-15 -->
+
+# docs
+
+## Purpose
+
+Long-form planning documents, design specs, and release-process notes. This directory is **not** auto-generated API docs — those are kept in code.
+
+## Subdirectories
+
+| Directory | Purpose |
+|-----------|---------|
+| `superpowers/` | Planning and spec docs produced via the `superpowers` skill workflow (see `superpowers/AGENTS.md`) |
+
+## For AI Agents
+
+### Working In This Directory
+
+- Treat existing plans/specs as historical artifacts — they describe past decisions and shouldn't be edited without reason.
+- When adding new planning docs, follow the date-prefixed naming convention used in `superpowers/plans/` (e.g. `2026-04-30-feature-name.md`).
+- Do **not** write per-session task notes or working memory here — those belong in `.omc/` or local scratch files.
+
+### Testing Requirements
+
+None — this directory is documentation only.
+
+### Common Patterns
+
+- Markdown only, with H1 title, status header, and dated entries.
+- Cross-link related plans/specs explicitly.
+
+## Dependencies
+
+### Internal
+
+- Plans may reference work in `src/` or `tests/` — keep references as relative paths.
+
+### External
+
+None.
+
+<!-- MANUAL: -->

--- a/docs/proposals/2026-05-15-smolagents-runtime-upgrade.md
+++ b/docs/proposals/2026-05-15-smolagents-runtime-upgrade.md
@@ -1,0 +1,173 @@
+# Upstream proposal: harden the Hermes Agent core runtime with smolagents
+
+**Target repo:** [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) (Python). This document is staged in `hermes-desktop` because the desktop UI is the workspace where the work was scoped, but **no desktop code changes** are implied.
+
+**Status:** Design proposal — not implemented. Owner: TBD. Date: 2026-05-15.
+
+**Inputs:**
+- smolagents @ main (https://github.com/huggingface/smolagents)
+- Local install at `~/.hermes/hermes-agent/` (commit reflected by the runtime; not pinned here)
+
+---
+
+## 1. Why touch this
+
+The hermes-agent runtime works, but the core is a **single 15,883-line `AIAgent` class in `run_agent.py`** (821 KB file). Its inner loop is implicit — there is no typed step record, no extension point that isn't a monkey-patch, and replaying or visualizing a run requires re-reading raw JSONL. `agent/trajectory.py` is **56 lines** and produces an untyped list of dicts.
+
+smolagents has solved the structural side of this problem:
+
+| Concept | smolagents | hermes-agent today |
+|---|---|---|
+| Loop control | `MultiStepAgent.run() / step()` (~few hundred LOC) | embedded in `AIAgent` (15.8k LOC) |
+| Step records | typed `ActionStep`, `PlanningStep`, `FinalAnswerStep` | untyped list of dicts (`trajectory.py`) |
+| Tool calls | `ToolCallingAgent.process_tool_calls()` (generator) | `model_tools.handle_function_call()` + 1k LOC of arg coercion in `run_agent.py` |
+| Code actions | `CodeAgent` writes Python; `PythonExecutor` runs it | none — code is only available as a tool (`tools/code_execution_tool.py`) the model *calls*, not the action format itself |
+| Sandbox | `LocalPythonExecutor` (banned imports, dunder block, op caps, 30s timeout) | `tools/environments/{local,docker,ssh,modal,daytona,vercel_sandbox,singularity}` — these are shell backends for one tool, not the agent's action executor |
+| Extensions | `step_callbacks` + `final_answer_checks` first-class | callsite-specific hooks scattered through `AIAgent` |
+| Planning | `planning_interval: int` | implicit; relies on context compression to reshape history |
+| Serialization | `from_dict / from_folder / from_hub` + `to_dict` | not present |
+| Run result | typed `RunResult(output, state, steps, token_usage, timing)` | ad-hoc dicts |
+
+The biggest robustness wins are typed step records and a clean loop boundary — **independent of whether we adopt smolagents code at all**.
+
+## 2. What hermes-agent has that smolagents lacks
+
+Adopting smolagents wholesale is **not** desirable. hermes-agent already does things smolagents doesn't:
+
+- **Provider depth** — bespoke adapters for Anthropic (`agent/anthropic_adapter.py`, 89 KB), Bedrock, Gemini Cloud Code, Gemini Native, Codex Responses, OpenAI proxy. Each handles prompt-caching, reasoning blocks, ID quirks, rate-limit recovery.
+- **Credential pooling** (`agent/credential_pool.py`, 68 KB) — multi-key rotation, per-account usage tracking (`agent/account_usage.py`).
+- **Context compression** (`agent/context_compressor.py`, 74 KB) — far more sophisticated than truncate-and-summarize.
+- **Tool ecosystem** — 153 KB browser tool, 140 KB MCP tool, 118 KB delegate tool, 71 KB code execution tool, 42 KB kanban, 41 KB image gen, …
+- **Approval/safety gating** (`tools/approval.py`, 59 KB) + `agent/tool_guardrails.py`.
+- **Skill curation loop** (`agent/curator.py`, 75 KB).
+- **MCP OAuth** (`tools/mcp_oauth_manager.py`, 26 KB).
+- **~17,000 tests** covering all of the above.
+
+A wholesale port would regress most of that. The right move is to **adopt smolagents' structure, not its code path**.
+
+## 3. Recommended approach: three tiers
+
+### Tier 1 — Adopt patterns (no dependency added)
+
+**Goal:** extract the loop from `AIAgent` into a thin typed step machine. No external dependency. Keep all provider adapters, compression, credentials, tools as-is.
+
+**Concretely (new modules, all under `agent/runtime/`):**
+
+```
+agent/runtime/
+├── __init__.py
+├── steps.py           # ActionStep, PlanningStep, FinalAnswerStep, MemoryStep (dataclasses, frozen)
+├── result.py          # RunResult(output, state, steps, token_usage, timing)
+├── callbacks.py       # StepCallback protocol + registry
+├── memory.py          # AgentMemory — append-only, typed, supports replay()
+└── loop.py            # MultiStepLoop: pure orchestration, no provider/tool knowledge
+```
+
+**`AIAgent` shrinks from 15.8k to ~3k LOC** by delegating loop control to `MultiStepLoop`. Provider adapters and tool handling stay where they are. The loop calls them through narrow interfaces.
+
+**Wins:**
+- Every step becomes a typed object you can serialize, replay, diff against a known-good trajectory.
+- `step_callbacks` give us a single extension point for: telemetry, redaction, budget enforcement (today scattered as `_should_parallelize_tool_batch`, `_extract_parallel_scope_path`, `IterationBudget`, etc. — all visible in `run_agent.py` lines 287–671).
+- `replay()` and `visualize()` become trivial.
+- Test surface: today most tests have to construct `AIAgent` with mock providers. After Tier 1, the loop is testable with stub callbacks.
+
+**Risk:** medium. Touches the hottest path. Requires backfilling tests against the new `MultiStepLoop` while not changing observable behavior of `AIAgent.run()`.
+
+**Effort:** ~3–4 weeks for one engineer.
+
+### Tier 2 — Add smolagents as an optional dependency for the CodeAgent path
+
+**Goal:** expose the **CodeAgent** pattern (write Python, execute, observe) as an opt-in mode alongside the existing tool-calling flow.
+
+**Concretely:**
+
+- Add `smolagents` to `pyproject.toml` under an extra: `[project.optional-dependencies] codeagent = ["smolagents>=...]`
+- New module `agent/runtime/code_mode.py` defines:
+  - `HermesModel(smolagents.Model)` — wraps existing hermes provider adapters so smolagents calls Anthropic/Gemini/etc. through hermes's credential pool, rate guard, and compression.
+  - `HermesCodeAgent(smolagents.CodeAgent)` — overrides `create_python_executor()` to plug in our existing `tools/environments/` backends as smolagents `PythonExecutor` implementations.
+- New config knob: `agent.mode: tool | code | hybrid` (default `tool`).
+- `hybrid` mode: ToolCallingAgent by default; switches to CodeAgent when the model emits a code block, or for prompts with `agent: code` front-matter.
+
+**Why this is safe:**
+- Zero impact on the default code path. CodeAgent is gated behind a config setting.
+- All hermes-specific behavior (credential pool, rate guard, compression) is preserved by injecting `HermesModel`.
+- Our existing sandboxes (docker, modal, daytona, vercel_sandbox, singularity) become smolagents `PythonExecutor` implementations — a clean adapter, ~150 LOC per backend.
+
+**Wins:**
+- Per smolagents' benchmarks, CodeAgent uses ~30% fewer steps on difficult tasks.
+- Users who already trust our Docker / Modal / Daytona sandboxes get the CodeAgent UX immediately.
+- Lets us evaluate smolagents in production without committing to it.
+
+**Risk:** low-medium. New code, gated. Main risk is `HermesModel` adapter completeness — smolagents' `Model` protocol differs from each provider's native shape.
+
+**Effort:** ~2 weeks after Tier 1 lands.
+
+### Tier 3 — Migrate the whole loop onto smolagents primitives
+
+**Goal:** retire `MultiStepLoop` from Tier 1 in favor of a real `smolagents.MultiStepAgent` subclass.
+
+**Concretely:** `AIAgent` becomes a subclass of `MultiStepAgent`. Compression, credential pool, rate guard become `step_callbacks`. Approval/guardrails become `final_answer_checks` + tool wrappers. The provider adapters become `Model` subclasses.
+
+**Why this is risky:** smolagents' `Model` abstraction is intentionally thin. Things like Anthropic prompt-caching, Gemini native function-call format, and the OpenAI Responses API quirks have all required custom adapter code in hermes. Pushing them through `smolagents.Model` either bloats `HermesModel` until it's not "smolagents-style" anymore, or loses behavior. The ~17k test suite would need to be reviewed end-to-end.
+
+**Recommendation:** **defer**. Revisit only if Tier 1 + Tier 2 prove the abstraction holds.
+
+**Effort:** 6+ months, multi-engineer.
+
+## 4. Sequencing & exit criteria
+
+| Tier | Land in | Exit criteria |
+|---|---|---|
+| 1 | `agent/runtime/` new package; `run_agent.py` shrinks | All existing tests pass; new tests for `MultiStepLoop` give >90% line coverage; trajectory replay matches byte-for-byte for ≥3 reference sessions |
+| 2 | `agent/runtime/code_mode.py` + `pyproject.toml` extra | `agent.mode: code` runs ≥10 reference tasks in CI against the local executor + Docker executor; CodeAgent benchmark within 1.2× ToolCallingAgent step count on hermes's task set |
+| 3 | Decision deferred | Tier 1 + Tier 2 in production for ≥2 quarters with no regression rollback |
+
+## 5. Things that change in the upstream repo
+
+| File | Change | Why |
+|---|---|---|
+| `agent/runtime/` | NEW package (6 files, ~600 LOC total) | Tier 1 — loop extraction |
+| `agent/trajectory.py` | Becomes a thin compatibility shim around `agent/runtime/memory.py::AgentMemory.to_jsonl()` | Preserves `batch_runner.py` consumers; deprecate the file in a later cycle |
+| `run_agent.py` | `AIAgent` shrinks; delegates `_main_loop_iteration` and `_should_parallelize_tool_batch` etc. to `MultiStepLoop` | Tier 1 |
+| `agent/anthropic_adapter.py`, `agent/gemini_*_adapter.py`, `agent/bedrock_adapter.py`, `agent/codex_responses_adapter.py` | UNCHANGED in Tier 1 | They are called through a narrow interface from the new loop |
+| `pyproject.toml` | Add `[project.optional-dependencies] codeagent = ["smolagents>=..."]` | Tier 2 |
+| `agent/runtime/code_mode.py` | NEW — `HermesModel`, `HermesCodeAgent`, executor adapters | Tier 2 |
+| `tools/environments/{docker,modal,daytona,vercel_sandbox,singularity}.py` | Each gets a `as_python_executor()` adapter method | Tier 2 |
+| `hermes_constants.py` / config schema | Add `agent.mode` setting | Tier 2 |
+| `cli.py` (HermesCLI) | Plumb `agent.mode` to runtime constructor | Tier 2 |
+| `tests/runtime/` | NEW directory mirroring Tier 1 / Tier 2 layout | Both tiers |
+
+## 6. Things that explicitly do **not** change
+
+- `gateway/` and all platform adapters — no change.
+- `plugins/` system — no change. Plugins continue to register at the existing extension points.
+- `agent/credential_pool.py`, `agent/nous_rate_guard.py`, `agent/account_usage.py` — unchanged code paths; called as before from the new loop.
+- `agent/context_compressor.py` — invoked via a `step_callback` on `ActionStep` rather than inline; same behavior.
+- `tools/registry.py` — unchanged. The tool registration mechanism is good as-is and orthogonal to the loop.
+- MCP, browser, kanban, delegate, memory tools — unchanged.
+- Skill curation (`agent/curator.py`) — unchanged.
+- The HTTP / SSE protocol that `hermes-desktop` consumes at `127.0.0.1:8642` — **unchanged**. The desktop app does not need any modifications.
+
+## 7. Open questions
+
+1. **Step replay format.** smolagents serializes via `to_dict()`; hermes ships ShareGPT-formatted JSONL via `trajectory.py`. Do we keep both, or migrate `batch_runner.py` consumers to the new format and deprecate the old one over a release?
+2. **Streaming.** smolagents' `stream_outputs=True` flag streams from `agent.run(stream=True)`. hermes's existing SSE flow lives in `cli.py` HTTP handlers. Tier 1 needs the loop to support both event-emission shapes — either via callback or via the same generator pattern smolagents uses.
+3. **Interrupts.** smolagents has `agent.interrupt()`; hermes has `tools/interrupt.py` + signal handling. Decide whether `MultiStepLoop` owns interrupt semantics or delegates to the existing mechanism.
+4. **Authorized imports for CodeAgent.** What's the default `additional_authorized_imports` list for hermes? Reuse the list from `tools/code_execution_tool.py`, or define a narrower default?
+5. **smolagents pin.** smolagents iterates fast. Pin to a tested commit (not `>=`) and update on a deliberate cadence.
+
+## 8. Recommended first PR
+
+A single PR that lands Tier 1 in scope:
+
+- New `agent/runtime/` package.
+- `AIAgent.run()` delegates to `MultiStepLoop.run()`.
+- Backward-compatible `agent/trajectory.py` shim.
+- New `tests/runtime/` covering `MultiStepLoop` independently of `AIAgent`.
+- Existing test suite green; no behavior change.
+
+Estimated ~1,500 LOC added, ~3,000 LOC moved out of `run_agent.py`.
+
+---
+
+**Out of scope for this proposal:** any desktop changes, gateway changes, plugin changes, MCP changes. This document deliberately constrains the blast radius to the agent loop.

--- a/docs/superpowers/AGENTS.md
+++ b/docs/superpowers/AGENTS.md
@@ -1,0 +1,52 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-05-15 | Updated: 2026-05-15 -->
+
+# superpowers
+
+## Purpose
+
+Planning and design-spec documents produced via the `superpowers` skill workflow. Each plan describes a discrete project (date-prefixed); each spec captures the design decisions for the same project. These are **historical artifacts** — they describe what we chose to build and why, not what we are currently building.
+
+## Subdirectories
+
+| Directory | Purpose |
+|-----------|---------|
+| `plans/` | Implementation plans (one large markdown per project, date-prefixed) |
+| `specs/` | Design specs paired with the plans |
+
+## Current Contents
+
+| File | Project |
+|------|---------|
+| `plans/2026-04-30-windows-winget-fedora-rpm-release.md` | Plan: ship Windows winget + Fedora RPM release artifacts |
+| `specs/2026-04-30-windows-winget-fedora-rpm-release-design.md` | Design spec for the same project |
+
+## For AI Agents
+
+### Working In This Directory
+
+- **Don't edit historical plans/specs** without a strong reason. They document past decisions and serve as audit trail.
+- **Adding a new plan**: use `YYYY-MM-DD-short-slug.md` in `plans/`, paired with `YYYY-MM-DD-short-slug-design.md` in `specs/`.
+- **Don't use these for session notes.** Working memory belongs in `.omc/` or local scratch files. Plans here are durable, shared with the team.
+- Cross-link between plan and spec, and reference relevant code paths with relative paths.
+
+### Testing Requirements
+
+None.
+
+### Common Patterns
+
+- Markdown with H1 title, status/owner header, dated entries, and explicit "Open Questions" / "Decisions" sections.
+- Heavy use of code-fenced examples and command snippets.
+
+## Dependencies
+
+### Internal
+
+- May reference code in `src/main/installer.ts`, `scripts/generate-winget-manifests.mjs`, `build/winget/`, `.github/workflows/release.yml`.
+
+### External
+
+None.
+
+<!-- MANUAL: -->

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,43 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-05-15 | Updated: 2026-05-15 -->
+
+# scripts
+
+## Purpose
+
+Build-time Node scripts that produce release artifacts. Run by CI or manually after a release.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `generate-winget-manifests.mjs` | Generates Microsoft winget package manifests (Installer / Locale / Version YAML) from `build/winget/*.template.yaml` for the latest release |
+
+## For AI Agents
+
+### Working In This Directory
+
+- Scripts are ESM (`.mjs`) and use Node 22+ built-ins only — no external dependencies should be added without checking `package.json` first.
+- The winget generator reads the version from `package.json` and the installer URL/SHA from a GitHub release; keep both inputs explicit.
+- Output of the generator is intended for submission to [`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs); do not commit the generated YAMLs into this repo.
+
+### Testing Requirements
+
+- `tests/winget-generator.test.ts` exercises the template substitution path.
+
+### Common Patterns
+
+- Scripts log progress to stdout, exit non-zero on failure, and write artifacts to a path passed via CLI args (no implicit cwd writes).
+
+## Dependencies
+
+### Internal
+
+- `build/winget/*.template.yaml` — input templates
+- `package.json` — version source
+
+### External
+
+- Node 22+ standard library only
+
+<!-- MANUAL: -->

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,0 +1,55 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-05-15 | Updated: 2026-05-15 -->
+
+# src
+
+## Purpose
+
+All application source code, partitioned by Electron's process model: `main/` (Node main process), `preload/` (context-isolated bridge), `renderer/` (React UI), and `shared/` (code safe to import from any process — currently just i18n + the askpass IPC channel name).
+
+## Key Files
+
+None at this level — only subdirectories.
+
+## Subdirectories
+
+| Directory | Purpose |
+|-----------|---------|
+| `main/` | Electron main process — IPC handlers, Hermes installer, SSE proxy, SQLite, gateway/cron orchestration (see `main/AGENTS.md`) |
+| `preload/` | contextBridge — exposes a narrow, typed surface to the renderer (see `preload/AGENTS.md`) |
+| `renderer/` | React 19 single-page app served by Vite (see `renderer/AGENTS.md`) |
+| `shared/` | Code consumed by both main and renderer — i18n catalog + cross-process constants (see `shared/AGENTS.md`) |
+
+## For AI Agents
+
+### Working In This Directory
+
+- **Never** import `electron`, `node:*`, `fs`, `child_process`, or `better-sqlite3` from `renderer/` — these only exist in `main/`.
+- **Never** add direct `ipcRenderer.invoke` calls in the renderer — go through `preload/` so the typed surface stays accurate.
+- When adding a new feature: think main → preload → renderer. Skipping the preload typing layer breaks `window.api` typings.
+- `shared/` must not import from `main/` or `renderer/` (it must be runnable in both contexts).
+
+### Testing Requirements
+
+Tests live in `/tests/` (main-process logic) and inside renderer source (e.g. `*.test.tsx` next to components). See the root and tests AGENTS.md.
+
+### Common Patterns
+
+- **IPC channel naming**: `domain:verb` (e.g. `hermes:start`, `session:list`, `kanban:save`).
+- **SSE streaming**: main process owns the upstream connection and forwards parsed events to the renderer via `webContents.send`.
+- **Three process types**:
+  - Main (`main/`) is a long-lived Node process — owns disk, network, child processes.
+  - Preload (`preload/`) runs in the renderer's V8 isolate but before page scripts — only place to use `contextBridge`.
+  - Renderer (`renderer/`) is the React app — no Node, no Electron APIs except `window.api`.
+
+## Dependencies
+
+### Internal
+
+None at this level — children depend on each other through the IPC contract.
+
+### External
+
+See parent `AGENTS.md`.
+
+<!-- MANUAL: -->

--- a/src/main/AGENTS.md
+++ b/src/main/AGENTS.md
@@ -1,0 +1,90 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-05-15 | Updated: 2026-05-15 -->
+
+# main
+
+## Purpose
+
+The Electron main process. Owns the BrowserWindow lifecycle, IPC handlers, the local Hermes Agent child process, the Hermes installer, SSE stream parsing/forwarding, SQLite session storage, profile/skill/tool/cron CRUD, gateway orchestration, SSH-tunneled remote mode, and Claw3d (Office) management. All disk and network I/O lives here.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `index.ts` | Entry point — creates BrowserWindow, registers all IPC handlers, manages app lifecycle, auto-updater (~39 KB, the largest file) |
+| `installer.ts` | Hermes Agent installer — runs the official install script with progress reporting, dependency resolution, platform branching (~36 KB) |
+| `hermes.ts` | Hermes Agent local process orchestration — start/stop, health, config writing (~26 KB) |
+| `ssh-remote.ts` | Remote-mode SSH tunneling for connecting to a Hermes API server over SSH (~44 KB) |
+| `claw3d.ts` | Claw3d (Hermes Office) management — dev server, adapter resolution (~20 KB) |
+| `config.ts` | `~/.hermes/.env` and `~/.hermes/config.yaml` read/write (~13 KB) |
+| `kanban.ts` | Kanban board persistence |
+| `cronjobs.ts` | Scheduled-task CRUD against `~/.hermes/cron/jobs.json` |
+| `skills.ts` | Bundled and installed skill discovery + management |
+| `tools.ts` | Toolset enable/disable |
+| `profiles.ts` | Hermes profile CRUD (named environments under `~/.hermes/profiles/`) |
+| `sessions.ts` | Session metadata listing |
+| `session-cache.ts` | Local ↔ remote session cache reconciliation |
+| `memory.ts` | Memory entry CRUD |
+| `models.ts` | Saved model config CRUD |
+| `default-models.ts` | Per-provider default model identifiers |
+| `soul.ts` | SOUL.md (persona) read/write |
+| `sse-parser.ts` | SSE event-stream parser (handles partial buffers, multi-line `data:` frames) — covered by `tests/sse-parser.test.ts` |
+| `askpass.ts` | sudo askpass IPC channel — must never leak credentials (see `tests/askpass-security.test.ts`) |
+| `sudoCreds.ts` | Short-lived sudo credential cache |
+| `security.ts` | Electron security policy helpers |
+| `locale.ts` | Locale detection + persistence for i18n |
+| `process-options.ts` | Process spawn flag construction (covered by `tests/process-options.test.ts`) |
+| `ssh-options.ts` | SSH connection option parsing |
+| `ssh-tunnel.ts` | SSH tunnel lifecycle helpers |
+| `session-cache.ts` | Local cache for remote session metadata |
+| `utils.ts` | Miscellaneous shared helpers |
+
+## For AI Agents
+
+### Working In This Directory
+
+- **All Node/Electron APIs are allowed here.** `child_process`, `fs`, `better-sqlite3`, `electron`, `electron-updater` — this is the only place to use them.
+- **IPC handler registration** lives in `index.ts`. Adding a handler is a three-step change: register in `index.ts` (or a feature module), expose in `src/preload/index.ts`, add the type in `src/preload/index.d.ts`. The renderer cannot use a handler until all three exist.
+- **`better-sqlite3` is externalized** from the main bundle (see `electron.vite.config.ts`). It is loaded at runtime, so do not statically bundle it.
+- **Streaming**: outbound SSE from Hermes Agent is parsed by `sse-parser.ts` and forwarded to the renderer via `webContents.send("chat:event", ...)`. Backpressure is handled by Electron's IPC queue — do not buffer unbounded.
+- **Hermes paths**: always go through `~/.hermes/` (resolved via `os.homedir()` + `process.env.HERMES_HOME`). Never hard-code absolute paths.
+- **`HERMES_HOME` env override** is honored everywhere — the `dev:fresh` script uses this to run against a temp directory.
+
+### Security (load-bearing)
+
+- `nodeIntegration: false`, `contextIsolation: true`, `sandbox: true` on the BrowserWindow. Tests in `tests/electron-security.test.ts` enforce this.
+- The askpass channel (`askpass.ts`) gets sudo passwords from the user; it must **never** echo, log, or persist the credential. Test coverage: `tests/askpass-security.test.ts`.
+- Renderer URLs are restricted; do not enable `allowRunningInsecureContent` or weaken CSP.
+
+### Testing Requirements
+
+Main-process unit tests live in `/tests/`. Key suites:
+
+- `tests/ipc-handlers.test.ts` — when adding a handler, add it here too
+- `tests/preload-api-surface.test.ts` — keep the renderer-facing surface accurate
+- `tests/sse-parser.test.ts` — any change to `sse-parser.ts` must keep all assertions green
+- `tests/electron-security.test.ts` / `tests/askpass-security.test.ts` — security regressions block release
+
+### Common Patterns
+
+- **IPC channel naming**: `domain:verb` (`hermes:start`, `session:list`, `cron:save`, `kanban:export`).
+- **Error responses**: handlers either return `{ ok: true, data }` or `{ ok: false, error }` — never throw across the IPC boundary.
+- **Long-running ops** (installer, hermes start) push progress via `webContents.send("topic:progress", ...)` while the invoke returns a job handle.
+- **File modules** are organized by feature (kanban, profiles, skills, ...) rather than by layer; the IPC registration is in `index.ts` but the implementation is in the feature module.
+
+## Dependencies
+
+### Internal
+
+- `src/preload/index.d.ts` — must mirror IPC surface
+- `src/shared/i18n` — main process loads locale for native dialog strings
+- `src/shared/askpass.ts` — channel name constant shared with preload
+
+### External
+
+- `electron`, `electron-updater`
+- `@electron-toolkit/utils`, `@electron-toolkit/preload`
+- `better-sqlite3` (externalized)
+- Node built-ins: `fs`, `child_process`, `os`, `path`, `crypto`, `net`
+
+<!-- MANUAL: -->

--- a/src/preload/AGENTS.md
+++ b/src/preload/AGENTS.md
@@ -1,0 +1,59 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-05-15 | Updated: 2026-05-15 -->
+
+# preload
+
+## Purpose
+
+The context-isolated preload bridge. Runs in the renderer's V8 isolate before page scripts, with access to both Node and the DOM. Exposes a **narrow, typed** API surface to the renderer via `contextBridge.exposeInMainWorld("api", { ... })`. No business logic lives here — only IPC wiring + type declarations.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `index.ts` | Main preload — defines `window.api` surface via `contextBridge`, wraps every renderer-callable IPC channel from `src/main/index.ts` (~24 KB) |
+| `index.d.ts` | TypeScript declaration of `window.api` — the **source of truth** for the renderer's view of IPC (~17 KB) |
+| `askpass.ts` | Separate preload entry for the sudo askpass child window — minimal surface, security-sensitive |
+
+## For AI Agents
+
+### Working In This Directory
+
+- This directory has **two preload entry points** (see `electron.vite.config.ts`):
+  - `index.ts` — main window preload
+  - `askpass.ts` — askpass child window preload (gives the dedicated sudo prompt window only what it needs)
+- **`contextBridge` is mandatory.** Never assign to `window.*` directly. Never use `nodeIntegration` to short-circuit this.
+- **`index.d.ts` must mirror `index.ts`.** When you add a method to the bridge, add its signature here, otherwise the renderer loses type safety.
+- Keep the surface **small** — every method here is a permanent ABI for the renderer. Group by domain (`window.api.hermes.*`, `window.api.session.*`, etc.) rather than flat namespacing.
+- The preload is the only place that calls `ipcRenderer.invoke` / `ipcRenderer.on`. The renderer must never import `electron`.
+
+### Security (load-bearing)
+
+- `contextIsolation: true` is enforced — do not weaken.
+- The askpass preload exposes a **minimal** surface (submit + cancel only). Do not extend it with general IPC.
+- Strings passed across the bridge must be primitive (no functions, no DOM nodes).
+
+### Testing Requirements
+
+- `tests/preload-api-surface.test.ts` — snapshot of the exposed methods. Update intentionally; an accidental new method should fail this test.
+- `tests/askpass-security.test.ts` — guards on the askpass channel.
+
+### Common Patterns
+
+- One file per preload entry point.
+- Bridge methods are async (`async (...) => ipcRenderer.invoke(...)`) or event subscriptions (`on(channel, cb)` returning an unsubscribe).
+- Subscriptions return an `() => void` unsubscribe — React effects must call it on cleanup.
+
+## Dependencies
+
+### Internal
+
+- `src/main/index.ts` — every IPC channel must have a matching `ipcMain.handle` in main
+- `src/shared/askpass.ts` — shared channel-name constant
+
+### External
+
+- `electron` (`contextBridge`, `ipcRenderer`)
+- `@electron-toolkit/preload`
+
+<!-- MANUAL: -->

--- a/src/renderer/AGENTS.md
+++ b/src/renderer/AGENTS.md
@@ -1,0 +1,59 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-05-15 | Updated: 2026-05-15 -->
+
+# renderer
+
+## Purpose
+
+The Electron renderer process — a React 19 single-page app served by Vite during development and bundled into `out/renderer` for production. Sandboxed: no Node APIs, no direct `electron` import; all privileged operations go through `window.api` (defined in `../preload/`).
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `index.html` | Vite entry HTML — loads `src/main.tsx`, sets CSP meta tag |
+
+## Subdirectories
+
+| Directory | Purpose |
+|-----------|---------|
+| `src/` | React app source — App.tsx root, screens, components, assets, constants, i18n bootstrap (see `src/AGENTS.md`) |
+
+## For AI Agents
+
+### Working In This Directory
+
+- The renderer is **sandboxed**. No `import "electron"`, no `process.*`, no `require()`. Use `window.api` (typed via `src/preload/index.d.ts`) for anything privileged.
+- Tailwind CSS 4 is configured via `@tailwindcss/vite`; `index.html` does **not** import a separate CSS file — base CSS comes from `src/assets/base.css` and `src/assets/main.css`.
+- The Vite alias `@renderer` resolves to `src/renderer/src` (see `electron.vite.config.ts`).
+- All UI strings should go through `useI18n()` — never hard-code English text in components.
+
+### Testing Requirements
+
+- Component tests use Vitest + jsdom + Testing Library (`@testing-library/react`).
+- Component test files sit next to the component: e.g. `components/I18nProvider.test.tsx`.
+- Setup file: `src/test/setup.ts`.
+
+### Common Patterns
+
+- `App.tsx` is the top-level router/shell.
+- One screen = one folder under `src/screens/` (most are a single `.tsx`, except `Chat/` which has multiple files + `hooks/`).
+- Shared UI primitives live in `src/components/`.
+- Cross-screen constants (slash commands, provider lists, model defaults) live in `src/constants.ts` and **must** stay in sync with i18n catalogs in `src/shared/i18n/locales/`.
+
+## Dependencies
+
+### Internal
+
+- `src/preload/index.d.ts` — types `window.api`
+- `src/shared/i18n/**` — translation catalogs
+
+### External
+
+- React 19 + react-dom
+- Tailwind CSS 4 (`@tailwindcss/vite`)
+- `react-i18next`, `i18next`
+- `react-markdown` + `remark-gfm` + `react-syntax-highlighter`
+- `lucide-react` (icons)
+
+<!-- MANUAL: -->

--- a/src/renderer/src/AGENTS.md
+++ b/src/renderer/src/AGENTS.md
@@ -1,0 +1,65 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-05-15 | Updated: 2026-05-15 -->
+
+# renderer/src
+
+## Purpose
+
+React 19 application source. The Vite alias `@renderer` resolves here. Organized into top-level `App.tsx` + `main.tsx` entry, shared `components/`, route-style `screens/`, static `assets/`, and the renderer-wide `constants.ts`.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `main.tsx` | React bootstrap — `createRoot(...).render(<App />)` |
+| `App.tsx` | Top-level shell — providers (Theme, I18n, ErrorBoundary), routing between Setup → Layout → screens (~6 KB) |
+| `constants.ts` | App-wide constants: slash commands, provider list, default models, gateway list. **Must stay in sync with i18n catalogs** (~21 KB) |
+| `env.d.ts` | Vite/TS ambient declarations |
+
+## Subdirectories
+
+| Directory | Purpose |
+|-----------|---------|
+| `assets/` | Static assets — fonts, icons, logos, CSS (see `assets/AGENTS.md`) |
+| `components/` | Shared UI primitives + providers (see `components/AGENTS.md`) |
+| `screens/` | Route-level screens, one folder per top-level view (see `screens/AGENTS.md`) |
+| `test/` | Vitest setup file (`setup.ts`) for renderer-side tests |
+
+## For AI Agents
+
+### Working In This Directory
+
+- Renderer is **sandboxed** — no Node, no `electron`. Use `window.api.*` (typed in `src/preload/index.d.ts`).
+- **Strings**: route everything through `useI18n()` / `t()`. Don't hard-code user-facing English in components.
+- **Constants drift**: when you add a slash command, provider, gateway, or model to `constants.ts`, also add the i18n key in every locale under `src/shared/i18n/locales/*/constants.ts`. Tests in `tests/constants.test.ts` catch obvious omissions.
+- **Theme**: dark/light is handled by `components/ThemeProvider.tsx` (CSS variables + Tailwind class strategy).
+- **Error boundaries**: wrap risky screens in `<ErrorBoundary>` from `components/ErrorBoundary.tsx`.
+
+### Testing Requirements
+
+- Renderer tests use Vitest + jsdom + Testing Library, set up by `test/setup.ts`.
+- Place component tests next to the component (e.g. `components/I18nProvider.test.tsx`).
+- Slash-command keyboard handling has a dedicated test: `screens/Chat/keyboard.test.ts`.
+
+### Common Patterns
+
+- One screen folder per top-level view. Single-file screens have just `<Name>.tsx`; complex ones (only `Chat/`) get a folder of pieces + `hooks/`.
+- Hooks live next to the screen that owns them, not in a global `hooks/` directory.
+- Icons come from `lucide-react` first; brand SVGs come from `assets/logos/`.
+
+## Dependencies
+
+### Internal
+
+- `src/preload/index.d.ts` (via implicit `window.api` typing)
+- `src/shared/i18n` (translation runtime + catalogs)
+
+### External
+
+- `react`, `react-dom`
+- `react-i18next`, `i18next`
+- `react-markdown`, `remark-gfm`, `react-syntax-highlighter`
+- `lucide-react`
+- `tailwindcss`
+
+<!-- MANUAL: -->

--- a/src/renderer/src/assets/AGENTS.md
+++ b/src/renderer/src/assets/AGENTS.md
@@ -1,0 +1,57 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-05-15 | Updated: 2026-05-15 -->
+
+# assets
+
+## Purpose
+
+Static assets bundled into the renderer build by Vite: brand images, splash, fonts, app icon, base + main CSS, provider/gateway SVG logos, and the lucide-react icon barrel.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `base.css` | CSS reset + Tailwind `@import` directives |
+| `main.css` | App-wide CSS (~96 KB) — generated/extended Tailwind layer with custom utilities |
+| `hermes.png` / `hermesbg.webp` | Hero / background brand imagery |
+| `icon.png` | App icon for in-app display (build icons live in `/build/`) |
+| `splash.png` / `splashtext.png` / `splashtext-w.webp` | Splash-screen artwork |
+
+## Subdirectories
+
+| Directory | Purpose |
+|-----------|---------|
+| `fonts/` | Google Sans TTF family (Regular, Italic, Medium, MediumItalic, SemiBold, Bold) — referenced from `main.css` `@font-face` |
+| `icons/` | `index.tsx` re-exports lucide-react icons used across the app, so screens import from one place |
+| `logos/` | 35+ SVG logos for LLM providers and messaging gateways (OpenAI, Claude, Gemini, Discord, Slack, Telegram, ...) — light/dark variants where needed |
+
+## For AI Agents
+
+### Working In This Directory
+
+- **Don't add large new fonts** unless explicitly required — each Google Sans variant is ~2 MB.
+- **SVG logos** must use `currentColor` for fills wherever possible so they re-tint with theme; otherwise add a `-color` suffix to the filename and accept that they're fixed-color (e.g. `openai.svg` is monochrome; `gemini-color.svg` is full-color).
+- **CSS**: `main.css` is large because it includes generated utilities — prefer adding Tailwind classes in components over hand-editing this file.
+- **Asset paths**: import via the `@renderer` alias or a relative path; Vite handles fingerprinting.
+- **Adding a new provider/gateway logo**: drop the SVG here, add a mapping in `../constants.ts` and the corresponding screen, and add the i18n string in each locale.
+
+### Testing Requirements
+
+None — assets are validated by the build (Vite errors on missing imports).
+
+### Common Patterns
+
+- Filenames: lowercase, kebab-case, `-color` suffix for non-monochrome variants, `-dark` suffix for explicitly-dark variants.
+
+## Dependencies
+
+### Internal
+
+- `../constants.ts` references logo files by relative path
+- Screens import icons via `./icons/index.tsx`
+
+### External
+
+- `lucide-react` (re-exported through `icons/index.tsx`)
+
+<!-- MANUAL: -->

--- a/src/renderer/src/components/AGENTS.md
+++ b/src/renderer/src/components/AGENTS.md
@@ -1,0 +1,63 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-05-15 | Updated: 2026-05-15 -->
+
+# components
+
+## Purpose
+
+Shared UI primitives, providers (Theme, I18n), and cross-screen widgets. Anything used by **more than one** screen lives here. Screen-specific UI stays in the screen folder.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `AgentMarkdown.tsx` | Markdown renderer for assistant messages — uses react-markdown + remark-gfm + syntax highlighter |
+| `ThemeProvider.tsx` | Dark/light theme provider — reads/writes preference via `window.api`, applies via Tailwind class strategy |
+| `I18nProvider.tsx` | i18next provider wrapper — initializes from `src/shared/i18n` and reacts to locale changes |
+| `I18nProvider.test.tsx` | Vitest coverage for the provider |
+| `I18nContext.ts` | React context for i18n |
+| `useI18n.ts` | Convenience hook wrapping `useTranslation()` with the project's namespaces |
+| `ErrorBoundary.tsx` | Reusable React error boundary — wraps risky screens, shows fallback UI |
+| `RemoteNotice.tsx` | Banner shown when in remote-mode (connected to a remote Hermes API server) |
+| `VerifyWarningBanner.tsx` | Banner warning when the user is running an unverified Hermes Agent build |
+| `Versions.tsx` | Renders Electron / Chromium / Node versions (debug footer) |
+
+## Subdirectories
+
+| Directory | Purpose |
+|-----------|---------|
+| `common/` | Branding components (HermesLogo, BrandLogo) (see `common/AGENTS.md`) |
+
+## For AI Agents
+
+### Working In This Directory
+
+- Components here are **stateless** wherever possible — state belongs in screens, providers expose state via context.
+- Providers go through `App.tsx`; do not instantiate a second `<I18nProvider>` or `<ThemeProvider>` inside a screen.
+- Use `useI18n()` from `useI18n.ts`, not the raw `useTranslation()` from `react-i18next` — it pins the namespace tuple consistently.
+- New shared components should have a co-located `.test.tsx` covering the rendering + at least one interaction.
+- Markdown renderer (`AgentMarkdown.tsx`) is performance-sensitive — token streams update it many times per second. Memoize anything heavy.
+
+### Testing Requirements
+
+- Vitest + Testing Library, jsdom.
+- Co-located `*.test.tsx`.
+
+### Common Patterns
+
+- Provider files end in `Provider.tsx` and pair with a `Context.ts` + hook (`useXxx.ts`).
+- Banner components are presentational — they receive their visibility flag as a prop or via context.
+
+## Dependencies
+
+### Internal
+
+- `useI18n.ts` ↔ `src/shared/i18n`
+- Many components consume `window.api.*` (typed by `src/preload/index.d.ts`)
+
+### External
+
+- `react`, `react-i18next`, `react-markdown`, `remark-gfm`, `react-syntax-highlighter`
+- `lucide-react`
+
+<!-- MANUAL: -->

--- a/src/renderer/src/components/common/AGENTS.md
+++ b/src/renderer/src/components/common/AGENTS.md
@@ -1,0 +1,44 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-05-15 | Updated: 2026-05-15 -->
+
+# components/common
+
+## Purpose
+
+Branding components used across multiple screens. Kept separate from `components/` so the broader components dir stays focused on functional primitives.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `BrandLogo.tsx` | Composable brand logo (text + glyph variants, supports light/dark theming) |
+| `HermesLogo.tsx` | Hermes glyph only — used in splash, header, narrow contexts |
+
+## For AI Agents
+
+### Working In This Directory
+
+- These are **presentation-only** components; no state, no IPC.
+- Logo SVGs are inlined as JSX where possible; raster fallbacks live in `../../assets/`.
+- Respect the active theme via the `useTheme()` hook from `../ThemeProvider.tsx` rather than CSS-only media queries — the app's theme is user-configurable, not just OS-driven.
+
+### Testing Requirements
+
+None at the moment — purely presentational. Add tests if behavior is added.
+
+### Common Patterns
+
+- Components accept a `className` prop to allow per-use sizing/spacing.
+- SVGs use `currentColor` so Tailwind text utility classes can colorize them.
+
+## Dependencies
+
+### Internal
+
+- `../ThemeProvider.tsx` (for theme detection)
+
+### External
+
+- `react`
+
+<!-- MANUAL: -->

--- a/src/renderer/src/screens/AGENTS.md
+++ b/src/renderer/src/screens/AGENTS.md
@@ -1,0 +1,68 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-05-15 | Updated: 2026-05-15 -->
+
+# screens
+
+## Purpose
+
+Route-level screens for the app. Each folder corresponds to one top-level view selectable from the nav. Most screens are a single `<Name>.tsx` file; the **only** screen with internal structure is `Chat/`, which has hooks and helper files.
+
+## Subdirectories (single-file screens unless noted)
+
+| Directory | Purpose |
+|-----------|---------|
+| `Agents/` | Hermes profile CRUD (`Agents.tsx`) |
+| `Chat/` | Streaming conversation UI — **multi-file**, has `hooks/`, slash commands, message rendering (see `Chat/AGENTS.md`) |
+| `Gateway/` | Messaging platform integration setup (Telegram, Discord, Slack, ...) |
+| `Install/` | First-run Hermes Agent installer UI |
+| `Kanban/` | Kanban board (~34 KB single file) |
+| `Layout/` | Top-level shell after Setup — sidebar nav, header, content slot |
+| `Memory/` | Memory entries CRUD + memory provider config |
+| `Models/` | Saved model configurations per provider |
+| `Office/` | Claw3d (Hermes Office) dev server + adapter management |
+| `Providers/` | LLM provider configuration + credential entry |
+| `Schedules/` | Cron job builder + delivery target picker |
+| `Sessions/` | Session history (search, resume, date-grouped) |
+| `Settings/` | All settings — provider config, credentials, backup/import, log viewer, theme, locale (~35 KB) |
+| `Setup/` | First-run flow router (local vs remote, provider pick) |
+| `Skills/` | Bundled + installed skills browser |
+| `Soul/` | Persona (SOUL.md) editor |
+| `SplashScreen/` | Boot splash shown before main window renders |
+| `Tools/` | Toolset enable/disable |
+| `Welcome/` | Welcome screen shown before Setup |
+
+## For AI Agents
+
+### Working In This Directory
+
+- **One folder = one screen.** Do not flatten — folders give us room to grow without renames if a screen ever needs hooks or sub-components.
+- **Single-file screens** stay single-file until they actually need splitting. Don't preemptively explode small screens into folders.
+- **Naming**: folder is PascalCase, file is `<Folder>.tsx`.
+- **Routing**: `App.tsx` picks the screen based on app state (Setup → Welcome → Layout); inside `Layout`, the active screen is picked from sidebar state. There is no react-router.
+- **IPC**: every screen calls `window.api.*`. Failures should be caught and surfaced via toast or inline error UI — never let an IPC rejection unmount the screen.
+- **Strings**: every visible label goes through `useI18n()`. The matching namespace usually matches the screen name (e.g. `Settings.tsx` uses `settings:*`).
+
+### Testing Requirements
+
+- Screens are not currently unit-tested in isolation; coverage comes from main-process tests in `/tests/` plus the Chat keyboard test.
+- When adding a new screen, add at least one smoke test if it has non-trivial logic.
+
+### Common Patterns
+
+- Screen file structure: top-of-file imports → component → default export.
+- Heavy logic (IPC orchestration, derived state) gets extracted into hooks colocated with the screen (see `Chat/hooks/` as the canonical example).
+- Cross-screen state: keep it minimal — most state is screen-local + read-on-mount from `window.api`. There is no global Redux/Zustand store.
+
+## Dependencies
+
+### Internal
+
+- `../components/**` (providers, banners, shared UI)
+- `../constants.ts` (slash commands, providers, gateways, models)
+- `window.api.*` from preload
+
+### External
+
+- `react`, `lucide-react`, `react-i18next`
+
+<!-- MANUAL: -->

--- a/src/renderer/src/screens/Chat/AGENTS.md
+++ b/src/renderer/src/screens/Chat/AGENTS.md
@@ -1,0 +1,68 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-05-15 | Updated: 2026-05-15 -->
+
+# Chat
+
+## Purpose
+
+The streaming conversation screen — the centerpiece of the app. Owns SSE event handling from the Hermes Agent backend, slash-command parsing, model picker, tool progress rendering, markdown + syntax-highlighted output, token-usage display, fast mode, and input history. The only screen broken into multiple files.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `Chat.tsx` | Screen root — composes header, message list, input; orchestrates the hooks (~5 KB) |
+| `ChatHeader.tsx` | Top bar — session title, model picker trigger, token usage |
+| `ChatEmptyState.tsx` | Empty-session placeholder with quick-start prompts |
+| `ChatInput.tsx` | Multi-line input — slash-command dropdown, send/stop button, drop-target wiring (~9 KB) |
+| `MessageList.tsx` | Scroll-managed message viewport |
+| `MessageRow.tsx` | Single message row (user/assistant/tool/system) — feeds content into `AgentMarkdown` |
+| `ModelPicker.tsx` | Popover for switching active model |
+| `slashCommands.ts` | Slash-command registry, parser, suggestion matcher (~4 KB) |
+| `keyboard.ts` | Keyboard event helpers (Enter to send, Shift+Enter newline, history nav, slash trigger) |
+| `keyboard.test.ts` | Vitest coverage for `keyboard.ts` |
+| `types.ts` | Shared local types for chat |
+
+## Subdirectories
+
+| Directory | Purpose |
+|-----------|---------|
+| `hooks/` | Custom hooks that hold the screen's logic (chat IPC, scroll, fast mode, input history, local commands, model config, actions) (see `hooks/AGENTS.md`) |
+
+## For AI Agents
+
+### Working In This Directory
+
+- **SSE events** arrive via `window.api.chat.onEvent(cb)` (typed in `src/preload/index.d.ts`) — never call `ipcRenderer` directly. The hook `useChatIPC` is the canonical subscriber.
+- **Slash commands**: the registry in `slashCommands.ts` is the source of truth for the dropdown; the **descriptions** are localized in `src/shared/i18n/locales/*/chat.ts`. Adding a slash command means updating both, plus possibly handling it in `useLocalCommands.ts` if the command runs entirely client-side.
+- **Markdown rendering** is done by `../../components/AgentMarkdown.tsx` — performance-sensitive because the assistant stream re-renders many times per second. Memoize.
+- **Keyboard handling** lives in `keyboard.ts` with a co-located test — keep it covered.
+- **Input history** is managed by `hooks/useInputHistory.ts` (↑/↓ keys cycle through past inputs). Don't bypass it from `ChatInput.tsx` directly.
+- **Model config**: read/write via `hooks/useModelConfig.ts` (it talks to `window.api.models.*`).
+
+### Testing Requirements
+
+- `keyboard.test.ts` covers the keyboard helper.
+- Streaming behavior is exercised by `tests/sse-parser.test.ts` at the main-process boundary.
+- Manual smoke test after changes: start a chat, send a message, watch token usage update, try a slash command, try Fast Mode.
+
+### Common Patterns
+
+- Hooks own state and effects. Components are presentational and receive callbacks from hooks.
+- Stream-derived state (`isStreaming`, `currentMessage`) is computed by `useChatIPC` and threaded down — never re-derived from scratch in child components.
+- Local slash commands (`/clear`, `/help`) short-circuit before sending to the backend — see `useLocalCommands.ts`.
+
+## Dependencies
+
+### Internal
+
+- `../../components/AgentMarkdown.tsx`
+- `../../constants.ts` (default models, fast-mode flag)
+- `window.api.chat.*`, `window.api.session.*`, `window.api.models.*`
+
+### External
+
+- `react`, `react-markdown`, `remark-gfm`, `react-syntax-highlighter`
+- `lucide-react`
+
+<!-- MANUAL: -->

--- a/src/renderer/src/screens/Chat/hooks/AGENTS.md
+++ b/src/renderer/src/screens/Chat/hooks/AGENTS.md
@@ -1,0 +1,55 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-05-15 | Updated: 2026-05-15 -->
+
+# Chat/hooks
+
+## Purpose
+
+Custom React hooks that hold the Chat screen's state and side effects. Components in `..` stay presentational by delegating logic here. Each hook has one clear responsibility.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `useChatIPC.ts` | Subscribes to `window.api.chat.onEvent`, parses incoming SSE events, builds the message list and streaming state |
+| `useChatActions.ts` | Send / stop / retry / undo / new — the user-initiated action surface that the input and header call |
+| `useChatScroll.ts` | Scroll-position management for `MessageList` — auto-stick to bottom while streaming, release on user scroll-up |
+| `useFastMode.ts` | Toggle + persistence for Fast Mode (Opus with faster output, model-side feature) |
+| `useInputHistory.ts` | ↑/↓ navigation through past inputs; persists per-session history |
+| `useLocalCommands.ts` | Handles slash commands that run entirely client-side (`/clear`, `/help`, `/undo`, ...) without hitting the backend (~7 KB) |
+| `useModelConfig.ts` | Reads + writes the active model configuration via `window.api.models.*` |
+
+## For AI Agents
+
+### Working In This Directory
+
+- **One concern per hook.** If a hook starts taking more than one ~3 KB-worth of responsibility, split it.
+- **Hooks return objects, not tuples.** Named keys make additive changes safe.
+- **Cleanup**: every effect that subscribes via `window.api.*.onEvent` must return the unsubscribe function from the cleanup. The bridge contract is that all `on*` calls return an unsubscribe.
+- **Fast Mode** state is persisted via `window.api.config.*`; don't keep it in `useState` alone.
+- **Local commands** (`useLocalCommands.ts`) should fail loudly if a slash command is registered but no handler exists — silent no-ops are worse than errors.
+
+### Testing Requirements
+
+- Hooks here are not currently unit-tested. If you add complex logic, prefer extracting pure helpers and testing those.
+- Integration: exercise via manual chat smoke test.
+
+### Common Patterns
+
+- File name = `useXxx.ts`; exports a single default or named hook.
+- IPC subscribed inside `useEffect` with explicit dependency arrays.
+- Refs (`useRef`) hold mutable streaming buffers to avoid re-renders mid-stream.
+
+## Dependencies
+
+### Internal
+
+- `../slashCommands.ts` (registry)
+- `../types.ts`
+- `window.api.chat.*`, `window.api.config.*`, `window.api.models.*`, `window.api.session.*`
+
+### External
+
+- `react`
+
+<!-- MANUAL: -->

--- a/src/shared/AGENTS.md
+++ b/src/shared/AGENTS.md
@@ -1,0 +1,51 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-05-15 | Updated: 2026-05-15 -->
+
+# shared
+
+## Purpose
+
+Code consumed by **both** main and renderer processes. Must be runnable in either context — no Node-only imports (`fs`, `child_process`, ...) and no DOM-only imports (`window`, `document`, ...). Currently holds the i18n catalog and a single shared IPC channel name constant.
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `askpass.ts` | Single shared constant — the IPC channel name for the askpass bridge. Defined here so main and preload can't drift. |
+
+## Subdirectories
+
+| Directory | Purpose |
+|-----------|---------|
+| `i18n/` | i18next bootstrap, type aliases, and per-locale translation catalogs (see `i18n/AGENTS.md`) |
+
+## For AI Agents
+
+### Working In This Directory
+
+- **No Node imports.** No `fs`, `os`, `path`, `child_process`. If you need filesystem access, the caller in `main/` should pass the data in.
+- **No browser-only imports.** No `window`, `document`, `localStorage`. If you need DOM, the caller in `renderer/` should pass it in.
+- Keep things pure and serializable so values can cross the IPC boundary unchanged.
+- Add new shared constants here when both main and renderer must agree on a string (channel names, default paths, magic constants).
+
+### Testing Requirements
+
+- `i18n/index.test.ts` covers the i18next bootstrap.
+- New shared code should be testable with vanilla Vitest (no jsdom dependency).
+
+### Common Patterns
+
+- Plain TypeScript modules, no framework imports.
+- Constants are `export const NAME = "value" as const`.
+
+## Dependencies
+
+### Internal
+
+None — shared is a leaf in the dependency graph.
+
+### External
+
+- `i18next`, `react-i18next` (only used by `i18n/`)
+
+<!-- MANUAL: -->

--- a/src/shared/i18n/AGENTS.md
+++ b/src/shared/i18n/AGENTS.md
@@ -1,0 +1,56 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-05-15 | Updated: 2026-05-15 -->
+
+# i18n
+
+## Purpose
+
+i18next bootstrap, namespace types, and translation catalogs for every supported UI language. Used by both main (native dialog strings) and renderer (all visible UI text).
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `index.ts` | i18next init — registers all namespaces, sets fallback chain, exposes a single `i18n` instance (~11 KB) |
+| `index.test.ts` | Smoke test that all namespaces load and `t()` returns strings |
+| `config.ts` | Locale list + default locale + fallback configuration |
+| `types.ts` | `Resources` type and namespace declarations for type-safe `t()` calls |
+
+## Subdirectories
+
+| Directory | Purpose |
+|-----------|---------|
+| `locales/` | Per-language catalogs — one folder per locale, each with the same set of namespace files (see `locales/AGENTS.md`) |
+
+## For AI Agents
+
+### Working In This Directory
+
+- **Adding a translation key**: add it to **every** locale in `locales/*/<namespace>.ts`. Tests do not currently enforce key parity — manual diligence required.
+- **Adding a new namespace**: register it in `index.ts` and `types.ts`, then add a corresponding `.ts` file in every locale.
+- **Adding a new locale**: add an entry to `config.ts`, create `locales/<lang>/` mirroring `locales/en/`, and add the language to the locale picker in `src/renderer/src/screens/Settings/Settings.tsx`.
+- The English catalog (`locales/en/`) is the **source of truth** — copy from it when starting a new locale.
+- Constants strings (slash commands, provider names) live in `locales/<lang>/constants.ts` and must stay aligned with `src/renderer/src/constants.ts`.
+
+### Testing Requirements
+
+- `index.test.ts` — basic load + lookup smoke test
+- Component tests (e.g. `I18nProvider.test.tsx`) exercise the integration
+
+### Common Patterns
+
+- Each namespace exports a default object of `key: string` (or nested objects for grouped keys).
+- `t("namespace:key")` is the standard call form; `useI18n()` pre-binds namespaces.
+
+## Dependencies
+
+### Internal
+
+- Consumed by `src/renderer/src/components/I18nProvider.tsx` and `useI18n.ts`
+- Main process imports for native dialog text
+
+### External
+
+- `i18next`, `react-i18next`
+
+<!-- MANUAL: -->

--- a/src/shared/i18n/locales/AGENTS.md
+++ b/src/shared/i18n/locales/AGENTS.md
@@ -1,0 +1,76 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-05-15 | Updated: 2026-05-15 -->
+
+# locales
+
+## Purpose
+
+Per-language translation catalogs. Each language has its own folder containing the same set of namespace files (`agents.ts`, `chat.ts`, `common.ts`, `constants.ts`, ...). English is the source of truth.
+
+## Subdirectories
+
+| Directory | Purpose |
+|-----------|---------|
+| `en/` | English — source of truth, populated for every namespace |
+| `es/` | Spanish |
+| `id/` | Indonesian |
+| `ja/` | Japanese |
+| `pt-BR/` | Brazilian Portuguese |
+| `zh-CN/` | Simplified Chinese |
+
+## Namespace Files (per locale)
+
+| File | Covers |
+|------|--------|
+| `agents.ts` | Agents/profiles screen |
+| `chat.ts` | Chat UI, slash commands, model picker |
+| `common.ts` | Buttons, dialogs, generic actions |
+| `constants.ts` | Slash command descriptions, provider/gateway labels — mirrors `src/renderer/src/constants.ts` |
+| `errors.ts` | Error/failure messages |
+| `gateway.ts` | Messaging gateway screen |
+| `install.ts` | Installer steps and prompts |
+| `memory.ts` | Memory screen |
+| `models.ts` | Models screen |
+| `navigation.ts` | Side nav / tab labels |
+| `office.ts` | Claw3d Office screen |
+| `providers.ts` | LLM provider picker |
+| `schedules.ts` | Schedules / cron screen |
+| `sessions.ts` | Sessions list |
+| `settings.ts` | Settings screen |
+| `setup.ts` | First-run setup flow |
+| `skills.ts` | Skills screen |
+| `soul.ts` | Persona / SOUL.md screen |
+| `tools.ts` | Tools screen |
+| `welcome.ts` | Welcome / initial screen |
+
+## For AI Agents
+
+### Working In This Directory
+
+- **Source of truth**: `en/`. When starting a new locale, copy the full `en/` tree and translate each value.
+- **Key parity is not enforced by tests** — add new keys to every locale or the UI will fall back to English (or show the raw key, depending on i18next config).
+- **Don't translate technical strings** that match a product term: provider names, brand names, slash command identifiers (only the *descriptions* should be translated, not `/new` itself).
+- **Plurals and interpolations**: use i18next syntax (`{{count}}`, `_one` / `_other` suffix keys) — see the English catalog for examples.
+
+### Testing Requirements
+
+- `../index.test.ts` ensures all namespaces in the default locale load.
+- Manual verification: change locale in Settings and walk through each screen.
+
+### Common Patterns
+
+- Each `.ts` file `export default { key: "value", group: { nested: "value" } } as const`.
+- Identical shape across locales — diffing two catalogs for the same namespace should reveal only value changes.
+
+## Dependencies
+
+### Internal
+
+- Consumed by `../index.ts` (i18next registration)
+- `constants.ts` mirrors `src/renderer/src/constants.ts` shape
+
+### External
+
+None.
+
+<!-- MANUAL: -->

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,67 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-05-15 | Updated: 2026-05-15 -->
+
+# tests
+
+## Purpose
+
+Vitest test suites for main-process logic, preload surface, installer utilities, security boundaries, and SSE parsing. Renderer component tests live next to the components themselves (e.g. `src/renderer/src/components/I18nProvider.test.tsx`).
+
+## Key Files
+
+| File | Description |
+|------|-------------|
+| `sse-parser.test.ts` | Tests `src/main/sse-parser.ts` event framing, partial buffers, multi-line data |
+| `ipc-handlers.test.ts` | Verifies main-process IPC handler registration |
+| `preload-api-surface.test.ts` | Snapshot of the typed `window.api` surface exposed via contextBridge |
+| `installer-utils.test.ts` | Hermes installer helper logic (dependency detection, path resolution) |
+| `installer-platform.test.ts` | Per-platform installer branching (win/mac/linux) |
+| `askpass-security.test.ts` | Guards on the sudo askpass IPC channel — must not leak credentials |
+| `electron-security.test.ts` | Asserts `nodeIntegration: false`, `contextIsolation: true`, sandboxed renderer, CSP |
+| `env-validation.test.ts` | Validation of `~/.hermes/.env` parsing |
+| `hermes-api.test.ts` | HTTP client against the Hermes Agent local API |
+| `claw3d-command-resolution.test.ts` | Claw3d (Office) executable resolution |
+| `constants.test.ts` | Sanity-checks `src/renderer/src/constants.ts` (slash commands, provider lists) |
+| `process-options.test.ts` | `src/main/process-options.ts` flag construction |
+| `profile-validation.test.ts` / `profiles.test.ts` | Hermes profile CRUD + validation |
+| `remote-history.test.ts` | Remote-mode session history sync |
+| `session-cache-sync.test.ts` | Local ↔ remote session cache reconciliation |
+| `ssh-options.test.ts` / `ssh-remote.test.ts` | SSH remote-mode option parsing and connection logic |
+| `winget-generator.test.ts` | `scripts/generate-winget-manifests.mjs` output validation |
+
+## For AI Agents
+
+### Working In This Directory
+
+- Use Vitest's mocking for `electron`, `fs`, `child_process` — never let tests actually launch Electron or spawn subprocesses.
+- Tests run in jsdom OR node depending on `vitest.config.ts` — check the env if you see DOM-related failures.
+- When adding a new IPC handler in `src/main/index.ts`, add a matching entry to `ipc-handlers.test.ts` AND `preload-api-surface.test.ts` so the renderer surface stays exhaustive.
+
+### Testing Requirements
+
+```bash
+npm run test         # single run
+npm run test:watch   # iterative dev
+```
+
+All tests must pass before push. CI gates on this.
+
+### Common Patterns
+
+- `describe` per module, `it` per behavior — keep tests close to the unit, not the file.
+- Fixtures inline; avoid a shared fixtures directory.
+- Security tests (`askpass-security`, `electron-security`) are **load-bearing** — they enforce that nothing weakens process isolation. Treat any failure here as a P0.
+
+## Dependencies
+
+### Internal
+
+- `src/main/**` — primary test target
+- `src/preload/**` — surface snapshot
+- `src/renderer/src/constants.ts` — slash-command and provider constants
+
+### External
+
+- `vitest`, `@testing-library/dom`, `@testing-library/jest-dom`, `jsdom`
+
+<!-- MANUAL: -->


### PR DESCRIPTION
Adds AI-readable AGENTS.md documentation across the hermes-desktop codebase (20 files), plus a design proposal for hardening the upstream hermes-agent core runtime with smolagents-inspired structure.

AGENTS.md tree:
  - Root + src/{main,preload,renderer,shared}/
  - src/renderer/src/{assets,components,screens}/ + Chat/hooks/
  - src/shared/i18n/locales/
  - tests/, build/, scripts/, docs/superpowers/ Each file: purpose, key files, AI-agent guidance, dependencies. Every non-root file has a `<!-- Parent: ../AGENTS.md -->` reference; all 19 parent references resolve.

Runtime-kernel proposal (`docs/proposals/2026-05-15-smolagents-runtime-upgrade.md`):
  Three-tier rollout plan for the upstream NousResearch/hermes-agent
  runtime — adopt typed step machine + governance gate first (no
  smolagents dep), add CodeAgent as an optional dep second, defer full
  migration. The concrete kernel implementation lives in the companion
  PR on the hermes-agent fork
  (dislovelhl/hermes-agent#runtime/multistep-loop-kernel).

No source changes to hermes-desktop. SSE contract, IPC, and Electron process boundaries are unaffected.