### PR TITLE
fix: recognize oauth profiles and authenticate desktop chat to local api server

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -177,6 +177,7 @@ export function setEnvValue(
 
   const { envFile } = profilePaths(profile);
   invalidateCache(`env:${profile || "default"}`);
+  if (key === "API_SERVER_KEY") invalidateCache("apiServerKey:");
 
   if (!existsSync(envFile)) {
     safeWriteFile(envFile, `${key}=${value}\n`);
@@ -233,6 +234,7 @@ export function setConfigValue(
   value: string,
   profile?: string,
 ): void {
+  if (key === "API_SERVER_KEY") invalidateCache("apiServerKey:");
   const { configFile } = profilePaths(profile);
   if (!existsSync(configFile)) return;
 
@@ -486,6 +488,45 @@ export function setModelConfig(
 
 export function getHermesHome(profile?: string): string {
   return profilePaths(profile).home;
+}
+
+/**
+ * Resolve the API server's shared secret. Honoured by the local hermes
+ * gateway (api_server.token in config.yaml / API_SERVER_KEY in .env) when
+ * present; the desktop must include it as `Authorization: Bearer …` on
+ * every chat request, otherwise the gateway responds with "Invalid API
+ * key".
+ *
+ * Search order: profile's config.yaml → default config.yaml → profile's
+ * .env → default .env. Returns "" when none configured.
+ *
+ * Hot path: called per chat message and per error-probe. Reuse the same
+ * 5s TTL cache as readEnv() so we don't re-parse config.yaml + .env
+ * every call. Invalidated by setEnvValue / setConfigValue when the key
+ * being written is API_SERVER_KEY.
+ */
+export function getApiServerKey(profile?: string): string {
+  const cacheKey = `apiServerKey:${profile || "default"}`;
+  const cached = getCached<string>(cacheKey);
+  if (cached !== undefined) return cached;
+
+  const candidates = [
+    getConfigValue("API_SERVER_KEY", profile),
+    profile && profile !== "default" ? getConfigValue("API_SERVER_KEY") : null,
+    readEnv(profile).API_SERVER_KEY || null,
+    profile && profile !== "default" ? readEnv().API_SERVER_KEY || null : null,
+  ];
+
+  let value = "";
+  for (const candidate of candidates) {
+    const trimmed = String(candidate || "").trim();
+    if (trimmed) {
+      value = trimmed;
+      break;
+    }
+  }
+  setCache(cacheKey, value);
+  return value;
 }
 
 // ── Platform enabled/disabled ─────────────────────────────

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -1,7 +1,13 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { join } from "path";
 import { HERMES_HOME } from "./installer";
-import { profilePaths, escapeRegex, safeWriteFile } from "./utils";
+import {
+  escapeRegex,
+  getActiveProfileNameSync,
+  profileHome,
+  profilePaths,
+  safeWriteFile,
+} from "./utils";
 import { getYamlPath } from "./yaml-path";
 
 // ── Connection Config (local / remote / ssh) ─────────────
@@ -701,20 +707,23 @@ export function setPlatformEnabled(
   }
 }
 
-// ── Credential Pool (auth.json) ──────────────────────────
+// ── Credential Pool / OAuth store (auth.json) ─────────────────────────
 
-function authFilePath(): string {
-  return join(HERMES_HOME, "auth.json");
+function authFilePath(profile?: string): string {
+  return join(profileHome(profile || getActiveProfileNameSync()), "auth.json");
 }
 
 interface CredentialEntry {
-  key: string;
-  label: string;
+  key?: string;
+  api_key?: string;
+  access_token?: string;
+  refresh_token?: string;
+  label?: string;
 }
 
-function readAuthStore(): Record<string, unknown> {
+function readAuthStore(profile?: string): Record<string, unknown> {
   try {
-    const p = authFilePath();
+    const p = authFilePath(profile);
     if (!existsSync(p)) return {};
     return JSON.parse(readFileSync(p, "utf-8"));
   } catch {
@@ -722,12 +731,14 @@ function readAuthStore(): Record<string, unknown> {
   }
 }
 
-function writeAuthStore(store: Record<string, unknown>): void {
-  safeWriteFile(authFilePath(), JSON.stringify(store, null, 2));
+function writeAuthStore(store: Record<string, unknown>, profile?: string): void {
+  safeWriteFile(authFilePath(profile), JSON.stringify(store, null, 2));
 }
 
-export function getCredentialPool(): Record<string, CredentialEntry[]> {
-  const store = readAuthStore();
+export function getCredentialPool(
+  profile?: string,
+): Record<string, CredentialEntry[]> {
+  const store = readAuthStore(profile);
   const pool = store.credential_pool;
   if (!pool || typeof pool !== "object") return {};
   return pool as Record<string, CredentialEntry[]>;
@@ -736,12 +747,75 @@ export function getCredentialPool(): Record<string, CredentialEntry[]> {
 export function setCredentialPool(
   provider: string,
   entries: CredentialEntry[],
+  profile?: string,
 ): void {
-  const store = readAuthStore();
+  const store = readAuthStore(profile);
   if (!store.credential_pool || typeof store.credential_pool !== "object") {
     store.credential_pool = {};
   }
   (store.credential_pool as Record<string, CredentialEntry[]>)[provider] =
     entries;
-  writeAuthStore(store);
+  writeAuthStore(store, profile);
+}
+
+/**
+ * True iff the given provider has usable OAuth or stored-credential evidence
+ * in auth.json. Recognized fields are `access_token`, `refresh_token`, and
+ * `api_key`, looked up under both `providers[<name>]` and any entry in
+ * `credential_pool[<name>]`. When a named profile is given without its own
+ * auth.json, fall back to the default-profile store.
+ *
+ * Stricter than just "provider key exists in JSON" — an empty
+ * `providers: { anthropic: {} }` or a bare `active_provider` no longer
+ * counts as configured. The previous looser check masked real onboarding
+ * errors where a credential record existed but contained no token.
+ */
+export function hasOAuthCredentials(
+  provider: string,
+  profile?: string,
+): boolean {
+  const cleanProvider = provider.trim();
+  if (!cleanProvider) return false;
+
+  const stores = [readAuthStore(profile)];
+  if (profile && profile !== "default") {
+    stores.push(readAuthStore());
+  }
+
+  for (const store of stores) {
+    const providers = store.providers;
+    if (providers && typeof providers === "object") {
+      const entry = (providers as Record<string, CredentialEntry>)[cleanProvider];
+      if (
+        entry &&
+        (String(entry.access_token || "").trim() ||
+          String(entry.refresh_token || "").trim() ||
+          String(entry.api_key || "").trim())
+      ) {
+        return true;
+      }
+    }
+
+    const pool = store.credential_pool;
+    const entries =
+      pool && typeof pool === "object"
+        ? (pool as Record<string, CredentialEntry[]>)[cleanProvider]
+        : undefined;
+    if (
+      Array.isArray(entries) &&
+      entries.some(
+        (entry) =>
+          !!(
+            entry &&
+            (String(entry.api_key || "").trim() ||
+              String(entry.access_token || "").trim() ||
+              String(entry.refresh_token || "").trim())
+          ),
+      )
+    ) {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -11,7 +11,12 @@ import {
   hermesCliArgs,
   getEnhancedPath,
 } from "./installer";
-import { getModelConfig, readEnv, getConnectionConfig } from "./config";
+import {
+  getApiServerKey,
+  getConnectionConfig,
+  getModelConfig,
+  readEnv,
+} from "./config";
 import {
   getSshTunnelUrl,
   isSshTunnelActive,
@@ -294,6 +299,16 @@ function sendMessageViaApi(
     "Content-Type": "application/json",
     ...getRemoteAuthHeader(),
   };
+  // Local API server key (API_SERVER_KEY in the profile's .env /
+  // config.yaml) only applies in local mode — in remote/SSH mode the
+  // remote endpoint's own auth header (set above) is authoritative and
+  // must not be overwritten.
+  if (!isRemoteMode()) {
+    const apiServerKey = getApiServerKey(profile);
+    if (apiServerKey) {
+      headers.Authorization = `Bearer ${apiServerKey}`;
+    }
+  }
 
   let sessionId = _resumeSessionId || "";
   let hasContent = false;
@@ -323,13 +338,7 @@ function sendMessageViaApi(
     const probeMod = probeUrl.startsWith("https") ? https : http;
     const probeReq = probeMod.request(
       probeUrl,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...getRemoteAuthHeader(),
-        },
-      },
+      { method: "POST", headers },
       (res) => {
         let raw = "";
         res.on("data", (d) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -952,16 +952,22 @@ function setupIPC(): void {
     return searchSessions(query, limit);
   });
 
-  // Credential Pool
-  ipcMain.handle("get-credential-pool", () => getCredentialPool());
+  // Credential Pool — profile-aware. When `profile` is omitted, the
+  // credential pool helpers default to the currently active profile's
+  // auth.json (see config.ts:authFilePath), so the renderer can pass an
+  // explicit profile or rely on the active-profile fallback.
+  ipcMain.handle("get-credential-pool", (_event, profile?: string) =>
+    getCredentialPool(profile),
+  );
   ipcMain.handle(
     "set-credential-pool",
     (
       _event,
       provider: string,
       entries: Array<{ key: string; label: string }>,
+      profile?: string,
     ) => {
-      setCredentialPool(provider, entries);
+      setCredentialPool(provider, entries, profile);
       return true;
     },
   );

--- a/src/main/installer.ts
+++ b/src/main/installer.ts
@@ -10,8 +10,12 @@ import { join, delimiter } from "path";
 import { homedir, tmpdir } from "os";
 import { randomBytes } from "crypto";
 import type { BrowserWindow } from "electron";
-import { getModelConfig, getConnectionConfig } from "./config";
-import { profileHome, stripAnsi } from "./utils";
+import {
+  getConnectionConfig,
+  getModelConfig,
+  hasOAuthCredentials,
+} from "./config";
+import { getActiveProfileNameSync, profileHome, stripAnsi } from "./utils";
 import { setupAskpass, AskpassHandle } from "./askpass";
 import { precacheSudoCredentials } from "./sudoCreds";
 import { HIDDEN_SUBPROCESS_OPTIONS } from "./process-options";
@@ -87,6 +91,7 @@ export interface InstallStatus {
   configured: boolean;
   hasApiKey: boolean;
   verified: boolean;
+  activeProfile?: string;
 }
 
 export interface InstallProgress {
@@ -177,21 +182,16 @@ function resolveNvmBin(home: string): string[] {
   return [];
 }
 
-export function hasHermesAuthCredential(provider: string): boolean {
-  if (!provider || !existsSync(HERMES_AUTH_FILE)) return false;
-  try {
-    const auth = JSON.parse(readFileSync(HERMES_AUTH_FILE, "utf-8")) as {
-      active_provider?: string;
-      credential_pool?: Record<string, unknown[]>;
-      providers?: Record<string, unknown>;
-    };
-    const pool = auth.credential_pool?.[provider];
-    if (Array.isArray(pool) && pool.length > 0) return true;
-    if (auth.active_provider === provider) return true;
-    return Boolean(auth.providers?.[provider]);
-  } catch {
-    return false;
-  }
+function activeEnvFile(profile: string): string {
+  return profile === "default"
+    ? HERMES_ENV_FILE
+    : join(HERMES_HOME, "profiles", profile, ".env");
+}
+
+function activeAuthFile(profile: string): string {
+  return profile === "default"
+    ? HERMES_AUTH_FILE
+    : join(HERMES_HOME, "profiles", profile, "auth.json");
 }
 
 // Canonical env-var name per known model provider. Keys here are values
@@ -296,6 +296,8 @@ function envHasUsableValue(content: string, expectedKey: string | null): boolean
 }
 
 export function checkInstallStatus(): InstallStatus {
+  const activeProfile = getActiveProfileNameSync();
+
   // Remote mode: skip local checks entirely
   const conn = getConnectionConfig();
   if (conn.mode === "remote" && conn.remoteUrl) {
@@ -304,6 +306,7 @@ export function checkInstallStatus(): InstallStatus {
       configured: true,
       hasApiKey: true,
       verified: true,
+      activeProfile,
     };
   }
 
@@ -312,19 +315,22 @@ export function checkInstallStatus(): InstallStatus {
   // latency, so it now lives in `verifyInstall()` and is invoked lazily
   // by the renderer after the main UI is mounted.
   const installed = existsSync(HERMES_PYTHON) && existsSync(HERMES_SCRIPT);
-  const configured = existsSync(HERMES_ENV_FILE);
+  const envFile = activeEnvFile(activeProfile);
+  const authFile = activeAuthFile(activeProfile);
+  const configured = existsSync(envFile) || existsSync(authFile);
   let hasApiKey = false;
   const verified = installed;
 
   // Local/custom providers don't need an API key. OAuth-backed providers
-  // can be configured through Hermes auth.json instead of .env.
+  // (including credential-pool entries) can be configured through Hermes
+  // auth.json instead of .env, so check those before falling back to keys.
   let mc: { provider: string; model: string; baseUrl: string } | null = null;
   try {
-    mc = getModelConfig();
+    mc = getModelConfig(activeProfile);
     const localProviders = ["custom", "lmstudio", "ollama", "vllm", "llamacpp"];
     if (
       localProviders.includes(mc.provider) ||
-      hasHermesAuthCredential(mc.provider)
+      hasOAuthCredentials(mc.provider, activeProfile)
     ) {
       hasApiKey = true;
     }
@@ -332,9 +338,9 @@ export function checkInstallStatus(): InstallStatus {
     /* ignore */
   }
 
-  if (!hasApiKey && configured) {
+  if (!hasApiKey && configured && existsSync(envFile)) {
     try {
-      const content = readFileSync(HERMES_ENV_FILE, "utf-8");
+      const content = readFileSync(envFile, "utf-8");
       const expectedKey = mc
         ? expectedEnvKeyForModel(mc.provider, mc.baseUrl)
         : null;
@@ -344,7 +350,7 @@ export function checkInstallStatus(): InstallStatus {
     }
   }
 
-  return { installed, configured, hasApiKey, verified };
+  return { installed, configured, hasApiKey, verified, activeProfile };
 }
 
 // Lazy background verification: actually invoke Python to confirm the

--- a/src/main/profiles.ts
+++ b/src/main/profiles.ts
@@ -10,6 +10,7 @@ import {
   getEnhancedPath,
 } from "./installer";
 import {
+  getActiveProfileNameSync,
   isValidNamedProfileName,
   isValidProfileName,
   pidIsAliveAs,
@@ -97,13 +98,7 @@ async function isGatewayRunning(profilePath: string): Promise<boolean> {
 }
 
 async function getActiveProfileName(): Promise<string> {
-  const activeFile = join(HERMES_HOME, "active_profile");
-  try {
-    const name = await fs.readFile(activeFile, "utf-8");
-    return name.trim() || "default";
-  } catch {
-    return "default";
-  }
+  return getActiveProfileNameSync();
 }
 
 async function fileExists(path: string): Promise<boolean> {

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from "child_process";
 import { join, dirname } from "path";
-import { existsSync, mkdirSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { HERMES_HOME } from "./installer";
 
 const PROFILE_NAME_RE = /^[a-z0-9_][a-z0-9_-]{0,63}$/;
@@ -147,6 +147,22 @@ export function pidIsAliveAs(
   return expectedImagePrefixes.some((prefix) =>
     lower.startsWith(prefix.toLowerCase()),
   );
+}
+
+/**
+ * Read the active profile name from ~/.hermes/active_profile. Returns "default"
+ * when the file is missing, empty, or unreadable. Shared sync helper used by
+ * installer.ts and config.ts; profiles.ts's async wrapper delegates here.
+ */
+export function getActiveProfileNameSync(): string {
+  try {
+    const activeFile = join(HERMES_HOME, "active_profile");
+    if (!existsSync(activeFile)) return "default";
+    const name = readFileSync(activeFile, "utf-8").trim();
+    return name || "default";
+  } catch {
+    return "default";
+  }
 }
 
 /**

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -17,6 +17,7 @@ interface InstallStatus {
   configured: boolean;
   hasApiKey: boolean;
   verified: boolean;
+  activeProfile?: string;
 }
 
 interface InstallProgress {
@@ -391,13 +392,14 @@ interface HermesAPI {
     }>
   >;
 
-  // Credential Pool
-  getCredentialPool: () => Promise<
-    Record<string, Array<{ key: string; label: string }>>
-  >;
+  // Credential Pool (profile-aware)
+  getCredentialPool: (
+    profile?: string,
+  ) => Promise<Record<string, Array<{ key: string; label: string }>>>;
   setCredentialPool: (
     provider: string,
     entries: Array<{ key: string; label: string }>,
+    profile?: string,
   ) => Promise<boolean>;
 
   // Models

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -464,15 +464,18 @@ const hermesAPI = {
     }>
   > => ipcRenderer.invoke("search-sessions", query, limit),
 
-  // Credential Pool
-  getCredentialPool: (): Promise<
-    Record<string, Array<{ key: string; label: string }>>
-  > => ipcRenderer.invoke("get-credential-pool"),
+  // Credential Pool (profile-aware: reads/writes the named profile's
+  // auth.json; defaults to the currently active profile when omitted)
+  getCredentialPool: (
+    profile?: string,
+  ): Promise<Record<string, Array<{ key: string; label: string }>>> =>
+    ipcRenderer.invoke("get-credential-pool", profile),
   setCredentialPool: (
     provider: string,
     entries: Array<{ key: string; label: string }>,
+    profile?: string,
   ): Promise<boolean> =>
-    ipcRenderer.invoke("set-credential-pool", provider, entries),
+    ipcRenderer.invoke("set-credential-pool", provider, entries, profile),
 
   // Models
   listModels: (): Promise<

--- a/tests/installer-utils.test.ts
+++ b/tests/installer-utils.test.ts
@@ -201,15 +201,22 @@ describe("Memory provider discovery", () => {
   });
 });
 
-// ─── Hermes auth credential discovery ─────────────────
+// ─── OAuth credential discovery ─────────────────
+//
+// The previous installer-side `hasHermesAuthCredential` accepted a bare
+// `active_provider` and empty `providers: { name: {} }` entries as
+// configured. That looser check could mask onboarding failures where a
+// credential record existed but contained no token. The replacement,
+// `hasOAuthCredentials` (in config.ts, profile-aware), only counts an
+// entry that has at least one of access_token / refresh_token / api_key.
 
-describe("Hermes auth credential discovery", () => {
-  async function importInstallerWithHome(
+describe("OAuth credential discovery", () => {
+  async function importConfigWithHome(
     home: string,
-  ): Promise<typeof import("../src/main/installer")> {
+  ): Promise<typeof import("../src/main/config")> {
     vi.resetModules();
     process.env.HERMES_HOME = home;
-    return await import("../src/main/installer");
+    return await import("../src/main/config");
   }
 
   afterEach(() => {
@@ -220,40 +227,53 @@ describe("Hermes auth credential discovery", () => {
   it("detects OAuth credentials stored in auth.json credential_pool", async () => {
     writeFileSync(
       join(TEST_DIR, "auth.json"),
-      JSON.stringify({ credential_pool: { "openai-codex": [{ id: "acct" }] } }),
+      JSON.stringify({
+        credential_pool: {
+          "openai-codex": [{ access_token: "sk-test-token" }],
+        },
+      }),
     );
 
-    const { HERMES_AUTH_FILE, hasHermesAuthCredential } =
-      await importInstallerWithHome(TEST_DIR);
+    const { hasOAuthCredentials } = await importConfigWithHome(TEST_DIR);
 
-    expect(HERMES_AUTH_FILE).toBe(join(TEST_DIR, "auth.json"));
-    expect(hasHermesAuthCredential("openai-codex")).toBe(true);
-    expect(hasHermesAuthCredential("anthropic")).toBe(false);
+    expect(hasOAuthCredentials("openai-codex")).toBe(true);
+    expect(hasOAuthCredentials("anthropic")).toBe(false);
   });
 
-  it("accepts active_provider and providers entries as configured credentials", async () => {
+  it("requires actual token fields, not just a provider entry", async () => {
     writeFileSync(
       join(TEST_DIR, "auth.json"),
       JSON.stringify({
         active_provider: "openrouter",
-        providers: { anthropic: {} },
+        providers: {
+          anthropic: {}, // empty — no token, so not "configured"
+          openai: { access_token: "tok-openai" },
+          claude: { refresh_token: "ref-claude" },
+          mistral: { api_key: "key-mistral" },
+        },
       }),
     );
 
-    const { hasHermesAuthCredential } = await importInstallerWithHome(TEST_DIR);
+    const { hasOAuthCredentials } = await importConfigWithHome(TEST_DIR);
 
-    expect(hasHermesAuthCredential("openrouter")).toBe(true);
-    expect(hasHermesAuthCredential("anthropic")).toBe(true);
-    expect(hasHermesAuthCredential("openai-codex")).toBe(false);
+    // Empty providers entries and a bare active_provider no longer count
+    // — the previous behavior reported them as configured even with no
+    // actual credentials, which masked real onboarding errors.
+    expect(hasOAuthCredentials("anthropic")).toBe(false);
+    expect(hasOAuthCredentials("openrouter")).toBe(false);
+    // Any of access_token / refresh_token / api_key qualifies.
+    expect(hasOAuthCredentials("openai")).toBe(true);
+    expect(hasOAuthCredentials("claude")).toBe(true);
+    expect(hasOAuthCredentials("mistral")).toBe(true);
   });
 
   it("returns false when auth.json is missing or malformed", async () => {
-    const missing = await importInstallerWithHome(TEST_DIR);
-    expect(missing.hasHermesAuthCredential("openai-codex")).toBe(false);
+    const missing = await importConfigWithHome(TEST_DIR);
+    expect(missing.hasOAuthCredentials("openai-codex")).toBe(false);
 
     writeFileSync(join(TEST_DIR, "auth.json"), "{not-json");
-    const malformed = await importInstallerWithHome(TEST_DIR);
-    expect(malformed.hasHermesAuthCredential("openai-codex")).toBe(false);
+    const malformed = await importConfigWithHome(TEST_DIR);
+    expect(malformed.hasOAuthCredentials("openai-codex")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Supersedes #10 (original PR has been inactive for >30 days, in CONFLICTING state and not mergeable as-is). Two independent fixes from that PR, rebased onto current `main` with the reviewer's outstanding feedback addressed. Original work by `Hermes Agent <hermes@local.invalid>` (credited via `Co-authored-by`).

Both commits left intact as separate units so they can land or be revisited independently.

## Commit 1 — `fix: detect oauth-backed active profiles in install gate`

Profiles whose only credential is an OAuth grant in `auth.json` (e.g. `openai-codex` under a named profile) were reported by `checkInstallStatus` as un-configured, so the desktop showed the install/setup screen instead of letting the user proceed. The check was also default-profile only — named profiles never had their own `auth.json` or `.env` consulted.

- `checkInstallStatus` now reads the active profile from `~/.hermes/active_profile` and probes that profile's `.env` and `auth.json`.
- New `hasOAuthCredentials()` in `config.ts` recognizes a credential as configured only when the entry contains at least one of `access_token` / `refresh_token` / `api_key` (under either `providers[<name>]` or `credential_pool[<name>]`). The previous looser installer-side check accepted empty `providers: { x: {} }` or a bare `active_provider`, which masked real onboarding errors.

## Commit 2 — `fix: send api server auth for desktop chat`

The local hermes gateway can require a shared secret (`api_server.token` in `config.yaml` / `API_SERVER_KEY` in `.env`). When set, the desktop's chat must include it as `Authorization: Bearer …` on every chat request — without it the gateway returns *Invalid API key* and chat fails for users who otherwise have a working local setup.

- New `getApiServerKey()` resolves the value per profile (profile `config.yaml` → root `config.yaml` → profile `.env` → root `.env`).
- `sendMessageViaApi` attaches the Bearer header **only in local mode** — in remote/SSH mode the existing `getRemoteAuthHeader()` already populates `Authorization` and must not be overwritten.
- The error-probe request now reuses the same headers object so it carries identical auth (previously the probe built a separate header dict that omitted the api server key).

## Reviewer feedback from #10 addressed

1. **Shared `getActiveProfileNameSync` helper.** Lives once in `utils.ts`; `profiles.ts`'s async wrapper delegates to it. No more three near-identical copies across `installer.ts` / `config.ts` / `profiles.ts`.
2. **`InstallStatus.activeProfile` on the interface itself.** Both `src/main/installer.ts` and `src/preload/index.d.ts` carry the optional field, so renderers see it through TypeScript instead of via an `& { activeProfile? }` intersection at the call site.
3. **Credential-pool IPC threads `profile`.** `getCredentialPool` / `setCredentialPool` in the preload, main IPC handlers, and `HermesAPI` type all accept an optional `profile`. Renderers can target an explicit profile; omitting it falls back to the currently active profile (consistent with the renderer's existing default behavior).
4. **`getApiServerKey` cached via the existing 5s TTL.** Routed through the same `_cache` mechanism `readEnv()` uses, with invalidation hooks in `setEnvValue` / `setConfigValue` when the key being written is `API_SERVER_KEY`.

Test file `tests/installer-utils.test.ts` updated to assert the new (stricter) `hasOAuthCredentials` semantics: empty `providers: { x: {} }` and bare `active_provider` no longer count as configured; `access_token`, `refresh_token`, or `api_key` all qualify.

## Test plan

- [x] `npm run typecheck` (node + web) passes.
- [x] `npm test` — all 317 tests across 22 files pass.
- [x] Verified locally on a native Windows install: OAuth-only profile (`openai-codex`) no longer triggers the install gate, and chat against the local API server with `API_SERVER_KEY` set succeeds (returns the expected response instead of "Invalid API key").
- [ ] Toggle into remote mode and confirm the local Bearer header doesn't overwrite the remote auth header (covered by the `!isRemoteMode()` gate, but worth a manual sanity check).
- [ ] Settings UI credential pool on a named profile — confirm it reads/writes that profile's `auth.json` rather than the root one.

Closes #30.

Closes #41.



Closes #67.

Closes #126.

Closes #185.
