### PR TITLE
fix(ssh): prevent tunnel state reset when ControlMaster takes over

### DIFF
--- a/src/main/ssh-tunnel.ts
+++ b/src/main/ssh-tunnel.ts
@@ -25,7 +25,7 @@ export function getSshTunnelUrl(): string | null {
 }
 
 export function isSshTunnelActive(): boolean {
-  return tunnelProcess !== null && tunnelRunning;
+  return tunnelRunning && activeConfig !== null;
 }
 
 function checkTunnelHealth(port: number, timeoutMs = 3000): Promise<boolean> {
@@ -132,15 +132,26 @@ export async function startSshTunnel(config: SshConfig): Promise<void> {
   });
 
   tunnelProcess.on("exit", () => {
-    tunnelRunning = false;
     tunnelProcess = null;
-    activeConfig = null;
+    // With ControlMaster=auto, the spawned SSH process exits immediately
+    // after handing off to the master. The tunnel may still be alive via
+    // the mux master, so check health before declaring it dead.
+    checkTunnelHealth(localPort, 2000).then((healthy) => {
+      if (!healthy) {
+        tunnelRunning = false;
+        activeConfig = null;
+      }
+    });
   });
 
   tunnelProcess.on("error", () => {
-    tunnelRunning = false;
     tunnelProcess = null;
-    activeConfig = null;
+    checkTunnelHealth(localPort, 2000).then((healthy) => {
+      if (!healthy) {
+        tunnelRunning = false;
+        activeConfig = null;
+      }
+    });
   });
 
   try {


### PR DESCRIPTION
## Summary

- Fix SSH Tunnel mode chat hanging silently when `ControlMaster=auto` is used
- The spawned SSH process exits immediately after handing off to the mux master, but the `exit` callback was unconditionally clearing `tunnelRunning` and `activeConfig`, causing `getApiUrl()` to throw "SSH tunnel is not active"
- Now `exit`/`error` callbacks perform a health check before declaring the tunnel dead, and `isSshTunnelActive()` no longer requires the spawned process to still be alive

## Test plan

- [ ] Configure SSH Tunnel mode with a remote Hermes agent
- [ ] Send a chat message — should receive streaming response
- [ ] Verify tunnel remains stable after SSH process hands off to ControlMaster
- [ ] Verify tunnel state is correctly cleared when remote is actually unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)