### PR TITLE
fix(gateway): detect platform enabled state from env vars (match Pyth…

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -304,93 +304,223 @@ export function getHermesHome(profile?: string): string {
   return profilePaths(profile).home;
 }
 
-// ── Platform enabled/disabled in config.yaml ────────────
+// ── Platform enabled/disabled ─────────────────────────────
+//
+// The Python hermes gateway (gateway/config.py) decides which messaging
+// platforms to start from env vars in .env; it doesn't look at a fictional
+// `platforms:` YAML section. config.yaml only carries an override-disable
+// switch: `<platform>.enabled: false` at the top level. Earlier the desktop
+// read and wrote a `platforms:\n  <name>:\n    enabled: …` block that the
+// gateway never inspected, so the Gateway UI's toggles were cosmetic.
+//
+// `envCheck` returns true when the platform's required env vars are present
+// (and, for whatsapp, set to a truthy literal). Add new platforms here as
+// their Python-side activation rules are confirmed.
+interface PlatformRule {
+  envCheck: (env: Record<string, string>) => boolean;
+  // YAML key for the override-disable lookup. Defaults to the platform key
+  // itself; provide an explicit value when the desktop's display key
+  // diverges from the Python CLI's config.yaml key (e.g. "home_assistant"
+  // in the desktop vs "homeassistant" in the Python gateway).
+  configKey?: string;
+}
 
-const SUPPORTED_PLATFORMS = [
-  "telegram",
-  "discord",
-  "slack",
-  "whatsapp",
-  "signal",
-];
+const TRUTHY_VALUES = new Set(["true", "1", "yes", "on"]);
+
+const PLATFORM_RULES: Record<string, PlatformRule> = {
+  telegram: { envCheck: (e) => !!e.TELEGRAM_BOT_TOKEN?.trim() },
+  discord: { envCheck: (e) => !!e.DISCORD_BOT_TOKEN?.trim() },
+  slack: { envCheck: (e) => !!e.SLACK_BOT_TOKEN?.trim() },
+  whatsapp: {
+    envCheck: (e) =>
+      TRUTHY_VALUES.has((e.WHATSAPP_ENABLED || "").trim().toLowerCase()),
+  },
+  signal: {
+    envCheck: (e) => !!e.SIGNAL_HTTP_URL?.trim() && !!e.SIGNAL_ACCOUNT?.trim(),
+  },
+  matrix: {
+    envCheck: (e) =>
+      !!e.MATRIX_ACCESS_TOKEN?.trim() || !!e.MATRIX_PASSWORD?.trim(),
+  },
+  mattermost: { envCheck: (e) => !!e.MATTERMOST_TOKEN?.trim() },
+  home_assistant: {
+    envCheck: (e) => !!e.HASS_TOKEN?.trim(),
+    configKey: "homeassistant",
+  },
+};
+
+const SUPPORTED_PLATFORMS = Object.keys(PLATFORM_RULES);
+
+/**
+ * Match a top-level YAML block's `enabled: <bool>` field, e.g.:
+ *
+ *     telegram:
+ *       reactions: false
+ *       enabled: false      ← captured
+ *       allowed_chats: ''
+ *
+ * Returns true/false if found, null if absent. The block must start at
+ * column 0; `enabled:` is captured if it sits anywhere inside the
+ * contiguous indented sub-block (any depth, in any position).
+ */
+function readPlatformOverride(
+  content: string,
+  platform: string,
+): boolean | null {
+  const blockStartRe = new RegExp(`^${escapeRegex(platform)}:[ \\t]*\\r?\\n`, "m");
+  const startMatch = content.match(blockStartRe);
+  if (!startMatch || startMatch.index === undefined) return null;
+
+  const after = content.slice(startMatch.index + startMatch[0].length);
+  const lines = after.split(/\r?\n/);
+  for (const line of lines) {
+    if (line.trim() === "") continue;
+    if (!/^\s/.test(line)) break; // hit next top-level key
+    const m = line.match(/^[ \t]+enabled:[ \t]*(true|false)\b/);
+    if (m) return m[1] === "true";
+  }
+  return null;
+}
 
 export function getPlatformEnabled(profile?: string): Record<string, boolean> {
+  const env = readEnv(profile);
   const { configFile } = profilePaths(profile);
-  if (!existsSync(configFile)) return {};
+  const content = existsSync(configFile) ? readFileSync(configFile, "utf-8") : "";
 
-  const content = readFileSync(configFile, "utf-8");
   const result: Record<string, boolean> = {};
-
   for (const platform of SUPPORTED_PLATFORMS) {
-    // Match "  platform:\n    enabled: true/false" under the platforms: block
-    const re = new RegExp(
-      `^[ \\t]+${platform}:\\s*\\n[ \\t]+enabled:\\s*(true|false)`,
-      "m",
-    );
-    const match = content.match(re);
-    result[platform] = match ? match[1] === "true" : false;
+    const rule = PLATFORM_RULES[platform];
+    const envEnabled = rule.envCheck(env);
+    const configKey = rule.configKey || platform;
+    const override = content ? readPlatformOverride(content, configKey) : null;
+    // Python's rule: env-driven activation, config.yaml `enabled: false`
+    // can force-disable. An explicit `enabled: true` doesn't bypass a
+    // missing token (the Python gateway still requires the credential),
+    // so reflect that here too.
+    result[platform] = envEnabled && override !== false;
   }
-
   return result;
 }
 
+/**
+ * Toggle a platform's force-disable override in config.yaml.
+ *
+ * The Python gateway activates a platform when its env vars are set;
+ * config can force-disable with `<platform>.enabled: false` at the top
+ * level. So toggling here writes/removes that single key:
+ *
+ *   - enabled=false → ensure `enabled: false` exists in the top-level
+ *     `<platform>:` block (modify in place, append a child, or create
+ *     the block).
+ *   - enabled=true  → remove any existing `enabled: false` line.
+ *
+ * Filling in the platform's token env vars is what actually starts it;
+ * this function only manages the disable override.
+ */
 export function setPlatformEnabled(
   platform: string,
   enabled: boolean,
   profile?: string,
 ): void {
-  if (!SUPPORTED_PLATFORMS.includes(platform)) return;
+  const rule = PLATFORM_RULES[platform];
+  if (!rule) return;
+  // Use the Python-side YAML key when writing the override, not the
+  // desktop's display key (matters for home_assistant → homeassistant).
+  const configKey = rule.configKey || platform;
 
   const { configFile } = profilePaths(profile);
-  if (!existsSync(configFile)) return;
+  if (!existsSync(configFile)) {
+    // Only need to write a file when we're recording a disable override;
+    // enabling a platform that has no config is the default.
+    if (enabled) return;
+    safeWriteFile(configFile, `${configKey}:\n  enabled: false\n`);
+    return;
+  }
 
   let content = readFileSync(configFile, "utf-8");
-
-  // Check if the platform entry already exists under platforms:
-  const existingRe = new RegExp(
-    `^([ \\t]+${platform}:\\s*\\n[ \\t]+enabled:\\s*)(?:true|false)`,
+  const enabledLineRe = new RegExp(
+    `^([ \\t]+enabled:[ \\t]*)(true|false)\\b([ \\t]*)$`,
+    "m",
+  );
+  const blockStartRe = new RegExp(
+    `^(${escapeRegex(configKey)}:[ \\t]*\\r?\\n)`,
+    "m",
+  );
+  const flowStyleRe = new RegExp(
+    `^${escapeRegex(configKey)}:[ \\t]*\\{\\s*\\}[ \\t]*$`,
     "m",
   );
 
-  if (existingRe.test(content)) {
-    // Update existing entry
-    content = content.replace(existingRe, `$1${enabled}`);
-  } else {
-    // Append new platform entry after the platforms: block
-    // Find the platforms: line and insert after the last existing platform entry
-    const platformsIdx = content.indexOf("\nplatforms:");
-    if (platformsIdx === -1) {
-      // No platforms section at all — append one
-      content += `\nplatforms:\n  ${platform}:\n    enabled: ${enabled}\n`;
-    } else {
-      // Insert the new platform at the end of the platforms block.
-      // Find the next top-level key (non-indented, non-comment, non-empty line)
-      // after the platforms: line.
-      const afterPlatforms = content.substring(platformsIdx + 1);
-      const lines = afterPlatforms.split("\n");
-      let insertOffset = platformsIdx + 1; // after the \n
-      // Skip the "platforms:" line itself
-      insertOffset += lines[0].length + 1;
+  const blockMatch = content.match(blockStartRe);
+  const hasBlock = !!blockMatch;
+  const isFlowEmpty = flowStyleRe.test(content);
 
-      // Skip all indented lines (children of platforms:)
-      for (let i = 1; i < lines.length; i++) {
-        const line = lines[i];
-        if (line.trim() === "" || /^\s/.test(line)) {
-          insertOffset += line.length + 1;
-        } else {
-          break;
-        }
-      }
-
-      const entry = `  ${platform}:\n    enabled: ${enabled}\n`;
-      content =
-        content.substring(0, insertOffset) +
-        entry +
-        content.substring(insertOffset);
-    }
+  if (isFlowEmpty) {
+    // Convert `<platform>: {}` to a block we can edit.
+    content = content.replace(flowStyleRe, `${configKey}:\n  enabled: ${enabled}`);
+    safeWriteFile(configFile, content);
+    return;
   }
 
-  safeWriteFile(configFile, content);
+  if (hasBlock && blockMatch?.index !== undefined) {
+    const blockStart = blockMatch.index + blockMatch[0].length;
+    const rest = content.slice(blockStart);
+    const restLines = rest.split(/\r?\n/);
+
+    // Find the extent of the platform's sub-block (indented children).
+    let subBlockEndOffset = 0;
+    let existingEnabledLineStart: number | null = null;
+    let existingEnabledLineEnd: number | null = null;
+    for (const line of restLines) {
+      const lineLen = line.length + 1; // include trailing \n
+      if (line.trim() === "") {
+        subBlockEndOffset += lineLen;
+        continue;
+      }
+      if (!/^\s/.test(line)) break;
+      const localStart = blockStart + subBlockEndOffset;
+      const enabledMatch = line.match(enabledLineRe);
+      if (enabledMatch) {
+        existingEnabledLineStart = localStart;
+        existingEnabledLineEnd = localStart + line.length;
+      }
+      subBlockEndOffset += lineLen;
+    }
+
+    if (existingEnabledLineStart !== null && existingEnabledLineEnd !== null) {
+      if (enabled) {
+        // Remove the entire `  enabled: false` line, including its newline.
+        const removeEnd =
+          content[existingEnabledLineEnd] === "\n"
+            ? existingEnabledLineEnd + 1
+            : existingEnabledLineEnd;
+        content =
+          content.slice(0, existingEnabledLineStart) + content.slice(removeEnd);
+      } else {
+        content =
+          content.slice(0, existingEnabledLineStart) +
+          `  enabled: false` +
+          content.slice(existingEnabledLineEnd);
+      }
+    } else if (!enabled) {
+      // Append `enabled: false` as the first child of the block.
+      content =
+        content.slice(0, blockStart) +
+        `  enabled: false\n` +
+        content.slice(blockStart);
+    }
+    // (enabled=true with no existing override: nothing to do.)
+
+    safeWriteFile(configFile, content);
+    return;
+  }
+
+  // No block at all — only need to materialize one when recording a disable.
+  if (!enabled) {
+    const trailingNewline = content.endsWith("\n") ? "" : "\n";
+    content += `${trailingNewline}${configKey}:\n  enabled: false\n`;
+    safeWriteFile(configFile, content);
+  }
 }
 
 // ── Credential Pool (auth.json) ──────────────────────────

--- a/src/main/ssh-remote.ts
+++ b/src/main/ssh-remote.ts
@@ -527,14 +527,21 @@ export async function sshReadEnv(config: SshConfig, profile?: string): Promise<R
     if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) v = v.slice(1, -1);
     if (v) result[k] = v;
   }
-  // Alias alternate env var names so the app can display them regardless of which name the server uses
-  const ENV_ALIASES: Array<[string, string]> = [
-    ["HA_URL", "HOMEASSISTANT_URL"],
-    ["HA_TOKEN", "HOMEASSISTANT_TOKEN"],
+  // Home Assistant has accumulated three naming conventions across hermes
+  // versions: HASS_* (what gateway/config.py currently reads), HOMEASSISTANT_*
+  // (legacy), and HA_* (older desktop builds). Mirror all three so the UI
+  // can display the value regardless of which one the remote server uses.
+  const HA_ALIAS_GROUPS: string[][] = [
+    ["HASS_URL", "HOMEASSISTANT_URL", "HA_URL"],
+    ["HASS_TOKEN", "HOMEASSISTANT_TOKEN", "HA_TOKEN"],
   ];
-  for (const [appKey, serverKey] of ENV_ALIASES) {
-    if (!result[appKey] && result[serverKey]) result[appKey] = result[serverKey];
-    if (!result[serverKey] && result[appKey]) result[serverKey] = result[appKey];
+  for (const group of HA_ALIAS_GROUPS) {
+    const present = group.find((k) => result[k]);
+    if (!present) continue;
+    const value = result[present];
+    for (const k of group) {
+      if (!result[k]) result[k] = value;
+    }
   }
   return result;
 }

--- a/src/renderer/src/constants.ts
+++ b/src/renderer/src/constants.ts
@@ -636,13 +636,13 @@ export const GATEWAY_SECTIONS: SectionDef[] = [
         hint: "constants.webhookHint",
       },
       {
-        key: "HA_URL",
+        key: "HASS_URL",
         label: "constants.haUrl",
         type: "text",
         hint: "constants.haUrlHint",
       },
       {
-        key: "HA_TOKEN",
+        key: "HASS_TOKEN",
         label: "constants.haToken",
         type: "password",
         hint: "constants.haTokenHint",
@@ -763,7 +763,7 @@ export const GATEWAY_PLATFORMS: PlatformDef[] = [
     key: "home_assistant",
     label: "constants.platformHomeAssistant",
     description: "constants.platformHomeAssistantDesc",
-    fields: ["HA_URL", "HA_TOKEN"],
+    fields: ["HASS_URL", "HASS_TOKEN"],
   },
 ];
 


### PR DESCRIPTION
…on CLI)

`getPlatformEnabled` / `setPlatformEnabled` were reading and writing a
`platforms:\n  <name>:\n    enabled: true` YAML schema that the Python
hermes gateway never inspects. Every toggle in the Gateway pane was
therefore cosmetic — platforms that were actually running showed as
off, and toggling on/off changed nothing the gateway cared about.

Python's actual convention (gateway/config.py): each messaging platform is activated by specific env vars, and config.yaml only carries an override-disable switch at the top level (`<platform>.enabled: false`):

  telegram        TELEGRAM_BOT_TOKEN
  discord         DISCORD_BOT_TOKEN
  slack           SLACK_BOT_TOKEN
  whatsapp        WHATSAPP_ENABLED ∈ {true,1,yes,on}
  signal          SIGNAL_HTTP_URL AND SIGNAL_ACCOUNT
  matrix          MATRIX_ACCESS_TOKEN OR MATRIX_PASSWORD
  mattermost      MATTERMOST_TOKEN
  home_assistant  HASS_TOKEN  (YAML override key: `homeassistant`)

Replace the dead YAML schema with a PLATFORM_RULES table. The new getPlatformEnabled returns `envEnabled && override !== false`; setPlatformEnabled writes/removes the top-level `enabled: false` line — the only YAML key Python honors — so the toggle becomes a meaningful force-disable switch. Per-rule `configKey` lets the desktop's display key diverge from the Python YAML key (home_assistant → homeassistant) without surface changes elsewhere.

Side fixes:
  - Home Assistant env var names in GATEWAY_PLATFORMS / GATEWAY_SECTIONS: HA_URL/HA_TOKEN → HASS_URL/HASS_TOKEN so the UI inputs match the env vars Python actually reads. Without this, users filled in fields the gateway never looked at.
  - ssh-remote.ts: extend the HA env alias group from two-way (HA_* ↔ HOMEASSISTANT_*) to three-way (HASS_* ↔ HOMEASSISTANT_* ↔ HA_*) so older Python servers using either legacy name still display correctly in the desktop UI.