### PR TITLE
fix(ssh-tunnel): disable multiplexing for tunnel processes (#195, #159)

### DIFF
--- a/src/main/ssh-options.ts
+++ b/src/main/ssh-options.ts
@@ -1,5 +1,16 @@
-export function buildSshControlOptions(platform = process.platform): string[] {
-  if (platform === "win32") {
+export interface SshControlOptions {
+  // Long-running tunnel processes (ssh -N -L) must keep the spawned ssh
+  // process in the foreground so tunnelProcess lifecycle tracking works.
+  // ControlPersist forks a background master and exits the foreground
+  // process, which breaks lifecycle tracking on Linux and macOS (#195, #159).
+  forTunnel?: boolean;
+}
+
+export function buildSshControlOptions(
+  platform = process.platform,
+  options: SshControlOptions = {},
+): string[] {
+  if (platform === "win32" || options.forTunnel) {
     return [
       "-o",
       "ControlMaster=no",

--- a/src/main/ssh-tunnel.ts
+++ b/src/main/ssh-tunnel.ts
@@ -110,7 +110,7 @@ function buildSshArgs(config: SshConfig, localPort: number): string[] {
     "-i", keyPath,
     "-o", "StrictHostKeyChecking=accept-new",
     "-o", "BatchMode=yes",
-    ...buildSshControlOptions(),
+    ...buildSshControlOptions(process.platform, { forTunnel: true }),
     "-o", "ExitOnForwardFailure=yes",
     "-o", "ServerAliveInterval=30",
     "-o", "ServerAliveCountMax=3",

--- a/tests/ssh-options.test.ts
+++ b/tests/ssh-options.test.ts
@@ -1,26 +1,45 @@
 import { describe, expect, it } from "vitest";
 import { buildSshControlOptions } from "../src/main/ssh-options";
 
+const NO_MULTIPLEXING = [
+  "-o",
+  "ControlMaster=no",
+  "-o",
+  "ControlPath=none",
+  "-o",
+  "ControlPersist=no",
+];
+
+const MULTIPLEXING_ENABLED = [
+  "-o",
+  "ControlMaster=auto",
+  "-o",
+  "ControlPath=~/.ssh/cm-hermes-%r@%h:%p",
+  "-o",
+  "ControlPersist=60s",
+];
+
 describe("ssh control options", () => {
   it("disables SSH multiplexing on Windows", () => {
-    expect(buildSshControlOptions("win32")).toEqual([
-      "-o",
-      "ControlMaster=no",
-      "-o",
-      "ControlPath=none",
-      "-o",
-      "ControlPersist=no",
-    ]);
+    expect(buildSshControlOptions("win32")).toEqual(NO_MULTIPLEXING);
   });
 
-  it("keeps SSH multiplexing enabled on non-Windows platforms", () => {
-    expect(buildSshControlOptions("linux")).toEqual([
-      "-o",
-      "ControlMaster=auto",
-      "-o",
-      "ControlPath=~/.ssh/cm-hermes-%r@%h:%p",
-      "-o",
-      "ControlPersist=60s",
-    ]);
+  it("keeps SSH multiplexing enabled on non-Windows for one-shot commands", () => {
+    expect(buildSshControlOptions("linux")).toEqual(MULTIPLEXING_ENABLED);
+    expect(buildSshControlOptions("darwin")).toEqual(MULTIPLEXING_ENABLED);
+  });
+
+  it("disables SSH multiplexing for tunnel processes on every platform", () => {
+    // ControlPersist forks a background master and exits the foreground
+    // process, which breaks tunnelProcess lifecycle tracking (#195, #159).
+    expect(
+      buildSshControlOptions("linux", { forTunnel: true }),
+    ).toEqual(NO_MULTIPLEXING);
+    expect(
+      buildSshControlOptions("darwin", { forTunnel: true }),
+    ).toEqual(NO_MULTIPLEXING);
+    expect(
+      buildSshControlOptions("win32", { forTunnel: true }),
+    ).toEqual(NO_MULTIPLEXING);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #195 — and likely #159, since both share the same root cause.

On Linux and macOS, the SSH tunnel uses `ssh -N -L` as a long-running process tracked via `tunnelProcess.on('exit', ...)`. With `ControlPersist=60s`, OpenSSH **forks a background master and the foreground process exits immediately** — even when no pre-existing control socket exists. That fires the `exit` handler, sets `activeConfig = null`, and `getSshTunnelUrl()` returns `null` even though port forwarding is still alive via the backgrounded daemon.

The user-visible symptom matches both reported issues:

- **#195 (Linux):** every chat throws "SSH tunnel is not active" while `GET /health` on the forwarded port keeps returning 200.
- **#159 (macOS):** chat `sendMessage` hangs indefinitely while management screens (Sessions, Skills, Memory) — which go through `sshExec` instead of relying on `activeConfig` — keep working.

## Fix

Add a `forTunnel` option to `buildSshControlOptions()`:

- Tunnel call sites (`ssh-tunnel.ts`) request `forTunnel: true` → no multiplexing on every platform.
- One-shot `sshExec` / `ssh-remote` calls keep `ControlMaster=auto` + `ControlPersist=60s` on non-Windows, since multiplexing is genuinely useful there.

This is a more surgical fix than the diff proposed in #195 (which would globally disable multiplexing); it preserves the perf win for management-screen calls while fixing the lifecycle bug for tunnels.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test -- ssh-options` — 3 tests pass (Windows multiplexing-disabled, non-Windows multiplexing-enabled, tunnel-mode multiplexing-disabled on linux/darwin/win32)
- [ ] Manual: SSH tunnel mode on Linux against a remote Hermes — chat sends successfully (reporter of #195 ideally verifies)
- [ ] Manual: SSH tunnel mode on macOS — chat sends successfully (reporter of #159 ideally verifies)
- [ ] Manual: SSH tunnel mode on Windows — no regression (multiplexing was already disabled there)

## Files changed

- `src/main/ssh-options.ts` — add `forTunnel` option
- `src/main/ssh-tunnel.ts` — pass `forTunnel: true` in `buildSshArgs()`
- `tests/ssh-options.test.ts` — add tunnel-mode tests, cover darwin alongside linux