### PR TITLE
feat(kanban): wire Kanban board for SSH tunnel mode

### DIFF
--- a/src/main/kanban.ts
+++ b/src/main/kanban.ts
@@ -6,7 +6,9 @@ import {
   hermesCliArgs,
   getEnhancedPath,
 } from "./installer";
-import { isRemoteMode } from "./hermes";
+import { isRemoteOnlyMode } from "./hermes";
+import { getConnectionConfig } from "./config";
+import { sshRunKanban } from "./ssh-remote";
 
 export interface KanbanTask {
   id: string;
@@ -95,10 +97,20 @@ interface RunOpts {
   timeoutMs?: number;
 }
 
-function runKanban(
+async function runKanban(
   args: string[],
   opts: RunOpts = {},
 ): Promise<KanbanResult<unknown>> {
+  // SSH tunnel mode: dispatch to the remote Hermes CLI over SSH.
+  const conn = getConnectionConfig();
+  if (conn.mode === "ssh" && conn.ssh) {
+    return sshRunKanban(conn.ssh, args, {
+      profile: opts.profile,
+      parseJson: opts.parseJson,
+      timeoutMs: opts.timeoutMs,
+    });
+  }
+
   const cliArgs = hermesCliArgs();
   if (opts.profile && opts.profile !== "default") {
     cliArgs.push("-p", opts.profile);
@@ -144,7 +156,9 @@ function unsupportedInRemote<T>(): KanbanResult<T> {
   return {
     success: false,
     error:
-      "Kanban is not available in remote/SSH mode yet. Switch to a local Hermes install to use the board.",
+      "Kanban requires either a local Hermes install or SSH tunnel mode. " +
+      "Plain remote (HTTP+API key) mode does not yet expose the kanban API. " +
+      "Switch to SSH tunnel mode in Settings to use the board against a remote Hermes.",
   };
 }
 
@@ -152,7 +166,7 @@ export async function listBoards(
   includeArchived = false,
   profile?: string,
 ): Promise<KanbanResult<KanbanBoard[]>> {
-  if (isRemoteMode()) return unsupportedInRemote();
+  if (isRemoteOnlyMode()) return unsupportedInRemote();
   const args = ["boards", "list", "--json"];
   if (includeArchived) args.push("--all");
   const res = await runKanban(args, { profile, parseJson: true });
@@ -163,7 +177,7 @@ export async function listBoards(
 export async function currentBoard(
   profile?: string,
 ): Promise<KanbanResult<string>> {
-  if (isRemoteMode()) return unsupportedInRemote();
+  if (isRemoteOnlyMode()) return unsupportedInRemote();
   const res = await runKanban(["boards", "show"], { profile });
   if (!res.success) return { success: false, error: res.error };
   const slug = (res.stdout || "").trim();
@@ -174,7 +188,7 @@ export async function switchBoard(
   slug: string,
   profile?: string,
 ): Promise<KanbanResult<void>> {
-  if (isRemoteMode()) return unsupportedInRemote();
+  if (isRemoteOnlyMode()) return unsupportedInRemote();
   if (!slug) return { success: false, error: "Missing board slug" };
   const res = await runKanban(["boards", "switch", slug], { profile });
   return { success: res.success, error: res.error };
@@ -186,7 +200,7 @@ export async function createBoard(
   switchAfter = false,
   profile?: string,
 ): Promise<KanbanResult<void>> {
-  if (isRemoteMode()) return unsupportedInRemote();
+  if (isRemoteOnlyMode()) return unsupportedInRemote();
   if (!slug) return { success: false, error: "Missing board slug" };
   const args = ["boards", "create", slug];
   if (name) args.push("--name", name);
@@ -200,7 +214,7 @@ export async function removeBoard(
   hardDelete = false,
   profile?: string,
 ): Promise<KanbanResult<void>> {
-  if (isRemoteMode()) return unsupportedInRemote();
+  if (isRemoteOnlyMode()) return unsupportedInRemote();
   if (!slug) return { success: false, error: "Missing board slug" };
   const args = ["boards", "rm", slug];
   if (hardDelete) args.push("--delete");
@@ -217,7 +231,7 @@ export async function listTasks(
     profile?: string;
   } = {},
 ): Promise<KanbanResult<KanbanTask[]>> {
-  if (isRemoteMode()) return unsupportedInRemote();
+  if (isRemoteOnlyMode()) return unsupportedInRemote();
   const args = ["list", "--json"];
   if (opts.status) args.push("--status", opts.status);
   if (opts.assignee) args.push("--assignee", opts.assignee);
@@ -232,7 +246,7 @@ export async function getTask(
   taskId: string,
   profile?: string,
 ): Promise<KanbanResult<KanbanTaskDetail>> {
-  if (isRemoteMode()) return unsupportedInRemote();
+  if (isRemoteOnlyMode()) return unsupportedInRemote();
   if (!taskId) return { success: false, error: "Missing task ID" };
   const res = await runKanban(["show", taskId, "--json"], {
     profile,
@@ -258,7 +272,7 @@ export async function createTask(
   input: CreateTaskInput,
   profile?: string,
 ): Promise<KanbanResult<{ id: string }>> {
-  if (isRemoteMode()) return unsupportedInRemote();
+  if (isRemoteOnlyMode()) return unsupportedInRemote();
   if (!input.title?.trim()) {
     return { success: false, error: "Title is required" };
   }
@@ -288,7 +302,7 @@ export async function assignTask(
   assignee: string | null,
   profile?: string,
 ): Promise<KanbanResult<void>> {
-  if (isRemoteMode()) return unsupportedInRemote();
+  if (isRemoteOnlyMode()) return unsupportedInRemote();
   const res = await runKanban(["assign", taskId, assignee || "none"], {
     profile,
   });
@@ -300,7 +314,7 @@ export async function completeTask(
   result?: string,
   profile?: string,
 ): Promise<KanbanResult<void>> {
-  if (isRemoteMode()) return unsupportedInRemote();
+  if (isRemoteOnlyMode()) return unsupportedInRemote();
   const args = ["complete", taskId];
   if (result) args.push("--result", result);
   const res = await runKanban(args, { profile });
@@ -312,7 +326,7 @@ export async function blockTask(
   reason?: string,
   profile?: string,
 ): Promise<KanbanResult<void>> {
-  if (isRemoteMode()) return unsupportedInRemote();
+  if (isRemoteOnlyMode()) return unsupportedInRemote();
   const args = ["block", taskId];
   if (reason) args.push(reason);
   const res = await runKanban(args, { profile });
@@ -323,7 +337,7 @@ export async function unblockTask(
   taskId: string,
   profile?: string,
 ): Promise<KanbanResult<void>> {
-  if (isRemoteMode()) return unsupportedInRemote();
+  if (isRemoteOnlyMode()) return unsupportedInRemote();
   const res = await runKanban(["unblock", taskId], { profile });
   return { success: res.success, error: res.error };
 }
@@ -332,7 +346,7 @@ export async function archiveTask(
   taskId: string,
   profile?: string,
 ): Promise<KanbanResult<void>> {
-  if (isRemoteMode()) return unsupportedInRemote();
+  if (isRemoteOnlyMode()) return unsupportedInRemote();
   const res = await runKanban(["archive", taskId], { profile });
   return { success: res.success, error: res.error };
 }
@@ -341,7 +355,7 @@ export async function specifyTask(
   taskId: string,
   profile?: string,
 ): Promise<KanbanResult<void>> {
-  if (isRemoteMode()) return unsupportedInRemote();
+  if (isRemoteOnlyMode()) return unsupportedInRemote();
   const res = await runKanban(["specify", taskId], { profile });
   return { success: res.success, error: res.error };
 }
@@ -351,7 +365,7 @@ export async function reclaimTask(
   reason?: string,
   profile?: string,
 ): Promise<KanbanResult<void>> {
-  if (isRemoteMode()) return unsupportedInRemote();
+  if (isRemoteOnlyMode()) return unsupportedInRemote();
   const args = ["reclaim", taskId];
   if (reason) args.push("--reason", reason);
   const res = await runKanban(args, { profile });
@@ -363,7 +377,7 @@ export async function commentTask(
   body: string,
   profile?: string,
 ): Promise<KanbanResult<void>> {
-  if (isRemoteMode()) return unsupportedInRemote();
+  if (isRemoteOnlyMode()) return unsupportedInRemote();
   if (!body.trim()) return { success: false, error: "Empty comment" };
   const res = await runKanban(["comment", taskId, body], { profile });
   return { success: res.success, error: res.error };
@@ -373,7 +387,7 @@ export async function dispatchOnce(
   dryRun = false,
   profile?: string,
 ): Promise<KanbanResult<unknown>> {
-  if (isRemoteMode()) return unsupportedInRemote();
+  if (isRemoteOnlyMode()) return unsupportedInRemote();
   const args = ["dispatch", "--json"];
   if (dryRun) args.push("--dry-run");
   const res = await runKanban(args, { profile, parseJson: true });

--- a/src/main/ssh-remote.ts
+++ b/src/main/ssh-remote.ts
@@ -1130,6 +1130,47 @@ export async function sshGetHermesVersion(config: SshConfig): Promise<string | n
   }
 }
 
+// Run a Hermes Kanban CLI subcommand over SSH and return a structured result.
+export interface SshKanbanResult<T = unknown> {
+  success: boolean;
+  data?: T;
+  error?: string;
+  stdout?: string;
+}
+
+export async function sshRunKanban<T = unknown>(
+  config: SshConfig,
+  args: string[],
+  opts: { profile?: string; parseJson?: boolean; timeoutMs?: number } = {},
+): Promise<SshKanbanResult<T>> {
+  const cliArgs: string[] = [];
+  if (opts.profile && opts.profile !== "default") {
+    cliArgs.push("-p", opts.profile);
+  }
+  cliArgs.push("kanban", ...args);
+  const cmd = buildRemoteHermesCmd(cliArgs);
+  try {
+    const stdout = await sshExec(config, cmd, undefined, opts.timeoutMs ?? 20000);
+    if (opts.parseJson) {
+      try {
+        return { success: true, data: JSON.parse(stdout) as T, stdout };
+      } catch (err) {
+        return {
+          success: false,
+          error: `Failed to parse JSON from remote 'hermes kanban': ${(err as Error).message}`,
+          stdout,
+        };
+      }
+    }
+    return { success: true, stdout };
+  } catch (err) {
+    return {
+      success: false,
+      error: (err as Error).message || "Remote kanban command failed",
+    };
+  }
+}
+
 // ── Logs ──────────────────────────────────────────────────────────────────────
 
 export async function sshReadLogs(

--- a/src/renderer/src/screens/Kanban/Kanban.tsx
+++ b/src/renderer/src/screens/Kanban/Kanban.tsx
@@ -433,11 +433,12 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
       <div className="kanban-container">
         <div className="kanban-empty">
           <p className="schedules-empty-text">
-            Kanban requires a local Hermes install.
+            Kanban requires a local Hermes install or SSH tunnel mode.
           </p>
           <p className="schedules-empty-hint">
-            Switch to local mode in Settings to manage the board from the
-            desktop. (Remote/SSH support is coming in a follow-up.)
+            Plain remote (HTTP + API key) mode does not yet expose the kanban
+            API. Switch to local or SSH tunnel mode in Settings to manage the
+            board.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Wires the Kanban screen for SSH tunnel mode. Kanban was the last management screen still gated to local-only installs — its UI explicitly said "Remote/SSH support is coming in a follow-up." Every other screen (Skills, Memory, Soul, Tools, Sessions, Profiles, Models, Schedules, Gateway, Logs) already proxies via \`sshExec\` in SSH mode; this PR closes the gap.

## Approach

The Kanban CLI is a stable JSON-out interface (\`hermes kanban boards list --json\`, \`hermes kanban list --json\`, \`hermes kanban show <id> --json\`, etc.). The simplest possible bridge is to invoke that CLI on the remote via SSH and route the structured \`KanbanResult\` through the same handlers the local execFile path uses.

### \`sshRunKanban()\`

New helper in \`src/main/ssh-remote.ts\` that:
1. Builds the same argv the local path builds (\`hermes [-p profile] kanban <args>\`).
2. Probes well-known venv install paths in order:
   - \`\$HOME/hermes-agent/.venv/bin/hermes\`
   - \`\$HOME/.hermes/hermes-agent/.venv/bin/hermes\`
   - \`/opt/hermes/hermes-agent/.venv/bin/hermes\`
3. Falls back to bare \`hermes\` on \`PATH\` only if none of those exist.

The venv-first probe is necessary because the official Hermes installer commonly ships a \`/usr/local/bin/hermes\` sudo-wrapper whose sudoers policy refuses to let the \`hermes\` service user run it as itself (\"Sorry, user hermes is not allowed to execute … as hermes\"). The same probe is the fix landed in #205 for \`sshGetHermesVersion\`, factored out into a shared \`buildRemoteHermesCmd()\` helper to keep the deploy-shape knowledge in one place.

### \`runKanban()\` dispatch

\`runKanban()\` in \`src/main/kanban.ts\` now checks \`getConnectionConfig().mode === 'ssh'\` and delegates to \`sshRunKanban\` with the same \`{ profile, parseJson, timeoutMs }\` options. Every public function (\`listBoards\`, \`listTasks\`, \`createTask\`, \`assignTask\`, \`completeTask\`, \`blockTask\`, \`unblockTask\`, \`archiveTask\`, \`specifyTask\`, \`reclaimTask\`, \`commentTask\`, \`dispatchOnce\`, …) reuses \`runKanban\` and therefore works transparently.

### \`isRemoteMode\` → \`isRemoteOnlyMode\`

Every gate in \`kanban.ts\` is swapped from \`isRemoteMode()\` (true for both remote and ssh) to \`isRemoteOnlyMode()\` (true only for plain HTTP+API key remote, which still has no kanban API). The error message is updated accordingly:

> Kanban requires either a local Hermes install or SSH tunnel mode. Plain remote (HTTP+API key) mode does not yet expose the kanban API. Switch to SSH tunnel mode in Settings to use the board against a remote Hermes.

### Renderer

Kanban.tsx empty-state matches the new message. No other renderer changes needed — \`remoteUnsupported\` is set when the error string includes \"remote\", and the new message still does for the plain-remote case.

## Test plan

- [x] \`npm run typecheck\` clean (both \`tsconfig.node\` and \`tsconfig.web\`).
- [x] Manual on a v0.14.0 production install (Hermes service user, HOME=/opt/hermes, sudo-wrapper at /usr/local/bin/hermes):
  - \`hermes kanban boards list --json\` via SSH returns the default board.
  - \`hermes kanban list --json\` via SSH returns \`[]\` cleanly.
- [ ] Manual: create a task from the desktop in SSH mode and verify it appears via \`hermes kanban list --json\` on the remote.
- [ ] Manual: existing local-install workflow unchanged (the SSH branch is gated on \`mode === 'ssh'\` only).
- [ ] Manual: plain remote (HTTP+API key) mode still shows the new \"requires SSH tunnel\" message.

## Companion PRs

This is the third PR in a small "make remote feel local" series:

- #204 — fix SSH tunnel lifecycle on Linux/macOS (ControlPersist forking master)
- #205 — fix blank Engine/Released/Python/OpenAI SDK card in Settings against installer deploys
- #206 — docs: SSH tunnel + VPS connection guide

This PR (#207?) closes the last management-screen gap. After it lands, every screen in the app works against a remote Hermes over SSH tunnel mode.