### PR TITLE
feat(models): auto-detect provider from Base URL in Add/Edit dialog

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -4385,6 +4385,13 @@ body {
   color: var(--text-muted);
 }
 
+.models-modal-auto-badge {
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
 .models-modal-field .input,
 .models-modal-field select.input {
   padding: 8px 12px;

--- a/src/renderer/src/screens/Models/Models.tsx
+++ b/src/renderer/src/screens/Models/Models.tsx
@@ -3,6 +3,7 @@ import { Plus, Trash, Search, X } from "../../assets/icons";
 import { PROVIDERS } from "../../constants";
 import { useI18n } from "../../components/useI18n";
 import BrandLogo from "../../components/common/BrandLogo";
+import { detectProviderFromUrl } from "./detect-provider";
 
 interface SavedModel {
   id: string;
@@ -34,6 +35,12 @@ function Models(): React.JSX.Element {
   const [formApiKey, setFormApiKey] = useState("");
   const [showApiKey, setShowApiKey] = useState(false);
   const [formError, setFormError] = useState("");
+  // Whether the user has manually picked a value from the Provider dropdown
+  // for this open of the modal. While false, the dropdown follows whatever
+  // detectProviderFromUrl() infers from the Base URL field. Once the user
+  // touches the dropdown we stop overriding their choice.
+  const [providerTouched, setProviderTouched] = useState(false);
+  const [providerAutoFilled, setProviderAutoFilled] = useState(false);
 
   function resolveCustomEnvKey(url: string): string {
     if (!url) return "CUSTOM_API_KEY";
@@ -70,6 +77,8 @@ function Models(): React.JSX.Element {
     setFormApiKey("");
     setShowApiKey(false);
     setFormError("");
+    setProviderTouched(false);
+    setProviderAutoFilled(false);
     setShowModal(true);
   }
 
@@ -82,6 +91,9 @@ function Models(): React.JSX.Element {
     setFormApiKey("");
     setShowApiKey(false);
     setFormError("");
+    // Editing an existing entry — respect the saved provider, don't auto-overwrite it.
+    setProviderTouched(true);
+    setProviderAutoFilled(false);
     setShowModal(true);
   }
 
@@ -89,7 +101,27 @@ function Models(): React.JSX.Element {
     setShowModal(false);
     setEditingModel(null);
     setFormError("");
+    setProviderTouched(false);
+    setProviderAutoFilled(false);
   }
+
+  // Auto-detect provider from base URL while the modal is open and the user
+  // hasn't manually picked a provider yet. Detection runs on every URL
+  // change so backspacing the URL also clears the auto-fill flag.
+  useEffect(() => {
+    if (!showModal || providerTouched) {
+      if (!showModal) setProviderAutoFilled(false);
+      return;
+    }
+    const detected = detectProviderFromUrl(formBaseUrl);
+    if (detected && detected !== formProvider) {
+      setFormProvider(detected);
+      setProviderAutoFilled(true);
+    } else if (!detected && providerAutoFilled) {
+      // URL no longer matches; drop the badge but keep whatever's selected.
+      setProviderAutoFilled(false);
+    }
+  }, [formBaseUrl, showModal, providerTouched, formProvider, providerAutoFilled]);
 
   async function handleSave(): Promise<void> {
     const name = formName.trim();
@@ -279,11 +311,20 @@ function Models(): React.JSX.Element {
               <div className="models-modal-field">
                 <label className="models-modal-label">
                   {t("common.provider")}
+                  {providerAutoFilled && !providerTouched && (
+                    <span className="models-modal-auto-badge">
+                      &nbsp;· auto-detected from base URL
+                    </span>
+                  )}
                 </label>
                 <select
                   className="input"
                   value={formProvider}
-                  onChange={(e) => setFormProvider(e.target.value)}
+                  onChange={(e) => {
+                    setFormProvider(e.target.value);
+                    setProviderTouched(true);
+                    setProviderAutoFilled(false);
+                  }}
                 >
                   {PROVIDERS.options.map((p) => (
                     <option key={p.value} value={p.value}>

--- a/src/renderer/src/screens/Models/detect-provider.ts
+++ b/src/renderer/src/screens/Models/detect-provider.ts
@@ -1,0 +1,61 @@
+// Map a base URL to the PROVIDERS.options `value` it most likely corresponds
+// to. Returns null when the URL is empty or doesn't match any known pattern,
+// in which case the caller should leave the provider field untouched.
+//
+// Used by the Add/Edit Model dialog to pre-fill the provider dropdown so
+// users entering an Ollama / LM Studio / private-network URL don't end up
+// silently saving with the dialog's default (which is OpenRouter) and then
+// wonder why the model card displays the wrong provider.
+export function detectProviderFromUrl(rawUrl: string): string | null {
+  const url = rawUrl.trim().toLowerCase();
+  if (!url) return null;
+
+  // Hosted providers — match by hostname.
+  if (/(^|\/\/)openrouter\.ai(\/|:|$)/.test(url)) return "openrouter";
+  if (/(^|\/\/)api\.anthropic\.com(\/|:|$)/.test(url)) return "anthropic";
+  if (/(^|\/\/)api\.openai\.com(\/|:|$)/.test(url)) return "openai";
+  if (/(^|\/\/)generativelanguage\.googleapis\.com(\/|:|$)/.test(url))
+    return "google";
+  if (/(^|\/\/)api\.x\.ai(\/|:|$)/.test(url)) return "xai";
+  if (/nousresearch\.com/.test(url)) return "nous";
+  if (/dashscope(-intl)?\.aliyuncs\.com/.test(url)) return "qwen";
+  if (/api\.minimax(i)?\.(chat|com)/.test(url)) return "minimax";
+
+  // Anything pointing at a private or loopback address is almost always a
+  // self-hosted OpenAI-compatible endpoint (Ollama, LM Studio, vLLM,
+  // llama.cpp) — surface that as "Local / Custom" so the model card label
+  // matches user expectation.
+  const host = extractHost(url);
+  if (host && isPrivateOrLoopback(host)) return "custom";
+
+  // Well-known local-LLM ports on any host — Ollama 11434, LM Studio 1234,
+  // vLLM 8000, llama.cpp 8080. These run on LAN VMs too, so we don't
+  // require a private-IP match for the port-only heuristic.
+  if (/:(11434|1234|8000|8080)(\/|$)/.test(url)) return "custom";
+
+  return null;
+}
+
+function extractHost(url: string): string | null {
+  // Strip scheme and path; accept bare host:port too.
+  const stripped = url.replace(/^https?:\/\//, "").split("/")[0];
+  if (!stripped) return null;
+  return stripped.split(":")[0] || null;
+}
+
+function isPrivateOrLoopback(host: string): boolean {
+  if (host === "localhost") return true;
+  if (host === "127.0.0.1" || host === "::1" || host === "[::1]") return true;
+  // RFC1918 IPv4 ranges
+  if (/^10\./.test(host)) return true;
+  if (/^192\.168\./.test(host)) return true;
+  // 172.16.0.0 – 172.31.255.255
+  const m = host.match(/^172\.(\d+)\./);
+  if (m) {
+    const second = parseInt(m[1], 10);
+    if (second >= 16 && second <= 31) return true;
+  }
+  // .local mDNS hostnames (common for self-hosted home-network services)
+  if (/\.local$/.test(host)) return true;
+  return false;
+}

--- a/tests/detect-provider.test.ts
+++ b/tests/detect-provider.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { detectProviderFromUrl } from "../src/renderer/src/screens/Models/detect-provider";
+
+describe("detectProviderFromUrl", () => {
+  it("returns null for empty input", () => {
+    expect(detectProviderFromUrl("")).toBeNull();
+    expect(detectProviderFromUrl("   ")).toBeNull();
+  });
+
+  it("identifies hosted providers by hostname", () => {
+    expect(detectProviderFromUrl("https://openrouter.ai/api/v1")).toBe("openrouter");
+    expect(detectProviderFromUrl("https://api.anthropic.com")).toBe("anthropic");
+    expect(detectProviderFromUrl("https://api.openai.com/v1")).toBe("openai");
+    expect(detectProviderFromUrl("https://generativelanguage.googleapis.com/v1beta")).toBe("google");
+    expect(detectProviderFromUrl("https://api.x.ai/v1")).toBe("xai");
+    expect(detectProviderFromUrl("https://inference-api.nousresearch.com/v1")).toBe("nous");
+    expect(detectProviderFromUrl("https://dashscope-intl.aliyuncs.com/compatible-mode/v1")).toBe("qwen");
+    expect(detectProviderFromUrl("https://api.minimax.chat/v1")).toBe("minimax");
+  });
+
+  it("identifies private-network and loopback addresses as custom", () => {
+    expect(detectProviderFromUrl("http://localhost:11434")).toBe("custom");
+    expect(detectProviderFromUrl("http://127.0.0.1:11434/v1")).toBe("custom");
+    expect(detectProviderFromUrl("http://192.168.1.50:11434")).toBe("custom");
+    expect(detectProviderFromUrl("http://10.0.0.5:8000")).toBe("custom");
+    expect(detectProviderFromUrl("http://172.20.0.3:1234")).toBe("custom");
+    expect(detectProviderFromUrl("http://hermes.local:11434")).toBe("custom");
+  });
+
+  it("identifies well-known local-LLM ports on any host as custom", () => {
+    // Ollama on a LAN VM with a public-looking hostname
+    expect(detectProviderFromUrl("http://ollama.andrea-house.com:11434/v1")).toBe("custom");
+    // LM Studio
+    expect(detectProviderFromUrl("http://my-workstation.example.com:1234/v1")).toBe("custom");
+    // vLLM
+    expect(detectProviderFromUrl("http://gpu-rig.example.com:8000")).toBe("custom");
+    // llama.cpp server
+    expect(detectProviderFromUrl("http://llama.example.com:8080")).toBe("custom");
+  });
+
+  it("excludes 172.x outside the RFC1918 range", () => {
+    expect(detectProviderFromUrl("http://172.15.0.1:11434")).toBe("custom"); // port hits
+    expect(detectProviderFromUrl("http://172.32.0.1:9999")).toBeNull();
+  });
+
+  it("returns null for unknown public URLs without a local-LLM port", () => {
+    expect(detectProviderFromUrl("https://example.com/v1")).toBeNull();
+    expect(detectProviderFromUrl("https://api.example.com:443")).toBeNull();
+  });
+
+  it("is case-insensitive", () => {
+    expect(detectProviderFromUrl("HTTPS://API.OPENAI.COM")).toBe("openai");
+    expect(detectProviderFromUrl("HTTP://LOCALHOST:11434")).toBe("custom");
+  });
+
+  it("tolerates bare host:port without a scheme", () => {
+    expect(detectProviderFromUrl("localhost:1234")).toBe("custom");
+    expect(detectProviderFromUrl("192.168.1.10:8080")).toBe("custom");
+  });
+});


### PR DESCRIPTION
## Summary

The Add Model dialog defaults the Provider dropdown to **OpenRouter** and never adjusts when the user types a Base URL. Users adding an Ollama / LM Studio / vLLM / llama.cpp endpoint they think of as "local" end up silently saving with the wrong provider value, and the model card then displays "OpenRouter" (or whatever was left selected) — confusing when the actual HTTP request hits a self-hosted OpenAI-compatible server. This is the same trap I fell into when seeding a Qwen3 Coder entry for a user testing PR #209 — I left \`provider: "openai"\` because the Ollama port returns OpenAI-shaped responses, and the model card labeled it "OpenAI" instead of "Local / Custom" until the user manually fixed it.

## Behavior

A new \`detectProviderFromUrl(url)\` helper maps Base URLs to the PROVIDERS.options \`value\` they most likely correspond to:

- **Hosted providers by hostname:** \`openrouter.ai\` → \`openrouter\`, \`api.anthropic.com\` → \`anthropic\`, \`api.openai.com\` → \`openai\`, \`generativelanguage.googleapis.com\` → \`google\`, \`api.x.ai\` → \`xai\`, \`nousresearch.com\` → \`nous\`, \`dashscope(-intl).aliyuncs.com\` → \`qwen\`, \`api.minimax.chat\` → \`minimax\`.
- **Private / loopback addresses:** \`localhost\`, \`127.0.0.1\`, \`::1\`, \`10/8\`, \`192.168/16\`, \`172.16–31/12\`, \`*.local\` → \`custom\`.
- **Well-known local-LLM ports on any host:** \`11434\` (Ollama), \`1234\` (LM Studio), \`8000\` (vLLM), \`8080\` (llama.cpp) → \`custom\`. The port-only heuristic matters because LAN VMs frequently have public-looking DNS names (e.g. \`ollama.example.com:11434\`).

The Add Model dialog watches the Base URL field and overrides the dropdown **only while the user hasn't manually touched it**. As soon as the user picks a value, detection stops overriding their choice for that modal session. Opening the Edit dialog on an existing model marks the dropdown as touched, so the saved provider isn't rewritten when an existing entry is edited.

When detection has changed the dropdown value, a small italic *"auto-detected from base URL"* badge appears next to the Provider label so the user understands why the value moved.

## Tests

\`tests/detect-provider.test.ts\` covers:

- Empty / whitespace input returns null
- All hosted-provider hostnames return their canonical value
- All RFC1918 ranges + loopback + .local return \`custom\`
- 172.16–31 boundary (172.15.x and 172.32.x are NOT in range)
- Well-known local-LLM ports on public hostnames return \`custom\`
- Case-insensitivity
- Scheme-less \`host:port\` input
- Public URLs without a local-LLM port return null

8 tests, all passing. \`npm run typecheck\` clean.

## Test plan

- [x] \`npm run test -- detect-provider\` — 8/8 pass.
- [x] \`npm run typecheck\` clean (node + web).
- [ ] Manual: open Add Model, paste \`http://ollama.example.com:11434/v1\`, verify Provider flips to "Local / Custom" with the badge.
- [ ] Manual: while badge is showing, click the dropdown and pick "OpenAI" — verify the badge disappears and subsequent URL edits no longer override.
- [ ] Manual: Edit an existing model — Provider field is NOT auto-overwritten by detection (the editing path marks it as touched on open).
- [ ] Manual: clear the Base URL — Provider stays where it is (we don't reset to the default).

## Series

Sixth and final PR in the "make remote feel local" series:

- #204 — fix SSH tunnel lifecycle on Linux/macOS
- #205 — fix blank Engine/Released/Python/OpenAI SDK against installer deploys
- #206 — docs: SSH tunnel + VPS connection guide
- #207 — wire Kanban board for SSH tunnel mode
- #208 — auto-detect remote Claw3D in SSH tunnel mode
- #209 — route Models Add/Remove/Update through SSH in tunnel mode

This PR closes the last user-reported papercut: when a user finally edits the saved model via the (now-working) SSH-routed Add dialog, they shouldn't have to know the OpenAI-compatibility detail of their Ollama install to pick the right Provider value.