### PR TITLE
chore(tsconfig): drop deprecated baseUrl, use relative paths

### DIFF
--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -11,9 +11,8 @@
     "composite": true,
     "jsx": "react-jsx",
     "types": ["vitest/globals"],
-    "baseUrl": ".",
     "paths": {
-      "@renderer/*": ["src/renderer/src/*"]
+      "@renderer/*": ["./src/renderer/src/*"]
     }
   }
 }


### PR DESCRIPTION
## Summary

TypeScript surfaces this deprecation on \`tsconfig.web.json\`:

\`\`\`
Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.
Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
\`\`\`

TS 5.x already resolves \`paths\` patterns relative to the tsconfig file itself when \`baseUrl\` is omitted, so the existing \`@renderer/*\` alias keeps working. This PR removes \`baseUrl\` and rewrites the pattern with an explicit leading \`./\` so the resolver lookup is anchored to this tsconfig without ambiguity.

## Notes

- \`@renderer/*\` isn't currently imported anywhere in the codebase (\`grep -rn "from ['\\"]@renderer/" src\` returns nothing), but I'm intentionally keeping the alias defined — removing it entirely is out of scope for a TS-deprecation cleanup.
- No other \`tsconfig*.json\` in the repo declares \`baseUrl\`.

## Test plan

- [x] \`npm run typecheck\` clean (both \`tsconfig.node\` and \`tsconfig.web\`).
- [ ] VS Code Problems panel — the \`tsconfig.web.json\` deprecation warning drops to 0.