### PR TITLE
fix: persist interface locale across restartsfix: persist interface locale

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -27,7 +27,7 @@ function desktopConfigFile(): string {
   return join(HERMES_HOME, "desktop.json");
 }
 
-function readDesktopConfig(): Record<string, unknown> {
+export function readDesktopConfig(): Record<string, unknown> {
   try {
     const f = desktopConfigFile();
     if (!existsSync(f)) return {};
@@ -37,7 +37,7 @@ function readDesktopConfig(): Record<string, unknown> {
   }
 }
 
-function writeDesktopConfig(data: Record<string, unknown>): void {
+export function writeDesktopConfig(data: Record<string, unknown>): void {
   if (!existsSync(HERMES_HOME)) {
     mkdirSync(HERMES_HOME, { recursive: true });
   }
@@ -274,7 +274,7 @@ export function setModelConfig(
     // Append base_url line after the provider line in the model section
     content = content.replace(
       /^(\s*provider:\s*"[^"]*"\s*\n)/m,
-      `$1  base_url: "${baseUrl}"\n`
+      `$1  base_url: "${baseUrl}"\n`,
     );
   }
 

--- a/src/main/locale.ts
+++ b/src/main/locale.ts
@@ -1,14 +1,40 @@
 import {
+  APP_LOCALES,
   DEFAULT_ACTIVE_LOCALE,
   getLocale as getSharedLocale,
   setLocale as setSharedLocale,
   type AppLocale,
 } from "../shared/i18n";
+import { readDesktopConfig, writeDesktopConfig } from "./config";
+
+const DESKTOP_LOCALE_KEY = "locale";
+
+function isAppLocale(value: unknown): value is AppLocale {
+  return typeof value === "string" && APP_LOCALES.includes(value as AppLocale);
+}
+
+function readSavedLocale(): AppLocale | undefined {
+  const value = readDesktopConfig()[DESKTOP_LOCALE_KEY];
+  return isAppLocale(value) ? value : undefined;
+}
+
+function writeSavedLocale(locale: AppLocale): void {
+  const data = readDesktopConfig();
+  data[DESKTOP_LOCALE_KEY] = locale;
+  writeDesktopConfig(data);
+}
+
+const savedLocale = readSavedLocale();
+if (savedLocale) {
+  setSharedLocale(savedLocale);
+}
 
 export function getAppLocale(): AppLocale {
-  return getSharedLocale() || DEFAULT_ACTIVE_LOCALE;
+  return readSavedLocale() || getSharedLocale() || DEFAULT_ACTIVE_LOCALE;
 }
 
 export function setAppLocale(locale: AppLocale): AppLocale {
-  return setSharedLocale(locale);
+  const nextLocale = setSharedLocale(locale);
+  writeSavedLocale(nextLocale);
+  return nextLocale;
 }

--- a/src/renderer/src/components/I18nProvider.test.tsx
+++ b/src/renderer/src/components/I18nProvider.test.tsx
@@ -3,6 +3,7 @@ import { vi } from "vitest";
 import {
   DEFAULT_ACTIVE_LOCALE,
   setLocale as setSharedLocale,
+  type AppLocale,
 } from "../../../shared/i18n";
 import { I18nProvider } from "./I18nProvider";
 import { useI18n } from "./useI18n";
@@ -23,15 +24,24 @@ function LocaleSwitcherProbe(): React.JSX.Element {
   );
 }
 
+function installHermesAPI(
+  api: Pick<Window["hermesAPI"], "getLocale" | "setLocale">,
+): void {
+  Object.defineProperty(window, "hermesAPI", {
+    configurable: true,
+    value: api,
+  });
+}
+
 describe("I18nProvider", () => {
   const getLocale = vi.fn().mockResolvedValue(DEFAULT_ACTIVE_LOCALE);
   const setLocale = vi.fn().mockResolvedValue(DEFAULT_ACTIVE_LOCALE);
 
   beforeEach(() => {
-    (window as any).hermesAPI = {
+    installHermesAPI({
       getLocale,
       setLocale,
-    };
+    });
     getLocale.mockClear();
     setLocale.mockClear();
     getLocale.mockResolvedValue(DEFAULT_ACTIVE_LOCALE);
@@ -67,7 +77,35 @@ describe("I18nProvider", () => {
     );
 
     await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: "Switch to Spanish" }));
+      fireEvent.click(
+        screen.getByRole("button", { name: "Switch to Spanish" }),
+      );
+    });
+
+    expect(setLocale).toHaveBeenLastCalledWith("es");
+    expect(await screen.findByText("Bienvenido a Hermes")).toBeInTheDocument();
+  });
+
+  it("does not overwrite the main-process locale with the startup fallback", async () => {
+    let resolveMainLocale: (locale: AppLocale) => void = () => {};
+    getLocale.mockReturnValue(
+      new Promise<AppLocale>((resolve) => {
+        resolveMainLocale = resolve;
+      }),
+    );
+
+    render(
+      <I18nProvider>
+        <Probe />
+      </I18nProvider>,
+    );
+
+    await act(async () => {});
+
+    expect(setLocale).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveMainLocale("es");
     });
 
     expect(setLocale).toHaveBeenLastCalledWith("es");

--- a/src/renderer/src/components/I18nProvider.tsx
+++ b/src/renderer/src/components/I18nProvider.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { I18nextProvider, initReactI18next } from "react-i18next";
 import {
   APP_LOCALES,
@@ -34,18 +34,36 @@ export function I18nProvider({
   children: React.ReactNode;
 }): React.JSX.Element {
   const [locale, setLocaleState] = useState<AppLocale>(initialLocale);
+  const [mainLocaleLoaded, setMainLocaleLoaded] = useState(
+    () => !window.hermesAPI?.getLocale,
+  );
+  const userSelectedLocale = useRef(false);
+
+  const setLocale = useCallback((nextLocale: AppLocale) => {
+    userSelectedLocale.current = true;
+    setLocaleState(nextLocale);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
+    const getMainLocale = window.hermesAPI?.getLocale;
 
-    void window.hermesAPI
-      ?.getLocale?.()
+    if (!getMainLocale) {
+      return;
+    }
+
+    void getMainLocale()
       .then((mainLocale) => {
-        if (cancelled || !mainLocale || mainLocale === locale) return;
+        if (cancelled || !mainLocale || userSelectedLocale.current) return;
         setLocaleState(mainLocale);
       })
       .catch(() => {
         /* ignore */
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setMainLocaleLoaded(true);
+        }
       });
 
     return () => {
@@ -54,6 +72,8 @@ export function I18nProvider({
   }, []);
 
   useEffect(() => {
+    if (!mainLocaleLoaded && !userSelectedLocale.current) return;
+
     if (sharedI18n.language !== locale) {
       setSharedLocale(locale);
     }
@@ -65,14 +85,14 @@ export function I18nProvider({
     } catch {
       /* ignore */
     }
-  }, [locale]);
+  }, [locale, mainLocaleLoaded]);
 
   const value = useMemo<I18nContextValue>(
     () => ({
       locale,
-      setLocale: setLocaleState,
+      setLocale,
     }),
-    [locale],
+    [locale, setLocale],
   );
 
   return (

--- a/tests/locale-persistence.test.ts
+++ b/tests/locale-persistence.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+let testHome: string;
+
+async function loadLocaleModule(): Promise<
+  typeof import("../src/main/locale")
+> {
+  vi.resetModules();
+  vi.stubEnv("HERMES_HOME", testHome);
+  return await import("../src/main/locale");
+}
+
+describe("app locale persistence", () => {
+  beforeEach(() => {
+    testHome = mkdtempSync(join(tmpdir(), "hermes-locale-"));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    rmSync(testHome, { recursive: true, force: true });
+  });
+
+  it("reloads the saved locale after the main process restarts", async () => {
+    const firstRun = await loadLocaleModule();
+
+    expect(firstRun.setAppLocale("es")).toBe("es");
+
+    const secondRun = await loadLocaleModule();
+
+    expect(secondRun.getAppLocale()).toBe("es");
+  });
+});


### PR DESCRIPTION
## Summary

- Persist the selected interface locale in `desktop.json`
- Restore the saved locale when the main process starts
- Prevent the renderer from overwriting the saved main-process locale with the startup fallback before `getLocale()` resolves
- Add regression coverage for locale persistence and startup synchronization

## Verification

- `npm test` passed: 319 tests
- `npm run build` passed
- ESLint passed on the changed files