### PR TITLE
feat(chat): add clipboard image paste support

### DIFF
--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -165,27 +165,45 @@ export interface ChatCallbacks {
   }) => void;
 }
 
+type ContentPart =
+  | { type: "text"; text: string }
+  | { type: "image_url"; image_url: { url: string } };
+
+function buildMessageContent(
+  text: string,
+  images?: string[],
+): string | ContentPart[] {
+  if (!images || images.length === 0) return text;
+  const parts: ContentPart[] = [];
+  if (text) parts.push({ type: "text", text });
+  for (const url of images) {
+    parts.push({ type: "image_url", image_url: { url } });
+  }
+  return parts;
+}
+
 function sendMessageViaApi(
   message: string,
   cb: ChatCallbacks,
   profile?: string,
   _resumeSessionId?: string,
-  history?: Array<{ role: string; content: string }>,
+  history?: Array<{ role: string; content: string; images?: string[] }>,
+  images?: string[],
 ): ChatHandle {
   const mc = getModelConfig(profile);
   const controller = new AbortController();
 
   // Build full conversation from history + current message (standard OpenAI format)
-  const messages: Array<{ role: string; content: string }> = [];
+  const messages: Array<{ role: string; content: string | ContentPart[] }> = [];
   if (history && history.length > 0) {
     for (const msg of history) {
       messages.push({
         role: msg.role === "agent" ? "assistant" : msg.role,
-        content: msg.content,
+        content: buildMessageContent(msg.content, msg.images),
       });
     }
   }
-  messages.push({ role: "user", content: message });
+  messages.push({ role: "user", content: buildMessageContent(message, images) });
 
   const body = JSON.stringify({
     model: mc.model || "hermes-agent",
@@ -657,13 +675,14 @@ export async function sendMessage(
   cb: ChatCallbacks,
   profile?: string,
   resumeSessionId?: string,
-  history?: Array<{ role: string; content: string }>,
+  history?: Array<{ role: string; content: string; images?: string[] }>,
+  images?: string[],
 ): Promise<ChatHandle> {
   ensureInitialized();
 
   // Remote mode: always use API, no CLI fallback
   if (isRemoteMode()) {
-    return sendMessageViaApi(message, cb, profile, resumeSessionId, history);
+    return sendMessageViaApi(message, cb, profile, resumeSessionId, history, images);
   }
 
   // Check API server availability (cache the result, re-check periodically)
@@ -672,7 +691,7 @@ export async function sendMessage(
   }
 
   if (apiServerAvailable) {
-    return sendMessageViaApi(message, cb, profile, resumeSessionId, history);
+    return sendMessageViaApi(message, cb, profile, resumeSessionId, history, images);
   }
 
   // Fallback to CLI

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -567,7 +567,8 @@ function setupIPC(): void {
       message: string,
       profile?: string,
       resumeSessionId?: string,
-      history?: Array<{ role: string; content: string }>,
+      history?: Array<{ role: string; content: string; images?: string[] }>,
+      images?: string[],
     ) => {
       if (!isRemoteMode() && !isGatewayRunning()) {
         startGateway(profile);
@@ -650,6 +651,7 @@ function setupIPC(): void {
         profile,
         resumeSessionId,
         history,
+        images,
       );
 
       currentChatAbort = handle.abort;

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -194,7 +194,8 @@ interface HermesAPI {
     message: string,
     profile?: string,
     resumeSessionId?: string,
-    history?: Array<{ role: string; content: string }>,
+    history?: Array<{ role: string; content: string; images?: string[] }>,
+    images?: string[],
   ) => Promise<{ response: string; sessionId?: string }>;
   abortChat: () => Promise<void>;
   onChatChunk: (callback: (chunk: string) => void) => () => void;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -160,7 +160,8 @@ const hermesAPI = {
     message: string,
     profile?: string,
     resumeSessionId?: string,
-    history?: Array<{ role: string; content: string }>,
+    history?: Array<{ role: string; content: string; images?: string[] }>,
+    images?: string[],
   ): Promise<{ response: string; sessionId?: string }> =>
     ipcRenderer.invoke(
       "send-message",
@@ -168,6 +169,7 @@ const hermesAPI = {
       profile,
       resumeSessionId,
       history,
+      images,
     ),
 
   abortChat: (): Promise<void> => ipcRenderer.invoke("abort-chat"),

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1621,6 +1621,62 @@ body {
   color: var(--text-muted);
 }
 
+.chat-attachments {
+  display: flex;
+  gap: 8px;
+  padding: 8px 12px;
+  overflow-x: auto;
+}
+
+.chat-attachment-item {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.chat-attachment-thumb {
+  width: 64px;
+  height: 64px;
+  object-fit: cover;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+}
+
+.chat-attachment-remove {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--danger, #ef4444);
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  padding: 0;
+}
+
+.chat-attachment-remove:hover {
+  opacity: 0.8;
+}
+
+.chat-message-images {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+
+.chat-message-image {
+  max-width: 200px;
+  max-height: 200px;
+  border-radius: var(--radius-sm);
+  object-fit: contain;
+}
+
 .chat-send-btn {
   width: 34px;
   height: 34px;

--- a/src/renderer/src/screens/Chat/ChatInput.tsx
+++ b/src/renderer/src/screens/Chat/ChatInput.tsx
@@ -7,7 +7,7 @@ import {
   forwardRef,
   useImperativeHandle,
 } from "react";
-import { Send, Square as Stop, Slash } from "lucide-react";
+import { Send, Square as Stop, Slash, X } from "lucide-react";
 import { isImeComposing } from "./keyboard";
 import { useI18n } from "../../components/useI18n";
 import { SLASH_COMMANDS, type SlashCommand } from "./slashCommands";
@@ -22,8 +22,8 @@ export interface ChatInputHandle {
 interface ChatInputProps {
   isLoading: boolean;
   hasSession: boolean;
-  onSubmit: (text: string) => void;
-  onQuickAsk: (text: string) => void;
+  onSubmit: (text: string, images?: string[]) => void;
+  onQuickAsk: (text: string, images?: string[]) => void;
   onAbort: () => void;
 }
 
@@ -34,6 +34,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
   ): React.JSX.Element {
     const { t } = useI18n();
     const [input, setInput] = useState("");
+    const [attachments, setAttachments] = useState<string[]>([]);
     const [slashMenuOpen, setSlashMenuOpen] = useState(false);
     const [slashFilter, setSlashFilter] = useState("");
     const [slashSelectedIndex, setSlashSelectedIndex] = useState(0);
@@ -130,22 +131,25 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
     function clearAfterSend(text: string): void {
       history.push(text);
       setInput("");
+      setAttachments([]);
       if (inputRef.current) inputRef.current.style.height = "auto";
     }
 
     function handleSend(): void {
       const text = input.trim();
-      if (!text || isLoading) return;
+      if ((!text && attachments.length === 0) || isLoading) return;
       setSlashMenuOpen(false);
-      clearAfterSend(text);
-      onSubmit(text);
+      const imgs = attachments.length > 0 ? [...attachments] : undefined;
+      clearAfterSend(text || "(image)");
+      onSubmit(text || "(image)", imgs);
     }
 
     function handleQuickAsk(): void {
       const text = input.trim();
-      if (!text || isLoading) return;
-      clearAfterSend(text);
-      onQuickAsk(text);
+      if ((!text && attachments.length === 0) || isLoading) return;
+      const imgs = attachments.length > 0 ? [...attachments] : undefined;
+      clearAfterSend(text || "(image)");
+      onQuickAsk(text || "(image)", imgs);
     }
 
     function handleSlashSelect(cmd: SlashCommand): void {
@@ -160,6 +164,30 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
       // Backend commands that take arguments: insert prefix and wait for the user
       setInput(cmd.name + " ");
       inputRef.current?.focus();
+    }
+
+    function handlePaste(e: React.ClipboardEvent<HTMLTextAreaElement>): void {
+      const items = e.clipboardData?.items;
+      if (!items) return;
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        if (item.type.startsWith("image/")) {
+          e.preventDefault();
+          const blob = item.getAsFile();
+          if (!blob) continue;
+          const reader = new FileReader();
+          reader.onload = () => {
+            const dataUrl = reader.result as string;
+            setAttachments((prev) => [...prev, dataUrl]);
+          };
+          reader.readAsDataURL(blob);
+          return;
+        }
+      }
+    }
+
+    function removeAttachment(index: number): void {
+      setAttachments((prev) => prev.filter((_, i) => i !== index));
     }
 
     function handleInputChange(
@@ -262,6 +290,21 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
             </div>
           </div>
         )}
+        {attachments.length > 0 && (
+          <div className="chat-attachments">
+            {attachments.map((src, i) => (
+              <div key={i} className="chat-attachment-item">
+                <img src={src} alt="" className="chat-attachment-thumb" />
+                <button
+                  className="chat-attachment-remove"
+                  onClick={() => removeAttachment(i)}
+                >
+                  <X size={12} />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
         <div className="chat-input-wrapper">
           <textarea
             ref={inputRef}
@@ -270,6 +313,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
             value={input}
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
             rows={1}
             autoFocus
           />
@@ -295,7 +339,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
               <button
                 className="chat-send-btn"
                 onClick={handleSend}
-                disabled={!input.trim()}
+                disabled={!input.trim() && attachments.length === 0}
                 title={t("chat.send")}
               >
                 <Send size={16} />

--- a/src/renderer/src/screens/Chat/MessageRow.tsx
+++ b/src/renderer/src/screens/Chat/MessageRow.tsx
@@ -52,7 +52,16 @@ export const MessageRow = memo(function MessageRow({
         {msg.role === "agent" ? (
           <AgentMarkdown>{msg.content}</AgentMarkdown>
         ) : (
-          msg.content
+          <>
+            {msg.images && msg.images.length > 0 && (
+              <div className="chat-message-images">
+                {msg.images.map((src, i) => (
+                  <img key={i} src={src} alt="" className="chat-message-image" />
+                ))}
+              </div>
+            )}
+            {msg.content !== "(image)" && msg.content}
+          </>
         )}
       </div>
       {showApprovalBar && (

--- a/src/renderer/src/screens/Chat/hooks/useChatActions.ts
+++ b/src/renderer/src/screens/Chat/hooks/useChatActions.ts
@@ -20,8 +20,8 @@ interface UseChatActionsArgs {
 }
 
 interface UseChatActionsResult {
-  handleSend: (text: string) => Promise<void>;
-  handleQuickAsk: (text: string) => Promise<void>;
+  handleSend: (text: string, images?: string[]) => Promise<void>;
+  handleQuickAsk: (text: string, images?: string[]) => Promise<void>;
   handleAbort: () => void;
   handleApprove: () => void;
   handleDeny: () => void;
@@ -52,17 +52,17 @@ export function useChatActions({
   });
 
   const pushUser = useCallback(
-    (content: string, idPrefix = "user") => {
+    (content: string, idPrefix = "user", images?: string[]) => {
       setMessages((prev) => [
         ...prev,
-        { id: `${idPrefix}-${Date.now()}`, role: "user", content },
+        { id: `${idPrefix}-${Date.now()}`, role: "user", content, images },
       ]);
     },
     [setMessages],
   );
 
   const sendToAgent = useCallback(
-    async (text: string): Promise<void> => {
+    async (text: string, images?: string[]): Promise<void> => {
       try {
         await window.hermesAPI.sendMessage(
           text,
@@ -71,7 +71,9 @@ export function useChatActions({
           messagesRef.current.map((m) => ({
             role: m.role,
             content: m.content,
+            images: m.images,
           })),
+          images,
         );
       } catch {
         // onChatError IPC already surfaces this to the user
@@ -81,30 +83,30 @@ export function useChatActions({
   );
 
   const handleSend = useCallback(
-    async (text: string): Promise<void> => {
+    async (text: string, images?: string[]): Promise<void> => {
       if (!text || isLoadingRef.current) return;
 
       if (localCommands.isLocal(text)) {
         const cmd = text.split(/\s+/)[0].toLowerCase();
-        if (cmd !== "/new" && cmd !== "/clear") pushUser(text);
+        if (cmd !== "/new" && cmd !== "/clear") pushUser(text, "user", images);
         await localCommands.executeLocal(text);
         return;
       }
 
       setIsLoading(true);
-      pushUser(text);
+      pushUser(text, "user", images);
       onSessionStarted?.();
-      await sendToAgent(text);
+      await sendToAgent(text, images);
     },
     [localCommands, pushUser, onSessionStarted, sendToAgent, setIsLoading],
   );
 
   const handleQuickAsk = useCallback(
-    async (text: string): Promise<void> => {
+    async (text: string, images?: string[]): Promise<void> => {
       if (!text || isLoadingRef.current) return;
       setIsLoading(true);
-      pushUser(`💭 ${text}`, "user-btw");
-      await sendToAgent(`/btw ${text}`);
+      pushUser(`💭 ${text}`, "user-btw", images);
+      await sendToAgent(`/btw ${text}`, images);
     },
     [pushUser, sendToAgent, setIsLoading],
   );

--- a/src/renderer/src/screens/Chat/types.ts
+++ b/src/renderer/src/screens/Chat/types.ts
@@ -2,6 +2,7 @@ export interface ChatMessage {
   id: string;
   role: "user" | "agent";
   content: string;
+  images?: string[];
 }
 
 export interface ModelGroup {


### PR DESCRIPTION
## Summary
 
Adds support for pasting screenshots and images from the clipboard directly into the chat input. Images are converted to base64 data URLs and sent to the API using OpenAI multimodal content format (`text` + `image_url` parts).
 
## Changes
 
- **ChatInput**: `onPaste` handler detects `image/*` clipboard items, stores as base64 data URL attachments with thumbnail preview and remove button
- **ChatMessage type**: Added optional `images?: string[]` field
- **useChatActions**: [handleSend](cci:1://file:///Users/insomnia/tools/hermes-desktop/src/renderer/src/screens/Chat/ChatInput.tsx:13:4-19:5) / [handleQuickAsk](cci:1://file:///Users/insomnia/tools/hermes-desktop/src/renderer/src/screens/Chat/ChatInput.tsx:146:4-152:5) / `pushUser` / `sendToAgent` now accept and forward `images` parameter
- **IPC layer**: [sendMessage](cci:1://file:///Users/insomnia/tools/hermes-desktop/src/main/hermes.ts:5:0-30:1) in preload and main process updated with `images` parameter
- **hermes.ts**: New [buildMessageContent()](cci:1://file:///Users/insomnia/tools/hermes-desktop/src/main/hermes.ts:171:0-182:1) helper builds OpenAI multimodal content parts when images are present
- **MessageRow**: Renders attached images in user message bubbles
- **CSS**: Styles for attachment previews and inline message images
 
## How to test
 
1. Take a screenshot on macOS (`Cmd+Shift+4` or `Cmd+Shift+Ctrl+4`)
2. Focus the chat input and press `Cmd+V`
3. Image appears as a thumbnail preview above the textarea
4. Optionally add text, then send
5. Image is displayed in the user message bubble and sent to the model as multimodal content
 