### PR TITLE
fix(office): start Gateway before Claw3D and avoid Windows npm shim issues

### DIFF
--- a/src/main/claw3d.ts
+++ b/src/main/claw3d.ts
@@ -6,7 +6,7 @@ import {
   unlinkSync,
   mkdirSync,
 } from "fs";
-import { join } from "path";
+import { join, win32 } from "path";
 import { homedir } from "os";
 import { createConnection } from "net";
 import { getEnhancedPath, HERMES_HOME } from "./installer";
@@ -34,11 +34,23 @@ export interface ResolvedCommand {
   windowsScript: boolean;
 }
 
-interface CommandInvocation {
+export interface CommandInvocation {
   command: string;
   args: string[];
   windowsVerbatimArguments?: boolean;
 }
+
+interface NpmInvocationOptions {
+  platform?: NodeJS.Platform;
+  fileExists?: (path: string) => boolean;
+}
+
+type Claw3dScript = "dev" | "hermes-adapter";
+
+const CLAW3D_SCRIPT_ARGS: Record<Claw3dScript, string[]> = {
+  dev: ["server/index.js", "--dev"],
+  "hermes-adapter": ["server/hermes-gateway-adapter.js"],
+};
 
 export function isWindowsCommandScript(command: string): boolean {
   return /\.(cmd|bat)$/i.test(command);
@@ -130,6 +142,61 @@ function createCommandInvocation(
   }
 
   return { command: resolved.command, args };
+}
+
+function createWindowsNpmCliInvocation(
+  npmCommand: string,
+  args: string[],
+  fileExists: (path: string) => boolean,
+): CommandInvocation | null {
+  const npmDir = win32.dirname(npmCommand);
+  const nodeCandidates = [
+    win32.join(npmDir, "node.exe"),
+    win32.join(npmDir, "..", "..", "..", "node.exe"),
+  ];
+  const npmCliCandidates = [
+    win32.join(npmDir, "node_modules", "npm", "bin", "npm-cli.js"),
+    win32.join(npmDir, "npm-cli.js"),
+  ];
+
+  const nodeExe = nodeCandidates.find(fileExists);
+  const npmCli = npmCliCandidates.find(fileExists);
+  if (!npmCli) return null;
+
+  return {
+    command: nodeExe || "node",
+    args: [npmCli, ...args],
+  };
+}
+
+export function createNpmCommandInvocation(
+  resolved: ResolvedCommand,
+  args: string[],
+  options: NpmInvocationOptions = {},
+): CommandInvocation {
+  const platform = options.platform ?? process.platform;
+  const fileExists = options.fileExists ?? existsSync;
+
+  if (platform === "win32") {
+    const directNpm = createWindowsNpmCliInvocation(
+      resolved.command,
+      args,
+      fileExists,
+    );
+    if (directNpm) return directNpm;
+  }
+
+  return createCommandInvocation(resolved, args);
+}
+
+export function createClaw3dScriptInvocation(
+  script: Claw3dScript,
+  nodeCommand = "node",
+): CommandInvocation {
+  return {
+    command: nodeCommand,
+    args: CLAW3D_SCRIPT_ARGS[script],
+  };
 }
 
 function getSavedPort(): number {
@@ -509,7 +576,7 @@ export async function setupClaw3d(
 
   // Step 2: npm install
   emit(2, "Installing dependencies...", "Running npm install...\n");
-  const npm = createCommandInvocation(findNpm(env.PATH), ["install"]);
+  const npm = createNpmCommandInvocation(findNpm(env.PATH), ["install"]);
 
   await new Promise<void>((resolve, reject) => {
     const proc = spawn(npm.command, npm.args, {
@@ -584,14 +651,15 @@ export function startDevServer(): boolean {
     TERM: "dumb",
     PORT: String(port),
   };
-  const npm = createCommandInvocation(findNpm(env.PATH), ["run", "dev"]);
-  const proc = spawn(npm.command, npm.args, {
+  const node = resolveCommand("node", env.PATH);
+  const devScript = createClaw3dScriptInvocation("dev", node.command);
+  const proc = spawn(devScript.command, devScript.args, {
     cwd: HERMES_OFFICE_DIR,
     env,
     stdio: ["ignore", "pipe", "pipe"],
     detached: true,
     windowsHide: true,
-    windowsVerbatimArguments: npm.windowsVerbatimArguments,
+    windowsVerbatimArguments: devScript.windowsVerbatimArguments,
   });
 
   devServerProcess = proc;
@@ -661,17 +729,18 @@ export function startAdapter(): boolean {
     HOME: homedir(),
     TERM: "dumb",
   };
-  const npm = createCommandInvocation(findNpm(env.PATH), [
-    "run",
+  const node = resolveCommand("node", env.PATH);
+  const adapterScript = createClaw3dScriptInvocation(
     "hermes-adapter",
-  ]);
-  const proc = spawn(npm.command, npm.args, {
+    node.command,
+  );
+  const proc = spawn(adapterScript.command, adapterScript.args, {
     cwd: HERMES_OFFICE_DIR,
     env,
     stdio: ["ignore", "pipe", "pipe"],
     detached: true,
     windowsHide: true,
-    windowsVerbatimArguments: npm.windowsVerbatimArguments,
+    windowsVerbatimArguments: adapterScript.windowsVerbatimArguments,
   });
 
   adapterProcess = proc;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -65,6 +65,7 @@ import {
   getClaw3dWsUrl,
   Claw3dSetupProgress,
 } from "./claw3d";
+import { startOfficeStack } from "./office-start";
 import {
   readEnv,
   setEnvValue,
@@ -924,7 +925,19 @@ function setupIPC(): void {
     return true;
   });
 
-  ipcMain.handle("claw3d-start-all", () => startClaw3dAll());
+  ipcMain.handle("claw3d-start-all", (_event, profile?: string) =>
+    startOfficeStack(profile, {
+      getConnectionConfig,
+      isGatewayRunning,
+      startGateway,
+      sshGatewayStatus,
+      sshStartGateway,
+      startSshTunnel,
+      sshReadRemoteApiKey,
+      setSshRemoteApiKey,
+      startClaw3dAll,
+    }),
+  );
   ipcMain.handle("claw3d-stop-all", () => {
     stopClaw3d();
     return true;

--- a/src/main/office-start.ts
+++ b/src/main/office-start.ts
@@ -1,0 +1,42 @@
+import type { ConnectionConfig, SshConnectionConfig } from "./config";
+
+type StartResult = { success: boolean; error?: string };
+
+export interface OfficeStartDependencies {
+  getConnectionConfig: () => ConnectionConfig;
+  isGatewayRunning: () => boolean;
+  startGateway: (profile?: string) => boolean;
+  sshGatewayStatus: (config: SshConnectionConfig) => Promise<boolean>;
+  sshStartGateway: (config: SshConnectionConfig) => Promise<void>;
+  startSshTunnel: (config: SshConnectionConfig) => Promise<void>;
+  sshReadRemoteApiKey: (config: SshConnectionConfig) => Promise<string>;
+  setSshRemoteApiKey: (key: string) => void;
+  startClaw3dAll: () => StartResult;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function startOfficeStack(
+  profile: string | undefined,
+  deps: OfficeStartDependencies,
+): Promise<StartResult> {
+  try {
+    const conn = deps.getConnectionConfig();
+
+    if (conn.mode === "ssh") {
+      if (!(await deps.sshGatewayStatus(conn.ssh))) {
+        await deps.sshStartGateway(conn.ssh);
+      }
+      await deps.startSshTunnel(conn.ssh);
+      deps.setSshRemoteApiKey(await deps.sshReadRemoteApiKey(conn.ssh));
+    } else if (conn.mode === "local" && !deps.isGatewayRunning()) {
+      deps.startGateway(profile);
+    }
+
+    return deps.startClaw3dAll();
+  } catch (error) {
+    return { success: false, error: errorMessage(error) };
+  }
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -442,7 +442,9 @@ interface HermesAPI {
   claw3dSetPort: (port: number) => Promise<boolean>;
   claw3dGetWsUrl: () => Promise<string>;
   claw3dSetWsUrl: (url: string) => Promise<boolean>;
-  claw3dStartAll: () => Promise<{ success: boolean; error?: string }>;
+  claw3dStartAll: (
+    profile?: string,
+  ) => Promise<{ success: boolean; error?: string }>;
   claw3dStopAll: () => Promise<boolean>;
   claw3dGetLogs: () => Promise<string>;
   claw3dStartDev: () => Promise<boolean>;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -514,8 +514,10 @@ const hermesAPI = {
   claw3dSetWsUrl: (url: string): Promise<boolean> =>
     ipcRenderer.invoke("claw3d-set-ws-url", url),
 
-  claw3dStartAll: (): Promise<{ success: boolean; error?: string }> =>
-    ipcRenderer.invoke("claw3d-start-all"),
+  claw3dStartAll: (
+    profile?: string,
+  ): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke("claw3d-start-all", profile),
   claw3dStopAll: (): Promise<boolean> => ipcRenderer.invoke("claw3d-stop-all"),
   claw3dGetLogs: (): Promise<string> => ipcRenderer.invoke("claw3d-get-logs"),
 

--- a/src/renderer/src/screens/Layout/Layout.tsx
+++ b/src/renderer/src/screens/Layout/Layout.tsx
@@ -313,7 +313,7 @@ function Layout({
 
         {visitedViews.has("office") && (
           <div style={paneStyle("office")}>
-            <Office visible={view === "office"} />
+            <Office profile={activeProfile} visible={view === "office"} />
           </div>
         )}
 

--- a/src/renderer/src/screens/Office/Office.tsx
+++ b/src/renderer/src/screens/Office/Office.tsx
@@ -17,7 +17,13 @@ interface SetupProgress {
   log: string;
 }
 
-function Office({ visible }: { visible?: boolean }): React.JSX.Element {
+function Office({
+  profile,
+  visible,
+}: {
+  profile?: string;
+  visible?: boolean;
+}): React.JSX.Element {
   const { t } = useI18n();
   const [state, setState] = useState<OfficeState>("checking");
   const [running, setRunning] = useState(false);
@@ -168,7 +174,7 @@ function Office({ visible }: { visible?: boolean }): React.JSX.Element {
       setError("");
       setWebviewError("");
       setStarting(true);
-      const result = await window.hermesAPI.claw3dStartAll();
+      const result = await window.hermesAPI.claw3dStartAll(profile);
       if (!result.success) {
         setError(result.error || "Failed to start Claw3D");
         setStarting(false);

--- a/tests/claw3d-command-resolution.test.ts
+++ b/tests/claw3d-command-resolution.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   buildWindowsScriptCommandLine,
+  createClaw3dScriptInvocation,
+  createNpmCommandInvocation,
   isWindowsCommandScript,
   pickWindowsCommandCandidate,
 } from "../src/main/claw3d";
@@ -43,5 +45,76 @@ describe("Claw3D command resolution", () => {
         "dev",
       ]),
     ).toBe('""C:\\Program Files\\nodejs\\npm.cmd" "run" "dev""');
+  });
+
+  it("runs Windows npm scripts through node.exe instead of cmd.exe when npm CLI is available", () => {
+    const invocation = createNpmCommandInvocation(
+      {
+        command: "C:\\nvm4w\\nodejs\\npm.cmd",
+        windowsScript: true,
+      },
+      ["run", "dev"],
+      {
+        platform: "win32",
+        fileExists: (path) =>
+          [
+            "C:\\nvm4w\\nodejs\\node.exe",
+            "C:\\nvm4w\\nodejs\\node_modules\\npm\\bin\\npm-cli.js",
+          ].includes(path),
+      },
+    );
+
+    expect(invocation).toEqual({
+      command: "C:\\nvm4w\\nodejs\\node.exe",
+      args: [
+        "C:\\nvm4w\\nodejs\\node_modules\\npm\\bin\\npm-cli.js",
+        "run",
+        "dev",
+      ],
+    });
+  });
+
+  it("falls back to node on PATH for Windows npm shims without a sibling node.exe", () => {
+    const invocation = createNpmCommandInvocation(
+      {
+        command: "C:\\Users\\me\\AppData\\Roaming\\npm\\npm.cmd",
+        windowsScript: true,
+      },
+      ["run", "hermes-adapter"],
+      {
+        platform: "win32",
+        fileExists: (path) =>
+          path ===
+          "C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\npm\\bin\\npm-cli.js",
+      },
+    );
+
+    expect(invocation).toEqual({
+      command: "node",
+      args: [
+        "C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\npm\\bin\\npm-cli.js",
+        "run",
+        "hermes-adapter",
+      ],
+    });
+  });
+
+  it("runs Claw3D start scripts directly through node without npm or cmd.exe", () => {
+    expect(
+      createClaw3dScriptInvocation("dev", "C:\\nvm4w\\nodejs\\node.exe"),
+    ).toEqual({
+      command: "C:\\nvm4w\\nodejs\\node.exe",
+      args: ["server/index.js", "--dev"],
+    });
+
+    expect(
+      createClaw3dScriptInvocation(
+        "hermes-adapter",
+        "C:\\nvm4w\\nodejs\\node.exe",
+      ),
+    ).toEqual({
+      command: "C:\\nvm4w\\nodejs\\node.exe",
+      args: ["server/hermes-gateway-adapter.js"],
+    });
   });
 });

--- a/tests/office-start.test.ts
+++ b/tests/office-start.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  startOfficeStack,
+  type OfficeStartDependencies,
+} from "../src/main/office-start";
+import type { ConnectionConfig } from "../src/main/config";
+
+function localConnection(): ConnectionConfig {
+  return {
+    mode: "local",
+    remoteUrl: "",
+    apiKey: "",
+    ssh: {
+      host: "",
+      port: 22,
+      username: "",
+      keyPath: "",
+      remotePort: 8642,
+      localPort: 18642,
+    },
+  };
+}
+
+function sshConnection(): ConnectionConfig {
+  return {
+    ...localConnection(),
+    mode: "ssh",
+    ssh: {
+      host: "office.example.com",
+      port: 22,
+      username: "hermes",
+      keyPath: "C:\\keys\\id_rsa",
+      remotePort: 8642,
+      localPort: 18642,
+    },
+  };
+}
+
+function makeDeps(
+  connection: ConnectionConfig,
+  overrides: Partial<OfficeStartDependencies> = {},
+): { calls: string[]; deps: OfficeStartDependencies } {
+  const calls: string[] = [];
+  const deps: OfficeStartDependencies = {
+    getConnectionConfig: () => connection,
+    isGatewayRunning: () => false,
+    startGateway: (profile) => {
+      calls.push(`startGateway:${profile ?? ""}`);
+      return true;
+    },
+    sshGatewayStatus: async () => false,
+    sshStartGateway: async () => {
+      calls.push("sshStartGateway");
+    },
+    startSshTunnel: async () => {
+      calls.push("startSshTunnel");
+    },
+    sshReadRemoteApiKey: async () => "remote-key",
+    setSshRemoteApiKey: (key) => {
+      calls.push(`setSshRemoteApiKey:${key}`);
+    },
+    startClaw3dAll: () => {
+      calls.push("startClaw3dAll");
+      return { success: true };
+    },
+    ...overrides,
+  };
+  return { calls, deps };
+}
+
+describe("startOfficeStack", () => {
+  it("starts the local gateway with the active profile before Claw3D", async () => {
+    const { calls, deps } = makeDeps(localConnection());
+
+    const result = await startOfficeStack("research", deps);
+
+    expect(result).toEqual({ success: true });
+    expect(calls).toEqual(["startGateway:research", "startClaw3dAll"]);
+  });
+
+  it("does not restart a local gateway that is already running", async () => {
+    const { calls, deps } = makeDeps(localConnection(), {
+      isGatewayRunning: () => true,
+    });
+
+    const result = await startOfficeStack("research", deps);
+
+    expect(result).toEqual({ success: true });
+    expect(calls).toEqual(["startClaw3dAll"]);
+  });
+
+  it("starts the SSH gateway and tunnel before Claw3D", async () => {
+    const { calls, deps } = makeDeps(sshConnection());
+
+    const result = await startOfficeStack("research", deps);
+
+    expect(result).toEqual({ success: true });
+    expect(calls).toEqual([
+      "sshStartGateway",
+      "startSshTunnel",
+      "setSshRemoteApiKey:remote-key",
+      "startClaw3dAll",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes Office startup so Claw3D is launched only after the Hermes Gateway path is ready.

This PR also avoids Windows `npm.cmd`/`cmd.exe` startup issues by running Claw3D scripts directly through the resolved `node` executable where possible.

## Changes

- Add `startOfficeStack()` to coordinate Office startup.
- In local mode, start the Hermes Gateway with the active profile before starting Claw3D.
- In SSH mode, ensure the remote Gateway is running, start the SSH tunnel, read the remote API key, then start Claw3D.
- Pass the active profile from the renderer to the `claw3d-start-all` IPC call.
- Run Claw3D dev server and Hermes adapter directly via:
  - `node server/index.js --dev`
  - `node server/hermes-gateway-adapter.js`
- Improve Windows npm handling for setup by resolving `npm-cli.js` and invoking it through `node.exe` instead of relying on `cmd.exe`.
- Add tests for Office startup sequencing and Windows command resolution.

## Why

On Windows, launching scripts through `npm.cmd` can fail or open unwanted shell behavior depending on the user’s Node/npm installation. Starting Claw3D directly through Node matches the upstream `hermes-office` npm scripts while avoiding the fragile shim layer.

Office startup also needs the Hermes Gateway to be available first, otherwise Claw3D can start but fail to connect to the local or SSH-backed Gateway.

## Cross-platform notes

The Windows npm rewrite is gated to `win32` only. Linux and macOS keep normal command invocation behavior.

The direct Claw3D commands are platform-neutral and match the current `hermes-office` scripts.

## Verification

- `npm run typecheck`
- `npm test`
- `npm run build`
- `git diff --check upstream/main...HEAD`
- Smoke: Claw3D dev server responded successfully.
- Smoke: Hermes adapter opened a WebSocket listener successfully.
- Smoke: Windows npm resolution works for both nvm-style and arbitrary install paths.
- Smoke: Linux/darwin command paths do not trigger Windows-specific npm rewrite.