### PR TITLE
feat(models): add "Fetch Available Models" feature

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -87,6 +87,7 @@ import {
   updateSessionTitle,
 } from "./session-cache";
 import { listModels, addModel, removeModel, updateModel } from "./models";
+import { fetchAvailableModels } from "./provider-models";
 import {
   listProfiles,
   createProfile,
@@ -897,6 +898,11 @@ function setupIPC(): void {
     "update-model",
     (_event, id: string, fields: Record<string, string>) =>
       updateModel(id, fields),
+  );
+  ipcMain.handle(
+    "fetch-available-models",
+    (_event, baseUrl: string, apiKey?: string) =>
+      fetchAvailableModels(baseUrl, apiKey),
   );
 
   // Claw3D

--- a/src/main/provider-models.ts
+++ b/src/main/provider-models.ts
@@ -1,0 +1,52 @@
+export interface AvailableModel {
+  id: string;
+  name: string;
+}
+
+interface OpenAiModelsResponse {
+  data?: Array<{
+    id?: string;
+  }>;
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.trim().replace(/\/+$/, "");
+}
+
+export async function fetchAvailableModels(
+  baseUrl: string,
+  apiKey?: string,
+): Promise<AvailableModel[]> {
+  const normalized = normalizeBaseUrl(baseUrl);
+  if (!normalized) {
+    throw new Error("Base URL is required");
+  }
+
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+  };
+  if (apiKey?.trim()) {
+    headers.Authorization = `Bearer ${apiKey.trim()}`;
+  }
+
+  const response = await fetch(`${normalized}/models`, { headers });
+  if (!response.ok) {
+    const details = await response.text().catch(() => "");
+    throw new Error(
+      `Model list request failed (${response.status}${details ? `: ${details.slice(0, 160)}` : ""})`,
+    );
+  }
+
+  const payload = (await response.json()) as OpenAiModelsResponse;
+  const seen = new Set<string>();
+  const models = (payload.data || [])
+    .map((entry) => entry.id?.trim() || "")
+    .filter((id) => Boolean(id) && !seen.has(id) && seen.add(id))
+    .map((id) => ({
+      id,
+      name: id.split("/").pop() || id,
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+
+  return models;
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -415,6 +415,10 @@ interface HermesAPI {
   }>;
   removeModel: (id: string) => Promise<boolean>;
   updateModel: (id: string, fields: Record<string, string>) => Promise<boolean>;
+  fetchAvailableModels: (
+    baseUrl: string,
+    apiKey?: string,
+  ) => Promise<Array<{ id: string; name: string }>>;
 
   // Claw3D
   claw3dStatus: () => Promise<{

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -463,6 +463,11 @@ const hermesAPI = {
 
   updateModel: (id: string, fields: Record<string, string>): Promise<boolean> =>
     ipcRenderer.invoke("update-model", id, fields),
+  fetchAvailableModels: (
+    baseUrl: string,
+    apiKey?: string,
+  ): Promise<Array<{ id: string; name: string }>> =>
+    ipcRenderer.invoke("fetch-available-models", baseUrl, apiKey),
 
   // Claw3D
   claw3dStatus: (): Promise<{

--- a/src/renderer/src/lib/modelCatalog.ts
+++ b/src/renderer/src/lib/modelCatalog.ts
@@ -1,0 +1,63 @@
+export interface ResolvedCatalogTarget {
+  baseUrl: string;
+  apiKey: string;
+}
+
+function trimUrl(value: string): string {
+  return value.trim().replace(/\/+$/, "");
+}
+
+export function resolveCatalogEnvKey(
+  provider: string,
+  baseUrl: string,
+): string | null {
+  if (provider === "openrouter") return "OPENROUTER_API_KEY";
+  if (provider === "openai") return "OPENAI_API_KEY";
+  if (provider === "anthropic") return "ANTHROPIC_API_KEY";
+  if (provider === "xai") return "XAI_API_KEY";
+  if (provider === "google") return "GOOGLE_API_KEY";
+  if (provider === "minimax") return "MINIMAX_API_KEY";
+
+  const url = trimUrl(baseUrl).toLowerCase();
+  if (!url) return "CUSTOM_API_KEY";
+  if (url.includes("openrouter.ai")) return "OPENROUTER_API_KEY";
+  if (url.includes("openai.com")) return "OPENAI_API_KEY";
+  if (url.includes("anthropic.com")) return "ANTHROPIC_API_KEY";
+  if (url.includes("x.ai")) return "XAI_API_KEY";
+  if (url.includes("googleapis.com") || url.includes("google.com")) {
+    return "GOOGLE_API_KEY";
+  }
+  if (url.includes("groq.com")) return "GROQ_API_KEY";
+  if (url.includes("deepseek.com")) return "DEEPSEEK_API_KEY";
+  if (url.includes("together.xyz")) return "TOGETHER_API_KEY";
+  if (url.includes("fireworks.ai")) return "FIREWORKS_API_KEY";
+  if (url.includes("cerebras.ai")) return "CEREBRAS_API_KEY";
+  if (url.includes("mistral.ai")) return "MISTRAL_API_KEY";
+  if (url.includes("perplexity.ai")) return "PERPLEXITY_API_KEY";
+  if (url.includes("huggingface.co")) return "HF_TOKEN";
+  if (url.includes("minimax")) return "MINIMAX_API_KEY";
+  if (url.includes("opencode") && url.includes("zen")) {
+    return "OPENCODE_ZEN_API_KEY";
+  }
+  if (url.includes("opencode")) return "OPENCODE_GO_API_KEY";
+  return "CUSTOM_API_KEY";
+}
+
+export function resolveCatalogTarget(
+  provider: string,
+  baseUrl: string,
+  env: Record<string, string>,
+): ResolvedCatalogTarget | null {
+  let resolvedBaseUrl = trimUrl(baseUrl);
+  if (!resolvedBaseUrl) {
+    if (provider === "openrouter") resolvedBaseUrl = "https://openrouter.ai/api/v1";
+    else if (provider === "openai") resolvedBaseUrl = "https://api.openai.com/v1";
+  }
+  if (!resolvedBaseUrl) return null;
+
+  const envKey = resolveCatalogEnvKey(provider, resolvedBaseUrl);
+  return {
+    baseUrl: resolvedBaseUrl,
+    apiKey: envKey ? env[envKey] || "" : "",
+  };
+}

--- a/src/renderer/src/screens/Models/Models.tsx
+++ b/src/renderer/src/screens/Models/Models.tsx
@@ -3,6 +3,10 @@ import { Plus, Trash, Search, X } from "../../assets/icons";
 import { PROVIDERS } from "../../constants";
 import { useI18n } from "../../components/useI18n";
 import BrandLogo from "../../components/common/BrandLogo";
+import {
+  resolveCatalogTarget,
+  resolveCatalogEnvKey,
+} from "../../lib/modelCatalog";
 
 interface SavedModel {
   id: string;
@@ -11,6 +15,11 @@ interface SavedModel {
   model: string;
   baseUrl: string;
   createdAt: number;
+}
+
+interface AvailableModel {
+  id: string;
+  name: string;
 }
 
 function providerLabelKey(value: string): string {
@@ -34,6 +43,10 @@ function Models(): React.JSX.Element {
   const [formApiKey, setFormApiKey] = useState("");
   const [showApiKey, setShowApiKey] = useState(false);
   const [formError, setFormError] = useState("");
+  const [env, setEnv] = useState<Record<string, string>>({});
+  const [availableModels, setAvailableModels] = useState<AvailableModel[]>([]);
+  const [fetchingModels, setFetchingModels] = useState(false);
+  const [fetchModelsError, setFetchModelsError] = useState("");
 
   function resolveCustomEnvKey(url: string): string {
     if (!url) return "CUSTOM_API_KEY";
@@ -52,8 +65,12 @@ function Models(): React.JSX.Element {
   }
 
   const loadModels = useCallback(async () => {
-    const list = await window.hermesAPI.listModels();
+    const [list, envData] = await Promise.all([
+      window.hermesAPI.listModels(),
+      window.hermesAPI.getEnv(),
+    ]);
     setModels(list);
+    setEnv(envData);
     setLoading(false);
   }, []);
 
@@ -70,6 +87,8 @@ function Models(): React.JSX.Element {
     setFormApiKey("");
     setShowApiKey(false);
     setFormError("");
+    setAvailableModels([]);
+    setFetchModelsError("");
     setShowModal(true);
   }
 
@@ -82,6 +101,8 @@ function Models(): React.JSX.Element {
     setFormApiKey("");
     setShowApiKey(false);
     setFormError("");
+    setAvailableModels([]);
+    setFetchModelsError("");
     setShowModal(true);
   }
 
@@ -89,6 +110,46 @@ function Models(): React.JSX.Element {
     setShowModal(false);
     setEditingModel(null);
     setFormError("");
+    setFetchModelsError("");
+  }
+
+  function resolveFormCatalogTarget() {
+    const envWithOverride = { ...env };
+    const envKey = resolveCatalogEnvKey(formProvider, formBaseUrl.trim());
+    if (formApiKey.trim() && envKey) {
+      envWithOverride[envKey] = formApiKey.trim();
+    }
+    return resolveCatalogTarget(formProvider, formBaseUrl, envWithOverride);
+  }
+
+  async function handleFetchModels(): Promise<void> {
+    const target = resolveFormCatalogTarget();
+    if (!target) {
+      setFetchModelsError(t("models.fetchNeedsBaseUrl"));
+      setAvailableModels([]);
+      return;
+    }
+
+    setFetchingModels(true);
+    setFetchModelsError("");
+    try {
+      const discovered = await window.hermesAPI.fetchAvailableModels(
+        target.baseUrl,
+        target.apiKey,
+      );
+      setAvailableModels(discovered);
+      if (!formModel && discovered[0]) {
+        setFormModel(discovered[0].id);
+        setFormName(discovered[0].name);
+      }
+    } catch (error) {
+      setFetchModelsError(
+        error instanceof Error ? error.message : t("models.fetchFailed"),
+      );
+      setAvailableModels([]);
+    } finally {
+      setFetchingModels(false);
+    }
   }
 
   async function handleSave(): Promise<void> {
@@ -301,9 +362,63 @@ function Models(): React.JSX.Element {
                   className="input"
                   type="text"
                   value={formModel}
-                  onChange={(e) => setFormModel(e.target.value)}
+                  onChange={(e) => {
+                    setFormModel(e.target.value);
+                    if (!formName.trim()) {
+                      setFormName(e.target.value.split("/").pop() || e.target.value);
+                    }
+                  }}
                   placeholder={t("models.modelIdPlaceholder")}
                 />
+                <div
+                  style={{
+                    display: "flex",
+                    gap: 8,
+                    marginTop: 10,
+                    alignItems: "center",
+                    flexWrap: "wrap",
+                  }}
+                >
+                  <button
+                    className="btn btn-secondary btn-sm"
+                    onClick={() => void handleFetchModels()}
+                    disabled={fetchingModels || !resolveFormCatalogTarget()}
+                    type="button"
+                  >
+                    {fetchingModels
+                      ? t("models.fetchingModels")
+                      : t("models.fetchModels")}
+                  </button>
+                  {availableModels.length > 0 && (
+                    <span className="models-modal-hint">
+                      {t("models.modelsFound", { count: availableModels.length })}
+                    </span>
+                  )}
+                </div>
+                {availableModels.length > 0 && (
+                  <select
+                    className="input"
+                    style={{ marginTop: 10 }}
+                    value={formModel}
+                    onChange={(e) => {
+                      const next = availableModels.find((m) => m.id === e.target.value);
+                      setFormModel(e.target.value);
+                      if (next) setFormName(next.name);
+                    }}
+                  >
+                    <option value="">{t("models.selectFetchedModel")}</option>
+                    {availableModels.map((entry) => (
+                      <option key={entry.id} value={entry.id}>
+                        {entry.id}
+                      </option>
+                    ))}
+                  </select>
+                )}
+                {fetchModelsError && (
+                  <div className="models-error" style={{ marginTop: 10 }}>
+                    {fetchModelsError}
+                  </div>
+                )}
               </div>
 
               <div className="models-modal-field">

--- a/src/renderer/src/screens/Providers/Providers.tsx
+++ b/src/renderer/src/screens/Providers/Providers.tsx
@@ -2,6 +2,12 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { SETTINGS_SECTIONS, PROVIDERS } from "../../constants";
 import { useI18n } from "../../components/useI18n";
 import BrandLogo from "../../components/common/BrandLogo";
+import { resolveCatalogTarget } from "../../lib/modelCatalog";
+
+interface AvailableModel {
+  id: string;
+  name: string;
+}
 
 function Providers({
   profile,
@@ -22,6 +28,9 @@ function Providers({
   const [modelName, setModelName] = useState("");
   const [modelBaseUrl, setModelBaseUrl] = useState("");
   const [modelSaved, setModelSaved] = useState(false);
+  const [availableModels, setAvailableModels] = useState<AvailableModel[]>([]);
+  const [fetchingModels, setFetchingModels] = useState(false);
+  const [fetchModelsError, setFetchModelsError] = useState("");
   const modelLoaded = useRef(false);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -91,6 +100,42 @@ function Providers({
     setModelSaved(true);
     setTimeout(() => setModelSaved(false), 2000);
   }, [modelProvider, modelName, modelBaseUrl, profile]);
+
+  async function handleFetchModels(): Promise<void> {
+    const target = resolveCatalogTarget(modelProvider, modelBaseUrl, env);
+    if (!target) {
+      setFetchModelsError(t("providers.fetchNeedsBaseUrl"));
+      setAvailableModels([]);
+      return;
+    }
+
+    setFetchingModels(true);
+    setFetchModelsError("");
+    try {
+      const discovered = await window.hermesAPI.fetchAvailableModels(
+        target.baseUrl,
+        target.apiKey,
+      );
+      setAvailableModels(discovered);
+      await Promise.all(
+        discovered.map((entry) =>
+          window.hermesAPI.addModel(
+            entry.name,
+            modelProvider === "auto" ? "custom" : modelProvider,
+            entry.id,
+            target.baseUrl,
+          ),
+        ),
+      );
+    } catch (error) {
+      setFetchModelsError(
+        error instanceof Error ? error.message : t("providers.fetchFailed"),
+      );
+      setAvailableModels([]);
+    } finally {
+      setFetchingModels(false);
+    }
+  }
 
   useEffect(() => {
     if (!modelLoaded.current) return;
@@ -211,6 +256,54 @@ function Providers({
             placeholder={t("settings.modelNamePlaceholder")}
           />
           <div className="settings-field-hint">{t("settings.modelHint")}</div>
+          <div
+            style={{
+              display: "flex",
+              gap: 8,
+              marginTop: 10,
+              alignItems: "center",
+              flexWrap: "wrap",
+            }}
+          >
+            <button
+              className="btn btn-secondary btn-sm"
+              onClick={() => void handleFetchModels()}
+              disabled={
+                fetchingModels ||
+                !resolveCatalogTarget(modelProvider, modelBaseUrl, env)
+              }
+              type="button"
+            >
+              {fetchingModels
+                ? t("providers.fetchingModels")
+                : t("providers.fetchModels")}
+            </button>
+            {availableModels.length > 0 && (
+              <span className="settings-field-hint" style={{ margin: 0 }}>
+                {t("providers.modelsFound", { count: availableModels.length })}
+              </span>
+            )}
+          </div>
+          {availableModels.length > 0 && (
+            <select
+              className="input settings-select"
+              style={{ marginTop: 10 }}
+              value={modelName}
+              onChange={(e) => setModelName(e.target.value)}
+            >
+              <option value="">{t("providers.selectFetchedModel")}</option>
+              {availableModels.map((entry) => (
+                <option key={entry.id} value={entry.id}>
+                  {entry.id}
+                </option>
+              ))}
+            </select>
+          )}
+          {fetchModelsError && (
+            <div className="settings-field-hint" style={{ color: "var(--error)" }}>
+              {fetchModelsError}
+            </div>
+          )}
         </div>
 
         {isCustomProvider && (

--- a/src/shared/i18n/locales/en/models.ts
+++ b/src/shared/i18n/locales/en/models.ts
@@ -24,4 +24,10 @@ export default {
   apiKeyLabel: "API Key",
   apiKeyHint:
     "Stored as an environment variable. Picks the matching env key based on the URL, or CUSTOM_API_KEY otherwise.",
+  fetchModels: "Fetch available models",
+  fetchingModels: "Loading models...",
+  selectFetchedModel: "Choose a discovered model",
+  modelsFound: "{{count}} models available",
+  fetchNeedsBaseUrl: "Set a base URL before fetching models.",
+  fetchFailed: "Could not load the model list.",
 } as const;

--- a/src/shared/i18n/locales/en/providers.ts
+++ b/src/shared/i18n/locales/en/providers.ts
@@ -1,4 +1,10 @@
 export default {
   title: "Providers",
   subtitle: "Configure LLM providers, API keys, and credential pools",
+  fetchModels: "Fetch available models",
+  fetchingModels: "Loading models...",
+  selectFetchedModel: "Choose a discovered model",
+  modelsFound: "{{count}} models available",
+  fetchNeedsBaseUrl: "Set a base URL before fetching models.",
+  fetchFailed: "Could not load the model list.",
 } as const;

--- a/src/shared/i18n/locales/zh-CN/models.ts
+++ b/src/shared/i18n/locales/zh-CN/models.ts
@@ -23,4 +23,10 @@ export default {
   apiKeyLabel: "API Key",
   apiKeyHint:
     "保存为环境变量。会按 URL 匹配对应的环境变量名,否则使用 CUSTOM_API_KEY。",
+  fetchModels: "获取可用模型",
+  fetchingModels: "正在加载模型...",
+  selectFetchedModel: "选择已发现的模型",
+  modelsFound: "找到 {{count}} 个模型",
+  fetchNeedsBaseUrl: "请先设置 Base URL 再获取模型。",
+  fetchFailed: "无法加载模型列表。",
 } as const;

--- a/src/shared/i18n/locales/zh-CN/providers.ts
+++ b/src/shared/i18n/locales/zh-CN/providers.ts
@@ -1,4 +1,10 @@
 export default {
   title: "提供商",
   subtitle: "配置 LLM 提供商、API 密钥和凭据池",
+  fetchModels: "获取可用模型",
+  fetchingModels: "正在加载模型...",
+  selectFetchedModel: "选择已发现的模型",
+  modelsFound: "找到 {{count}} 个模型",
+  fetchNeedsBaseUrl: "请先设置 Base URL 再获取模型。",
+  fetchFailed: "无法加载模型列表。",
 } as const;

--- a/tests/provider-models.test.ts
+++ b/tests/provider-models.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchAvailableModels } from "../src/main/provider-models";
+import {
+  resolveCatalogEnvKey,
+  resolveCatalogTarget,
+} from "../src/renderer/src/lib/modelCatalog";
+
+describe("fetchAvailableModels", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reads and normalizes an OpenAI-compatible /models response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [
+            { id: "z-model" },
+            { id: "a-model" },
+            { id: "a-model" },
+            { id: "folder/b-model" },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const models = await fetchAvailableModels("https://example.com/v1/", "sk-test");
+
+    expect(fetchMock).toHaveBeenCalledWith("https://example.com/v1/models", {
+      headers: {
+        Accept: "application/json",
+        Authorization: "Bearer sk-test",
+      },
+    });
+    expect(models).toEqual([
+      { id: "a-model", name: "a-model" },
+      { id: "folder/b-model", name: "b-model" },
+      { id: "z-model", name: "z-model" },
+    ]);
+  });
+});
+
+describe("model catalog target resolution", () => {
+  it("maps known custom endpoints to the matching environment variable", () => {
+    expect(resolveCatalogEnvKey("custom", "https://api.opencode.ai/v1")).toBe(
+      "OPENCODE_GO_API_KEY",
+    );
+    expect(resolveCatalogEnvKey("custom", "https://openrouter.ai/api/v1")).toBe(
+      "OPENROUTER_API_KEY",
+    );
+  });
+
+  it("fills default base URLs for supported providers", () => {
+    expect(resolveCatalogTarget("openrouter", "", { OPENROUTER_API_KEY: "x" })).toEqual({
+      baseUrl: "https://openrouter.ai/api/v1",
+      apiKey: "x",
+    });
+    expect(resolveCatalogTarget("openai", "", { OPENAI_API_KEY: "y" })).toEqual({
+      baseUrl: "https://api.openai.com/v1",
+      apiKey: "y",
+    });
+  });
+});


### PR DESCRIPTION
Add ability to fetch model list directly from OpenAI-compatible API endpoints:
- New provider-models.ts with fetchAvailableModels IPC handler
- New modelCatalog.ts helper for provider→env key resolution
- Updated Models and Providers UI with fetch/select UX
- i18n strings in en and zh-CN
- Unit tests for provider-models module