### PR TITLE
fix: persist setup model selection reliably

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -44,6 +44,116 @@ function writeDesktopConfig(data: Record<string, unknown>): void {
   writeFileSync(desktopConfigFile(), JSON.stringify(data, null, 2), "utf-8");
 }
 
+function getConfigSection(content: string, section: string): string {
+  const lines = content.split("\n");
+  const start = lines.findIndex((line) =>
+    new RegExp(`^${escapeRegex(section)}:\\s*$`).test(line),
+  );
+  if (start === -1) return "";
+
+  const body: string[] = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^[A-Za-z_][\w-]*:/.test(line)) break;
+    body.push(line);
+  }
+  return body.join("\n");
+}
+
+function readYamlValue(content: string, key: string, section?: string): string | null {
+  const source = section ? getConfigSection(content, section) : content;
+  const regex = new RegExp(
+    `^\\s*${escapeRegex(key)}:\\s*["']?([^"'\\n#]+)["']?`,
+    "m",
+  );
+  const match = source.match(regex);
+  return match ? match[1].trim() : null;
+}
+
+function ensureTopLevelSection(content: string, section: string): string {
+  if (new RegExp(`^${escapeRegex(section)}:\\s*$`, "m").test(content)) {
+    return content;
+  }
+  return `${content.trimEnd()}\n${section}:\n`;
+}
+
+function setYamlValueInSection(
+  content: string,
+  section: string,
+  key: string,
+  value: string,
+): string {
+  content = ensureTopLevelSection(content, section);
+  const lines = content.split("\n");
+  const start = lines.findIndex((line) =>
+    new RegExp(`^${escapeRegex(section)}:\\s*$`).test(line),
+  );
+  if (start === -1) return content;
+
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^[A-Za-z_][\w-]*:/.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+
+  const body = lines.slice(start + 1, end).join("\n");
+  const valueRegex = new RegExp(
+    `^(\\s*${escapeRegex(key)}:\\s*)["']?[^"'\\n#]*["']?`,
+    "m",
+  );
+  const nextBody = valueRegex.test(body)
+    ? body.replace(valueRegex, `$1"${value}"`)
+    : `${body.trimEnd()}\n  ${key}: "${value}"\n`;
+
+  lines.splice(start + 1, end - start - 1, ...nextBody.split("\n"));
+  return lines.join("\n");
+}
+
+async function setModelConfigViaApi(
+  provider: string,
+  model: string,
+  profile?: string,
+): Promise<boolean> {
+  if (profile && profile !== "default") return false;
+
+  try {
+    const { getApiUrl, getRemoteAuthHeader, isGatewayRunning } = await import(
+      "./hermes"
+    );
+    if (!isGatewayRunning()) return false;
+
+    const res = await fetch(`${getApiUrl()}/api/model/set`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...getRemoteAuthHeader(),
+      },
+      body: JSON.stringify({ scope: "main", provider, model }),
+    });
+    if (!res.ok) {
+      console.error("Failed to set model via Hermes API:", await res.text());
+      return false;
+    }
+    return true;
+  } catch (err) {
+    console.error("Failed to set model via Hermes API:", err);
+    return false;
+  }
+}
+
+export function readDesktopSetting<T>(key: string): T | undefined {
+  const data = readDesktopConfig();
+  return data[key] as T | undefined;
+}
+
+export function writeDesktopSetting(key: string, value: unknown): void {
+  const data = readDesktopConfig();
+  data[key] = value;
+  writeDesktopConfig(data);
+}
+
 export function getConnectionConfig(): ConnectionConfig {
   const data = readDesktopConfig();
   const ssh = (data.sshConfig as Partial<SshConnectionConfig>) ?? {};
@@ -231,51 +341,40 @@ export function getModelConfig(profile?: string): {
 
   const content = readFileSync(configFile, "utf-8");
 
-  const providerMatch = content.match(/^\s*provider:\s*["']?([^"'\n#]+)["']?/m);
-  const modelMatch = content.match(/^\s*default:\s*["']?([^"'\n#]+)["']?/m);
-  const baseUrlMatch = content.match(/^\s*base_url:\s*["']?([^"'\n#]+)["']?/m);
-
   const result = {
-    provider: providerMatch ? providerMatch[1].trim() : defaults.provider,
-    model: modelMatch ? modelMatch[1].trim() : defaults.model,
-    baseUrl: baseUrlMatch ? baseUrlMatch[1].trim() : defaults.baseUrl,
+    provider: readYamlValue(content, "provider", "model") || defaults.provider,
+    model: readYamlValue(content, "default", "model") || defaults.model,
+    baseUrl: readYamlValue(content, "base_url", "model") || defaults.baseUrl,
   };
 
   setCache(cacheKey, result);
   return result;
 }
 
-export function setModelConfig(
+export async function setModelConfig(
   provider: string,
   model: string,
   baseUrl: string,
   profile?: string,
-): void {
+): Promise<void> {
   invalidateCache(`mc:${profile || "default"}`);
+
+  const savedByApi = await setModelConfigViaApi(provider, model, profile);
   const { configFile } = profilePaths(profile);
-  if (!existsSync(configFile)) return;
+  let content = existsSync(configFile) ? readFileSync(configFile, "utf-8") : "";
 
-  let content = readFileSync(configFile, "utf-8");
-
-  const providerRegex = /^(\s*provider:\s*)["']?[^"'\n#]*["']?/m;
-  if (providerRegex.test(content)) {
-    content = content.replace(providerRegex, `$1"${provider}"`);
+  if (!savedByApi) {
+    content = setYamlValueInSection(content, "model", "provider", provider);
+    content = setYamlValueInSection(content, "model", "default", model);
   }
 
-  const modelRegex = /^(\s*default:\s*)["']?[^"'\n#]*["']?/m;
-  if (modelRegex.test(content)) {
-    content = content.replace(modelRegex, `$1"${model}"`);
-  }
-
-  const baseUrlRegex = /^(\s*base_url:\s*)["']?[^"'\n#]*["']?/m;
-  if (baseUrlRegex.test(content)) {
-    content = content.replace(baseUrlRegex, `$1"${baseUrl}"`);
-  } else if (baseUrl && provider !== "auto") {
-    // Append base_url line after the provider line in the model section
-    content = content.replace(
-      /^(\s*provider:\s*"[^"]*"\s*\n)/m,
-      `$1  base_url: "${baseUrl}"\n`
-    );
+  if (baseUrl) {
+    content = setYamlValueInSection(content, "model", "base_url", baseUrl);
+  } else {
+    const modelSection = getConfigSection(content, "model");
+    if (readYamlValue(modelSection, "base_url")) {
+      content = setYamlValueInSection(content, "model", "base_url", "");
+    }
   }
 
   // Disable smart_model_routing

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -359,14 +359,14 @@ export async function setModelConfig(
 ): Promise<void> {
   invalidateCache(`mc:${profile || "default"}`);
 
-  const savedByApi = await setModelConfigViaApi(provider, model, profile);
+  await setModelConfigViaApi(provider, model, profile);
   const { configFile } = profilePaths(profile);
   let content = existsSync(configFile) ? readFileSync(configFile, "utf-8") : "";
+  const existingModel = readYamlValue(content, "default", "model") || "";
+  const nextModel = model.trim() || existingModel;
 
-  if (!savedByApi) {
-    content = setYamlValueInSection(content, "model", "provider", provider);
-    content = setYamlValueInSection(content, "model", "default", model);
-  }
+  content = setYamlValueInSection(content, "model", "provider", provider);
+  content = setYamlValueInSection(content, "model", "default", nextModel);
 
   if (baseUrl) {
     content = setYamlValueInSection(content, "model", "base_url", baseUrl);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -472,7 +472,7 @@ function setupIPC(): void {
         return true;
       }
       const prev = getModelConfig(profile);
-      setModelConfig(provider, model, baseUrl, profile);
+      await setModelConfig(provider, model, baseUrl, profile);
 
       // Restart gateway when provider, model, or endpoint changes so it picks up new config
       if (

--- a/src/main/locale.ts
+++ b/src/main/locale.ts
@@ -4,11 +4,32 @@ import {
   setLocale as setSharedLocale,
   type AppLocale,
 } from "../shared/i18n";
+import { readDesktopSetting, writeDesktopSetting } from "./config";
+
+const LOCALE_KEY = "locale";
+
+function isAppLocale(value: unknown): value is AppLocale {
+  return (
+    value === "en" ||
+    value === "es" ||
+    value === "id" ||
+    value === "ja" ||
+    value === "pt-BR" ||
+    value === "zh-CN"
+  );
+}
 
 export function getAppLocale(): AppLocale {
+  const savedLocale = readDesktopSetting<unknown>(LOCALE_KEY);
+  if (isAppLocale(savedLocale)) {
+    setSharedLocale(savedLocale);
+    return savedLocale;
+  }
   return getSharedLocale() || DEFAULT_ACTIVE_LOCALE;
 }
 
 export function setAppLocale(locale: AppLocale): AppLocale {
-  return setSharedLocale(locale);
+  const nextLocale = setSharedLocale(locale);
+  writeDesktopSetting(LOCALE_KEY, nextLocale);
+  return nextLocale;
 }

--- a/src/renderer/src/screens/Setup/Setup.tsx
+++ b/src/renderer/src/screens/Setup/Setup.tsx
@@ -241,6 +241,26 @@ function Setup({
               </button>
             </div>
 
+            <label className="setup-label" style={{ marginTop: 16 }}>
+              {t("setup.modelName")} {" "}
+              <span className="setup-label-optional">
+                {t("common.optional")}
+              </span>
+            </label>
+            <input
+              className="input"
+              type="text"
+              placeholder={t("setup.modelNamePlaceholder")}
+              value={modelName}
+              onChange={(e) => {
+                setModelName(e.target.value);
+                setError("");
+              }}
+            />
+            <div className="setup-field-hint">
+              {t("setup.defaultModelHint")}
+            </div>
+
             <button
               className="setup-link"
               onClick={() => window.hermesAPI.openExternal(provider.url)}

--- a/tests/locale-persistence.test.ts
+++ b/tests/locale-persistence.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+let testHome: string;
+
+async function loadLocaleModule(): Promise<typeof import("../src/main/locale")> {
+  vi.resetModules();
+  vi.doMock("../src/main/installer", () => ({ HERMES_HOME: testHome }));
+  return await import("../src/main/locale");
+}
+
+describe("locale persistence", () => {
+  beforeEach(() => {
+    testHome = mkdtempSync(join(tmpdir(), "hermes-locale-"));
+  });
+
+  afterEach(() => {
+    vi.doUnmock("../src/main/installer");
+    rmSync(testHome, { recursive: true, force: true });
+  });
+
+  it("persists selected locale in desktop.json", async () => {
+    const { getAppLocale, setAppLocale } = await loadLocaleModule();
+
+    expect(setAppLocale("zh-CN")).toBe("zh-CN");
+
+    const desktopPath = join(testHome, "desktop.json");
+    expect(existsSync(desktopPath)).toBe(true);
+    expect(JSON.parse(readFileSync(desktopPath, "utf-8"))).toMatchObject({
+      locale: "zh-CN",
+    });
+    expect(getAppLocale()).toBe("zh-CN");
+  });
+});

--- a/tests/model-config.test.ts
+++ b/tests/model-config.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -56,5 +56,57 @@ describe("model config persistence", () => {
     const content = readFileSync(configPath, "utf-8");
     expect(content).toContain('provider: "anthropic"');
     expect(content).toContain('default: "claude-sonnet-4-5"');
+  });
+
+  it("preserves an existing default model when provider changes with an empty model", async () => {
+    const { getModelConfig, setModelConfig } = await loadConfigModule();
+    const configPath = join(testHome, "config.yaml");
+
+    writeFileSync(
+      configPath,
+      [
+        "model:",
+        '  provider: "gemini"',
+        '  default: "gemini-2.5-flash"',
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    await setModelConfig("google", "", "");
+
+    expect(getModelConfig()).toEqual({
+      provider: "google",
+      model: "gemini-2.5-flash",
+      baseUrl: "",
+    });
+
+    const content = readFileSync(configPath, "utf-8");
+    expect(content).toContain('provider: "google"');
+    expect(content).toContain('default: "gemini-2.5-flash"');
+  });
+
+  it("still persists provider and model to config when gateway api update succeeds", async () => {
+    vi.resetModules();
+    vi.doMock("../src/main/installer", () => ({ HERMES_HOME: testHome }));
+    vi.doMock("../src/main/hermes", () => ({
+      getApiUrl: () => "http://127.0.0.1:8642",
+      getRemoteAuthHeader: () => ({}),
+      isGatewayRunning: () => true,
+    }));
+
+    const { getModelConfig, setModelConfig } = await import("../src/main/config");
+
+    await setModelConfig("google", "gemini-2.5-flash", "");
+
+    expect(getModelConfig()).toEqual({
+      provider: "google",
+      model: "gemini-2.5-flash",
+      baseUrl: "",
+    });
+
+    const content = readFileSync(join(testHome, "config.yaml"), "utf-8");
+    expect(content).toContain('provider: "google"');
+    expect(content).toContain('default: "gemini-2.5-flash"');
   });
 });

--- a/tests/model-config.test.ts
+++ b/tests/model-config.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+let testHome: string;
+
+async function loadConfigModule(): Promise<typeof import("../src/main/config")> {
+  vi.resetModules();
+  vi.doMock("../src/main/installer", () => ({ HERMES_HOME: testHome }));
+  vi.doMock("../src/main/hermes", () => ({
+    getApiUrl: () => "http://127.0.0.1:8642",
+    getRemoteAuthHeader: () => ({}),
+    isGatewayRunning: () => false,
+  }));
+  return await import("../src/main/config");
+}
+
+describe("model config persistence", () => {
+  beforeEach(() => {
+    testHome = mkdtempSync(join(tmpdir(), "hermes-model-config-"));
+  });
+
+  afterEach(() => {
+    vi.doUnmock("../src/main/installer");
+    vi.doUnmock("../src/main/hermes");
+    rmSync(testHome, { recursive: true, force: true });
+  });
+
+  it("creates config.yaml when saving the first model config", async () => {
+    const { getModelConfig, setModelConfig } = await loadConfigModule();
+
+    await setModelConfig("openai", "gpt-4o-mini", "https://api.openai.com/v1");
+
+    const configPath = join(testHome, "config.yaml");
+    expect(existsSync(configPath)).toBe(true);
+    expect(readFileSync(configPath, "utf-8")).toContain("model:");
+    expect(getModelConfig()).toEqual({
+      provider: "openai",
+      model: "gpt-4o-mini",
+      baseUrl: "https://api.openai.com/v1",
+    });
+  });
+
+  it("only reads and updates values inside the model section", async () => {
+    const { getModelConfig, setModelConfig } = await loadConfigModule();
+    const configPath = join(testHome, "config.yaml");
+
+    await setModelConfig("anthropic", "claude-sonnet-4-5", "");
+    expect(getModelConfig()).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      baseUrl: "",
+    });
+
+    const content = readFileSync(configPath, "utf-8");
+    expect(content).toContain('provider: "anthropic"');
+    expect(content).toContain('default: "claude-sonnet-4-5"');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes desktop setup persistence so model configuration and locale survive app restarts.

This PR addresses cases where Hermes Desktop could repeatedly show setup/onboarding or lose selected settings because setup choices were not reliably written to the persistent config files.

Changes include:

- Persist desktop locale to `${HERMES_HOME}/desktop.json`
- Restore saved locale on app startup
- Ensure setup model config creates/updates `${HERMES_HOME}/config.yaml`
- Read and write model settings specifically under the `model:` YAML section
- Persist:
  - `model.provider`
  - `model.default`
  - `model.base_url`
- Avoid overwriting an existing default model with an empty value
- Keep writing `config.yaml` even when the live `/api/model/set` call succeeds
- Allow setup to persist an explicit model name for hosted providers
- Add regression tests for locale and model config persistence

## Why

Previously, `setModelConfig()` returned early if `config.yaml` did not exist. That meant first-run setup could save an API key but fail to persist the selected provider/model, causing the app to behave like setup was incomplete on later launches.

Locale selection was also only kept in memory, so language changes were lost after restart.

In addition, live model updates through the Hermes API could make the running gateway update successfully while leaving `config.yaml` unchanged, so the selection was lost after restart.

## Verification

Tested locally with `HERMES_HOME=D:\Programs\hermes`.

Ran:

```powershell
npm run typecheck:node
npm run typecheck:web
npx vitest run tests/model-config.test.ts tests/locale-persistence.test.ts tests/ipc-handlers.test.ts src/shared/i18n/index.test.ts src/renderer/src/components/I18nProvider.test.tsx