### PR TITLE
fix(gateway): treat EPERM as alive and verify python image on Windows

### DIFF
--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -18,7 +18,7 @@ import {
   isSshTunnelHealthy,
   startSshTunnel,
 } from "./ssh-tunnel";
-import { stripAnsi } from "./utils";
+import { pidIsAliveAs, stripAnsi } from "./utils";
 import { readModels } from "./models";
 import { HIDDEN_SUBPROCESS_OPTIONS } from "./process-options";
 import {
@@ -952,16 +952,16 @@ export function stopGateway(force = false): void {
   apiServerAvailable = false;
 }
 
+// Python image prefixes covering both native Windows (pythonw.exe / python.exe)
+// and POSIX (python, python3, pythonw). Used to verify the PID we read from
+// gateway.pid actually belongs to a python process before reporting alive.
+const GATEWAY_IMAGE_PREFIXES = ["python", "pythonw"];
+
 export function isGatewayRunning(): boolean {
   if (gatewayProcess && !gatewayProcess.killed) return true;
   const pid = readPidFile();
   if (!pid) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
+  return pidIsAliveAs(pid, GATEWAY_IMAGE_PREFIXES);
 }
 
 export function isApiReady(): boolean {

--- a/src/main/profiles.ts
+++ b/src/main/profiles.ts
@@ -12,6 +12,7 @@ import {
 import {
   isValidNamedProfileName,
   isValidProfileName,
+  pidIsAliveAs,
   PROFILE_NAME_ERROR,
 } from "./utils";
 import { HIDDEN_SUBPROCESS_OPTIONS } from "./process-options";
@@ -80,11 +81,16 @@ async function countSkills(profilePath: string): Promise<number> {
 async function isGatewayRunning(profilePath: string): Promise<boolean> {
   const pidFile = join(profilePath, "gateway.pid");
   try {
-    const raw = await fs.readFile(pidFile, "utf-8");
-    const pid = parseInt(raw.trim(), 10);
+    const raw = (await fs.readFile(pidFile, "utf-8")).trim();
+    // The Python hermes CLI writes JSON: {"pid": <n>, "kind": ..., ...}.
+    // Older builds wrote a bare integer, so fall back to parseInt.
+    const parsed = raw.startsWith("{")
+      ? (JSON.parse(raw) as { pid?: unknown }).pid
+      : parseInt(raw, 10);
+    const pid =
+      typeof parsed === "number" && Number.isFinite(parsed) ? parsed : NaN;
     if (isNaN(pid)) return false;
-    process.kill(pid, 0);
-    return true;
+    return pidIsAliveAs(pid, ["python", "pythonw"]);
   } catch {
     return false;
   }

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "child_process";
 import { join, dirname } from "path";
 import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { HERMES_HOME } from "./installer";
@@ -63,6 +64,89 @@ export function profilePaths(profile?: unknown): {
     envFile: join(home, ".env"),
     configFile: join(home, "config.yaml"),
   };
+}
+
+/**
+ * Liveness check for a PID, distinguishing "doesn't exist" from "exists but
+ * we can't open it". `process.kill(pid, 0)` is the POSIX-idiomatic check,
+ * but on Windows libuv requests PROCESS_TERMINATE access to issue the kill
+ * call — and a detached subprocess started by a different console (e.g. the
+ * Python hermes CLI launching the gateway as `pythonw` with `--replace`)
+ * commonly refuses that handle, raising EPERM. EPERM means the process
+ * exists; only ESRCH means it doesn't. The previous catch-all `try/catch
+ * return false` conflated those, so the desktop reported the gateway as
+ * "Stopped" while it was very much alive.
+ */
+export function pidIsAlive(pid: number): boolean {
+  if (!pid || !Number.isFinite(pid)) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    // ESRCH: no such process. Everything else (notably EPERM on Windows)
+    // means the process is there but we lack rights to signal it.
+    return code !== "ESRCH";
+  }
+}
+
+/**
+ * Return the image (.exe) name of the process at `pid` on Windows, or null
+ * if the PID isn't found or the lookup fails. Used as a second-stage check
+ * on top of `pidIsAlive` because EPERM from `process.kill` only confirms
+ * "some Windows process exists at this PID" — it doesn't confirm that
+ * process is ours.
+ *
+ * Important for the WSL coexistence case: when HERMES_HOME points into WSL
+ * via UNC, the PID file contains a Linux PID. `process.kill(linuxPid, 0)`
+ * runs against Windows' PID space; if a random Windows process happens to
+ * own that number, EPERM would lie. Verifying the image name (e.g. starts
+ * with "python") catches that.
+ *
+ * Synchronous tasklist call with a tight timeout — acceptable because it's
+ * gated behind a positive liveness check that already short-circuits the
+ * common "process is gone" path.
+ */
+export function getProcessImageNameWin(pid: number): string | null {
+  if (process.platform !== "win32") return null;
+  if (!pid || !Number.isFinite(pid)) return null;
+  try {
+    const output = execFileSync(
+      "tasklist",
+      ["/FI", `PID eq ${pid}`, "/FO", "CSV", "/NH"],
+      { encoding: "utf-8", timeout: 5000, windowsHide: true },
+    );
+    // CSV row format: "image.exe","27652","Console","1","45,000 K"
+    // Returns "INFO: No tasks are running…" if the PID doesn't exist.
+    const m = output.match(/^"([^"]+)"/);
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Like `pidIsAlive`, but on Windows also verifies the running process's
+ * image name matches one of `expectedImagePrefixes` (case-insensitive).
+ * This guards against false positives from PID reuse and from WSL-side
+ * PIDs being checked against the Windows PID space.
+ *
+ * If we can't read the image name (`tasklist` missing/timeout/etc.),
+ * fall back to trusting `pidIsAlive` rather than blocking — a flaky
+ * verification step shouldn't make a healthy gateway look dead.
+ */
+export function pidIsAliveAs(
+  pid: number,
+  expectedImagePrefixes: string[],
+): boolean {
+  if (!pidIsAlive(pid)) return false;
+  if (process.platform !== "win32") return true;
+  const image = getProcessImageNameWin(pid);
+  if (!image) return true; // lookup failed; don't penalize the caller
+  const lower = image.toLowerCase();
+  return expectedImagePrefixes.some((prefix) =>
+    lower.startsWith(prefix.toLowerCase()),
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

`process.kill(pid, 0)` is the POSIX-idiomatic existence check, but on Windows libuv requests `PROCESS_TERMINATE` access to issue the call. The gateway runs detached — whether the desktop spawned it (`spawn` with `detached: true`) or the Python CLI started it from a separate console (the CLI's daemon mode re-execs itself as `pythonw.exe` so the gateway runs windowless in the background). Either way, the detachment is enough that `OpenProcess` from an unrelated Electron main process refuses the `PROCESS_TERMINATE` handle — even though both run as the same user — and `process.kill` surfaces the failure as `EPERM`. The previous catch-all `try { ... } catch { return false }` conflated `EPERM` with `ESRCH`, so the desktop reported the gateway as **Stopped** while it was actually running.

## Changes

- Distinguish error codes: `ESRCH` means dead; anything else (notably `EPERM` on Windows) means alive. New `pidIsAlive(pid)` helper in `utils.ts`.
- Add a defensive image-name verifier `pidIsAliveAs(pid, prefixes)` that calls `tasklist` to confirm the live PID is in fact a python process — `python.exe` when the desktop spawned the gateway, `pythonw.exe` when it was started via the CLI's daemon mode. Guards against:
  - PID-reuse false positives on native Windows (PID recycled to an unrelated process after gateway crashed).
  - WSL coexistence false positives: when `HERMES_HOME` points into WSL via UNC mount and the PID file contains a Linux PID that happens to collide with a Windows PID.
- If `tasklist` is unavailable or times out, fall back to trusting the liveness check rather than blocking a healthy gateway on a flaky verifier.
- Fix `profiles.ts:isGatewayRunning` parsing only bare-integer PID files. The current Python CLI writes JSON (`{"pid": N, "kind": ..., "argv": [...]}`); the old `parseInt` silently failed on that, so per-profile gateway status was always **Stopped** regardless of actual state.

## Files

- `src/main/utils.ts` — new `pidIsAlive`, `pidIsAliveAs`, `getProcessImageNameWin` helpers.
- `src/main/hermes.ts` — `isGatewayRunning()` uses `pidIsAliveAs` with `[python, pythonw]` prefixes.
- `src/main/profiles.ts` — per-profile `isGatewayRunning()` handles JSON PID format and uses the shared verifier.

## Test plan

- [x] `npm run typecheck` passes (node + web).
- [x] `npm test` — all 317 tests pass across 22 files.
- [x] Verified against a real running gateway (PID owned by `pythonw.exe` started by `hermes gateway run`): old code reported Stopped, new code reports Running.
- [ ] macOS/Linux: `pidIsAliveAs` short-circuits to `pidIsAlive` (image check is Windows-only), so POSIX behavior is unchanged.
- [ ] Manual: kill the gateway and confirm UI flips to Stopped within the next 10s poll.