### PR TITLE
fix(ssh-remote): support dotted YAML paths in SSH config helpers

### DIFF
--- a/src/main/ssh-remote.ts
+++ b/src/main/ssh-remote.ts
@@ -567,6 +567,171 @@ export async function sshSetEnvValue(
   await sshWriteFile(config, envPath, lines.join("\n"));
 }
 
+// ─── Dotted-path YAML helpers (mirror of the local-mode fix) ───────────────
+//
+// The previous implementation used `^\s*<key>:` against the whole remote
+// config.yaml. Two problems, both observed in the wild (#240): dotted-path
+// keys like `model.provider` looked for a literal `model.provider:` line
+// that doesn't exist in real YAML, and flat keys leaked across blocks
+// (the first `default:` at any indent — typically `personalities.default`
+// — would shadow `model.default`). The new helpers walk path segments at
+// strictly-greater indent than each parent and pin single-segment keys
+// to column 0.
+//
+// Duplicates the navigator in config.ts intentionally to keep this PR
+// self-contained and independent. Once both land, a small consolidation
+// PR can lift these into a shared module.
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function stripYamlQuotes(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.length >= 2) {
+    const first = trimmed[0];
+    const last = trimmed[trimmed.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return trimmed.slice(1, -1);
+    }
+  }
+  return trimmed;
+}
+
+interface YamlPathHit {
+  value: string;
+  valueStart: number;
+  valueEnd: number;
+}
+
+interface SegmentMatch {
+  indent: number;
+  rawValue: string;
+  valueStart: number;
+  valueEnd: number;
+  afterLine: number;
+}
+
+function findSegmentInBlock(
+  content: string,
+  startAt: number,
+  parentIndent: number,
+  segment: string,
+): SegmentMatch | null {
+  const escapedSegment = escapeRegex(segment);
+  let directChildIndent: number | null = null;
+  let cursor = startAt;
+
+  while (cursor < content.length) {
+    const lineEnd = content.indexOf("\n", cursor);
+    const lineEndExclusive = lineEnd === -1 ? content.length : lineEnd;
+    const line = content.slice(cursor, lineEndExclusive);
+    const trimmed = line.trim();
+
+    if (trimmed === "" || trimmed.startsWith("#")) {
+      cursor =
+        lineEndExclusive === content.length ? content.length : lineEndExclusive + 1;
+      continue;
+    }
+
+    const indent = line.length - line.trimStart().length;
+    // Block boundary: a non-blank line at or shallower than the parent
+    // closes the parent's block.
+    if (indent <= parentIndent) return null;
+
+    if (directChildIndent === null) directChildIndent = indent;
+
+    if (indent === directChildIndent) {
+      // `[ \t]*` so this also matches top-level keys at column 0 (the
+      // first segment of a dotted path); the `indent === directChild`
+      // gate above already enforces depth.
+      const m = line.match(
+        new RegExp(
+          `^([ \\t]*)(${escapedSegment}):([ \\t]*)([^\\n#]*?)([ \\t]*)(#.*)?$`,
+        ),
+      );
+      if (m) {
+        const indentStr = m[1];
+        const gapBeforeValue = m[3];
+        const rawValue = m[4];
+        const keyEnd = cursor + indentStr.length + segment.length + 1;
+        const valueStart = keyEnd + gapBeforeValue.length;
+        const valueEnd = valueStart + rawValue.length;
+        return {
+          indent: indentStr.length,
+          rawValue,
+          valueStart,
+          valueEnd,
+          afterLine:
+            lineEndExclusive === content.length
+              ? content.length
+              : lineEndExclusive + 1,
+        };
+      }
+    }
+
+    cursor =
+      lineEndExclusive === content.length ? content.length : lineEndExclusive + 1;
+  }
+
+  return null;
+}
+
+/** Exported for unit testing. Walks a dotted YAML path through `content`. */
+export function findYamlPath(content: string, dottedPath: string): YamlPathHit | null {
+  const segments = dottedPath.split(".").filter(Boolean);
+  if (segments.length === 0) return null;
+
+  let cursor = 0;
+  let parentIndent = -1;
+
+  for (let i = 0; i < segments.length; i++) {
+    const isLast = i === segments.length - 1;
+    const found = findSegmentInBlock(content, cursor, parentIndent, segments[i]);
+    if (!found) return null;
+
+    if (isLast) {
+      return {
+        value: stripYamlQuotes(found.rawValue),
+        valueStart: found.valueStart,
+        valueEnd: found.valueEnd,
+      };
+    }
+    cursor = found.afterLine;
+    parentIndent = found.indent;
+  }
+
+  return null;
+}
+
+/** Exported for unit testing. Matches `<key>:` at column 0 only. */
+export function findTopLevelKey(content: string, key: string): YamlPathHit | null {
+  const re = new RegExp(
+    `^(${escapeRegex(key)}):([ \\t]*)([^\\n#]*?)([ \\t]*)(#.*)?$`,
+    "m",
+  );
+  const m = content.match(re);
+  if (!m || m.index === undefined) return null;
+  const gap = m[2];
+  const rawValue = m[3];
+  const lineStart = m.index;
+  const valueStart = lineStart + key.length + 1 + gap.length;
+  const valueEnd = valueStart + rawValue.length;
+  return {
+    value: stripYamlQuotes(rawValue),
+    valueStart,
+    valueEnd,
+  };
+}
+
+function locateInYaml(content: string, key: string): YamlPathHit | null {
+  const segments = key.split(".").filter(Boolean);
+  if (segments.length === 0) return null;
+  return segments.length === 1
+    ? findTopLevelKey(content, segments[0])
+    : findYamlPath(content, key);
+}
+
 export async function sshGetConfigValue(
   config: SshConfig,
   key: string,
@@ -574,9 +739,8 @@ export async function sshGetConfigValue(
 ): Promise<string | null> {
   const content = await sshReadFile(config, remoteConfigPath(profile));
   if (!content) return null;
-  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const match = content.match(new RegExp(`^\\s*${escapedKey}:\\s*["']?([^"'\\n#]+)["']?`, "m"));
-  return match ? match[1].trim() : null;
+  const hit = locateInYaml(content, key);
+  return hit ? hit.value : null;
 }
 
 export async function sshSetConfigValue(
@@ -591,9 +755,24 @@ export async function sshSetConfigValue(
   const configPath = remoteConfigPath(profile);
   const content = await sshReadFile(config, configPath);
   if (!content) return;
-  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const regex = new RegExp(`^(\\s*#?\\s*${escapedKey}:\\s*)["']?[^"'\\n#]*["']?`, "m");
-  const updated = regex.test(content) ? content.replace(regex, `$1"${value}"`) : content;
+
+  const hit = locateInYaml(content, key);
+  let updated: string;
+  if (hit) {
+    updated =
+      content.slice(0, hit.valueStart) +
+      `"${value}"` +
+      content.slice(hit.valueEnd);
+  } else if (!key.includes(".")) {
+    // Flat key missing → append at top level.
+    const sep = content.endsWith("\n") || content === "" ? "" : "\n";
+    updated = `${content}${sep}${key}: "${value}"\n`;
+  } else {
+    // Missing nested path — don't guess where to materialize a parent
+    // block; that risks corrupting the file. Leave the content alone.
+    return;
+  }
+
   await sshWriteFile(config, configPath, updated);
 }
 
@@ -606,10 +785,17 @@ export async function sshGetModelConfig(
   config: SshConfig,
   profile?: string,
 ): Promise<{ provider: string; model: string; baseUrl: string }> {
+  // Use dotted paths so the lookup is scoped to the `model:` block. The
+  // previous flat keys `provider` / `default` / `base_url` would each
+  // match the first occurrence at any indent — typically picking up
+  // `personalities.default` or `auxiliary.vision.provider` and reporting
+  // them as the model fields (#240).
   return {
-    provider: (await sshGetConfigValue(config, "provider", profile)) || "auto",
-    model: (await sshGetConfigValue(config, "default", profile)) || "",
-    baseUrl: (await sshGetConfigValue(config, "base_url", profile)) || "",
+    provider:
+      (await sshGetConfigValue(config, "model.provider", profile)) || "auto",
+    model: (await sshGetConfigValue(config, "model.default", profile)) || "",
+    baseUrl:
+      (await sshGetConfigValue(config, "model.base_url", profile)) || "",
   };
 }
 
@@ -620,9 +806,11 @@ export async function sshSetModelConfig(
   baseUrl: string,
   profile?: string,
 ): Promise<void> {
-  await sshSetConfigValue(config, "provider", provider, profile);
-  await sshSetConfigValue(config, "default", model, profile);
-  await sshSetConfigValue(config, "base_url", baseUrl, profile);
+  await sshSetConfigValue(config, "model.provider", provider, profile);
+  await sshSetConfigValue(config, "model.default", model, profile);
+  if (baseUrl) {
+    await sshSetConfigValue(config, "model.base_url", baseUrl, profile);
+  }
   const configPath = remoteConfigPath(profile);
   const content = await sshReadFile(config, configPath);
   if (!content) return;

--- a/tests/ssh-remote-paths.test.ts
+++ b/tests/ssh-remote-paths.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import { findTopLevelKey, findYamlPath } from "../src/main/ssh-remote";
+
+// Regression tests for #240: SSH-mode model config helpers used a loose
+// `^\s*<key>:` regex against the remote config.yaml, with FLAT keys
+// `provider` / `default` / `base_url`. Result: `personalities.default`'s
+// description text was being reported as the model name in the desktop
+// UI, and toggling the model would overwrite that personality string
+// instead of `model.default`.
+//
+// The fix mirrors the local-mode fix (PR #248 / issue #247) — a dotted-
+// path navigator that walks each segment at strictly-greater indent than
+// its parent, and pins flat (single-segment) keys to column 0 so they
+// can't silently match nested occurrences. These tests exercise the
+// pure helpers; the SSH wrappers are thin glue over them.
+
+describe("findYamlPath — dotted paths against remote-shaped config.yaml", () => {
+  it("resolves model.default against typical hermes config", () => {
+    const content = [
+      "model:",
+      '  default: "nemotron-120b"',
+      '  provider: "nvidia"',
+      '  base_url: "https://example/v1"',
+      "personalities:",
+      "  default: You give clear and accurate responses.",
+      "",
+    ].join("\n");
+
+    expect(findYamlPath(content, "model.default")?.value).toBe("nemotron-120b");
+    expect(findYamlPath(content, "model.provider")?.value).toBe("nvidia");
+    expect(findYamlPath(content, "model.base_url")?.value).toBe(
+      "https://example/v1",
+    );
+  });
+
+  it("does NOT match personalities.default when asked for model.default (#240)", () => {
+    // personalities.default appears BEFORE model.default in document
+    // order — the old flat regex picked that first occurrence.
+    const content = [
+      "personalities:",
+      "  default: You give clear and accurate responses.",
+      "model:",
+      '  default: "nemotron-120b"',
+      "",
+    ].join("\n");
+
+    expect(findYamlPath(content, "model.default")?.value).toBe("nemotron-120b");
+    expect(findYamlPath(content, "personalities.default")?.value).toBe(
+      "You give clear and accurate responses.",
+    );
+  });
+
+  it("returns null when the parent block is missing", () => {
+    const content = ["display:", "  compact: true", ""].join("\n");
+    expect(findYamlPath(content, "model.default")).toBeNull();
+  });
+
+  it("returns null when the leaf key is absent under an existing block", () => {
+    const content = ["model:", '  provider: "openai"', ""].join("\n");
+    expect(findYamlPath(content, "model.default")).toBeNull();
+  });
+
+  it("walks arbitrary nesting depth (e.g. agent.personalities.helpful)", () => {
+    const content = [
+      "agent:",
+      "  max_turns: 60",
+      "  personalities:",
+      "    helpful: 'You are a helpful assistant.'",
+      "    concise: 'Be brief.'",
+      "",
+    ].join("\n");
+
+    expect(findYamlPath(content, "agent.personalities.helpful")?.value).toBe(
+      "You are a helpful assistant.",
+    );
+    expect(findYamlPath(content, "agent.personalities.concise")?.value).toBe(
+      "Be brief.",
+    );
+  });
+
+  it("ignores grandchildren — model.default matches only the direct child", () => {
+    const content = [
+      "model:",
+      '  default: "real-model"',
+      "  fallback:",
+      '    default: "decoy"', // grandchild of model: must NOT match model.default
+      "",
+    ].join("\n");
+
+    expect(findYamlPath(content, "model.default")?.value).toBe("real-model");
+    expect(findYamlPath(content, "model.fallback.default")?.value).toBe(
+      "decoy",
+    );
+  });
+
+  it("doesn't cross block boundaries mid-walk", () => {
+    // service_tier appears as a top-level key AFTER agent — it's not
+    // nested under agent, so agent.service_tier must not satisfy on it.
+    const content = [
+      "agent:",
+      "  max_turns: 60",
+      "service_tier: top-level-orphan",
+      "",
+    ].join("\n");
+
+    expect(findYamlPath(content, "agent.service_tier")).toBeNull();
+  });
+
+  it("handles bare, single-quoted, and double-quoted values", () => {
+    const content = [
+      "model:",
+      "  default: bare-value",
+      "  provider: 'single-quoted'",
+      '  base_url: "double-quoted"',
+      "",
+    ].join("\n");
+
+    expect(findYamlPath(content, "model.default")?.value).toBe("bare-value");
+    expect(findYamlPath(content, "model.provider")?.value).toBe(
+      "single-quoted",
+    );
+    expect(findYamlPath(content, "model.base_url")?.value).toBe(
+      "double-quoted",
+    );
+  });
+
+  it("returns offsets pointing at the raw value substring (used by writers)", () => {
+    const content = ["model:", '  default: "nemotron"', ""].join("\n");
+    const hit = findYamlPath(content, "model.default");
+    expect(hit).not.toBeNull();
+    if (!hit) return;
+    expect(content.slice(hit.valueStart, hit.valueEnd)).toBe('"nemotron"');
+  });
+});
+
+describe("findTopLevelKey — flat keys pinned to column 0", () => {
+  it("matches a true top-level key", () => {
+    const content = [
+      "timezone: 'America/New_York'",
+      "model:",
+      "  default: gpt-5",
+      "",
+    ].join("\n");
+
+    expect(findTopLevelKey(content, "timezone")?.value).toBe(
+      "America/New_York",
+    );
+  });
+
+  it("does NOT match an indented occurrence", () => {
+    // Old behavior would have happily matched the indented `default:` line.
+    const content = ["model:", "  default: gpt-5", ""].join("\n");
+
+    expect(findTopLevelKey(content, "default")).toBeNull();
+  });
+
+  it("returns null when the key is absent at column 0", () => {
+    const content = [
+      "agent:",
+      "  service_tier: fast",
+      "telegram:",
+      "  service_tier: 'oops'",
+      "",
+    ].join("\n");
+
+    expect(findTopLevelKey(content, "service_tier")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

Reported in #240: a user connected the desktop to a remote hermes (Docker on Ubuntu) over SSH and observed that the model they had configured remotely didn't appear in the desktop UI, and selecting a new model in the app didn't persist.

Root cause is the SSH-mode mirror of the same regex-over-YAML bug as #242 / #247:

`sshGetConfigValue` ([src/main/ssh-remote.ts:570](https://github.com/fathah/hermes-desktop/blob/main/src/main/ssh-remote.ts#L570)) ran `^\s*<key>:` against the whole remote config.yaml. `sshGetModelConfig` ([line 605](https://github.com/fathah/hermes-desktop/blob/main/src/main/ssh-remote.ts#L605)) called it with flat keys `provider`, `default`, `base_url`. Three concrete failure modes followed:

1. **Model field reads return the wrong value.** The regex matches the *first* `default:` at any indent — typically `personalities.default`'s prompt-text description, not `model.default`. The desktop shows a personality string (or "auto") where the model name belongs.
2. **Model field writes corrupt the wrong key.** `sshSetModelConfig` calls `sshSetConfigValue(config, "default", model)`, which rewrites the same first match. Selecting a new model replaces the personality description with the model name string and leaves `model.default` untouched — explaining "doesn't seem to change or Save".
3. **Renderer dotted-path callers silently no-op in SSH mode.** Paths like `agent.service_tier` or `memory.provider` (the Fast Mode toggle, Memory provider, etc.) look for a flat line spelled exactly `agent.service_tier:` which doesn't exist in real YAML. Same issue as #247 but on the SSH side.

The pre-existing `sshGetConfigValue(config, "memory.provider", profile)` caller at [ssh-remote.ts:1093](https://github.com/fathah/hermes-desktop/blob/main/src/main/ssh-remote.ts#L1093) was already trying to use a dotted path — and quietly failing.

## Fix

Mirror the local-mode fix from PR #248 inside ssh-remote.ts:

- Add a small dotted-path navigator (`findYamlPath`, `findTopLevelKey`) that walks each segment at strictly-greater indent than its parent, and pins flat (single-segment) keys to column 0 so they can't silently match a nested occurrence. Pure-string, no I/O — directly testable.
- `sshGetConfigValue` / `sshSetConfigValue` route through it.
- `sshGetModelConfig` / `sshSetModelConfig` now pass **dotted** keys: `model.provider`, `model.default`, `model.base_url`. Scoping reads and writes to the right block fixes both #240 symptoms.

The navigator duplicates the one introduced in PR #248 (local mode). Kept intentionally inline here so this PR doesn't depend on #248 merging first; once both land, a small follow-up can lift them into a shared module.

## Tests

`tests/ssh-remote-paths.test.ts` — 12 cases against the exported pure helpers:

- ✅ `model.default` / `model.provider` / `model.base_url` against typical hermes config — direct #240 fix
- ✅ `personalities.default` declared *before* `model.default` in document order — order independence
- ✅ Missing parent block, missing leaf, mid-walk block boundary
- ✅ Arbitrary nesting depth (`agent.personalities.helpful`)
- ✅ Grandchildren ignored (`model.fallback.default` doesn't satisfy `model.default`)
- ✅ Bare, single-quoted, and double-quoted values
- ✅ `findTopLevelKey` pins flat keys to column 0

The SSH wrappers themselves stay thin glue over `sshReadFile` / `sshWriteFile` and the pure helpers — same testing approach as the existing `tests/ssh-remote.test.ts` (which mocks no SSH).

## Test plan

- [x] `npm run typecheck` (node + web) passes.
- [x] `npm test` — 23 files / **329 tests** pass (317 original + 12 new).
- [ ] Manual against a real SSH-connected hermes: confirm the configured model is reflected in the desktop's model field, and that selecting a new model in the app updates `model.default` on the remote (without overwriting `personalities.default`).

## Related

- #242 — same shape of bug, local-mode `getModelConfig` / `setModelConfig`. Fixed in #246.
- #247 — same shape, local-mode `getConfig` / `setConfig`. Fixed in #248.
- This PR is the SSH-mode equivalent.

Closes #240.