### PR TITLE
feat(office): auto-detect remote Claw3D in SSH tunnel mode

### DIFF
--- a/src/main/claw3d.ts
+++ b/src/main/claw3d.ts
@@ -11,6 +11,8 @@ import { homedir } from "os";
 import { createConnection } from "net";
 import { getEnhancedPath, HERMES_HOME } from "./installer";
 import { stripAnsi, safeWriteFile } from "./utils";
+import { getConnectionConfig } from "./config";
+import http from "http";
 
 const HERMES_OFFICE_REPO = "https://github.com/fathah/hermes-office";
 const HERMES_OFFICE_DIR = join(HERMES_HOME, "hermes-office");
@@ -254,6 +256,12 @@ export interface Claw3dStatus {
   portInUse: boolean;
   wsUrl: string;
   error: string; // last error from either process
+  // Populated in SSH tunnel mode when a Claw3D / hermes-office service is
+  // running on the remote host. Renderer should prefer this over launching
+  // a local dev server. Null/undefined when not in SSH mode or when the
+  // remote service is unreachable.
+  remoteUrl?: string | null;
+  remoteSource?: "ssh" | null;
 }
 
 export interface Claw3dSetupProgress {
@@ -310,6 +318,25 @@ function isAdapterRunning(): boolean {
   return false;
 }
 
+// Probe an HTTP endpoint with a short timeout. Returns true if any response
+// arrives (we don't care about the status code — even a 404 confirms a
+// listener). Used to detect remote Claw3D / hermes-office without dragging
+// in the SSH tunnel machinery.
+function probeHttp(url: string, timeoutMs = 1500): Promise<boolean> {
+  return new Promise((resolve) => {
+    const req = http.request(url, { method: "GET", timeout: timeoutMs }, (res) => {
+      res.resume();
+      resolve(true);
+    });
+    req.on("error", () => resolve(false));
+    req.on("timeout", () => {
+      req.destroy();
+      resolve(false);
+    });
+    req.end();
+  });
+}
+
 export async function getClaw3dStatus(): Promise<Claw3dStatus> {
   const cloned = existsSync(join(HERMES_OFFICE_DIR, "package.json"));
   const installed = existsSync(join(HERMES_OFFICE_DIR, "node_modules"));
@@ -319,16 +346,32 @@ export async function getClaw3dStatus(): Promise<Claw3dStatus> {
   const portInUse = devRunning ? false : await checkPort(port);
   const adapterUp = isAdapterRunning();
   const error = devServerError || adapterError;
+
+  // SSH tunnel mode: probe the remote host for a Claw3D / hermes-office
+  // service. The official systemd unit binds Next.js to :3000 by default,
+  // so we try the SSH host at the saved Claw3D port. When reachable, the
+  // renderer can point its webview at it instead of asking the user to
+  // install Claw3D locally.
+  let remoteUrl: string | null = null;
+  const conn = getConnectionConfig();
+  if (conn.mode === "ssh" && conn.ssh?.host) {
+    const candidateUrl = `http://${conn.ssh.host}:${port}`;
+    const reachable = await probeHttp(candidateUrl, 1500);
+    if (reachable) remoteUrl = candidateUrl;
+  }
+
   return {
     cloned,
-    installed,
+    installed: installed || Boolean(remoteUrl),
     devServerRunning: devRunning,
     adapterRunning: adapterUp,
-    running: devRunning && adapterUp,
+    running: (devRunning && adapterUp) || Boolean(remoteUrl),
     port,
     portInUse,
     wsUrl: getSavedWsUrl(),
     error,
+    remoteUrl,
+    remoteSource: remoteUrl ? "ssh" : null,
   };
 }
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -427,6 +427,8 @@ interface HermesAPI {
     wsUrl: string;
     running: boolean;
     error: string;
+    remoteUrl?: string | null;
+    remoteSource?: "ssh" | null;
   }>;
   claw3dSetup: () => Promise<{ success: boolean; error?: string }>;
   onClaw3dSetupProgress: (

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -475,6 +475,8 @@ const hermesAPI = {
     wsUrl: string;
     running: boolean;
     error: string;
+    remoteUrl?: string | null;
+    remoteSource?: "ssh" | null;
   }> => ipcRenderer.invoke("claw3d-status"),
 
   claw3dSetup: (): Promise<{ success: boolean; error?: string }> =>

--- a/src/renderer/src/screens/Office/Office.tsx
+++ b/src/renderer/src/screens/Office/Office.tsx
@@ -39,6 +39,10 @@ function Office({ visible }: { visible?: boolean }): React.JSX.Element {
   });
   const [webviewReady, setWebviewReady] = useState(false);
   const [webviewError, setWebviewError] = useState("");
+  // Set when the main process detects a Claw3D / hermes-office service
+  // running on the remote host (SSH tunnel mode). When present the webview
+  // points at this URL and the local install/start UX is bypassed.
+  const [remoteUrl, setRemoteUrl] = useState<string | null>(null);
   const logRef = useRef<HTMLDivElement>(null);
   const webviewRef = useRef<HTMLWebViewElement>(null);
 
@@ -53,13 +57,14 @@ function Office({ visible }: { visible?: boolean }): React.JSX.Element {
   const checkStatus = useCallback(async (): Promise<void> => {
     setState("checking");
     const status = await window.hermesAPI.claw3dStatus();
+    setRemoteUrl(status.remoteUrl ?? null);
     setRunning(status.running);
     setPort(status.port);
     setPortInput(String(status.port));
     setPortInUse(status.portInUse);
     setWsUrlInput(status.wsUrl || "ws://localhost:18789");
     if (status.error) setError(status.error);
-    if (status.installed) {
+    if (status.installed || status.remoteUrl) {
       setState("ready");
     } else {
       setState("not-installed");
@@ -75,6 +80,7 @@ function Office({ visible }: { visible?: boolean }): React.JSX.Element {
     if (state !== "ready" || !visible) return;
     const interval = setInterval(async () => {
       const status = await window.hermesAPI.claw3dStatus();
+      setRemoteUrl(status.remoteUrl ?? null);
       setRunning(status.running);
       setPort(status.port);
       setPortInUse(status.portInUse);
@@ -213,7 +219,10 @@ function Office({ visible }: { visible?: boolean }): React.JSX.Element {
       ? Math.round((progress.step / progress.totalSteps) * 100)
       : 0;
 
-  const claw3dUrl = `http://localhost:${port}`;
+  // Remote Claw3D (SSH tunnel mode) takes precedence: the remote
+  // hermes-office.service already runs, so we point the webview at it
+  // rather than asking the user to install Claw3D locally.
+  const claw3dUrl = remoteUrl || `http://localhost:${port}`;
 
   // --- Checking ---
   if (state === "checking") {


### PR DESCRIPTION
## Summary

In SSH tunnel mode the user almost always already runs a Hermes / Claw3D stack on the same VPS — typically via the \`hermes-office.service\` systemd unit binding Next.js to \`:3000\`. Today the Office screen still asks them to install Claw3D locally because \`getClaw3dStatus()\` only inspects the desktop host's filesystem and \`claw3dUrl\` is hard-coded to \`http://localhost:<port>\`.

## Behavior change

When connection mode is \`ssh\`, the main process performs a short HTTP probe (1.5s timeout) against \`http://<sshHost>:<savedClaw3dPort>\` during \`getClaw3dStatus()\`. If anything responds — any status code — the status payload includes:

- \`remoteUrl: "http://<sshHost>:<port>"\`
- \`remoteSource: "ssh"\`
- \`installed: true\` (suppresses the "Set Up Claw3D" install card)
- \`running: true\` (skips the start button)

Office.tsx keeps the remote URL in state and prefers it for the webview \`src\`. The existing local install / dev-server / adapter flows are untouched — they still drive the UI when \`remoteUrl\` is null.

A 1.5s probe is fast enough for the initial mount and cheap to retry on the existing 5-second status poll. Any HTTP response (including 400/404, which Next.js apps frequently return for bare GETs) confirms the listener; only network-level errors / timeouts mark the remote as unreachable.

## What this does NOT change

- Local mode behavior is identical — the SSH branch is gated on \`connectionMode === 'ssh'\`.
- Plain Remote mode (HTTP + API key) doesn't probe — no SSH host to derive a Claw3D URL from. The install prompt still renders for that mode, which is the right default since the URL is ambiguous.
- We do not tunnel Claw3D through SSH. If the user needs port-forwarding (Claw3D not exposed on the public host), they can edit \`~/.hermes/desktop.json\` to point Claw3D at \`127.0.0.1:<tunneledPort>\` via an external tunnel — this PR is intentionally scoped to the common case where Claw3D is already reachable.

## Test plan

- [x] \`npm run typecheck\` clean (node + web).
- [x] Manual: against a VPS running \`hermes-office.service\` on :3000, the Office screen now renders the webview pointing at \`http://<vps>:3000\` instead of the install prompt.
- [ ] Manual: with \`hermes-office.service\` stopped, the Office screen falls back to the install prompt (1.5s wait while the probe times out).
- [ ] Manual: local mode unchanged — \`http://localhost:<port>\` still used.
- [ ] Manual: webview interaction in the remote case works as expected (loading, errors, refresh button).

## Companion PRs

Fourth in the "make remote feel local" series:

- #204 — fix SSH tunnel lifecycle on Linux/macOS (ControlPersist forking master)
- #205 — fix blank Engine/Released/Python/OpenAI SDK against installer deploys
- #206 — docs: SSH tunnel + VPS connection guide
- #207 — wire Kanban board for SSH tunnel mode

After this lands, every management screen (including Office) treats a remote Hermes in SSH tunnel mode as a first-class deployment, matching the local-install UX.