### PR TITLE
fix(config): auto-populate model.api_key for known-host custom providers (#260)

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -671,7 +671,29 @@ function pickAutoApiKeyForCustomProvider(
   return trimmed || null;
 }
 
-const API_KEY_LINE_REGEX = /^[ \t]*api_key:\s*.*\n?/m;
+/**
+ * Locate the `model:` block in a YAML document and return the offsets that
+ * bracket its body (children lines, not counting the `model:` header line).
+ * Returns null when there's no `model:` block at all.
+ *
+ * The boundaries are needed to scope `api_key` add/update/remove operations
+ * to the model block — every `auxiliary.*` subsection has its own
+ * `api_key:` line, and a naive `/^api_key:/m` replace would clobber those
+ * instead.
+ */
+function findModelBlockBody(
+  content: string,
+): { start: number; end: number } | null {
+  const headerMatch = content.match(/^model:[^\S\r\n]*\r?\n/m);
+  if (!headerMatch) return null;
+  const start = headerMatch.index! + headerMatch[0].length;
+  // The body runs until the next line that starts at column 0 (next
+  // top-level key) or end of file.  Blank lines stay inside the block.
+  const after = content.slice(start);
+  const nextTopMatch = after.match(/^\S/m);
+  const end = nextTopMatch ? start + nextTopMatch.index! : content.length;
+  return { start, end };
+}
 
 export function setModelConfig(
   provider: string,
@@ -699,30 +721,51 @@ export function setModelConfig(
   }
 
   // Workaround for upstream gateway bug — see pickAutoApiKeyForCustomProvider.
+  // Scope all api_key add/update/remove operations to the `model:` block —
+  // `auxiliary.*` subsections each carry their own `api_key:` line and must
+  // not be touched.
   const autoApiKey = pickAutoApiKeyForCustomProvider(provider, baseUrl, profile);
-  if (autoApiKey) {
-    if (API_KEY_LINE_REGEX.test(content)) {
-      content = content.replace(
-        /^([ \t]*api_key:\s*).*$/m,
-        `$1"${autoApiKey}"`,
-      );
-    } else {
-      // Insert under base_url when present, otherwise under provider.
-      const afterBaseUrl = content.replace(
-        /^([ \t]*base_url:\s*"[^"]*"\s*\n)/m,
-        `$1  api_key: "${autoApiKey}"\n`,
-      );
-      content = afterBaseUrl !== content
-        ? afterBaseUrl
-        : content.replace(
-            /^([ \t]*provider:\s*"[^"]*"\s*\n)/m,
-            `$1  api_key: "${autoApiKey}"\n`,
-          );
+  const body = findModelBlockBody(content);
+  if (body) {
+    const block = content.slice(body.start, body.end);
+    const apiKeyInBlock = /^[ \t]+api_key:\s*.*\r?\n?/m;
+    let newBlock = block;
+    if (autoApiKey) {
+      if (apiKeyInBlock.test(block)) {
+        newBlock = block.replace(
+          /^([ \t]+api_key:\s*).*$/m,
+          `$1"${autoApiKey}"`,
+        );
+      } else {
+        // Insert after base_url within the block, otherwise after provider.
+        const eolMatch = block.match(/\r?\n/);
+        const eol = eolMatch ? eolMatch[0] : "\n";
+        const indentMatch = block.match(/^([ \t]+)\S/m);
+        const indent = indentMatch ? indentMatch[1] : "  ";
+        const apiKeyLine = `${indent}api_key: "${autoApiKey}"${eol}`;
+        const afterBaseUrl = block.replace(
+          /^([ \t]+base_url:\s*"[^"]*"\s*\r?\n)/m,
+          `$1${apiKeyLine}`,
+        );
+        newBlock =
+          afterBaseUrl !== block
+            ? afterBaseUrl
+            : block.replace(
+                /^([ \t]+provider:\s*"[^"]*"\s*\r?\n)/m,
+                `$1${apiKeyLine}`,
+              );
+        // Last-resort: if neither base_url nor provider lines were found
+        // (config got hand-edited), prepend api_key to the block.
+        if (newBlock === block) {
+          newBlock = `${apiKeyLine}${block}`;
+        }
+      }
+    } else if (apiKeyInBlock.test(block)) {
+      newBlock = block.replace(apiKeyInBlock, "");
     }
-  } else if (API_KEY_LINE_REGEX.test(content)) {
-    // No env var (or provider doesn't qualify) — strip any stale auto-key so
-    // it doesn't linger when the user switches providers or clears the env.
-    content = content.replace(API_KEY_LINE_REGEX, "");
+    if (newBlock !== block) {
+      content = content.slice(0, body.start) + newBlock + content.slice(body.end);
+    }
   }
 
   // Disable smart_model_routing

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -1,6 +1,6 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { join } from "path";
-import { HERMES_HOME } from "./installer";
+import { HERMES_HOME, expectedEnvKeyForModel } from "./installer";
 import {
   escapeRegex,
   getActiveProfileNameSync,
@@ -637,6 +637,42 @@ function upsertBlockChild(
   return `${content}${sep}${blockName}:\n  ${key}: "${value}"\n`;
 }
 
+/**
+ * Pick a value to write under model.api_key when the user configures a
+ * provider="custom" entry pointing at a known commercial host (DeepSeek,
+ * Groq, Mistral, etc.).
+ *
+ * Workaround for an upstream hermes-agent bug
+ * (NousResearch/hermes-agent #?? — see fathah/hermes-desktop#260): the
+ * gateway's ``_resolve_openrouter_runtime`` fallback chain reaches
+ * ``OPENAI_API_KEY``/``OPENROUTER_API_KEY`` when a bare ``custom``
+ * provider's credential pool is empty, which leaks unrelated keys to
+ * non-OpenAI endpoints (manifesting as ``****ired`` / 401 from
+ * api.deepseek.com).  Writing the matching env-var value to
+ * ``model.api_key`` makes ``cfg_api_key`` win that chain before the
+ * leak ever runs.
+ *
+ * Returns null when the provider/base_url combination doesn't match a
+ * known commercial host or no env var is set — leaves the user's
+ * config untouched for local LLMs (Ollama, vLLM, etc.).
+ */
+function pickAutoApiKeyForCustomProvider(
+  provider: string,
+  baseUrl: string,
+  profile?: string,
+): string | null {
+  if (provider !== "custom" || !baseUrl) return null;
+  const envKey = expectedEnvKeyForModel(provider, baseUrl);
+  if (!envKey) return null;
+  const env = readEnv(profile);
+  const raw = env[envKey];
+  if (!raw) return null;
+  const trimmed = raw.trim().replace(/^["']|["']$/g, "");
+  return trimmed || null;
+}
+
+const API_KEY_LINE_REGEX = /^[ \t]*api_key:\s*.*\n?/m;
+
 export function setModelConfig(
   provider: string,
   model: string,
@@ -660,6 +696,33 @@ export function setModelConfig(
   content = upsertBlockChild(content, "model", "default", model);
   if (baseUrl) {
     content = upsertBlockChild(content, "model", "base_url", baseUrl);
+  }
+
+  // Workaround for upstream gateway bug — see pickAutoApiKeyForCustomProvider.
+  const autoApiKey = pickAutoApiKeyForCustomProvider(provider, baseUrl, profile);
+  if (autoApiKey) {
+    if (API_KEY_LINE_REGEX.test(content)) {
+      content = content.replace(
+        /^([ \t]*api_key:\s*).*$/m,
+        `$1"${autoApiKey}"`,
+      );
+    } else {
+      // Insert under base_url when present, otherwise under provider.
+      const afterBaseUrl = content.replace(
+        /^([ \t]*base_url:\s*"[^"]*"\s*\n)/m,
+        `$1  api_key: "${autoApiKey}"\n`,
+      );
+      content = afterBaseUrl !== content
+        ? afterBaseUrl
+        : content.replace(
+            /^([ \t]*provider:\s*"[^"]*"\s*\n)/m,
+            `$1  api_key: "${autoApiKey}"\n`,
+          );
+    }
+  } else if (API_KEY_LINE_REGEX.test(content)) {
+    // No env var (or provider doesn't qualify) — strip any stale auto-key so
+    // it doesn't linger when the user switches providers or clears the env.
+    content = content.replace(API_KEY_LINE_REGEX, "");
   }
 
   // Disable smart_model_routing

--- a/tests/custom-provider-auto-key.test.ts
+++ b/tests/custom-provider-auto-key.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+/**
+ * Workaround coverage for fathah/hermes-desktop#260:
+ * setModelConfig should auto-populate `model.api_key` for custom
+ * providers that point at a known commercial host (DeepSeek, Groq,
+ * Mistral, …) using the matching `<NAME>_API_KEY` value from the
+ * profile's .env, so the upstream gateway's broken OPENAI_API_KEY
+ * fallback never gets a chance to leak.
+ */
+
+let testHome: string;
+
+async function loadConfig(): Promise<typeof import("../src/main/config")> {
+  vi.resetModules();
+  vi.stubEnv("HERMES_HOME", testHome);
+  return await import("../src/main/config");
+}
+
+function writeBaseFiles(env: string, yaml: string): void {
+  writeFileSync(join(testHome, ".env"), env, "utf-8");
+  writeFileSync(join(testHome, "config.yaml"), yaml, "utf-8");
+}
+
+const SEED_YAML = `model:
+  provider: "auto"
+  default: ""
+  base_url: ""
+`;
+
+describe("setModelConfig — known-host custom provider auto-api-key (issue #260)", () => {
+  beforeEach(() => {
+    testHome = mkdtempSync(join(tmpdir(), "hermes-auto-key-"));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    rmSync(testHome, { recursive: true, force: true });
+  });
+
+  it("writes api_key for custom+deepseek when DEEPSEEK_API_KEY is set", async () => {
+    writeBaseFiles("DEEPSEEK_API_KEY=sk-deepseek-real-key\n", SEED_YAML);
+    const { setModelConfig } = await loadConfig();
+
+    setModelConfig("custom", "deepseek-reasoner", "https://api.deepseek.com/v1");
+
+    const out = readFileSync(join(testHome, "config.yaml"), "utf-8");
+    expect(out).toContain('provider: "custom"');
+    expect(out).toContain('default: "deepseek-reasoner"');
+    expect(out).toContain('base_url: "https://api.deepseek.com/v1"');
+    expect(out).toContain('api_key: "sk-deepseek-real-key"');
+  });
+
+  it("strips surrounding quotes from .env values", async () => {
+    writeBaseFiles('DEEPSEEK_API_KEY="sk-quoted-key"\n', SEED_YAML);
+    const { setModelConfig } = await loadConfig();
+
+    setModelConfig("custom", "deepseek-reasoner", "https://api.deepseek.com/v1");
+
+    const out = readFileSync(join(testHome, "config.yaml"), "utf-8");
+    expect(out).toContain('api_key: "sk-quoted-key"');
+    expect(out).not.toContain('api_key: ""sk-quoted-key""');
+  });
+
+  it("works for groq", async () => {
+    writeBaseFiles("GROQ_API_KEY=gsk_test_value\n", SEED_YAML);
+    const { setModelConfig } = await loadConfig();
+
+    setModelConfig("custom", "llama-3.1-70b", "https://api.groq.com/openai/v1");
+
+    const out = readFileSync(join(testHome, "config.yaml"), "utf-8");
+    expect(out).toContain('api_key: "gsk_test_value"');
+  });
+
+  it("does NOT write api_key when env var is missing", async () => {
+    writeBaseFiles("UNRELATED=x\n", SEED_YAML);
+    const { setModelConfig } = await loadConfig();
+
+    setModelConfig("custom", "deepseek-reasoner", "https://api.deepseek.com/v1");
+
+    const out = readFileSync(join(testHome, "config.yaml"), "utf-8");
+    expect(out).not.toContain("api_key:");
+  });
+
+  it("does NOT write api_key for unknown hosts (local LLM)", async () => {
+    // Even with an OPENAI_API_KEY present, a custom provider pointed at a
+    // local URL must not have it auto-copied — the env-var leak is
+    // exactly what we're protecting against.
+    writeBaseFiles("OPENAI_API_KEY=sk-something\n", SEED_YAML);
+    const { setModelConfig } = await loadConfig();
+
+    setModelConfig("custom", "llama3", "http://localhost:11434/v1");
+
+    const out = readFileSync(join(testHome, "config.yaml"), "utf-8");
+    expect(out).not.toContain("api_key:");
+  });
+
+  it("does NOT write api_key when provider is not 'custom'", async () => {
+    writeBaseFiles("DEEPSEEK_API_KEY=sk-deepseek\n", SEED_YAML);
+    const { setModelConfig } = await loadConfig();
+
+    // Built-in providers go through their own gateway path; the workaround
+    // is scoped strictly to bare-`custom`.
+    setModelConfig("deepseek", "deepseek-reasoner", "https://api.deepseek.com/v1");
+
+    const out = readFileSync(join(testHome, "config.yaml"), "utf-8");
+    expect(out).not.toContain("api_key:");
+  });
+
+  it("removes a stale api_key when conditions no longer match", async () => {
+    // Existing config already has a stale auto-written api_key.
+    const stale = `model:
+  provider: "custom"
+  default: "deepseek-reasoner"
+  base_url: "https://api.deepseek.com/v1"
+  api_key: "sk-old-deepseek"
+`;
+    writeBaseFiles("ANTHROPIC_API_KEY=sk-ant-xxx\n", stale);
+    const { setModelConfig } = await loadConfig();
+
+    // User switches to Anthropic (built-in provider) — the leftover
+    // api_key for the prior custom provider should not linger.
+    setModelConfig("anthropic", "claude-3-5-sonnet", "");
+
+    const out = readFileSync(join(testHome, "config.yaml"), "utf-8");
+    expect(out).not.toContain("api_key:");
+  });
+
+  it("updates the existing api_key in place when the env var changes", async () => {
+    const initial = `model:
+  provider: "custom"
+  default: "deepseek-reasoner"
+  base_url: "https://api.deepseek.com/v1"
+  api_key: "sk-deepseek-old"
+`;
+    writeBaseFiles("DEEPSEEK_API_KEY=sk-deepseek-new\n", initial);
+    const { setModelConfig } = await loadConfig();
+
+    setModelConfig("custom", "deepseek-reasoner", "https://api.deepseek.com/v1");
+
+    const out = readFileSync(join(testHome, "config.yaml"), "utf-8");
+    expect(out).toContain('api_key: "sk-deepseek-new"');
+    expect(out).not.toContain("sk-deepseek-old");
+    // Sanity: only one api_key line.
+    expect(out.match(/api_key:/g) || []).toHaveLength(1);
+  });
+});

--- a/tests/custom-provider-auto-key.test.ts
+++ b/tests/custom-provider-auto-key.test.ts
@@ -129,6 +129,46 @@ describe("setModelConfig — known-host custom provider auto-api-key (issue #260
     expect(out).not.toContain("api_key:");
   });
 
+  it("does not clobber api_key lines outside the model: block (auxiliary scoping)", async () => {
+    // Real-world configs have `api_key: ''` lines under `auxiliary.vision`,
+    // `auxiliary.web_extract`, etc.  A naive `/^api_key:/m` replace would
+    // mangle those.  The model-block-scoped logic must leave them alone.
+    const realisticYaml = `model:
+  provider: "auto"
+  default: ""
+  base_url: ""
+providers: {}
+auxiliary:
+  vision:
+    provider: auto
+    model: ''
+    base_url: ''
+    api_key: ''
+    timeout: 120
+  web_extract:
+    provider: auto
+    model: ''
+    base_url: ''
+    api_key: ''
+    timeout: 360
+`;
+    writeBaseFiles("DEEPSEEK_API_KEY=sk-deepseek-real\n", realisticYaml);
+    const { setModelConfig } = await loadConfig();
+
+    setModelConfig("custom", "deepseek-reasoner", "https://api.deepseek.com/v1");
+
+    const out = readFileSync(join(testHome, "config.yaml"), "utf-8");
+    // Model block must have the auto-key
+    const modelBlock = out.match(/^model:[\s\S]*?(?=^\S)/m)?.[0] || "";
+    expect(modelBlock).toContain('api_key: "sk-deepseek-real"');
+    // Auxiliary sections must still have their original empty api_key
+    expect(out).toContain("vision:\n    provider: auto\n    model: ''\n    base_url: ''\n    api_key: ''");
+    expect(out).toContain("web_extract:\n    provider: auto\n    model: ''\n    base_url: ''\n    api_key: ''");
+    // Exactly one non-empty api_key value in the whole file (the model one)
+    const realKeys = out.match(/api_key:\s*"[^"]+"/g) || [];
+    expect(realKeys).toHaveLength(1);
+  });
+
   it("updates the existing api_key in place when the env var changes", async () => {
     const initial = `model:
   provider: "custom"


### PR DESCRIPTION
Closes #260 (workaround — see \"Why this is a workaround\" below).

## Symptom

User configures DeepSeek (or Groq, Mistral, etc.) as a custom provider through the Providers UI, sends a chat, gets:

\`\`\`
Error: Error code: 401 - {'error': {'message': 'Authentication Fails, Your api key: ****ired is invalid', ...}}
\`\`\`

The masked tail (\`****ired\`, or whatever the last 4 chars of the user's \`OPENAI_API_KEY\` happen to be) gives it away: an OpenAI key is being sent to api.deepseek.com.

## Root cause (upstream, not fixable here)

Lives in \`hermes-agent/hermes_cli/runtime_provider.py::_resolve_openrouter_runtime\`. When \`model.provider == \"custom\"\` and the credential pool for the resolved \`custom:<name>\` is empty, the api_key fallback chain reads:

\`\`\`python
api_key_candidates = [
    explicit_api_key,
    (cfg_api_key if use_config_base_url else \"\"),  # model.api_key
    (os.getenv(\"OLLAMA_API_KEY\") if _is_ollama_url else \"\"),
    os.getenv(\"OPENAI_API_KEY\"),       # ← leaks here
    os.getenv(\"OPENROUTER_API_KEY\"),   # ← or here
]
\`\`\`

There's no provision for \"if base_url points at DeepSeek, prefer \`DEEPSEEK_API_KEY\`\" — the matching env var is never consulted. So even though the user typed \`DEEPSEEK_API_KEY=...\` into the Providers UI's env section, the gateway routes around it.

The desktop UI's \"Credential Pool\" section doesn't help either: the dropdown only offers literal \"custom\", so keys land under \`credential_pool[\"custom\"]\`, while the gateway looks up \`credential_pool[\"custom:deepseek\"]\`.

## The workaround in this PR

\`cfg_api_key\` (inline \`model.api_key\` in config.yaml) **does** win the fallback chain before the leak. So \`setModelConfig\` now auto-copies the matching env var to \`model.api_key\` when:

- Provider is bare \`\"custom\"\`, **and**
- The configured \`base_url\` matches a known commercial host (\`expectedEnvKeyForModel\` from #250 already has the mapping table), **and**
- The matching \`<NAME>_API_KEY\` is set in the active profile's \`.env\`

If the env var is missing, or the provider switches, or the URL stops matching a known host, the stale \`api_key\` line is stripped on the next save — so it never lingers past relevance.

Scope is deliberately narrow:
- Local LLMs (Ollama, vLLM, LM Studio, …) → **untouched** (no URL match → no auto-key)
- Built-in providers (anthropic, openai, …) → **untouched** (only fires for bare \"custom\")
- Custom hosts with no \`<NAME>_API_KEY\` env var → **untouched**

## Why this is a workaround

Right fix is upstream: \`_resolve_openrouter_runtime\` should drop the \`OPENAI_API_KEY\`/\`OPENROUTER_API_KEY\` candidates when the resolved base_url isn't openai.com / openrouter.ai. I'll file that on \`NousResearch/hermes-agent\` separately. Once it lands, this PR can be reverted with no user-visible change.

## Tests

\`tests/custom-provider-auto-key.test.ts\` — 8 cases:
- DeepSeek + env set → writes api_key ✓
- Quoted env value → quotes stripped ✓
- Groq + env set → writes api_key ✓
- Env var missing → no api_key written ✓
- Localhost / unknown host → no api_key written ✓
- Non-custom provider → no api_key written ✓
- Stale api_key cleared on provider switch ✓
- Existing api_key updated in place when env value changes ✓

411/411 total passing. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)