### PR TITLE
fix(config): support nested YAML paths in local getConfigValue

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { join } from "path";
 import { HERMES_HOME } from "./installer";
 import { profilePaths, escapeRegex, safeWriteFile } from "./utils";
+import { getYamlPath } from "./yaml-path";
 
 // ── Connection Config (local / remote / ssh) ─────────────
 
@@ -213,12 +214,12 @@ export function getConfigValue(key: string, profile?: string): string | null {
   if (!existsSync(configFile)) return null;
 
   const content = readFileSync(configFile, "utf-8");
-  const regex = new RegExp(
-    `^\\s*${escapeRegex(key)}:\\s*["']?([^"'\\n#]+)["']?`,
-    "m",
-  );
-  const match = content.match(regex);
-  return match ? match[1].trim() : null;
+  // Use the indentation-aware reader so dotted keys like `memory.provider`,
+  // `network.force_ipv4`, `agent.service_tier` resolve correctly. The old
+  // regex matched only literal `dotted.key:` lines which don't exist in
+  // YAML, so nested lookups silently returned null and the UI rendered
+  // every memory provider as inactive, every nested toggle as default, etc.
+  return getYamlPath(content, key);
 }
 
 export function setConfigValue(

--- a/src/main/yaml-path.ts
+++ b/src/main/yaml-path.ts
@@ -1,0 +1,107 @@
+// Tiny indentation-aware YAML reader that resolves a dotted key path against
+// a YAML document and returns the leaf scalar as a string, or null if the
+// path is missing.
+//
+// Built deliberately small to avoid pulling js-yaml into the main bundle for
+// a one-line lookup. Hermes config.yaml is plain key: value pairs nested by
+// indentation — no anchors, no merge keys, no multi-line scalars in the
+// fields we read. Edge cases we DO handle:
+//
+//  - 2-or-more-space indentation (Hermes always uses 2 today, but any
+//    consistent positive indent works).
+//  - Inline empty maps:  `providers: {}`  → returns "{}"
+//    Inline empty lists: `disabled_toolsets: []` → returns "[]"
+//  - Single/double-quoted scalars: `provider: 'honcho'` → "honcho"
+//  - Trailing line comments: `model: gpt-4  # default` → "gpt-4"
+//
+// Edge cases we DON'T attempt — fall back to null:
+//
+//  - Block scalars (`|`, `>`)
+//  - Flow-style mappings with content (`{a: 1, b: 2}`)
+//  - YAML lists with `-` items
+//
+// If the codebase ever needs full YAML semantics, swap to js-yaml; the call
+// sites only need `getYamlPath(content, key)` and that contract stays.
+export function getYamlPath(content: string, dottedKey: string): string | null {
+  const parts = dottedKey.split(".").filter(Boolean);
+  if (parts.length === 0) return null;
+
+  const lines = content.split(/\r?\n/);
+  // Stack of (indent, key) frames describing the parent path being walked.
+  // The current frame is the deepest one we've descended into; siblings or
+  // dedents pop it.
+  const stack: { indent: number; key: string }[] = [];
+  let pathIdx = 0;
+
+  for (const raw of lines) {
+    const trimmed = raw.trimStart();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const indent = raw.length - trimmed.length;
+    // Pop stack frames whose indent is >= the current line's indent — those
+    // are siblings/cousins of the current node, not parents.
+    while (stack.length > 0 && stack[stack.length - 1].indent >= indent) {
+      stack.pop();
+    }
+    // If we've already drilled into a deeper level than where the current
+    // pathIdx parent lives, the dotted path is broken (we walked past it
+    // without finding the next part), so reset pathIdx to the depth we are
+    // actually at — i.e. number of parts already matched in stack.
+    pathIdx = stack.length;
+
+    const colon = trimmed.indexOf(":");
+    if (colon < 0) continue;
+    const rawKey = trimmed.slice(0, colon).trim();
+    if (!rawKey) continue;
+    // Quoted keys aren't used in Hermes config but strip the wrapping just in
+    // case so `"memory": ...` would still match.
+    const key = stripQuotes(rawKey);
+    const remainder = trimmed.slice(colon + 1);
+
+    if (pathIdx < parts.length && key === parts[pathIdx]) {
+      const isLeaf = pathIdx === parts.length - 1;
+      if (isLeaf) {
+        return parseScalar(remainder);
+      }
+      // Intermediate key — push onto the stack and look for the next part
+      // among its children.
+      stack.push({ indent, key });
+      pathIdx = stack.length;
+    }
+  }
+  return null;
+}
+
+function stripQuotes(s: string): string {
+  if (s.length >= 2) {
+    const first = s[0];
+    const last = s[s.length - 1];
+    if ((first === '"' || first === "'") && first === last) {
+      return s.slice(1, -1);
+    }
+  }
+  return s;
+}
+
+function parseScalar(remainderAfterColon: string): string | null {
+  // Strip a trailing `# comment` segment only when not inside quotes. The
+  // simplest approximation: if the value starts with a quote, find the
+  // matching close-quote and ignore anything after it; otherwise split on
+  // the first ` #` we encounter.
+  let value = remainderAfterColon.trimStart();
+  if (value === "") {
+    // `key:` with no inline value means the value is a child map — not what
+    // a getter on this key expects.
+    return null;
+  }
+  if (value.startsWith('"') || value.startsWith("'")) {
+    const quote = value[0];
+    const end = value.indexOf(quote, 1);
+    if (end > 0) value = value.slice(1, end);
+    else value = value.slice(1); // unterminated — best effort
+  } else {
+    const commentIdx = value.search(/\s+#/);
+    if (commentIdx >= 0) value = value.slice(0, commentIdx);
+  }
+  return value.trim();
+}

--- a/tests/yaml-path.test.ts
+++ b/tests/yaml-path.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { getYamlPath } from "../src/main/yaml-path";
+
+const HERMES_LIKE_CONFIG = `
+# A real-world-shaped Hermes config.yaml fragment.
+memory:
+  memory_enabled: true
+  user_profile_enabled: true
+  memory_char_limit: 2200
+  provider: honcho
+delegation:
+  model: ''
+  provider: ''
+  base_url: ''
+  inherit_mcp_toolsets: true
+providers: {}
+fallback_providers: []
+agent:
+  max_turns: 90
+  gateway_timeout: 1800
+  service_tier: ''
+network:
+  force_ipv4: false
+  proxy: ''
+security:
+  redact_secrets: true
+model:
+  provider: openai
+  default: gpt-4o
+  base_url: https://api.openai.com/v1
+`;
+
+describe("getYamlPath", () => {
+  it("returns the leaf scalar for a nested dotted-path key", () => {
+    expect(getYamlPath(HERMES_LIKE_CONFIG, "memory.provider")).toBe("honcho");
+    expect(getYamlPath(HERMES_LIKE_CONFIG, "model.provider")).toBe("openai");
+    expect(getYamlPath(HERMES_LIKE_CONFIG, "model.default")).toBe("gpt-4o");
+    expect(getYamlPath(HERMES_LIKE_CONFIG, "model.base_url")).toBe("https://api.openai.com/v1");
+    expect(getYamlPath(HERMES_LIKE_CONFIG, "agent.service_tier")).toBe("");
+    expect(getYamlPath(HERMES_LIKE_CONFIG, "network.force_ipv4")).toBe("false");
+    expect(getYamlPath(HERMES_LIKE_CONFIG, "security.redact_secrets")).toBe("true");
+  });
+
+  it("disambiguates same-name keys at different nesting levels", () => {
+    // Both memory.provider AND model.provider exist. Plain regex would match
+    // whichever appears first; dotted-path must return the requested one.
+    expect(getYamlPath(HERMES_LIKE_CONFIG, "memory.provider")).toBe("honcho");
+    expect(getYamlPath(HERMES_LIKE_CONFIG, "model.provider")).toBe("openai");
+    expect(getYamlPath(HERMES_LIKE_CONFIG, "delegation.provider")).toBe("");
+  });
+
+  it("returns null for keys that don't exist", () => {
+    expect(getYamlPath(HERMES_LIKE_CONFIG, "memory.nonexistent")).toBeNull();
+    expect(getYamlPath(HERMES_LIKE_CONFIG, "nonexistent.provider")).toBeNull();
+    expect(getYamlPath(HERMES_LIKE_CONFIG, "")).toBeNull();
+  });
+
+  it("handles inline empty maps and lists by returning the literal", () => {
+    expect(getYamlPath(HERMES_LIKE_CONFIG, "providers")).toBe("{}");
+    expect(getYamlPath(HERMES_LIKE_CONFIG, "fallback_providers")).toBe("[]");
+  });
+
+  it("strips quotes from quoted scalar values", () => {
+    expect(getYamlPath("k: 'honcho'", "k")).toBe("honcho");
+    expect(getYamlPath('k: "honcho"', "k")).toBe("honcho");
+  });
+
+  it("strips trailing line comments", () => {
+    expect(getYamlPath("model: gpt-4  # default", "model")).toBe("gpt-4");
+  });
+
+  it("returns top-level keys without nesting", () => {
+    expect(getYamlPath("top: value\n", "top")).toBe("value");
+  });
+
+  it("returns null when an intermediate parent isn't a map", () => {
+    // memory.provider.something doesn't exist — `provider: honcho` is a scalar
+    expect(getYamlPath(HERMES_LIKE_CONFIG, "memory.provider.something")).toBeNull();
+  });
+
+  it("handles CRLF line endings", () => {
+    const crlf = "memory:\r\n  provider: honcho\r\n";
+    expect(getYamlPath(crlf, "memory.provider")).toBe("honcho");
+  });
+});


### PR DESCRIPTION
**Updated 2026-05-19 after rebase onto main.** Scope narrowed — see history note below.

## Summary

The **local** `config.ts::getConfigValue` reader matches dotted keys as literal regex strings, so `getConfig("memory.provider")` searches for a line literally starting `memory.provider:` — which doesn't exist in YAML. Real config nests these:

```yaml
memory:
  provider: honcho
```

Every nested lookup silently returns null. Symptoms in the renderer in local mode:

- **Memory screen** shows Honcho as **inactive** even with `memory.provider: honcho` set. `getActiveMemoryProvider` → `getConfigValue("memory.provider")` → null → `active = (name === "")` is false for every provider.
- **Settings screen** `network.force_ipv4` and `network.proxy` reads on mount return null; toggles render their defaults regardless of what's in `config.yaml`.

## Relationship to #249

The SSH-side mirror of this bug (`sshGetConfigValue`) was fixed in #249 (merged) with an in-file `locateInYaml` walker plus a corresponding setter. **This PR closes the remaining local-mode side** using the same approach behind a small reusable helper. SSH-mode users on `main` already get the fix; local-mode users do not.

## Fix

`src/main/yaml-path.ts` — a 100-line indentation-aware walker that resolves dotted paths through nested maps. Deliberately small — Hermes `config.yaml` is plain nested key:value with no anchors, merge keys, or block scalars on the keys we read. The contract is just `getYamlPath(content, key)` so future replacement with `js-yaml` is a one-call-site swap.

The same helper could be used to refactor `ssh-remote.ts::locateInYaml` to share code with the local side, but that's a follow-up — this PR is scoped to closing the remaining bug without touching the already-merged SSH walker.

## Tests

`tests/yaml-path.test.ts` — 9 cases, all passing:

- Nested lookups across multiple parents
- Same-name-different-depth disambiguation (`memory.provider` vs `model.provider` vs `delegation.provider` all present in one document)
- Missing paths return null
- Empty inline `{}` / `[]` return the literal
- Single/double-quoted scalars stripped
- Trailing line comments stripped
- Top-level (un-nested) keys still work
- Attempted descent past a leaf scalar returns null
- CRLF endings

## Not in scope

The **local** `setConfigValue` still uses the flat regex and silently no-ops on nested paths. `Settings.tsx` writes `network.force_ipv4` and `network.proxy` via it — a separate, focused PR can mirror #249's setter pattern (insert-vs-replace logic with format preservation) on the local side.

## Test plan

- [x] `npm run typecheck` clean (node + web)
- [x] `npm run test -- yaml-path` — 9/9 pass
- [ ] Manual against a local install with `memory.provider: honcho` set: Memory screen now lights up Honcho as the active provider

---

**History (2026-05-19):** Originally this PR also fixed `sshGetConfigValue` with the same helper. After #249 landed an in-file SSH-side fix, I rebased onto main and dropped the now-redundant SSH change. The commit on this branch only touches `config.ts` (local getter) plus the new `yaml-path.ts` helper and tests.