### PR TITLE
fix: persist locale selection across app restarts

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -27,7 +27,7 @@ function desktopConfigFile(): string {
   return join(HERMES_HOME, "desktop.json");
 }
 
-function readDesktopConfig(): Record<string, unknown> {
+export function readDesktopConfig(): Record<string, unknown> {
   try {
     const f = desktopConfigFile();
     if (!existsSync(f)) return {};
@@ -37,7 +37,7 @@ function readDesktopConfig(): Record<string, unknown> {
   }
 }
 
-function writeDesktopConfig(data: Record<string, unknown>): void {
+export function writeDesktopConfig(data: Record<string, unknown>): void {
   if (!existsSync(HERMES_HOME)) {
     mkdirSync(HERMES_HOME, { recursive: true });
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -146,6 +146,8 @@ import {
   isAllowedWebviewUrl,
 } from "./security";
 import type { AppLocale } from "../shared/i18n/types";
+import { setLocale } from "../shared/i18n";
+import { readDesktopConfig } from "./config";
 import {
   sshListInstalledSkills,
   sshGetSkillContent,
@@ -1299,6 +1301,13 @@ function setupUpdater(): void {
 app.whenReady().then(() => {
   app.name = "Hermes";
   electronApp.setAppUserModelId("com.nousresearch.hermes");
+
+  // Restore directly via the shared setter; going through setAppLocale
+  // would needlessly re-write desktop.json with the value we just read.
+  const savedLocale = readDesktopConfig().locale as AppLocale | undefined;
+  if (savedLocale) {
+    setLocale(savedLocale);
+  }
 
   app.on("browser-window-created", (_, window) => {
     optimizer.watchWindowShortcuts(window);

--- a/src/main/locale.ts
+++ b/src/main/locale.ts
@@ -1,14 +1,26 @@
 import {
+  APP_LOCALES,
   DEFAULT_ACTIVE_LOCALE,
   getLocale as getSharedLocale,
   setLocale as setSharedLocale,
   type AppLocale,
 } from "../shared/i18n";
+import { readDesktopConfig, writeDesktopConfig } from "./config";
 
 export function getAppLocale(): AppLocale {
+  const saved = readDesktopConfig().locale;
+  if (
+    typeof saved === "string" &&
+    (APP_LOCALES as readonly string[]).includes(saved)
+  ) {
+    return saved as AppLocale;
+  }
   return getSharedLocale() || DEFAULT_ACTIVE_LOCALE;
 }
 
 export function setAppLocale(locale: AppLocale): AppLocale {
+  const data = readDesktopConfig();
+  data.locale = locale;
+  writeDesktopConfig(data);
   return setSharedLocale(locale);
 }


### PR DESCRIPTION
## Summary
Fixes the issue where users had to re-select their preferred language after every app launch.

## Problem
The app's language setting (`locale`) was only stored in memory. On restart, it always reset to the default (`\"en\"`), forcing users to reconfigure their language preference every time.

## Changes
- `src/main/config.ts`: Export `readDesktopConfig` / `writeDesktopConfig` so they can be used by the locale module
- `src/main/locale.ts`: `getAppLocale()` now reads saved locale from `~/.hermes/desktop.json`; `setAppLocale()` persists the locale to `desktop.json`
- `src/main/index.ts`: Restore the saved locale from `~/.hermes/desktop.json` on app startup

## Verification
- `npm run typecheck` passes
- `npm run test` passes (317 tests)
- `npm run build` succeeds