### PR TITLE
fix(config): allow empty environment variable values in readEnv

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -154,7 +154,7 @@ export function readEnv(profile?: string): Record<string, string> {
       value = value.slice(1, -1);
     }
 
-    if (value) result[key] = value;
+    result[key] = value;
   }
 
   setCache(cacheKey, result);

--- a/tests/env-validation.test.ts
+++ b/tests/env-validation.test.ts
@@ -72,4 +72,16 @@ describe("environment variable write validation", () => {
 
     expect(readEnvFile()).toBe("SAFE_KEY=original\n");
   });
+
+  it("keeps empty values in the read-back dict (valid POSIX env var)", async () => {
+    const { readEnv, setEnvValue } = await loadConfigModule();
+
+    setEnvValue("EMPTY_FLAG", "");
+    setEnvValue("WITH_VALUE", "present");
+
+    const env = readEnv();
+    expect(env.EMPTY_FLAG).toBe("");
+    expect(env.WITH_VALUE).toBe("present");
+    expect(readEnvFile()).toContain("EMPTY_FLAG=\n");
+  });
 });


### PR DESCRIPTION
Previously, empty values (e.g., KEY=) were silently dropped. This change ensures that empty strings are preserved in the returned dictionary, matching POSIX semantics.