### PR TITLE
Fix deleteSession to use writable database connection

### DIFF
--- a/src/main/sessions.ts
+++ b/src/main/sessions.ts
@@ -118,9 +118,9 @@ export interface SearchResult {
   snippet: string;
 }
 
-function getDb(): Database.Database | null {
+function getDb(readonly = true): Database.Database | null {
   if (!existsSync(DB_PATH)) return null;
-  return new Database(DB_PATH, { readonly: true });
+  return new Database(DB_PATH, readonly ? { readonly: true } : {});
 }
 
 export function listSessions(limit = 30, offset = 0): SessionSummary[] {
@@ -272,7 +272,7 @@ export function getSessionMessages(sessionId: string): SessionMessage[] {
 }
 
 export function deleteSession(sessionId: string): void {
-  const db = getDb();
+  const db = getDb(false);
   if (!db) return;
 
   try {

--- a/tests/sessions-delete-session.test.ts
+++ b/tests/sessions-delete-session.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { join } from "path";
+import { mkdirSync, rmSync, existsSync } from "fs";
+
+const { TEST_HOME, DB_PATH } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const path = require("path");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const os = require("os");
+  const home = path.join(
+    os.tmpdir(),
+    `hermes-delete-session-test-${Date.now()}`,
+  );
+  return {
+    TEST_HOME: home,
+    DB_PATH: path.join(home, "state.db"),
+  };
+});
+
+vi.mock("../src/main/installer", () => ({
+  HERMES_HOME: TEST_HOME,
+}));
+
+// Simulate better-sqlite3 faithfully: readonly connections reject writes
+// with SQLITE_READONLY, just like the real native module.
+vi.mock("better-sqlite3", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const fs = require("fs");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const path = require("path");
+
+  interface SessionRow {
+    id: string;
+    source: string;
+    started_at: number;
+    ended_at: number | null;
+    message_count: number;
+    model: string;
+    title: string | null;
+  }
+
+  interface MessageRow {
+    id: number;
+    session_id: string;
+    role: string;
+    content: string;
+    timestamp: number;
+  }
+
+  interface Store {
+    sessions: Map<string, SessionRow>;
+    messages: MessageRow[];
+    nextMessageId: number;
+  }
+
+  const stores = new Map<string, Store>();
+
+  function getStore(dbPath: string): Store {
+    if (!fs.existsSync(dbPath)) {
+      stores.set(dbPath, {
+        sessions: new Map<string, SessionRow>(),
+        messages: [],
+        nextMessageId: 1,
+      });
+      fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+      fs.writeFileSync(dbPath, "");
+    }
+
+    let store = stores.get(dbPath);
+    if (!store) {
+      store = {
+        sessions: new Map<string, SessionRow>(),
+        messages: [],
+        nextMessageId: 1,
+      };
+      stores.set(dbPath, store);
+    }
+    return store;
+  }
+
+  class FakeStatement {
+    constructor(
+      private readonly sql: string,
+      private readonly store: Store,
+      private readonly readonlyMode: boolean,
+    ) {}
+
+    run(...args: unknown[]): { changes: number } {
+      if (this.readonlyMode) {
+        const isWrite =
+          /\b(DELETE|INSERT|UPDATE|REPLACE|DROP|CREATE|ALTER)\b/i.test(
+            this.sql,
+          );
+        if (isWrite) {
+          const err = new Error(
+            "attempt to write a readonly database",
+          ) as Error & { code: string };
+          err.code = "SQLITE_READONLY";
+          throw err;
+        }
+      }
+
+      // INSERT / REPLACE handlers (used by seedDb and production code)
+      if (
+        this.sql.includes("INSERT OR REPLACE INTO sessions") ||
+        this.sql.includes("INSERT INTO sessions")
+      ) {
+        const [id, source, startedAt, _endedAt, messageCount, model, title] =
+          args;
+        this.store.sessions.set(String(id), {
+          id: String(id),
+          source: String(source),
+          started_at: Number(startedAt),
+          ended_at: null,
+          message_count: Number(messageCount),
+          model: String(model),
+          title: title === null || title === undefined ? null : String(title),
+        });
+        return { changes: 1 };
+      }
+
+      if (this.sql.includes("INSERT INTO messages")) {
+        const [sessionId, role, content, timestamp] = args;
+        this.store.messages.push({
+          id: this.store.nextMessageId++,
+          session_id: String(sessionId),
+          role: String(role),
+          content: String(content),
+          timestamp: Number(timestamp),
+        });
+        return { changes: 1 };
+      }
+
+      if (this.sql.includes("DELETE FROM messages")) {
+        const sessionId = String(args[0]);
+        const before = this.store.messages.length;
+        this.store.messages = this.store.messages.filter(
+          (m) => m.session_id !== sessionId,
+        );
+        return { changes: before - this.store.messages.length };
+      }
+
+      if (this.sql.includes("DELETE FROM sessions")) {
+        const sessionId = String(args[0]);
+        const existed = this.store.sessions.has(sessionId);
+        this.store.sessions.delete(sessionId);
+        return { changes: existed ? 1 : 0 };
+      }
+
+      throw new Error(`Unhandled fake run SQL: ${this.sql}`);
+    }
+
+    all(...args: unknown[]): SessionRow[] | MessageRow[] {
+      if (this.sql.includes("FROM sessions s")) {
+        const [limit, offset] = args.map(Number);
+        return Array.from(this.store.sessions.values())
+          .sort((a, b) => b.started_at - a.started_at)
+          .slice(offset, offset + limit);
+      }
+
+      if (this.sql.includes("FROM messages")) {
+        const sessionId = String(args[0]);
+        return this.store.messages
+          .filter(
+            (m) =>
+              m.session_id === sessionId &&
+              ["user", "assistant"].includes(m.role) &&
+              m.content !== null,
+          )
+          .sort((a, b) => a.timestamp - b.timestamp || a.id - b.id);
+      }
+
+      throw new Error(`Unhandled fake all SQL: ${this.sql}`);
+    }
+
+    get(_args: unknown[]): unknown {
+      throw new Error(`Unhandled fake get SQL: ${this.sql}`);
+    }
+  }
+
+  class FakeDatabase {
+    private readonly store: Store;
+    private readonly readonlyMode: boolean;
+
+    constructor(dbPath: string, options?: { readonly?: boolean }) {
+      this.store = getStore(dbPath);
+      this.readonlyMode = options?.readonly === true;
+    }
+
+    exec(): void {
+      /* no-op */
+    }
+
+    prepare(sql: string): FakeStatement {
+      return new FakeStatement(sql, this.store, this.readonlyMode);
+    }
+
+    close(): void {
+      /* no-op */
+    }
+  }
+
+  return { default: FakeDatabase };
+});
+
+import Database from "better-sqlite3";
+import {
+  deleteSession,
+  listSessions,
+  getSessionMessages,
+} from "../src/main/sessions";
+
+function seedDb(
+  sessions: Array<{
+    id: string;
+    started_at: number;
+    source?: string;
+    message_count?: number;
+    model?: string;
+    title?: string | null;
+    messages?: Array<{
+      role: "user" | "assistant";
+      content: string;
+      timestamp: number;
+    }>;
+  }>,
+): void {
+  mkdirSync(TEST_HOME, { recursive: true });
+  const db = new Database(DB_PATH);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS sessions (
+      id TEXT PRIMARY KEY,
+      source TEXT,
+      started_at INTEGER,
+      ended_at INTEGER,
+      message_count INTEGER,
+      model TEXT,
+      title TEXT
+    );
+    CREATE TABLE IF NOT EXISTS messages (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT,
+      role TEXT,
+      content TEXT,
+      timestamp INTEGER
+    );
+  `);
+  const insSession = db.prepare(
+    `INSERT OR REPLACE INTO sessions (id, source, started_at, ended_at, message_count, model, title)
+     VALUES (?, ?, ?, NULL, ?, ?, ?)`,
+  );
+  const insMessage = db.prepare(
+    `INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)`,
+  );
+  for (const s of sessions) {
+    insSession.run(
+      s.id,
+      s.source ?? "cli",
+      s.started_at,
+      s.message_count ?? (s.messages?.length ?? 0),
+      s.model ?? "gpt-4o",
+      s.title ?? null,
+    );
+    if (s.messages) {
+      for (const msg of s.messages) {
+        insMessage.run(s.id, msg.role, msg.content, msg.timestamp);
+      }
+    }
+  }
+  db.close();
+}
+
+beforeEach(() => {
+  mkdirSync(TEST_HOME, { recursive: true });
+});
+
+afterEach(() => {
+  if (existsSync(TEST_HOME)) {
+    rmSync(TEST_HOME, { recursive: true, force: true });
+  }
+});
+
+describe("deleteSession", () => {
+  it("deletes the session and all its messages from the database", () => {
+    const now = Math.floor(Date.now() / 1000);
+    seedDb([
+      {
+        id: "session-to-delete",
+        started_at: now,
+        message_count: 2,
+        messages: [
+          { role: "user", content: "hello", timestamp: now },
+          { role: "assistant", content: "hi there", timestamp: now + 1 },
+        ],
+      },
+      {
+        id: "session-to-keep",
+        started_at: now + 10,
+        message_count: 1,
+        messages: [
+          { role: "user", content: "keep me", timestamp: now + 10 },
+        ],
+      },
+    ]);
+
+    // Verify preconditions: both sessions exist
+    const beforeSessions = listSessions();
+    expect(beforeSessions).toHaveLength(2);
+    expect(beforeSessions.map((s) => s.id).sort()).toEqual([
+      "session-to-delete",
+      "session-to-keep",
+    ]);
+
+    const beforeMessages = getSessionMessages("session-to-delete");
+    expect(beforeMessages).toHaveLength(2);
+
+    // Act: delete the session
+    expect(() => deleteSession("session-to-delete")).not.toThrow();
+
+    // Assert: target session gone, other session untouched
+    const afterSessions = listSessions();
+    expect(afterSessions).toHaveLength(1);
+    expect(afterSessions[0].id).toBe("session-to-keep");
+
+    const deletedMessages = getSessionMessages("session-to-delete");
+    expect(deletedMessages).toHaveLength(0);
+  });
+
+  it("does nothing when deleting a non-existent session", () => {
+    const now = Math.floor(Date.now() / 1000);
+    seedDb([
+      {
+        id: "real-session",
+        started_at: now,
+        message_count: 1,
+        messages: [{ role: "user", content: "real", timestamp: now }],
+      },
+    ]);
+
+    const beforeSessions = listSessions();
+    expect(beforeSessions).toHaveLength(1);
+
+    // Deleting a non-existent session should not throw
+    expect(() => deleteSession("nonexistent")).not.toThrow();
+
+    // Existing session should still be there
+    const afterSessions = listSessions();
+    expect(afterSessions).toHaveLength(1);
+    expect(afterSessions[0].id).toBe("real-session");
+  });
+
+  it("returns early when the database file does not exist", () => {
+    // No DB seeded — HERMES_HOME/state.db doesn't exist
+    expect(() => deleteSession("any-session")).not.toThrow();
+  });
+});


### PR DESCRIPTION
- Add readonly parameter to getDb() function (defaults to true for backward compatibility)
- Update deleteSession() to request writable database connection
- Add comprehensive tests for deleteSession functionality
  - Test successful deletion of session and its messages
  - Test deletion of non-existent session (no-op)
  - Test deletion when database file doesn't exist