### PR TITLE
fix(installer): recognize all known providers in install-gate .env check

### DIFF
--- a/src/main/installer.ts
+++ b/src/main/installer.ts
@@ -151,6 +151,107 @@ export function hasHermesAuthCredential(provider: string): boolean {
   }
 }
 
+// Canonical env-var name per known model provider. Keys here are values
+// the user might see in `model.provider` in config.yaml; values are the
+// env vars the gateway expects to read from .env. Names that don't
+// appear here either don't need a key (local providers, nous) or have
+// OAuth-style credentials (covered separately via hasHermesAuthCredential).
+//
+// Used by the install-gate check below. Previously that check
+// hard-coded only OPENROUTER_API_KEY / ANTHROPIC_API_KEY / OPENAI_API_KEY,
+// so any user configured for DeepSeek, Groq, Mistral, etc. saw the
+// "set AI provider" first-run screen even with a valid key in .env.
+// See issue #236.
+const PROVIDER_ENV_KEYS: Record<string, string> = {
+  openrouter: "OPENROUTER_API_KEY",
+  anthropic: "ANTHROPIC_API_KEY",
+  openai: "OPENAI_API_KEY",
+  google: "GOOGLE_API_KEY",
+  xai: "XAI_API_KEY",
+  groq: "GROQ_API_KEY",
+  deepseek: "DEEPSEEK_API_KEY",
+  together: "TOGETHER_API_KEY",
+  fireworks: "FIREWORKS_API_KEY",
+  cerebras: "CEREBRAS_API_KEY",
+  mistral: "MISTRAL_API_KEY",
+  perplexity: "PERPLEXITY_API_KEY",
+  huggingface: "HF_TOKEN",
+  hf: "HF_TOKEN",
+  qwen: "QWEN_API_KEY",
+  minimax: "MINIMAX_API_KEY",
+  glm: "GLM_API_KEY",
+  kimi: "KIMI_API_KEY",
+};
+
+// When provider is "custom" or "auto", the desktop's setup flow falls
+// back to recognizing the endpoint by base URL. Same patterns hermes.ts
+// uses for runtime header injection.
+const URL_TO_ENV_KEY: Array<[RegExp, string]> = [
+  [/openrouter\.ai/i, "OPENROUTER_API_KEY"],
+  [/anthropic\.com/i, "ANTHROPIC_API_KEY"],
+  [/openai\.com/i, "OPENAI_API_KEY"],
+  [/huggingface\.co/i, "HF_TOKEN"],
+  [/api\.groq\.com/i, "GROQ_API_KEY"],
+  [/api\.deepseek\.com/i, "DEEPSEEK_API_KEY"],
+  [/api\.together\.xyz/i, "TOGETHER_API_KEY"],
+  [/api\.fireworks\.ai/i, "FIREWORKS_API_KEY"],
+  [/api\.cerebras\.ai/i, "CEREBRAS_API_KEY"],
+  [/api\.mistral\.ai/i, "MISTRAL_API_KEY"],
+  [/api\.perplexity\.ai/i, "PERPLEXITY_API_KEY"],
+];
+
+/**
+ * Resolve the env var name the gateway expects for a given model config.
+ * Returns null when the provider/URL combination has no known canonical
+ * env var (the caller falls back to a permissive `*_API_KEY|*_TOKEN`
+ * scan, matching the spirit of the prior hard-coded check).
+ *
+ * Exported for unit testing.
+ */
+export function expectedEnvKeyForModel(
+  provider: string,
+  baseUrl: string,
+): string | null {
+  const direct = PROVIDER_ENV_KEYS[provider.trim().toLowerCase()];
+  if (direct) return direct;
+  for (const [pattern, envKey] of URL_TO_ENV_KEY) {
+    if (pattern.test(baseUrl)) return envKey;
+  }
+  return null;
+}
+
+function envHasUsableValue(content: string, expectedKey: string | null): boolean {
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const m = trimmed.match(/^([A-Z][A-Z0-9_]*)=(.*)$/);
+    if (!m) continue;
+    const key = m[1];
+    let value = m[2].trim();
+    // Strip surrounding quotes so `KEY=""` or `KEY="abc"` parse the
+    // same way as `KEY=abc`.
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (!value) continue;
+
+    if (expectedKey) {
+      if (key === expectedKey) return true;
+    } else {
+      // No known mapping for this provider/URL — accept any value that
+      // looks like a credential. Avoids regressing users on providers
+      // we haven't catalogued explicitly, while still rejecting
+      // unrelated env vars (TELEGRAM_BOT_TOKEN etc. shouldn't satisfy
+      // the model install gate, but a custom `*_API_KEY` should).
+      if (/_API_KEY$/.test(key)) return true;
+    }
+  }
+  return false;
+}
+
 export function checkInstallStatus(): InstallStatus {
   // Remote mode: skip local checks entirely
   const conn = getConnectionConfig();
@@ -174,8 +275,9 @@ export function checkInstallStatus(): InstallStatus {
 
   // Local/custom providers don't need an API key. OAuth-backed providers
   // can be configured through Hermes auth.json instead of .env.
+  let mc: { provider: string; model: string; baseUrl: string } | null = null;
   try {
-    const mc = getModelConfig();
+    mc = getModelConfig();
     const localProviders = ["custom", "lmstudio", "ollama", "vllm", "llamacpp"];
     if (
       localProviders.includes(mc.provider) ||
@@ -190,21 +292,10 @@ export function checkInstallStatus(): InstallStatus {
   if (!hasApiKey && configured) {
     try {
       const content = readFileSync(HERMES_ENV_FILE, "utf-8");
-      for (const line of content.split("\n")) {
-        const trimmed = line.trim();
-        if (trimmed.startsWith("#")) continue;
-        const match = trimmed.match(
-          /^(OPENROUTER_API_KEY|ANTHROPIC_API_KEY|OPENAI_API_KEY)=(.+)$/,
-        );
-        if (
-          match &&
-          match[2].trim() &&
-          !['""', "''", ""].includes(match[2].trim())
-        ) {
-          hasApiKey = true;
-          break;
-        }
-      }
+      const expectedKey = mc
+        ? expectedEnvKeyForModel(mc.provider, mc.baseUrl)
+        : null;
+      hasApiKey = envHasUsableValue(content, expectedKey);
     } catch {
       /* ignore read errors */
     }

--- a/tests/install-gate-providers.test.ts
+++ b/tests/install-gate-providers.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { expectedEnvKeyForModel } from "../src/main/installer";
+
+// Regression tests for #236: the install gate's .env check hard-coded
+// only OPENROUTER_API_KEY / ANTHROPIC_API_KEY / OPENAI_API_KEY, so users
+// configured for DeepSeek, Groq, Mistral, etc. saw the "set AI provider"
+// first-run screen every restart, even with a valid key in .env.
+//
+// The new `expectedEnvKeyForModel(provider, baseUrl)` returns the
+// canonical env var name the gateway expects per provider, falling back
+// to URL-pattern matching for `custom` / `auto` providers pointed at a
+// known endpoint, then to null for unrecognized configurations (where
+// the caller does a permissive `*_API_KEY` scan).
+
+describe("expectedEnvKeyForModel — provider-name lookup", () => {
+  it.each([
+    ["openrouter", "OPENROUTER_API_KEY"],
+    ["anthropic", "ANTHROPIC_API_KEY"],
+    ["openai", "OPENAI_API_KEY"],
+    ["google", "GOOGLE_API_KEY"],
+    ["xai", "XAI_API_KEY"],
+    ["deepseek", "DEEPSEEK_API_KEY"], // the specific provider from issue #236
+    ["groq", "GROQ_API_KEY"],
+    ["mistral", "MISTRAL_API_KEY"],
+    ["together", "TOGETHER_API_KEY"],
+    ["fireworks", "FIREWORKS_API_KEY"],
+    ["cerebras", "CEREBRAS_API_KEY"],
+    ["perplexity", "PERPLEXITY_API_KEY"],
+    ["huggingface", "HF_TOKEN"], // exception to the *_API_KEY convention
+    ["qwen", "QWEN_API_KEY"],
+    ["minimax", "MINIMAX_API_KEY"],
+    ["glm", "GLM_API_KEY"],
+    ["kimi", "KIMI_API_KEY"],
+  ])("maps provider %s → %s", (provider, expected) => {
+    expect(expectedEnvKeyForModel(provider, "")).toBe(expected);
+  });
+
+  it("is case-insensitive on the provider name", () => {
+    expect(expectedEnvKeyForModel("DeepSeek", "")).toBe("DEEPSEEK_API_KEY");
+    expect(expectedEnvKeyForModel("ANTHROPIC", "")).toBe("ANTHROPIC_API_KEY");
+  });
+
+  it("trims surrounding whitespace from the provider name", () => {
+    expect(expectedEnvKeyForModel("  groq  ", "")).toBe("GROQ_API_KEY");
+  });
+});
+
+describe("expectedEnvKeyForModel — URL fallback for custom/auto providers", () => {
+  it("recognizes a known endpoint when provider is 'custom'", () => {
+    expect(
+      expectedEnvKeyForModel("custom", "https://api.deepseek.com/v1"),
+    ).toBe("DEEPSEEK_API_KEY");
+    expect(
+      expectedEnvKeyForModel("custom", "https://api.groq.com/openai/v1"),
+    ).toBe("GROQ_API_KEY");
+    expect(
+      expectedEnvKeyForModel("custom", "https://openrouter.ai/api/v1"),
+    ).toBe("OPENROUTER_API_KEY");
+  });
+
+  it("recognizes a known endpoint when provider is 'auto'", () => {
+    expect(
+      expectedEnvKeyForModel("auto", "https://api.mistral.ai/v1"),
+    ).toBe("MISTRAL_API_KEY");
+  });
+
+  it("returns null for unknown provider with unknown URL", () => {
+    expect(
+      expectedEnvKeyForModel("custom", "http://localhost:1234/v1"),
+    ).toBeNull();
+    expect(expectedEnvKeyForModel("custom", "")).toBeNull();
+    expect(expectedEnvKeyForModel("", "")).toBeNull();
+  });
+
+  it("provider-name match wins over URL fallback when both are present", () => {
+    // If somehow provider is "anthropic" but baseUrl points at deepseek
+    // (configuration error), trust the provider name — the gateway
+    // dispatches by provider, not URL.
+    expect(
+      expectedEnvKeyForModel("anthropic", "https://api.deepseek.com/v1"),
+    ).toBe("ANTHROPIC_API_KEY");
+  });
+});
+
+// The actual install-gate behavior is exercised end-to-end by importing
+// the module under a per-test HERMES_HOME — same pattern as the other
+// installer tests. Skipped here because the existing tests already cover
+// the file-existence half; the gap was provider awareness, which the
+// pure-function tests above pin down.


### PR DESCRIPTION
## Problem

Reported in #236 (macOS, confirmed on Windows): a user manually sets `DEEPSEEK_API_KEY=<key>` in `.env` after configuring a DeepSeek model, restarts the desktop, and gets bounced back to the *Set AI Provider* first-run screen — even though their key is right there in the file.

Root cause is the install-gate check at [installer.ts:196-198](https://github.com/fathah/hermes-desktop/blob/main/src/main/installer.ts#L196):

```ts
const match = trimmed.match(
  /^(OPENROUTER_API_KEY|ANTHROPIC_API_KEY|OPENAI_API_KEY)=(.+)$/,
);
```

Three providers, hardcoded. Every other provider the desktop supports (DeepSeek, Groq, Mistral, Together, Fireworks, Cerebras, xAI, Google, Hugging Face, Perplexity, Qwen, MiniMax, GLM, Kimi) silently fails this check. The desktop concludes the user has no key configured, and replays the setup flow on every launch.

## Fix

Replace the hardcoded regex with `expectedEnvKeyForModel(provider, baseUrl)` — a provider→env-key table plus a base-URL fallback for `"custom"` / `"auto"` providers pointed at a known endpoint. The install gate now:

1. Resolves the canonical env var the gateway expects for the currently configured model:
   - `deepseek` → `DEEPSEEK_API_KEY`
   - `mistral` → `MISTRAL_API_KEY`
   - `custom` + `api.deepseek.com` → `DEEPSEEK_API_KEY`
   - `huggingface` → `HF_TOKEN` (one of the few that doesn't follow `<NAME>_API_KEY`)
2. Checks for that specific key in `.env`, ignoring quoted-empty and commented values.
3. Falls back to a permissive `*_API_KEY` scan when the provider / URL combination isn't catalogued, so user-added providers that follow the naming convention work too without a code change.

The mapping is also re-usable: I considered extending it via the renderer's `PROVIDERS.setup` / `LOCAL_PRESETS`, but keeping it in main-process code avoids a new cross-process dependency. A small consolidation later could share these tables.

## Behavior change worth flagging

The previous check accepted *any* of the three hardcoded keys as evidence of "configured", regardless of which provider was currently selected. So a user with `OPENROUTER_API_KEY` set but `model.provider = "deepseek"` would have been reported as configured, then failed at chat time with "Invalid api key" (no DeepSeek key for the gateway to send).

The new check is **strict per-provider**: it looks for the env key matching the *current* model's provider. If you've switched to DeepSeek without setting `DEEPSEEK_API_KEY`, the gate now correctly surfaces that during launch instead of at chat time. Should improve onboarding error visibility, but reviewers should know to expect it.

## Tests

`tests/install-gate-providers.test.ts` — 23 cases against the exported pure helper:

- ✅ Direct provider lookup for all 17 catalogued providers (covers the specific one in #236 — DeepSeek — plus Anthropic/OpenAI/OpenRouter for regression).
- ✅ Case-insensitive provider matching, whitespace tolerance.
- ✅ URL fallback for `"custom"` / `"auto"` + known endpoint.
- ✅ Unknown provider + unknown URL returns `null` (caller falls back to permissive `*_API_KEY` scan).
- ✅ Provider-name match precedence over URL fallback when both are present.

## Test plan

- [x] `npm run typecheck` (node + web) passes.
- [x] `npm test` — 23 files / **340 tests** pass (317 original + 23 new).
- [ ] Manual: configure a DeepSeek model + set `DEEPSEEK_API_KEY` in `.env`; restart the app; confirm the chat screen loads instead of the setup flow.

## Scope

This PR closes **one half** of #236 — the "manually-edited `.env` doesn't help" half. The other half is the renderer's *Save Model Settings* flow not flushing typed API keys to `.env` (`Providers.tsx` auto-saves model config on every keystroke but env writes only fire on input blur). I have a small PR for that ready as a follow-up; keeping them separate per CONTRIBUTING.md's "one logical change per PR".

References: #236.