### PR TITLE
fix(ssh-remote): detect Hermes version via venv binary, not sudo-wrapper

### DIFF
--- a/src/main/ssh-remote.ts
+++ b/src/main/ssh-remote.ts
@@ -930,8 +930,24 @@ export async function sshReadRemoteApiKey(config: SshConfig): Promise<string> {
 // ── Versions ──────────────────────────────────────────────────────────────────
 
 export async function sshGetHermesVersion(config: SshConfig): Promise<string | null> {
+  // The full version string (Engine / Released / Python / OpenAI SDK) the
+  // Settings UI parses only comes from the real hermes Python entrypoint.
+  // Many production deploys ship a `/usr/local/bin/hermes` sudo-wrapper that
+  // refuses to run as the hermes service user itself (sudoers policy), so
+  // calling bare `hermes` returns nothing useful. Probe the venv binaries at
+  // their well-known install paths first; fall back to PATH only if none of
+  // those exist.
+  const candidates = [
+    "$HOME/hermes-agent/.venv/bin/hermes",
+    "$HOME/.hermes/hermes-agent/.venv/bin/hermes",
+    "/opt/hermes/hermes-agent/.venv/bin/hermes",
+  ];
+  const probe = candidates.map((p) => `[ -x ${p} ] && exec ${p} --version`).join("; ");
   try {
-    const out = await sshExec(config, `hermes --version 2>/dev/null || hermes version 2>/dev/null || echo ""`);
+    const out = await sshExec(
+      config,
+      `bash -c '${probe}; command -v hermes >/dev/null && exec hermes --version; echo ""'`,
+    );
     return out.trim() || null;
   } catch {
     return null;


### PR DESCRIPTION
## Summary

Settings → Hermes Agent shows blank **Engine**, **Released**, **Python**, and **OpenAI SDK** fields against a remote Hermes deployed via the official installer in SSH tunnel mode.

## Root cause

The Settings UI parses the long version string returned by the Python entrypoint:

```
Hermes Agent v0.14.0 (2026.5.16)
Project: /opt/hermes/hermes-agent
Python: 3.12.3
OpenAI SDK: 2.24.0
```

`sshGetHermesVersion()` calls `hermes --version` over SSH. Production installs commonly ship a `/usr/local/bin/hermes` sudo-wrapper that does `sudo -u hermes <venv>/bin/hermes "\$@"`. When SSH'd in as the `hermes` service user, the wrapper hits sudoers and fails with:

```
Sorry, user hermes is not allowed to execute '/usr/bin/bash -c ...' as hermes on <host>.
```

That goes to stderr, stdout is empty, the regex parser yields `null`, and all four fields render blank.

## Fix

Probe the well-known venv install paths first and `exec` the venv binary directly:

- `\$HOME/hermes-agent/.venv/bin/hermes`
- `\$HOME/.hermes/hermes-agent/.venv/bin/hermes`
- `/opt/hermes/hermes-agent/.venv/bin/hermes`

Fall back to bare `hermes` on PATH only if none of those exist, so non-installer deployments still work.

## Test plan

- [x] `npm run typecheck` clean
- [x] Manual: SSH'd into a production install (Hermes 0.14.0 under /opt/hermes), the new probe returns the full multi-line version string the Settings parser expects
- [ ] Manual: against an in-PATH-only deployment (no venv), the bare `hermes --version` fallback still works