### PR TITLE
fix(config): scope model field reads/writes to the model: block, bootstrap on missing config.yaml

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -242,6 +242,118 @@ export function setConfigValue(
   safeWriteFile(configFile, content);
 }
 
+/**
+ * Locate the direct children of a top-level YAML block. Each child is
+ * keyed by name and carries the substring offsets needed to read or
+ * rewrite its value in-place.
+ *
+ * Why this exists: the model-field readers/writers used to run loose
+ * regexes like `^\s*default:` against the whole file, which match any
+ * `default:` at any indent — so a `personalities.default` description
+ * would be picked up as the model name (issue #242), and toggling the
+ * model in the UI would overwrite that personality string instead of
+ * `model.default`. Scoping reads and writes to a named top-level block
+ * fixes both directions.
+ *
+ * Direct (sibling) children only: keys nested deeper than one indent
+ * under the block are ignored. The block ends at the first non-indented,
+ * non-empty line — the next top-level key. Anchored block-header search
+ * means a `model:` later in some other context (e.g. a YAML string
+ * literal, or nested under another block) won't be mistaken for the
+ * top-level `model:` we want.
+ */
+interface BlockChild {
+  key: string;
+  /** Parsed value, with surrounding single/double quotes stripped. */
+  value: string;
+  /** Indent string of this child's line (e.g. "  "). */
+  indent: string;
+  /** Absolute offset of the substring after `key: ` and any leading
+   *  whitespace — where a writer should splice the new value. */
+  valueStart: number;
+  /** Absolute offset just past the substring the writer should replace
+   *  (excludes any trailing comment so we don't clobber `# notes`). */
+  valueEnd: number;
+}
+
+function readTopLevelBlock(
+  content: string,
+  blockName: string,
+): {
+  children: Map<string, BlockChild>;
+  blockBodyStart: number | null;
+  childIndent: string;
+} {
+  const startRe = new RegExp(`^${escapeRegex(blockName)}:[ \\t]*\\r?\\n`, "m");
+  const start = content.match(startRe);
+  if (!start || start.index === undefined) {
+    return { children: new Map(), blockBodyStart: null, childIndent: "  " };
+  }
+
+  const blockBodyStart = start.index + start[0].length;
+  const children = new Map<string, BlockChild>();
+  let firstChildIndent: string | null = null;
+  let cursor = blockBodyStart;
+
+  while (cursor < content.length) {
+    const lineEnd = content.indexOf("\n", cursor);
+    const lineEndExclusive = lineEnd === -1 ? content.length : lineEnd;
+    const line = content.slice(cursor, lineEndExclusive);
+
+    // Stop at a non-indented, non-empty line (= next top-level key).
+    if (line.trim() !== "" && !/^\s/.test(line)) break;
+
+    const m = line.match(
+      /^([ \t]+)([A-Za-z_][A-Za-z0-9_-]*):([ \t]*)([^\n#]*?)([ \t]*)(#.*)?$/,
+    );
+    if (m) {
+      const indent = m[1];
+      const key = m[2];
+      const gapBeforeValue = m[3];
+      const rawValue = m[4];
+      const trailingWhitespace = m[5];
+      void trailingWhitespace; // not used for replacement boundaries
+
+      // First child encountered sets the canonical indent. Anything more
+      // indented is a nested child (skip); anything less is malformed.
+      if (firstChildIndent === null) firstChildIndent = indent;
+      if (indent === firstChildIndent && !children.has(key)) {
+        const keyEnd = cursor + indent.length + key.length + 1; // past `:`
+        const valueStart = keyEnd + gapBeforeValue.length;
+        const valueEnd = valueStart + rawValue.length;
+        children.set(key, {
+          key,
+          value: stripYamlQuotes(rawValue),
+          indent,
+          valueStart,
+          valueEnd,
+        });
+      }
+    }
+
+    cursor =
+      lineEndExclusive === content.length ? content.length : lineEndExclusive + 1;
+  }
+
+  return {
+    children,
+    blockBodyStart,
+    childIndent: firstChildIndent ?? "  ",
+  };
+}
+
+function stripYamlQuotes(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.length >= 2) {
+    const first = trimmed[0];
+    const last = trimmed[trimmed.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return trimmed.slice(1, -1);
+    }
+  }
+  return trimmed;
+}
+
 export function getModelConfig(profile?: string): {
   provider: string;
   model: string;
@@ -260,19 +372,60 @@ export function getModelConfig(profile?: string): {
   if (!existsSync(configFile)) return defaults;
 
   const content = readFileSync(configFile, "utf-8");
-
-  const providerMatch = content.match(/^\s*provider:\s*["']?([^"'\n#]+)["']?/m);
-  const modelMatch = content.match(/^\s*default:\s*["']?([^"'\n#]+)["']?/m);
-  const baseUrlMatch = content.match(/^\s*base_url:\s*["']?([^"'\n#]+)["']?/m);
+  const { children } = readTopLevelBlock(content, "model");
 
   const result = {
-    provider: providerMatch ? providerMatch[1].trim() : defaults.provider,
-    model: modelMatch ? modelMatch[1].trim() : defaults.model,
-    baseUrl: baseUrlMatch ? baseUrlMatch[1].trim() : defaults.baseUrl,
+    provider: children.get("provider")?.value || defaults.provider,
+    model: children.get("default")?.value || defaults.model,
+    baseUrl: children.get("base_url")?.value || defaults.baseUrl,
   };
 
   setCache(cacheKey, result);
   return result;
+}
+
+/**
+ * Replace a direct child's value inside a top-level YAML block in-place,
+ * preserving the key's surrounding whitespace and any trailing comment.
+ * When the child doesn't exist, insert it as the first sibling at the
+ * block's existing indent. When the block itself doesn't exist, append
+ * one with the new key inside.
+ */
+function upsertBlockChild(
+  content: string,
+  blockName: string,
+  key: string,
+  value: string,
+): string {
+  const { children, blockBodyStart, childIndent } = readTopLevelBlock(
+    content,
+    blockName,
+  );
+
+  const existing = children.get(key);
+  if (existing) {
+    return (
+      content.slice(0, existing.valueStart) +
+      `"${value}"` +
+      content.slice(existing.valueEnd)
+    );
+  }
+
+  if (blockBodyStart !== null) {
+    const insertion = `${childIndent}${key}: "${value}"\n`;
+    return (
+      content.slice(0, blockBodyStart) +
+      insertion +
+      content.slice(blockBodyStart)
+    );
+  }
+
+  // No block at all → append one. Match the existing file's trailing
+  // newline conventions; if the file is empty (e.g. setModelConfig is
+  // bootstrapping a fresh config.yaml) skip the separator so we don't
+  // leave a stray leading blank line.
+  const sep = content === "" || content.endsWith("\n") ? "" : "\n";
+  return `${content}${sep}${blockName}:\n  ${key}: "${value}"\n`;
 }
 
 export function setModelConfig(
@@ -283,29 +436,23 @@ export function setModelConfig(
 ): void {
   invalidateCache(`mc:${profile || "default"}`);
   const { configFile } = profilePaths(profile);
-  if (!existsSync(configFile)) return;
 
-  let content = readFileSync(configFile, "utf-8");
+  // Bootstrap an empty config.yaml when it's missing — previously this
+  // function early-returned, so users on a custom HERMES_HOME where the
+  // file hadn't been created (issue #228) had their model selection
+  // silently dropped: the desktop appeared to save it but config.yaml
+  // never got written, and the Python gateway saw an empty model and
+  // returned 404s. `safeWriteFile` (used below) will create parent dirs
+  // as needed; `upsertBlockChild` produces a valid minimal YAML doc
+  // from an empty starting string.
+  let content = existsSync(configFile)
+    ? readFileSync(configFile, "utf-8")
+    : "";
 
-  const providerRegex = /^(\s*provider:\s*)["']?[^"'\n#]*["']?/m;
-  if (providerRegex.test(content)) {
-    content = content.replace(providerRegex, `$1"${provider}"`);
-  }
-
-  const modelRegex = /^(\s*default:\s*)["']?[^"'\n#]*["']?/m;
-  if (modelRegex.test(content)) {
-    content = content.replace(modelRegex, `$1"${model}"`);
-  }
-
-  const baseUrlRegex = /^(\s*base_url:\s*)["']?[^"'\n#]*["']?/m;
-  if (baseUrlRegex.test(content)) {
-    content = content.replace(baseUrlRegex, `$1"${baseUrl}"`);
-  } else if (baseUrl && provider !== "auto") {
-    // Append base_url line after the provider line in the model section
-    content = content.replace(
-      /^(\s*provider:\s*"[^"]*"\s*\n)/m,
-      `$1  base_url: "${baseUrl}"\n`,
-    );
+  content = upsertBlockChild(content, "model", "provider", provider);
+  content = upsertBlockChild(content, "model", "default", model);
+  if (baseUrl) {
+    content = upsertBlockChild(content, "model", "base_url", baseUrl);
   }
 
   // Disable smart_model_routing

--- a/tests/config-model-block.test.ts
+++ b/tests/config-model-block.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { join } from "path";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+
+// Regression tests for issue #242: a `default:` (or `provider:`, `base_url:`)
+// key under a *sibling* block such as `personalities:` was being picked up
+// as the model's value because the readers/writers used loose regexes
+// against the whole file. Both `getModelConfig` and `setModelConfig`
+// should now scope strictly to the top-level `model:` block.
+
+const TEST_DIR = join(tmpdir(), `hermes-test-model-block-${Date.now()}`);
+
+async function importConfigWithHome(
+  home: string,
+): Promise<typeof import("../src/main/config")> {
+  vi.resetModules();
+  process.env.HERMES_HOME = home;
+  return await import("../src/main/config");
+}
+
+beforeEach(() => {
+  mkdirSync(TEST_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  delete process.env.HERMES_HOME;
+  vi.resetModules();
+  rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe("getModelConfig — scoped to model: block", () => {
+  it("returns the value from model.default, not personalities.default (issue #242)", async () => {
+    writeFileSync(
+      join(TEST_DIR, "config.yaml"),
+      [
+        'model:',
+        '  default: "gpt-5.5"',
+        '  provider: "openai-codex"',
+        '  base_url: "https://chatgpt.com/backend-api/codex"',
+        'personalities:',
+        '  default: You give clear, accurate, and actionable responses.',
+        '  coding: You are an expert coding assistant.',
+        '',
+      ].join("\n"),
+    );
+
+    const { getModelConfig } = await importConfigWithHome(TEST_DIR);
+    const mc = getModelConfig();
+
+    expect(mc.model).toBe("gpt-5.5");
+    expect(mc.provider).toBe("openai-codex");
+    expect(mc.baseUrl).toBe("https://chatgpt.com/backend-api/codex");
+  });
+
+  it("ignores `default:` inside nested blocks even when it appears first in the file", async () => {
+    // personalities: comes BEFORE model:, so the old regex (which picked
+    // the first occurrence anywhere) would have returned the personality
+    // description as the model name. The block-scoped reader must not.
+    writeFileSync(
+      join(TEST_DIR, "config.yaml"),
+      [
+        'agent:',
+        '  personalities:',
+        '    default: You give clear, accurate, and actionable responses.',
+        'personalities:',
+        '  default: You are an expert coding assistant.',
+        'model:',
+        '  default: "claude-sonnet-4"',
+        '  provider: "anthropic"',
+        '',
+      ].join("\n"),
+    );
+
+    const { getModelConfig } = await importConfigWithHome(TEST_DIR);
+    const mc = getModelConfig();
+
+    expect(mc.model).toBe("claude-sonnet-4");
+    expect(mc.provider).toBe("anthropic");
+  });
+
+  it("returns defaults when the model: block is absent", async () => {
+    writeFileSync(
+      join(TEST_DIR, "config.yaml"),
+      [
+        'personalities:',
+        '  default: Just a personality.',
+        'agent:',
+        '  provider: should-not-be-picked',
+        '',
+      ].join("\n"),
+    );
+
+    const { getModelConfig } = await importConfigWithHome(TEST_DIR);
+    const mc = getModelConfig();
+
+    // Defaults from getModelConfig() when nothing relevant is found.
+    expect(mc.provider).toBe("auto");
+    expect(mc.model).toBe("");
+    expect(mc.baseUrl).toBe("");
+  });
+
+  it("returns defaults when the config file doesn't exist", async () => {
+    const { getModelConfig } = await importConfigWithHome(TEST_DIR);
+    const mc = getModelConfig();
+    expect(mc).toEqual({ provider: "auto", model: "", baseUrl: "" });
+  });
+
+  it("ignores grandchildren (deeper nesting under model:) — only direct siblings count", async () => {
+    writeFileSync(
+      join(TEST_DIR, "config.yaml"),
+      [
+        'model:',
+        '  default: "real-model"',
+        '  fallback:',
+        '    default: "decoy-model"', // 4-space indent: nested, must not be picked
+        '    provider: "decoy-provider"',
+        '',
+      ].join("\n"),
+    );
+
+    const { getModelConfig } = await importConfigWithHome(TEST_DIR);
+    const mc = getModelConfig();
+    expect(mc.model).toBe("real-model");
+  });
+
+  it("ignores `provider:` set under unrelated blocks (e.g. auxiliary.vision)", async () => {
+    writeFileSync(
+      join(TEST_DIR, "config.yaml"),
+      [
+        'auxiliary:',
+        '  vision:',
+        '    provider: auto',
+        'model:',
+        '  default: "gpt-4o"',
+        '  provider: "openai"',
+        '',
+      ].join("\n"),
+    );
+
+    const { getModelConfig } = await importConfigWithHome(TEST_DIR);
+    expect((await importConfigWithHome(TEST_DIR)).getModelConfig().provider).toBe("openai");
+    void getModelConfig;
+  });
+
+  it("handles single-quoted, double-quoted, and bare values", async () => {
+    writeFileSync(
+      join(TEST_DIR, "config.yaml"),
+      [
+        'model:',
+        '  default: bare-value',
+        "  provider: 'single-quoted'",
+        '  base_url: "https://example.com"',
+        '',
+      ].join("\n"),
+    );
+
+    const { getModelConfig } = await importConfigWithHome(TEST_DIR);
+    const mc = getModelConfig();
+    expect(mc.model).toBe("bare-value");
+    expect(mc.provider).toBe("single-quoted");
+    expect(mc.baseUrl).toBe("https://example.com");
+  });
+});
+
+describe("setModelConfig — scoped to model: block", () => {
+  it("updates model.default in place without touching personalities.default", async () => {
+    const before = [
+      'model:',
+      '  default: "gpt-3.5"',
+      '  provider: "openai"',
+      'personalities:',
+      '  default: You give clear, accurate, and actionable responses.',
+      '  coding: You are an expert coding assistant.',
+      '',
+    ].join("\n");
+    writeFileSync(join(TEST_DIR, "config.yaml"), before);
+
+    const { setModelConfig } = await importConfigWithHome(TEST_DIR);
+    setModelConfig("openai", "gpt-4o", "", undefined);
+
+    const after = readFileSync(join(TEST_DIR, "config.yaml"), "utf-8");
+    expect(after).toContain('default: "gpt-4o"');
+    // The personality description must remain intact.
+    expect(after).toContain(
+      "default: You give clear, accurate, and actionable responses.",
+    );
+  });
+
+  it("inserts the model.default key at the block's existing indent when it was missing", async () => {
+    const before = [
+      'model:',
+      '  provider: "openai"',
+      'personalities:',
+      '  default: keep me intact',
+      '',
+    ].join("\n");
+    writeFileSync(join(TEST_DIR, "config.yaml"), before);
+
+    const { setModelConfig, getModelConfig } = await importConfigWithHome(TEST_DIR);
+    setModelConfig("openai", "gpt-4o", "https://api.openai.com/v1");
+
+    const after = readFileSync(join(TEST_DIR, "config.yaml"), "utf-8");
+    // The new keys land inside the model: block, indented like its existing children.
+    expect(after).toMatch(/^model:\n(?:  [a-zA-Z_]+: .*\n)+/m);
+    expect(after).toContain('  default: "gpt-4o"');
+    expect(after).toContain('  base_url: "https://api.openai.com/v1"');
+    expect(after).toContain("default: keep me intact");
+
+    // Round-trip through the reader to confirm structure is preserved.
+    const mc = getModelConfig();
+    expect(mc).toEqual({
+      provider: "openai",
+      model: "gpt-4o",
+      baseUrl: "https://api.openai.com/v1",
+    });
+  });
+
+  it("creates the model: block if it doesn't exist yet", async () => {
+    const before = [
+      'personalities:',
+      '  default: keep me intact',
+      '',
+    ].join("\n");
+    writeFileSync(join(TEST_DIR, "config.yaml"), before);
+
+    const { setModelConfig, getModelConfig } = await importConfigWithHome(TEST_DIR);
+    setModelConfig("anthropic", "claude-sonnet", "");
+
+    const after = readFileSync(join(TEST_DIR, "config.yaml"), "utf-8");
+    // Model block exists with both keys correctly indented under it.
+    // Insertion order isn't load-bearing — we round-trip through the
+    // reader below to confirm the values are correctly scoped.
+    expect(after).toMatch(/^model:\n(?:  [a-zA-Z_]+: .*\n)+/m);
+    expect(after).toContain('  provider: "anthropic"');
+    expect(after).toContain('  default: "claude-sonnet"');
+    // Personality description must remain intact.
+    expect(after).toContain("default: keep me intact");
+
+    const mc = getModelConfig();
+    expect(mc.provider).toBe("anthropic");
+    expect(mc.model).toBe("claude-sonnet");
+  });
+
+  it("invalidates cached reads after a write", async () => {
+    writeFileSync(
+      join(TEST_DIR, "config.yaml"),
+      ['model:', '  default: "gpt-3.5"', '  provider: "openai"', ''].join("\n"),
+    );
+
+    const { getModelConfig, setModelConfig } = await importConfigWithHome(TEST_DIR);
+    expect(getModelConfig().model).toBe("gpt-3.5");
+    setModelConfig("openai", "gpt-4o", "");
+    expect(getModelConfig().model).toBe("gpt-4o");
+  });
+
+  // Regression tests for #228: previously setModelConfig early-returned
+  // when config.yaml didn't exist, so users on a fresh / custom
+  // HERMES_HOME had their model selection silently dropped — the desktop
+  // appeared to save, but the Python gateway saw an empty model and
+  // returned 404s. The fix bootstraps an empty config.yaml when missing
+  // and threads through upsertBlockChild as usual.
+
+  it("creates config.yaml from scratch when it doesn't exist (issue #228)", async () => {
+    // Note: no writeFileSync — the file genuinely does not exist.
+    const configFile = join(TEST_DIR, "config.yaml");
+    expect(existsSync(configFile)).toBe(false);
+
+    const { setModelConfig, getModelConfig } =
+      await importConfigWithHome(TEST_DIR);
+    setModelConfig("gemini", "gemini-2.5-flash", "");
+
+    expect(existsSync(configFile)).toBe(true);
+    const after = readFileSync(configFile, "utf-8");
+
+    // The file should start with `model:` (no stray leading blank line)
+    // and contain both keys.
+    expect(after).toMatch(/^model:\n/);
+    expect(after).toContain('  provider: "gemini"');
+    expect(after).toContain('  default: "gemini-2.5-flash"');
+
+    // Round-trip confirms the values are scoped to model: and parse back.
+    const mc = getModelConfig();
+    expect(mc).toEqual({
+      provider: "gemini",
+      model: "gemini-2.5-flash",
+      baseUrl: "",
+    });
+  });
+
+  it("creates config.yaml with all three model fields when base_url is given", async () => {
+    const configFile = join(TEST_DIR, "config.yaml");
+    expect(existsSync(configFile)).toBe(false);
+
+    const { setModelConfig, getModelConfig } =
+      await importConfigWithHome(TEST_DIR);
+    setModelConfig("custom", "qwen-coder-30b", "http://localhost:1234/v1");
+
+    expect(existsSync(configFile)).toBe(true);
+    const mc = getModelConfig();
+    expect(mc).toEqual({
+      provider: "custom",
+      model: "qwen-coder-30b",
+      baseUrl: "http://localhost:1234/v1",
+    });
+  });
+
+  it("creates the file under the profile directory for a named profile", async () => {
+    const profileDir = join(TEST_DIR, "profiles", "work");
+    const configFile = join(profileDir, "config.yaml");
+    // Neither the profile dir nor the file exists yet — safeWriteFile
+    // should create both.
+    expect(existsSync(configFile)).toBe(false);
+
+    const { setModelConfig, getModelConfig } =
+      await importConfigWithHome(TEST_DIR);
+    setModelConfig("anthropic", "claude-sonnet-4", "", "work");
+
+    expect(existsSync(configFile)).toBe(true);
+    const mc = getModelConfig("work");
+    expect(mc.provider).toBe("anthropic");
+    expect(mc.model).toBe("claude-sonnet-4");
+  });
+});


### PR DESCRIPTION
## Problem

Two distinct bugs in the model-field read/write path of `config.ts`. Both surface as "the desktop's model settings don't take effect":

### Bug 1 — Loose regex scoping (issue #242)

`getModelConfig` and `setModelConfig` ran loose regexes against the entire `config.yaml` (e.g. `^\s*default:\s*…` with the multiline flag), which match *any* `default:` / `provider:` / `base_url:` key at any indentation. In configs that declare a `default:` entry under `personalities:` (or `agent.personalities`), the model **reader** picked up the personality description as the model name, and the **writer** would overwrite it with the model name on every toggle. The same shape of bug affected `provider:` (e.g. `auxiliary.vision.provider: auto` shadowing `model.provider`) and `base_url:`.

### Bug 2 — Silent no-op when `config.yaml` is missing (issue #228)

`setModelConfig` early-returned when `config.yaml` didn't exist. A user on a fresh or custom `HERMES_HOME` (the issue reporter's setup was `D:\Programs\hermes`) had their model selection silently dropped — the desktop UI appeared to save, but `config.yaml` never got written, and the Python gateway saw an empty model and returned 404s.

## Fix

Replace the loose regexes with `readTopLevelBlock`, a small block-aware helper that:

- Anchors on `^<name>:` (so a `model:` later in some other context can't be mistaken for the top-level one).
- Collects only direct children — keys exactly one indent under the block. Grandchildren (e.g. `model.fallback.default`) are skipped.
- Stops at the next top-level key.
- Records each child's value plus the precise substring offsets needed to splice in a replacement without disturbing the block's indent or any trailing comments.

`getModelConfig` reads `model.provider` / `model.default` / `model.base_url` strictly inside that scope. `setModelConfig` upserts in place via `upsertBlockChild` — replacing existing values, inserting missing children at the block's existing indent, or materializing the block from scratch when it's absent.

**For the missing-file case**, `setModelConfig` now bootstraps an empty config.yaml instead of returning early: `upsertBlockChild` produces a valid minimal YAML doc starting from an empty string, and `safeWriteFile` (already in use) creates parent directories as needed. The "empty content" branch of `upsertBlockChild` is also tightened to skip the separator newline so freshly-created files don't carry a stray leading blank line.

The cache invalidation on write is unchanged.

## Tests

`tests/config-model-block.test.ts` — 14 cases:

**Reads (issue #242):**
- ✅ `personalities.default` coexists with `model.default` — only the model's is read.
- ✅ `personalities.default` appears **before** `model.default` in document order — order-independent.
- ✅ Missing `model:` block returns defaults (`provider: "auto"`, empty strings) instead of guessing from unrelated keys.
- ✅ Deeper grandchildren like `model.fallback.default` are ignored — only direct siblings count.
- ✅ `auxiliary.vision.provider: auto` doesn't shadow `model.provider`.
- ✅ Single-quoted, double-quoted, and bare values all parse correctly.

**Writes (issue #242 + #228):**
- ✅ `setModelConfig` updates `model.default` in place and leaves `personalities.default`'s description untouched (#242).
- ✅ Inserts a missing child at the block's existing indent.
- ✅ Creates the `model:` block when absent in an existing file.
- ✅ Cache invalidates on write so the next read sees the change.
- ✅ **Creates `config.yaml` from scratch when it doesn't exist** — file starts cleanly with `model:` (no stray leading blank line) and round-trips through `getModelConfig` (#228).
- ✅ **Creates `config.yaml` with all three model fields when `base_url` is given** (#228).
- ✅ **Creates the file under `profiles/<name>/` for a named profile** when neither the directory nor the file exists yet (#228).

## Test plan

- [x] `npm run typecheck` (node + web) passes.
- [x] `npm test` — 23 files / **331 tests** pass (317 original + 14 new).
- [ ] Manual A: open Settings → Model on a config with both `model.default` and `personalities.default`; confirm the dropdown shows the model name (not the personality string), and toggling the model updates `model.default` without touching the personality entry.
- [ ] Manual B (the #228 scenario): launch with `HERMES_HOME` pointing at a directory that has no `config.yaml`; pick a model in the UI; quit and reopen; confirm the UI shows the saved selection and chat works without 404s.

Closes #242, closes #228.