### PR TITLE
chore(models): address a11y and inline-style warnings in Models.tsx

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -4556,6 +4556,18 @@ body {
   font-style: italic;
 }
 
+/* Tighten the Models page heading so the subtitle hugs the title.
+   Replaces an inline `style={{ marginBottom: 4 }}`. */
+.models-title-tight {
+  margin-bottom: 4px;
+}
+
+/* Red text on a small confirmation button (e.g. "Yes, delete").
+   Replaces an inline `style={{ color: "var(--error)" }}`. */
+.btn-danger-text {
+  color: var(--error);
+}
+
 .models-modal-field .input,
 .models-modal-field select.input {
   padding: 8px 12px;

--- a/src/renderer/src/screens/Models/Models.tsx
+++ b/src/renderer/src/screens/Models/Models.tsx
@@ -188,7 +188,7 @@ function Models(): React.JSX.Element {
     <div className="settings-container">
       <div className="models-header">
         <div>
-          <h1 className="settings-header" style={{ marginBottom: 4 }}>
+          <h1 className="settings-header models-title-tight">
             {t("models.title")}
           </h1>
           <p className="models-subtitle">{t("models.subtitle")}</p>
@@ -250,8 +250,8 @@ function Models(): React.JSX.Element {
                   >
                     <span>{t("models.deleteConfirm")}</span>
                     <button
-                      className="btn btn-sm"
-                      style={{ color: "var(--error)" }}
+                      type="button"
+                      className="btn btn-sm btn-danger-text"
                       onClick={() => handleDelete(m.id)}
                     >
                       {t("models.yes")}
@@ -288,7 +288,13 @@ function Models(): React.JSX.Element {
               <h2 className="models-modal-title">
                 {editingModel ? t("models.editModel") : t("models.addModel")}
               </h2>
-              <button className="btn-ghost" onClick={closeModal}>
+              <button
+                type="button"
+                className="btn-ghost"
+                onClick={closeModal}
+                aria-label={t("common.close")}
+                title={t("common.close")}
+              >
                 <X size={18} />
               </button>
             </div>
@@ -309,7 +315,7 @@ function Models(): React.JSX.Element {
               </div>
 
               <div className="models-modal-field">
-                <label className="models-modal-label">
+                <label className="models-modal-label" htmlFor="model-form-provider">
                   {t("common.provider")}
                   {providerAutoFilled && !providerTouched && (
                     <span className="models-modal-auto-badge">
@@ -318,6 +324,7 @@ function Models(): React.JSX.Element {
                   )}
                 </label>
                 <select
+                  id="model-form-provider"
                   className="input"
                   value={formProvider}
                   onChange={(e) => {
@@ -325,6 +332,7 @@ function Models(): React.JSX.Element {
                     setProviderTouched(true);
                     setProviderAutoFilled(false);
                   }}
+                  aria-label={t("common.provider")}
                 >
                   {PROVIDERS.options.map((p) => (
                     <option key={p.value} value={p.value}>


### PR DESCRIPTION
## Summary

VS Code's Microsoft Edge Tools surfaces 4 warnings on \`src/renderer/src/screens/Models/Models.tsx\`. This PR resolves them.

| # | Rule | Where | Fix |
| --- | --- | --- | --- |
| 1 | \`Buttons must have discernible text\` | Modal close (\`<X />\` only) | Add \`aria-label\`, \`title\`, and \`type="button"\` using the existing \`common.close\` i18n key |
| 2 | \`Select element must have an accessible name\` | Provider select | Connect the sibling \`<label>\` via \`htmlFor\`, add \`id\` and \`aria-label\` |
| 3 | \`CSS inline styles should not be used\` | Page title \`style={{ marginBottom: 4 }}\` | New utility class \`.models-title-tight\` |
| 4 | \`CSS inline styles should not be used\` | Confirm-delete "Yes" button \`style={{ color: "var(--error)" }}\` | New utility class \`.btn-danger-text\` |

Both new utility classes live alongside the existing \`models-modal-*\` rules in \`main.css\` with comments noting the inline style they replace, so the relationship stays grep-able.

Also adds \`type="button"\` to the inline delete-confirm "Yes" button — matches the convention elsewhere in this component and pre-empts the implicit \`submit\` type that would activate if the modal were ever wrapped in a \`<form>\`.

## Test plan

- [x] \`npm run typecheck\` clean (node + web).
- [ ] Manual: open Add Model modal — close button still closes, has tooltip on hover.
- [ ] Manual: tab into the Provider select — screen readers announce "Provider".
- [ ] Manual: click the trash icon, "Yes" still renders in red.
- [ ] Manual: VS Code Problems panel — the 4 Models.tsx warnings drop to 0.

No visible UI change.