### PR TITLE
fix(providers): persist typed API keys on change, not just on blur

### DIFF
--- a/src/renderer/src/screens/Providers/Providers.tsx
+++ b/src/renderer/src/screens/Providers/Providers.tsx
@@ -33,6 +33,21 @@ function Providers({
   const [poolNewKey, setPoolNewKey] = useState("");
   const [poolNewLabel, setPoolNewLabel] = useState("");
 
+  // Per-key debounce timers for env auto-save on change. Previously env
+  // values were persisted only on input blur, so users who clicked the
+  // model dropdown (triggering the model-config auto-save) without first
+  // blurring the API key input lost their typed key — config.yaml
+  // updated but .env didn't. Issue #236. The on-blur handler stays as a
+  // "flush immediately" fast path; the debounce here catches the
+  // change-but-no-blur case.
+  const envSaveTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+    new Map(),
+  );
+  // Mirror of `env` state, kept in a ref so the unmount cleanup can read
+  // the latest value when flushing pending debounces (a closure over
+  // `env` directly would capture a stale snapshot).
+  const envRef = useRef<Record<string, string>>({});
+
   const loadConfig = useCallback(async (): Promise<void> => {
     const [envData, mc, pool] = await Promise.all([
       window.hermesAPI.getEnv(profile),
@@ -104,6 +119,13 @@ function Providers({
   }, [modelProvider, modelName, modelBaseUrl, saveModelConfig]);
 
   async function handleBlur(key: string): Promise<void> {
+    // Cancel any pending debounced save for this key — the blur handler
+    // is a faster flush path with the "Saved" indicator.
+    const pending = envSaveTimers.current.get(key);
+    if (pending) {
+      clearTimeout(pending);
+      envSaveTimers.current.delete(key);
+    }
     const value = env[key] || "";
     await window.hermesAPI.setEnv(key, value, profile);
     setSavedKey(key);
@@ -112,7 +134,46 @@ function Providers({
 
   function handleChange(key: string, value: string): void {
     setEnv((prev) => ({ ...prev, [key]: value }));
+
+    // Persist the typed value on change (debounced 400ms) so users who
+    // navigate away — or trigger the model-config auto-save by changing
+    // the provider dropdown — don't lose what they typed if they never
+    // explicitly blurred the input. Matches the model config's
+    // auto-save behavior; resolves the asymmetry behind issue #236.
+    const pending = envSaveTimers.current.get(key);
+    if (pending) clearTimeout(pending);
+    const timer = setTimeout(() => {
+      envSaveTimers.current.delete(key);
+      void window.hermesAPI.setEnv(key, value, profile);
+    }, 400);
+    envSaveTimers.current.set(key, timer);
   }
+
+  // Keep envRef in sync with the latest env state so the unmount
+  // cleanup below can read it without stale-closure issues.
+  useEffect(() => {
+    envRef.current = env;
+  }, [env]);
+
+  useEffect(() => {
+    // On unmount, flush any pending debounced env writes synchronously
+    // (fire-and-forget — the IPC handler in the main process completes
+    // regardless of React lifecycle). Without this, typing an API key
+    // and immediately navigating away within the debounce window would
+    // lose the typed value, exactly the original bug.
+    const timers = envSaveTimers.current;
+    return () => {
+      for (const [key, timer] of timers) {
+        clearTimeout(timer);
+        void window.hermesAPI.setEnv(
+          key,
+          envRef.current[key] || "",
+          profile,
+        );
+      }
+      timers.clear();
+    };
+  }, [profile]);
 
   async function handleAddPoolKey(): Promise<void> {
     if (!poolProvider || !poolNewKey.trim()) return;


### PR DESCRIPTION
## Problem

Reported in #236 (macOS, confirmed on Windows): user types an API key in the Providers screen, but the key never reaches `.env`. Chat then fails with *Invalid api key*. Translation of the report:

> 保存模型设置时只更新了 config.yaml 的 provider、default（模型名）、base_url，没有把 API key 写入 .env 文件
> *"Saving model settings only updates `provider`, `default` (model name), and `base_url` in `config.yaml` — the API key isn't written to `.env`."*

Root cause is an asymmetry between two save paths in [Providers.tsx](https://github.com/fathah/hermes-desktop/blob/main/src/renderer/src/screens/Providers/Providers.tsx):

| State | Save trigger |
|---|---|
| Model config (provider / model / baseUrl) | **Auto-save** on change, debounced 500ms |
| Env values (API keys) | **On-blur only** |

If the user types an API key and then clicks the provider dropdown (or navigates away) without first explicitly blurring the input, the model-config auto-save fires but the env write never does. The state in React stays correct; the disk doesn't.

## Fix

Mirror the model-config auto-save for env values, with `onBlur` kept as a "flush immediately + show *Saved* indicator" fast path on top:

- `handleChange` (called on every keystroke) now schedules a 400ms debounced `setEnv` for that key, in addition to updating React state. The debounce coalesces rapid typing into one write per pause.
- `handleBlur` cancels any in-flight debounce for the key it's flushing — keeping the existing "Saved ✓" UX on tab-out.
- On unmount, pending debounced writes are flushed synchronously (fire-and-forget; the main-process IPC handler completes independently of React lifecycle). Without the flush, typing-then-immediately-navigating within the 400ms window would still drop the value.
- An `envRef` shadows the `env` state so the unmount cleanup reads the latest value instead of a stale closure.

400ms chosen to be tight enough to feel near-immediate while still coalescing typing bursts. Sits below the model-config's 500ms debounce so when the user changes the provider dropdown and types a key in parallel, env flushes first and the model save lands shortly after — matching what the user probably expects ("save my key with the new provider").

## Tests

- [x] `npm run typecheck` (node + web) passes.
- [x] `npm test` — 22 files / **317 tests** pass (no regression; matches origin/main baseline).
- [ ] Manual on Windows (issue reporter is on macOS):
  - Open Providers, type a DeepSeek API key, then click the model dropdown to change providers without blurring the input.
  - `.env` should contain `DEEPSEEK_API_KEY=<typed value>` afterward.
  - Same with: type a key, then immediately navigate to Chat → key should be written.

No new test file is added — the change is a contained ~15-line additive tweak to two existing handlers + one unmount cleanup effect. A renderer test exercising the debounce would be mostly React state machinery; the substantive logic (debounce coalescing, flush-on-unmount, blur cancels debounce) is more usefully verified by the manual checks above. Open to adding RTL coverage if reviewers prefer.

## Scope

This is the **renderer half** of #236. The other half — the install gate in `installer.ts` recognizing only `OPENROUTER_API_KEY` / `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` and ignoring DeepSeek/Groq/Mistral/etc., so even a manually-set `.env` reverts the user to the setup screen — is in a separate PR (#250). Both together resolve #236.

References: #236, #250.