### PR TITLE
fix(models): route Add/Remove/Update through SSH in tunnel mode

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -186,6 +186,9 @@ import {
   sshListCachedSessions,
   sshRunDoctor,
   sshListModels,
+  sshAddModel,
+  sshRemoveModel,
+  sshUpdateModel,
   sshRunUpdate,
   sshRunDump,
   sshDiscoverMemoryProviders,
@@ -889,14 +892,26 @@ function setupIPC(): void {
   });
   ipcMain.handle(
     "add-model",
-    (_event, name: string, provider: string, model: string, baseUrl: string) =>
-      addModel(name, provider, model, baseUrl),
+    (_event, name: string, provider: string, model: string, baseUrl: string) => {
+      const conn = getConnectionConfig();
+      if (conn.mode === "ssh" && conn.ssh) {
+        return sshAddModel(conn.ssh, name, provider, model, baseUrl);
+      }
+      return addModel(name, provider, model, baseUrl);
+    },
   );
-  ipcMain.handle("remove-model", (_event, id: string) => removeModel(id));
+  ipcMain.handle("remove-model", (_event, id: string) => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return sshRemoveModel(conn.ssh, id);
+    return removeModel(id);
+  });
   ipcMain.handle(
     "update-model",
-    (_event, id: string, fields: Record<string, string>) =>
-      updateModel(id, fields),
+    (_event, id: string, fields: Record<string, string>) => {
+      const conn = getConnectionConfig();
+      if (conn.mode === "ssh" && conn.ssh) return sshUpdateModel(conn.ssh, id, fields);
+      return updateModel(id, fields);
+    },
   );
 
   // Claw3D

--- a/src/main/ssh-remote.ts
+++ b/src/main/ssh-remote.ts
@@ -1142,3 +1142,58 @@ export async function sshListModels(config: SshConfig): Promise<SavedModel[]> {
 export async function sshSaveModels(config: SshConfig, models: SavedModel[]): Promise<void> {
   await sshWriteFile(config, "$HOME/.hermes/models.json", JSON.stringify(models, null, 2));
 }
+
+// Mirror the local CRUD helpers in models.ts against the remote
+// ~/.hermes/models.json. Each operation does a full read/mutate/write so the
+// SSH cost is the same as a manual edit — there is no remote API to call
+// instead, and the file is small (a few KB at most).
+
+function randomId(): string {
+  // RFC4122-ish v4 UUID without pulling in crypto.randomUUID, which is fine
+  // here because IDs only need to be unique within models.json.
+  const hex = (n: number): string => Math.floor(Math.random() * 16 ** n).toString(16).padStart(n, "0");
+  return `${hex(8)}-${hex(4)}-4${hex(3)}-${(8 + Math.floor(Math.random() * 4)).toString(16)}${hex(3)}-${hex(12)}`;
+}
+
+export async function sshAddModel(
+  config: SshConfig,
+  name: string,
+  provider: string,
+  model: string,
+  baseUrl: string,
+): Promise<SavedModel> {
+  const models = await sshListModels(config);
+  const existing = models.find((m) => m.model === model && m.provider === provider);
+  if (existing) return existing;
+  const entry: SavedModel = {
+    id: randomId(),
+    name,
+    provider,
+    model,
+    baseUrl: baseUrl || "",
+    createdAt: Date.now(),
+  };
+  await sshSaveModels(config, [...models, entry]);
+  return entry;
+}
+
+export async function sshRemoveModel(config: SshConfig, id: string): Promise<boolean> {
+  const models = await sshListModels(config);
+  const filtered = models.filter((m) => m.id !== id);
+  if (filtered.length === models.length) return false;
+  await sshSaveModels(config, filtered);
+  return true;
+}
+
+export async function sshUpdateModel(
+  config: SshConfig,
+  id: string,
+  fields: Partial<Pick<SavedModel, "name" | "provider" | "model" | "baseUrl">>,
+): Promise<boolean> {
+  const models = await sshListModels(config);
+  const idx = models.findIndex((m) => m.id === id);
+  if (idx === -1) return false;
+  models[idx] = { ...models[idx], ...fields };
+  await sshSaveModels(config, models);
+  return true;
+}


### PR DESCRIPTION
## Summary

\`list-models\` already dispatches to \`sshListModels\` when the connection mode is \`ssh\`, but \`add-model\`, \`remove-model\`, and \`update-model\` all unconditionally call the local-FS helpers in \`models.ts\`.

The visible bug:

1. User configures SSH tunnel mode pointing at a remote Hermes.
2. Models page (correctly) reads remote \`~/.hermes/models.json\` via \`sshListModels\` and shows whatever the remote has.
3. User clicks "+ Add Model" and saves.
4. A new entry is written to the **desktop host's** local \`~/.hermes/models.json\` (which may not even exist).
5. Models page refreshes from the remote and the new entry is gone.

Edit and delete have the same split-brain problem — they mutate the local FS while reads target the remote.

## Fix

Add three new helpers in \`ssh-remote.ts\` (\`sshAddModel\`, \`sshRemoveModel\`, \`sshUpdateModel\`) built on the existing \`sshListModels\` + \`sshSaveModels\` pair. Each is a thin read-modify-write — \`models.json\` is a few KB at most, so there's no benefit to a finer-grained remote protocol.

ID generation uses a self-contained RFC4122-ish v4 UUID generator inside \`ssh-remote.ts\`. The local path keeps using \`crypto.randomUUID\`; we don't pull in extra dependencies just for the SSH path.

Each IPC handler in \`src/main/index.ts\` (\`add-model\`, \`remove-model\`, \`update-model\`) now branches on \`mode === 'ssh'\`, mirroring the existing \`list-models\` shape.

## Test plan

- [x] \`npm run typecheck\` clean.
- [x] Manual: in SSH tunnel mode, add a model from the desktop and verify it appears on subsequent loads (proving it persisted to the remote, not the local FS).
- [x] Manual: edit a model, verify the change persists across reloads.
- [x] Manual: remove a model, verify it's gone.
- [ ] Manual: local mode is unchanged — the SSH branch is gated on \`mode === 'ssh'\`.

## Companion PRs

Fifth in the "make remote feel local" series:

- #204 — fix SSH tunnel lifecycle on Linux/macOS
- #205 — fix blank Engine/Released/Python/OpenAI SDK against installer deploys
- #206 — docs: SSH tunnel + VPS connection guide
- #207 — wire Kanban board for SSH tunnel mode
- #208 — auto-detect remote Claw3D in SSH tunnel mode

After this lands, every model management operation in the desktop app respects the connection mode the user has chosen.