### PR TITLE
feat(chat): show reasoning_content from thinking-mode models

### DIFF
--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -152,6 +152,12 @@ platforms:
 
 export interface ChatCallbacks {
   onChunk: (text: string) => void;
+  /**
+   * Streaming "thinking" content from reasoning models — sourced from
+   * `delta.reasoning_content` (most providers) or `delta.reasoning`
+   * (OpenRouter and some others). Issue #223.
+   */
+  onReasoning?: (text: string) => void;
   onDone: (sessionId?: string) => void;
   onError: (error: string) => void;
   onToolProgress?: (tool: string) => void;
@@ -314,6 +320,20 @@ function sendMessageViaApi(
           rateLimitRemaining: parsed.usage.rate_limit_remaining,
           rateLimitReset: parsed.usage.rate_limit_reset,
         });
+      }
+
+      // Reasoning / thinking-model chain-of-thought streams alongside
+      // regular content. Different upstreams use different field names;
+      // accept both common ones (issue #223). The block-typed
+      // extended-thinking format from Anthropic is not covered here.
+      const reasoning =
+        typeof delta?.reasoning_content === "string"
+          ? delta.reasoning_content
+          : typeof delta?.reasoning === "string"
+            ? delta.reasoning
+            : "";
+      if (reasoning && cb.onReasoning) {
+        cb.onReasoning(reasoning);
       }
 
       if (delta?.content) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -608,6 +608,9 @@ function setupIPC(): void {
             fullResponse += chunk;
             event.sender.send("chat-chunk", chunk);
           },
+          onReasoning: (text) => {
+            event.sender.send("chat-reasoning", text);
+          },
           onDone: (sessionId) => {
             currentChatAbort = null;
             event.sender.send("chat-done", sessionId || "");

--- a/src/main/sse-parser.ts
+++ b/src/main/sse-parser.ts
@@ -13,6 +13,16 @@ export interface ParsedUsage {
 
 export interface SseCallbacks {
   onChunk: (text: string) => void;
+  /**
+   * Streaming "thinking" / chain-of-thought content from reasoning models
+   * (DeepSeek-R1, OpenAI o-series via proxies, Gemini thinking, …).
+   * OpenAI-compatible APIs surface this under `delta.reasoning_content`
+   * (most providers) or `delta.reasoning` (OpenRouter and some others);
+   * we accept both. Anthropic's block-typed extended-thinking is not
+   * covered here — it streams as separate `thinking` blocks rather than
+   * a string field on the chat-completion delta. Issue #223.
+   */
+  onReasoning?: (text: string) => void;
   onToolProgress?: (tool: string) => void;
   onUsage?: (usage: ParsedUsage) => void;
   onError?: (message: string) => void;
@@ -89,6 +99,20 @@ export function processSseData(
         rateLimitRemaining: parsed.usage.rate_limit_remaining,
         rateLimitReset: parsed.usage.rate_limit_reset,
       });
+    }
+
+    // Reasoning / thinking-model chain-of-thought streams alongside
+    // regular content. Different upstreams use slightly different field
+    // names; accept both common ones. Empty/whitespace-only deltas are
+    // skipped (some providers emit a leading empty reasoning chunk).
+    const reasoning =
+      typeof delta?.reasoning_content === "string"
+        ? delta.reasoning_content
+        : typeof delta?.reasoning === "string"
+          ? delta.reasoning
+          : "";
+    if (reasoning && cb.onReasoning) {
+      cb.onReasoning(reasoning);
     }
 
     if (delta?.content) {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -198,6 +198,7 @@ interface HermesAPI {
   ) => Promise<{ response: string; sessionId?: string }>;
   abortChat: () => Promise<void>;
   onChatChunk: (callback: (chunk: string) => void) => () => void;
+  onChatReasoning: (callback: (text: string) => void) => () => void;
   onChatDone: (callback: (sessionId?: string) => void) => () => void;
   onChatToolProgress: (callback: (tool: string) => void) => () => void;
   onChatUsage: (

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -179,6 +179,13 @@ const hermesAPI = {
     return () => ipcRenderer.removeListener("chat-chunk", handler);
   },
 
+  onChatReasoning: (callback: (text: string) => void): (() => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, text: string): void =>
+      callback(text);
+    ipcRenderer.on("chat-reasoning", handler);
+    return () => ipcRenderer.removeListener("chat-reasoning", handler);
+  },
+
   onChatDone: (callback: (sessionId?: string) => void): (() => void) => {
     const handler = (
       _event: Electron.IpcRendererEvent,

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1283,6 +1283,64 @@ body {
   white-space: normal;
 }
 
+/* Collapsible "Thinking…" / "Reasoning" block at the top of an agent
+   bubble for chain-of-thought from reasoning models. Issue #223. */
+.chat-reasoning {
+  margin-bottom: 8px;
+  border-left: 3px solid var(--text-muted, #888);
+  padding-left: 8px;
+  opacity: 0.85;
+}
+
+.chat-reasoning-toggle {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--text-muted, #888);
+  font-size: 12px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.chat-reasoning-toggle:hover {
+  color: var(--text-default, inherit);
+}
+
+.chat-reasoning-chevron {
+  display: inline-block;
+  width: 0.7em;
+  font-size: 10px;
+}
+
+.chat-reasoning-label {
+  font-style: italic;
+}
+
+.chat-reasoning-streaming .chat-reasoning-label {
+  /* Subtle pulse while reasoning is still arriving and the answer
+     hasn't started — purely a "something is happening" affordance. */
+  animation: chat-reasoning-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes chat-reasoning-pulse {
+  0%, 100% { opacity: 0.6; }
+  50%      { opacity: 1; }
+}
+
+.chat-reasoning-body {
+  margin-top: 6px;
+  font-size: 13px;
+  font-family: var(--font-mono, monospace);
+  white-space: pre-wrap;
+  color: var(--text-muted, #888);
+  line-height: 1.5;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
 .chat-bubble-agent pre,
 .chat-bubble-agent code {
   /* Restore preserved whitespace inside code blocks and inline code. */

--- a/src/renderer/src/screens/Chat/MessageRow.test.tsx
+++ b/src/renderer/src/screens/Chat/MessageRow.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { I18nProvider } from "../../components/I18nProvider";
+import { MessageRow } from "./MessageRow";
+import type { ChatMessage } from "./types";
+
+// Regression tests for issue #223: reasoning_content from thinking-mode
+// models is now plumbed through the renderer and displayed in a
+// collapsible block above the main response.
+
+beforeEach(() => {
+  (window as unknown as { hermesAPI: unknown }).hermesAPI = {
+    getLocale: vi.fn().mockResolvedValue("en"),
+    setLocale: vi.fn().mockResolvedValue("en"),
+  };
+});
+
+function renderRow(
+  msg: ChatMessage,
+  overrides: Partial<{
+    isLast: boolean;
+    isLoading: boolean;
+    onApprove: () => void;
+    onDeny: () => void;
+  }> = {},
+): void {
+  return void render(
+    <I18nProvider>
+      <MessageRow
+        msg={msg}
+        isLast={overrides.isLast ?? true}
+        isLoading={overrides.isLoading ?? false}
+        onApprove={overrides.onApprove ?? (() => {})}
+        onDeny={overrides.onDeny ?? (() => {})}
+      />
+    </I18nProvider>,
+  );
+}
+
+describe("MessageRow — reasoning display (issue #223)", () => {
+  it("doesn't render a reasoning block when the message has no reasoning", async () => {
+    await act(async () => {
+      renderRow({
+        id: "m1",
+        role: "agent",
+        content: "Just a normal reply.",
+      });
+    });
+    expect(screen.queryByTestId("chat-reasoning")).toBeNull();
+  });
+
+  it("doesn't render a reasoning block for user messages even if a field is present", async () => {
+    await act(async () => {
+      renderRow({
+        id: "u1",
+        role: "user",
+        content: "hi",
+        // Defensive — reasoning is only meaningful for agent replies; the
+        // UI should treat it as not-present on user rows.
+        reasoning: "this should be ignored",
+      });
+    });
+    expect(screen.queryByTestId("chat-reasoning")).toBeNull();
+  });
+
+  it("renders a collapsed reasoning block by default once the answer has arrived", async () => {
+    await act(async () => {
+      renderRow({
+        id: "a1",
+        role: "agent",
+        content: "The answer is 42.",
+        reasoning: "Step 1. Consider 41. Step 2. Add one. Therefore: 42.",
+      });
+    });
+
+    expect(screen.getByTestId("chat-reasoning")).toBeInTheDocument();
+    // Toggle button visible with the collapsed label ("Reasoning").
+    const toggle = screen.getByRole("button", { name: /reasoning/i });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    // Body is NOT rendered while collapsed.
+    expect(screen.queryByTestId("chat-reasoning-body")).toBeNull();
+  });
+
+  it("expands the reasoning block when the user clicks the toggle", async () => {
+    await act(async () => {
+      renderRow({
+        id: "a2",
+        role: "agent",
+        content: "Final answer.",
+        reasoning: "Internal monologue here.",
+      });
+    });
+
+    const toggle = screen.getByRole("button", { name: /reasoning/i });
+    await act(async () => {
+      fireEvent.click(toggle);
+    });
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByTestId("chat-reasoning-body")).toHaveTextContent(
+      "Internal monologue here.",
+    );
+  });
+
+  it("auto-expands the reasoning while still streaming with no answer yet (Thinking… label)", async () => {
+    // Simulate the in-flight state: isLast + isLoading and content is
+    // still empty but reasoning has started arriving. The block should
+    // be visible without the user clicking, and labelled "Thinking…".
+    await act(async () => {
+      renderRow(
+        {
+          id: "a3",
+          role: "agent",
+          content: "",
+          reasoning: "Considering the problem…",
+        },
+        { isLast: true, isLoading: true },
+      );
+    });
+
+    expect(screen.getByTestId("chat-reasoning")).toBeInTheDocument();
+    const toggle = screen.getByRole("button", { name: /thinking/i });
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByTestId("chat-reasoning-body")).toHaveTextContent(
+      "Considering the problem…",
+    );
+  });
+
+  it("flips to collapsed-by-default once the answer starts arriving", async () => {
+    // Same in-flight scenario but content has now started — the block
+    // should switch to the "Reasoning" label and collapse by default
+    // (the user can still click to re-expand).
+    await act(async () => {
+      renderRow(
+        {
+          id: "a4",
+          role: "agent",
+          content: "Th",
+          reasoning: "Considering the problem…",
+        },
+        { isLast: true, isLoading: true },
+      );
+    });
+
+    const toggle = screen.getByRole("button", { name: /reasoning/i });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByTestId("chat-reasoning-body")).toBeNull();
+  });
+
+  it("treats whitespace-only reasoning as no reasoning", async () => {
+    await act(async () => {
+      renderRow({
+        id: "a5",
+        role: "agent",
+        content: "Hi.",
+        reasoning: "   \n   \n   ",
+      });
+    });
+    expect(screen.queryByTestId("chat-reasoning")).toBeNull();
+  });
+});

--- a/src/renderer/src/screens/Chat/MessageRow.tsx
+++ b/src/renderer/src/screens/Chat/MessageRow.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useState } from "react";
 import icon from "../../assets/icon.png";
 import { AgentMarkdown } from "../../components/AgentMarkdown";
 import { useI18n } from "../../components/useI18n";
@@ -40,6 +40,14 @@ export const MessageRow = memo(function MessageRow({
     !isLoading &&
     isLast &&
     APPROVAL_RE.test(msg.content);
+  const hasReasoning =
+    msg.role === "agent" && !!msg.reasoning && msg.reasoning.trim().length > 0;
+  // Auto-expand while the model is still streaming reasoning and no
+  // visible answer has arrived yet — gives the user immediate feedback
+  // that "thinking" is happening. Once content starts, collapse.
+  const isStreamingReasoning = hasReasoning && isLast && isLoading && !msg.content;
+  const [expanded, setExpanded] = useState(false);
+  const open = expanded || isStreamingReasoning;
 
   return (
     <div className={`chat-message chat-message-${msg.role}`}>
@@ -49,6 +57,15 @@ export const MessageRow = memo(function MessageRow({
         <HermesAvatar />
       )}
       <div className={`chat-bubble chat-bubble-${msg.role}`}>
+        {hasReasoning && (
+          <ReasoningBlock
+            text={msg.reasoning as string}
+            open={open}
+            onToggle={() => setExpanded((v) => !v)}
+            streaming={isStreamingReasoning}
+            t={t}
+          />
+        )}
         {msg.role === "agent" ? (
           <AgentMarkdown>{msg.content}</AgentMarkdown>
         ) : (
@@ -66,6 +83,53 @@ export const MessageRow = memo(function MessageRow({
           <button className="chat-approval-btn chat-deny" onClick={onDeny}>
             {t("chat.deny")}
           </button>
+        </div>
+      )}
+    </div>
+  );
+});
+
+/**
+ * Collapsible "Thinking…" block that renders chain-of-thought from
+ * reasoning models above the main response. Defaults collapsed once the
+ * answer starts arriving; auto-expanded while reasoning is still streaming
+ * with no visible answer yet, so the user gets immediate feedback that
+ * the model is working. Issue #223.
+ */
+const ReasoningBlock = memo(function ReasoningBlock({
+  text,
+  open,
+  onToggle,
+  streaming,
+  t,
+}: {
+  text: string;
+  open: boolean;
+  onToggle: () => void;
+  streaming: boolean;
+  t: (key: string) => string;
+}): React.JSX.Element {
+  return (
+    <div
+      className={`chat-reasoning${open ? " chat-reasoning-open" : ""}${streaming ? " chat-reasoning-streaming" : ""}`}
+      data-testid="chat-reasoning"
+    >
+      <button
+        type="button"
+        className="chat-reasoning-toggle"
+        onClick={onToggle}
+        aria-expanded={open}
+      >
+        <span className="chat-reasoning-chevron" aria-hidden>
+          {open ? "▾" : "▸"}
+        </span>
+        <span className="chat-reasoning-label">
+          {streaming ? t("chat.thinking") : t("chat.reasoning")}
+        </span>
+      </button>
+      {open && (
+        <div className="chat-reasoning-body" data-testid="chat-reasoning-body">
+          {text}
         </div>
       )}
     </div>

--- a/src/renderer/src/screens/Chat/hooks/useChatIPC.ts
+++ b/src/renderer/src/screens/Chat/hooks/useChatIPC.ts
@@ -41,6 +41,32 @@ export function useChatIPC({
       });
     });
 
+    // Reasoning / thinking content from thinking-mode models. Appended to
+    // the current agent bubble's `reasoning` field; the MessageRow renders
+    // it as a collapsible block above the main response. Reasoning chunks
+    // often start arriving BEFORE the first content chunk, so we may need
+    // to create the agent bubble here too. Issue #223.
+    const cleanupReasoning = window.hermesAPI.onChatReasoning((text) => {
+      setMessages((prev) => {
+        const last = prev[prev.length - 1];
+        if (last && last.role === "agent") {
+          return [
+            ...prev.slice(0, -1),
+            { ...last, reasoning: (last.reasoning || "") + text },
+          ];
+        }
+        return [
+          ...prev,
+          {
+            id: `agent-${Date.now()}`,
+            role: "agent",
+            content: "",
+            reasoning: text,
+          },
+        ];
+      });
+    });
+
     const cleanupDone = window.hermesAPI.onChatDone((sessionId) => {
       if (sessionId) setHermesSessionId(sessionId);
       setToolProgress(null);
@@ -75,6 +101,7 @@ export function useChatIPC({
 
     return () => {
       cleanupChunk();
+      cleanupReasoning();
       cleanupDone();
       cleanupError();
       cleanupToolProgress();

--- a/src/renderer/src/screens/Chat/types.ts
+++ b/src/renderer/src/screens/Chat/types.ts
@@ -2,6 +2,12 @@ export interface ChatMessage {
   id: string;
   role: "user" | "agent";
   content: string;
+  /**
+   * Chain-of-thought / "thinking" content from reasoning models, accumulated
+   * via the `chat-reasoning` IPC channel. Surfaced in the chat bubble as a
+   * collapsible block above the main response. Issue #223.
+   */
+  reasoning?: string;
 }
 
 export interface ModelGroup {

--- a/src/shared/i18n/locales/en/chat.ts
+++ b/src/shared/i18n/locales/en/chat.ts
@@ -20,6 +20,8 @@ export default {
   suggestionAnalyze: "Analyze data",
   approve: "Approve",
   deny: "Deny",
+  thinking: "Thinking…",
+  reasoning: "Reasoning",
   newChat: "New chat (Cmd+N)",
   clearChat: "Clear chat",
   fastMode: "Fast Mode",

--- a/src/shared/i18n/locales/zh-CN/chat.ts
+++ b/src/shared/i18n/locales/zh-CN/chat.ts
@@ -19,6 +19,8 @@ export default {
   suggestionAnalyze: "分析数据",
   approve: "批准",
   deny: "拒绝",
+  thinking: "正在思考…",
+  reasoning: "推理过程",
   newChat: "新聊天 (Cmd+N)",
   clearChat: "清空聊天",
   fastMode: "快速模式",

--- a/tests/sse-parser.test.ts
+++ b/tests/sse-parser.test.ts
@@ -144,6 +144,111 @@ describe("processSseData", () => {
     expect(onChunk).toHaveBeenCalledWith("Hello world");
   });
 
+  // ─── Reasoning / thinking-model deltas (issue #223) ─────
+
+  it("forwards delta.reasoning_content to onReasoning (most providers' shape)", () => {
+    const onChunk = vi.fn();
+    const onReasoning = vi.fn();
+    const state = makeState();
+    const data = JSON.stringify({
+      choices: [
+        {
+          delta: {
+            reasoning_content: "Let me think about this step by step...",
+          },
+        },
+      ],
+    });
+    const result = processSseData(
+      data,
+      { onChunk, onReasoning },
+      state,
+    );
+    expect(result.done).toBe(false);
+    // Reasoning chunks don't count as visible content — onChunk is not
+    // called, and hasContent stays false until the answer actually starts.
+    expect(onChunk).not.toHaveBeenCalled();
+    expect(result.hasContent).toBe(false);
+    expect(onReasoning).toHaveBeenCalledWith(
+      "Let me think about this step by step...",
+    );
+  });
+
+  it("forwards delta.reasoning to onReasoning (OpenRouter shape)", () => {
+    const onReasoning = vi.fn();
+    const state = makeState();
+    const data = JSON.stringify({
+      choices: [{ delta: { reasoning: "First, consider..." } }],
+    });
+    processSseData(data, { onChunk: vi.fn(), onReasoning }, state);
+    expect(onReasoning).toHaveBeenCalledWith("First, consider...");
+  });
+
+  it("emits both onReasoning and onChunk when a chunk carries both", () => {
+    // Some providers emit reasoning and content in the same delta as the
+    // reasoning trails off. Both callbacks should fire.
+    const onChunk = vi.fn();
+    const onReasoning = vi.fn();
+    const state = makeState();
+    const data = JSON.stringify({
+      choices: [
+        {
+          delta: {
+            reasoning_content: "…concluding now.",
+            content: "The answer is 42.",
+          },
+        },
+      ],
+    });
+    processSseData(data, { onChunk, onReasoning }, state);
+    expect(onReasoning).toHaveBeenCalledWith("…concluding now.");
+    expect(onChunk).toHaveBeenCalledWith("The answer is 42.");
+    expect(state.hasContent).toBe(true);
+  });
+
+  it("ignores empty reasoning fields", () => {
+    const onReasoning = vi.fn();
+    const state = makeState();
+    const data = JSON.stringify({
+      choices: [{ delta: { reasoning_content: "" } }],
+    });
+    processSseData(data, { onChunk: vi.fn(), onReasoning }, state);
+    expect(onReasoning).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-string reasoning fields (provider quirk)", () => {
+    const onReasoning = vi.fn();
+    const state = makeState();
+    // Some upstreams briefly emit a null delta.reasoning before the
+    // string form starts; that should be silently skipped.
+    const data = JSON.stringify({
+      choices: [{ delta: { reasoning: null, content: "x" } }],
+    });
+    const onChunk = vi.fn();
+    processSseData(data, { onChunk, onReasoning }, state);
+    expect(onReasoning).not.toHaveBeenCalled();
+    expect(onChunk).toHaveBeenCalledWith("x");
+  });
+
+  it("is a no-op for reasoning when no onReasoning callback is provided", () => {
+    // The callback is optional — its absence must not break the parser
+    // or affect chunk handling.
+    const onChunk = vi.fn();
+    const state = makeState();
+    const data = JSON.stringify({
+      choices: [
+        {
+          delta: {
+            reasoning_content: "ignored",
+            content: "visible",
+          },
+        },
+      ],
+    });
+    expect(() => processSseData(data, { onChunk }, state)).not.toThrow();
+    expect(onChunk).toHaveBeenCalledWith("visible");
+  });
+
   it("extracts usage data including cost and rate limits", () => {
     const onUsage = vi.fn();
     const onChunk = vi.fn();


### PR DESCRIPTION
## Summary

Thinking-mode models (DeepSeek-R1, OpenAI o-series via proxies, Gemini thinking, etc.) stream a `delta.reasoning_content` field alongside `delta.content`. The Hermes CLI displays this; the Desktop's chat UI silently drops it. Reported in #223 — *"使用思考模式的模型，响应中的 resoning_content 的内容不会在 ui 界面显示，Hermes agent 本身是可以显示 resoning_content 的"* (when using thinking-mode models, the response's reasoning_content isn't shown in the UI; the Hermes agent itself can show it).

## What it looks like

Three rendering states (visual sanity check via Preview):

1. **Streaming** — reasoning is arriving, no answer yet → auto-expanded, label reads *"Thinking…"* with a subtle pulse animation.
2. **Answered, collapsed** — once content starts arriving, collapses to *"Reasoning ▸"*. The reasoning stays available; the user can re-expand any time.
3. **Answered, expanded** — body in monospace, gray, scrollable, gated to 320px max-height.

Layout uses existing chat color tokens / theme variables, so dark mode and skin variants inherit automatically.

## Implementation — three thin layers

| Layer | File | What |
|---|---|---|
| Parser | `src/main/sse-parser.ts`, `src/main/hermes.ts` | Read `delta.reasoning_content` (most providers) or `delta.reasoning` (OpenRouter shape) — either string is forwarded via a new optional `cb.onReasoning(text)`. Empty / non-string values are skipped. Reasoning chunks don't count as visible content, so the SSE `hasContent` state for the existing probe-on-empty-response error path stays accurate. |
| IPC + preload | `src/main/index.ts`, `src/preload/index.ts`, `src/preload/index.d.ts` | Main forwards `cb.onReasoning` to renderer via a new `chat-reasoning` channel; preload exposes `onChatReasoning(cb)` on the `HermesAPI` type. |
| Renderer | `src/renderer/src/screens/Chat/types.ts`, `…/hooks/useChatIPC.ts`, `…/MessageRow.tsx`, `…/assets/main.css` | `ChatMessage.reasoning?: string` field; `useChatIPC` appends incoming reasoning chunks to the current agent bubble (or creates the bubble if reasoning arrives before any answer, which it usually does); `MessageRow` renders the collapsible block with state per-row. |

Block-typed extended-thinking from Anthropic Claude is **not** covered in this PR — it streams as separate `thinking`-typed blocks rather than a string field on the chat-completion delta, which needs a different parser path. Flagged as a follow-up in the code comments.

## Tests — 13 new, suite goes 317 → 330

**`tests/sse-parser.test.ts` — 6 new cases:**
- ✅ `delta.reasoning_content` (most providers' shape) → `onReasoning`, not `onChunk`
- ✅ `delta.reasoning` (OpenRouter shape) → `onReasoning`
- ✅ Both reasoning and content in the same delta → both callbacks fire
- ✅ Empty reasoning fields are skipped
- ✅ Non-string (`null`) reasoning is skipped, content still routed
- ✅ Missing `onReasoning` callback → no throw, content unaffected

**`src/renderer/src/screens/Chat/MessageRow.test.tsx` (new file) — 7 cases:**
- ✅ No reasoning field → no block rendered
- ✅ Reasoning on a user message → ignored (defensive — reasoning is agent-only)
- ✅ Reasoning + content → collapsed by default, `aria-expanded="false"`, body not in DOM
- ✅ Click toggle → body appears, `aria-expanded="true"`
- ✅ Streaming state (`isLast && isLoading && !content`) → auto-expanded with "Thinking…" label
- ✅ Same state once content starts arriving → flips to collapsed "Reasoning" label
- ✅ Whitespace-only reasoning → no block rendered (treated as no reasoning)

## i18n

Added `chat.thinking` and `chat.reasoning` keys to **en** and **zh-CN** locales (since the issue reporter is Chinese-speaking). Other locales fall back to English via the existing fallback chain and are translatable in a follow-up.

## Test plan

- [x] `npm run typecheck` (node + web) passes.
- [x] `npm test` — 23 files / **330 tests** pass (317 origin + 13 new).
- [x] Visual sanity check on all three rendering states via standalone HTML preview using the actual CSS classes verbatim.
- [ ] End-to-end against a real thinking-mode endpoint (DeepSeek-R1 via OpenRouter or similar). Couldn't do this on the dev box without a thinking-model account — manual smoke check is recommended before merge.

Closes #223.