### PR TITLE
chore(css): add vendor prefixes and Electron browserslist target

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,7 @@
+# Target the Chromium version that the bundled Electron ships. Tooling that
+# reads browserslist (PostCSS / Microsoft Edge Tools / linters) will stop
+# warning about features that are only "missing" on engines we never ship to.
+#
+# Electron 39.x bundles Chromium 130+. Bumping this when we upgrade Electron
+# keeps the lint signal honest without silencing legitimate compat issues.
+last 2 Chrome versions

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -416,6 +416,7 @@ body {
   font-size: 12px;
   color: var(--text-secondary);
   word-break: break-all;
+  -webkit-user-select: text;
   user-select: text;
 }
 
@@ -568,6 +569,7 @@ body {
   line-height: 1.7;
   white-space: pre-wrap;
   word-break: break-all;
+  -webkit-user-select: text;
   user-select: text;
 }
 
@@ -1263,6 +1265,7 @@ body {
   min-width: 0;
   max-width: 100%;
   overflow-x: auto;
+  -webkit-user-select: text;
   user-select: text;
 }
 
@@ -4173,6 +4176,7 @@ body {
   border-radius: var(--radius-md);
   cursor: pointer;
   transition: all var(--transition);
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -4662,6 +4666,7 @@ body {
   text-align: center;
   box-sizing: border-box;
   -moz-appearance: textfield;
+  appearance: textfield;
 }
 
 .office-port-input::-webkit-inner-spin-button,


### PR DESCRIPTION
## Summary

VS Code's Microsoft Edge Tools surfaces 7 compatibility warnings on \`src/renderer/src/assets/main.css\`. This PR resolves them.

| # | Rule | Lines | Fix |
| --- | --- | --- | --- |
| 4 | \`user-select\` missing \`-webkit-user-select\` partner (Safari 3+ / iOS 3+) | 419, 571, 1266, 4176 | Add the prefixed property in the same rule |
| 1 | \`-moz-appearance: textfield\` missing standard \`appearance: textfield\` partner | 4671 | Add standard property in the same rule |
| 1 | \`-webkit-app-region\` flagged as unsupported in Firefox | 151 | \`.browserslistrc\` target (see below) |
| 1 | \`border-color: color-mix(...)\` flagged for Chrome <111 / Safari iOS <16.2 | 4184 | \`.browserslistrc\` target |

## Two classes of warning, two different fixes

The first 5 are real omissions — the prefixed/standard partner is cheap to add and doesn't change behavior on engines that already support the prefixed form. The cascade order is preserved.

The last 2 are **spurious for this codebase**: hermes-desktop ships only inside Electron 39+, which bundles Chromium 130+. Firefox compatibility of \`-webkit-app-region\` (an Electron-only window-drag affordance) and Chrome <111 / Safari iOS <16.2 support for \`color-mix()\` are not engines we ever render in.

Add a project-root \`.browserslistrc\` pinning \`last 2 Chrome versions\` so PostCSS, browser-compat linters, and future tooling get the right target instead of the caniuse-database-wide default. Comment in the file notes that this needs to be bumped when we upgrade Electron, so the lint signal stays honest.

## Test plan

- [x] \`npm run typecheck\` clean.
- [ ] Manual: reload the dev build and confirm there's no visible regression on selectable text or number-input spinner styling on Windows.
- [ ] Manual: VS Code Problems panel — the 7 main.css warnings drop to 0.