### PR TITLE
cleanup: ship paused Office.tsx work from 2026-05-02

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ release/
 **/src-tauri/target/
 **/src-tauri/gen/
 **/src-tauri/WixTools/
+
+# Local launcher scripts (user-specific, do not commit)
+/*.bat
+/*.ps1

--- a/src/renderer/src/screens/Office/Office.tsx
+++ b/src/renderer/src/screens/Office/Office.tsx
@@ -107,15 +107,30 @@ function Office({ visible }: { visible?: boolean }): React.JSX.Element {
       executeJavaScript?: (code: string) => Promise<unknown>;
     };
     if (!wv) return;
-    const onLoad = (): void => {
-      setWebviewReady(true);
-      setWebviewError("");
+
+    const ONBOARDING_JS =
+      `try { localStorage.setItem("claw3d:onboarding:completed", "true") } catch(e) {}`;
+
+    // Inject onboarding flag as early as possible (before Claw3D's scripts run).
+    // did-start-loading fires before any page resources load, so the injection
+    // is queued early enough that Claw3D's useOnboardingState hook sees it.
+    const injectOnboardingFlag = (): void => {
       if (wv.executeJavaScript) {
-        wv.executeJavaScript(
-          `try { localStorage.setItem("claw3d:onboarding:completed", "true") } catch(e) {}`,
-        ).catch(() => {});
+        wv.executeJavaScript(ONBOARDING_JS).catch(() => {});
       }
     };
+
+    const onStartLoad = (): void => {
+      injectOnboardingFlag();
+    };
+
+    const onDomReady = (): void => {
+      // Defense-in-depth: re-inject in case the first attempt didn't stick
+      injectOnboardingFlag();
+      setWebviewReady(true);
+      setWebviewError("");
+    };
+
     const onFail = (evt: unknown): void => {
       setWebviewReady(false);
       const e = evt as { errorDescription?: string; errorCode?: number };
@@ -125,10 +140,14 @@ function Office({ visible }: { visible?: boolean }): React.JSX.Element {
           "Failed to load Claw3D. The dev server may still be starting up.",
       );
     };
-    wv.addEventListener("did-finish-load", onLoad);
+
+    wv.addEventListener("did-start-loading", onStartLoad);
+    wv.addEventListener("dom-ready", onDomReady);
     wv.addEventListener("did-fail-load", onFail);
+
     return () => {
-      wv.removeEventListener("did-finish-load", onLoad);
+      wv.removeEventListener("did-start-loading", onStartLoad);
+      wv.removeEventListener("dom-ready", onDomReady);
       wv.removeEventListener("did-fail-load", onFail);
     };
   }, [running, port]);


### PR DESCRIPTION
## Summary

Inject the Claw3D onboarding-completion flag earlier in the embedded webview lifecycle so the Claw3D app reliably skips its onboarding screen on first launch.

Previously the `localStorage.setItem("claw3d:onboarding:completed", "true")` write only ran on `did-finish-load`. That races Claw3D's `useOnboardingState` hook — the hook reads `localStorage` before our injection happens, so the onboarding screen still shows on first launch.

## Change

- Hook `did-start-loading` instead, so the flag is queued before any Claw3D scripts run.
- Re-inject on `dom-ready` as defense-in-depth in case the early write didn't stick.
- Split `onLoad` into `onStartLoad` + `onDomReady` with matching addEventListener / removeEventListener pairs.

## Test plan

- [ ] Fresh install: launch Hermes Desktop, open Office tab, verify Claw3D loads straight into main UI (no onboarding screen).
- [ ] Reload the webview a few times — main UI stays, no onboarding regression.
- [ ] Webview load failure path (`did-fail-load`) still shows the existing error UI.

Also gitignores root-level launcher scripts (`/*.bat`, `/*.ps1`) — these are machine-specific shortcuts with hardcoded paths and shouldn't be versioned.