### PR TITLE
fix(session-cache): refresh messageCount for old sessions on every sync

### DIFF
--- a/src/main/session-cache.ts
+++ b/src/main/session-cache.ts
@@ -109,7 +109,9 @@ export function syncSessionCache(): CachedSession[] {
     for (const s of cache.sessions) existingById.set(s.id, s);
     const newSessions: CachedSession[] = [];
 
+    const refreshedIds = new Set<string>();
     for (const row of rows) {
+      refreshedIds.add(row.id);
       const existing = existingById.get(row.id);
       if (existing) {
         // Update existing entry (message count may have changed)
@@ -144,6 +146,41 @@ export function syncSessionCache(): CachedSession[] {
         messageCount: row.message_count,
         model: row.model || "",
       });
+    }
+
+    // Phase 2: refresh message_count for cached sessions that weren't
+    // returned by the lastSync-windowed query above. Without this, an
+    // old session that's still accumulating messages keeps the stale
+    // count it had at first sync — the renderer reads from the cache,
+    // so the UI reports e.g. 15 messages when the conversation actually
+    // has 200+. Issue #226. Cheap (single column, no joins, batched IN
+    // clause), and skipped entirely on a first sync since cache.sessions
+    // is empty.
+    const staleIds = cache.sessions
+      .map((s) => s.id)
+      .filter((id) => !refreshedIds.has(id));
+    if (staleIds.length > 0) {
+      // SQLite caps prepared-statement parameters; chunk well under
+      // SQLITE_MAX_VARIABLE_NUMBER (default 999 on older builds) for
+      // portability across the better-sqlite3 versions hermes ships.
+      const CHUNK = 500;
+      const countsById = new Map<string, number>();
+      for (let i = 0; i < staleIds.length; i += CHUNK) {
+        const chunk = staleIds.slice(i, i + CHUNK);
+        const placeholders = chunk.map(() => "?").join(", ");
+        const refreshed = db
+          .prepare(
+            `SELECT id, message_count FROM sessions WHERE id IN (${placeholders})`,
+          )
+          .all(...chunk) as Array<{ id: string; message_count: number }>;
+        for (const r of refreshed) countsById.set(r.id, r.message_count);
+      }
+      for (const s of cache.sessions) {
+        const fresh = countsById.get(s.id);
+        if (fresh !== undefined && fresh !== s.messageCount) {
+          s.messageCount = fresh;
+        }
+      }
     }
 
     // Merge: new sessions first (most recent), then existing

--- a/tests/session-cache-sync.test.ts
+++ b/tests/session-cache-sync.test.ts
@@ -128,12 +128,25 @@ vi.mock("better-sqlite3", () => {
       throw new Error(`Unhandled fake run SQL: ${this.sql}`);
     }
 
-    all(...args: unknown[]): SessionRow[] {
+    all(...args: unknown[]): SessionRow[] | Array<{ id: string; message_count: number }> {
       if (this.sql.includes("FROM sessions s")) {
         const threshold = Number(args[0] ?? 0);
         return Array.from(this.store.sessions.values())
           .filter((session) => session.started_at > threshold)
           .sort((a, b) => b.started_at - a.started_at);
+      }
+
+      // Phase-2 refresh query introduced for issue #226:
+      //   SELECT id, message_count FROM sessions WHERE id IN (?, ?, …)
+      if (
+        this.sql.includes("SELECT id, message_count FROM sessions") &&
+        this.sql.includes("WHERE id IN")
+      ) {
+        const ids = args.map(String);
+        return ids
+          .map((id) => this.store.sessions.get(id))
+          .filter((s): s is SessionRow => !!s)
+          .map((s) => ({ id: s.id, message_count: s.message_count }));
       }
 
       throw new Error(`Unhandled fake all SQL: ${this.sql}`);
@@ -340,6 +353,76 @@ describe("syncSessionCache", () => {
     const result = syncSessionCache();
 
     expect(result.map((r) => r.id)).toEqual(["s2", "s1"]);
+  });
+
+  it("refreshes messageCount for old sessions outside the lastSync window (issue #226)", () => {
+    // Session started well before the 5-minute incremental sync window
+    // looks (lastSync - 300). Without the Phase 2 refresh, the cache
+    // pegs messageCount at whatever was first observed — the user
+    // reports the symptom as "messageCount records only 15 messages
+    // when there are actually 200+".
+    const oldStart = Math.floor(Date.now() / 1000) - 86400 * 30; // 30 days ago
+    seedDb([
+      {
+        id: "old-session",
+        started_at: oldStart,
+        message_count: 1,
+        firstUserMessage: "first",
+      },
+    ]);
+    // First sync acquires the session at messageCount: 1.
+    const first = syncSessionCache();
+    expect(first).toHaveLength(1);
+    expect(first[0].messageCount).toBe(1);
+
+    // Simulate the user accumulating many messages over time — the
+    // session's started_at stays put (well in the past) but its
+    // message_count grows.
+    seedDb([
+      {
+        id: "old-session",
+        started_at: oldStart,
+        message_count: 200,
+        firstUserMessage: "first",
+      },
+    ]);
+    const second = syncSessionCache();
+
+    expect(second).toHaveLength(1);
+    expect(second[0].id).toBe("old-session");
+    expect(second[0].messageCount).toBe(200);
+    // Title and other metadata are preserved (Phase 2 only touches the
+    // count field — no re-running of title generation).
+    expect(second[0].title).toContain("first");
+  });
+
+  it("refreshes some old, leaves others untouched, all in one sync", () => {
+    // Mix: one session inside the lastSync window (handled by Phase 1)
+    // and two outside it (handled by Phase 2). All three counts grow
+    // between syncs; both phases should keep the cache accurate.
+    const now = Math.floor(Date.now() / 1000);
+    const oldA = now - 86400 * 7;
+    const oldB = now - 86400 * 3;
+    const future = now + 600;
+
+    seedDb([
+      { id: "old-a", started_at: oldA, message_count: 5, firstUserMessage: "a" },
+      { id: "old-b", started_at: oldB, message_count: 10, firstUserMessage: "b" },
+      { id: "new-c", started_at: future, message_count: 1, firstUserMessage: "c" },
+    ]);
+    syncSessionCache();
+
+    seedDb([
+      { id: "old-a", started_at: oldA, message_count: 50, firstUserMessage: "a" },
+      { id: "old-b", started_at: oldB, message_count: 25, firstUserMessage: "b" },
+      { id: "new-c", started_at: future, message_count: 7, firstUserMessage: "c" },
+    ]);
+    const result = syncSessionCache();
+
+    const byId = new Map(result.map((r) => [r.id, r] as const));
+    expect(byId.get("old-a")?.messageCount).toBe(50);
+    expect(byId.get("old-b")?.messageCount).toBe(25);
+    expect(byId.get("new-c")?.messageCount).toBe(7);
   });
 
   it("handles a large existing cache without quadratic blowup (issue #16)", () => {


### PR DESCRIPTION
## Problem

Reported in #226: `messageCount` in `~/.hermes/desktop/sessions.json` lags behind the real value. The reporter's example was *"records only 15 messages when there are actually 200+"*.

Root cause is the windowed query in [`syncSessionCache`](https://github.com/fathah/hermes-desktop/blob/main/src/main/session-cache.ts#L88-L95):

```ts
const rows = db
  .prepare(
    `SELECT s.id, s.started_at, s.source, s.message_count, s.model, s.title
     FROM sessions s
     WHERE s.started_at > ?
     ORDER BY s.started_at DESC`,
  )
  .all(cache.lastSync > 0 ? cache.lastSync - 300 : 0);
```

The filter is on `started_at`. That's correct for *finding newly-created sessions*, but it misses any session whose `started_at` predates `lastSync - 300` regardless of whether messages have been added since. So a chat the user keeps talking to over weeks gets its `messageCount` pinned at whatever was observed on first sync. The renderer reads from the cached value, so the Sessions list shows the stale number.

## Fix

Add a **Phase 2 refresh** that updates `message_count` for every cached session not already covered by the Phase 1 windowed query:

```ts
const staleIds = cache.sessions.map(s => s.id).filter(id => !refreshedIds.has(id));
if (staleIds.length > 0) {
  // chunked WHERE id IN (?, ?, …) — single column, no joins
  for (const chunk of chunkOf(staleIds, 500)) {
    const refreshed = db.prepare(
      `SELECT id, message_count FROM sessions WHERE id IN (${placeholders})`,
    ).all(...chunk);
    for (const r of refreshed) countsById.set(r.id, r.message_count);
  }
  for (const s of cache.sessions) {
    const fresh = countsById.get(s.id);
    if (fresh !== undefined && fresh !== s.messageCount) s.messageCount = fresh;
  }
}
```

- Cheap: single column, no joins, batched `IN (…)` chunked at 500 to stay under SQLite's 999-parameter cap on older builds.
- Skipped entirely on a first sync (`cache.sessions` is empty).
- Skipped on subsequent syncs where every cached session is already in the Phase 1 result set (the `started_at`-windowed query catches them).
- Title generation is *not* re-run for old sessions — Phase 2 only touches the count field.
- Mutations are in-place against `cache.sessions`, so the existing merge-and-sort logic picks them up unchanged.

## Tests

`tests/session-cache-sync.test.ts` — 2 new cases (5 → 7 in this file, full suite 317 → **319 passing**):

- ✅ **Direct repro**: session started 30 days ago, `message_count` grows from 1 to 200 between syncs, cache reflects 200 after the fix.
- ✅ **Mixed scenario**: one fresh session inside the `lastSync` window + two old sessions outside it all grow at once; Phase 1 handles the fresh one, Phase 2 handles the olds; all three counts correct in a single sync.

The existing mock `all()` method is extended to handle the new Phase 2 query shape (`SELECT id, message_count FROM sessions WHERE id IN (…)`) — small symmetric change to the test infrastructure.

Performance regression test from #16 (1500 sessions, all in Phase 1's window, second sync stays under 500ms) still passes — the new code path is a no-op when Phase 1 already covers every cached ID.

## Test plan

- [x] `npm run typecheck` (node + web) passes.
- [x] `npm test` — 22 files / **319 tests** pass (317 origin/main + 2 new).
- [ ] Manual: keep an existing conversation open for >5 minutes, send a new message, navigate to Sessions, confirm the count increments to the right value (was: stayed at whatever was observed on first sync).

## Scope: only one of the three symptoms in #226

The issue lists three symptoms; this PR closes the first. The other two are not desktop bugs as far as I can tell:

| Symptom | Diagnosis |
|---|---|
| **#1 `messageCount` mismatch** | ✅ Fixed here. |
| **#2 "Some session files `(sessions/*.json)` are mysteriously missing"** | `~/.hermes/desktop/sessions/` doesn't exist — the desktop never writes individual session files, only the `sessions.json` index (`src/main/session-cache.ts:69`). `grep -rn "unlinkSync\|fs.unlink\|sessions/"` in `src/main` returns no matches. Either upstream `hermes-agent` file layout, or pathing confusion on the reporter's end. |
| **#3 Incomplete content after close/reopen** | `getSessionMessages` reads directly from `state.db.messages` with no cache and no limit. If messages are missing from the UI, they were never persisted — upstream concern. |

The reporter's symptom 1 is the concrete, reproducible, desktop-side bug; symptoms 2/3 would benefit from more diagnostic info from them (paths, agent logs) before pursuing further.

Refs: #226.