### PR TITLE
fix(remote): URL doubling, local-spawn leak, and credential UX (#266)

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -26,6 +26,10 @@ export interface PublicConnectionConfig {
   mode: "local" | "remote" | "ssh";
   remoteUrl: string;
   hasApiKey: boolean;
+  // Length of the stored API key, exposed so the renderer can show a
+  // mask that matches the real value's width. The secret itself never
+  // leaves the main process. 0 when no key is set.
+  apiKeyLength: number;
   ssh: SshConnectionConfig;
 }
 
@@ -76,6 +80,7 @@ export function getPublicConnectionConfig(): PublicConnectionConfig {
     mode: config.mode,
     remoteUrl: config.remoteUrl,
     hasApiKey: config.apiKey.length > 0,
+    apiKeyLength: config.apiKey.length,
     ssh: config.ssh,
   };
 }

--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -91,16 +91,12 @@ export function getRemoteAuthHeader(): Record<string, string> {
   return {};
 }
 
-function stripTrailingSlashes(url: string): string {
-  return url.replace(/\/+$/, "");
-}
-
 function resolveRemoteApiKey(url: string, apiKey?: string): string {
   if (apiKey !== undefined) return apiKey;
 
   const conn = getConnectionConfig();
   if (conn.mode !== "remote" || !conn.apiKey || !conn.remoteUrl) return "";
-  if (stripTrailingSlashes(conn.remoteUrl) !== stripTrailingSlashes(url)) {
+  if (normaliseRemoteUrl(conn.remoteUrl) !== normaliseRemoteUrl(url)) {
     return "";
   }
   return conn.apiKey;
@@ -1005,7 +1001,7 @@ export function testRemoteConnection(
   apiKey?: string,
 ): Promise<boolean> {
   return new Promise((resolve) => {
-    const target = `${stripTrailingSlashes(url)}/health`;
+    const target = `${normaliseRemoteUrl(url)}/health`;
     const mod = target.startsWith("https") ? https : http;
     const headers: Record<string, string> = {};
     const resolvedApiKey = resolveRemoteApiKey(url, apiKey);

--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -28,15 +28,35 @@ import {
 
 const LOCAL_API_URL = "http://127.0.0.1:8642";
 
+/**
+ * Normalise a remote-mode URL the user typed into the connection
+ * settings.  Strips trailing slashes and, importantly, a trailing
+ * `/v1` segment — callers append `/v1/<path>` themselves, so leaving
+ * the user's `/v1` would produce `http://host/v1/v1/chat/completions`
+ * → 404.  Reported as #266 (multiple users entered the URL "with
+ * /v1" because the gateway's curl examples show that form).
+ *
+ * Also tolerates trailing whitespace and the rare `/v1/` (slash-suffixed)
+ * form.  Returns the cleaned string.
+ */
+export function normaliseRemoteUrl(raw: string): string {
+  let url = (raw || "").trim();
+  // Strip trailing slashes
+  url = url.replace(/\/+$/, "");
+  // Strip trailing `/v1` (callers append /v1/<path> themselves)
+  url = url.replace(/\/v1$/i, "");
+  return url;
+}
+
 export function getApiUrl(): string {
   const conn = getConnectionConfig();
   if (conn.mode === "ssh") {
     const sshUrl = getSshTunnelUrl();
     if (!sshUrl) throw new Error("SSH tunnel is not active");
-    return sshUrl;
+    return normaliseRemoteUrl(sshUrl);
   }
   if (conn.mode === "remote" && conn.remoteUrl) {
-    return conn.remoteUrl.replace(/\/+$/, "");
+    return normaliseRemoteUrl(conn.remoteUrl);
   }
   return LOCAL_API_URL;
 }
@@ -859,6 +879,18 @@ let gatewayProcess: ChildProcess | null = null;
 let gatewayStartedByApp = false;
 
 export function startGateway(profile?: string): boolean {
+  // Defensive: the local gateway is never the right thing to spawn in
+  // remote/SSH mode — the user is pointing at an off-machine server.
+  // Callers should already gate, but several IPC handlers historically
+  // forgot to (issue #266), and reaching `spawn(HERMES_PYTHON, …)` when
+  // there's no local hermes-agent install produces an uncaught ENOENT
+  // that pops a generic error dialog.  Refuse cleanly here.
+  if (isRemoteMode()) {
+    console.warn(
+      "[gateway] startGateway() called in remote/SSH mode — refusing local spawn",
+    );
+    return false;
+  }
   ensureInitialized();
   if (isGatewayRunning()) return false;
 
@@ -996,6 +1028,10 @@ export function testRemoteConnection(
 }
 
 export function restartGateway(profile?: string): void {
+  // Same defensive gate as startGateway — the local gateway has no role
+  // in remote/SSH mode.  Cheap to check; catches IPC paths that don't
+  // wrap their restart calls in an isRemoteMode() check.
+  if (isRemoteMode()) return;
   if (!gatewayStartedByApp && !isGatewayRunning()) return;
   stopGateway(true);
   setTimeout(() => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -415,12 +415,19 @@ function setupIPC(): void {
         return true;
       }
       setEnvValue(key, value, profile);
-      // Restart gateway so it picks up the new API key
-      if (
-        (isGatewayRunning() && key.endsWith("_API_KEY")) ||
+      // Restart gateway so it picks up the new API key.
+      // The earlier condition had a precedence bug —
+      //   `(isGatewayRunning() && _API_KEY) || _TOKEN || HF_TOKEN`
+      // — that triggered a restart for `_TOKEN`/`HF_TOKEN` writes even
+      // when no local gateway was running, which in remote mode hit the
+      // `startGateway` path with no local install (issue #266).
+      // restartGateway() now also self-gates on isRemoteMode(), so this
+      // is belt-and-braces, but the condition is fixed too for clarity.
+      const looksLikeCredential =
+        key.endsWith("_API_KEY") ||
         key.endsWith("_TOKEN") ||
-        key === "HF_TOKEN"
-      ) {
+        key === "HF_TOKEN";
+      if (isGatewayRunning() && looksLikeCredential) {
         restartGateway(profile);
       }
       return true;
@@ -723,12 +730,22 @@ function setupIPC(): void {
       await sshStartGateway(conn.ssh);
       return true;
     }
+    if (conn.mode === "remote") {
+      // The remote server runs its own gateway; nothing to start locally.
+      // Without this guard we'd fall through to `startGateway()` and
+      // spawn a non-existent local hermes-agent (issue #266).
+      return false;
+    }
     return startGateway();
   });
   ipcMain.handle("stop-gateway", async () => {
     const conn = getConnectionConfig();
     if (conn.mode === "ssh" && conn.ssh) {
       await sshStopGateway(conn.ssh);
+      return true;
+    }
+    if (conn.mode === "remote") {
+      // No local gateway to stop in pure remote mode.
       return true;
     }
     stopGateway(true);

--- a/src/renderer/src/screens/Settings/Settings.tsx
+++ b/src/renderer/src/screens/Settings/Settings.tsx
@@ -17,7 +17,16 @@ const LANGUAGE_NATIVE_NAMES: Record<AppLocale, string> = {
   "zh-TW": "繁體中文（台灣）",
 };
 
-const REMOTE_API_KEY_MASK = "********";
+// Build a mask string the same width as the stored API key so the
+// "saved" state of the input looks like a key, not a constant blob.
+// Length is exposed by the main process via PublicConnectionConfig.
+// 0 falls back to 8 dots so the user gets a visible "set" indicator
+// even if main didn't report a length yet. Capped to keep absurdly
+// long keys from blowing up the field.
+function makeApiKeyMask(length: number): string {
+  const n = Math.min(Math.max(length, 8), 128);
+  return "*".repeat(n);
+}
 
 // Read cached values from localStorage for instant display
 function getCachedVersion(): string | null {
@@ -78,6 +87,7 @@ function Settings({ profile }: { profile?: string }): React.JSX.Element {
   const [connMode, setConnMode] = useState<"local" | "remote" | "ssh">("local");
   const [connRemoteUrl, setConnRemoteUrl] = useState("");
   const [connApiKey, setConnApiKey] = useState("");
+  const [connApiKeyMask, setConnApiKeyMask] = useState("");
   const [connHasApiKey, setConnHasApiKey] = useState(false);
   const [connTesting, setConnTesting] = useState(false);
   const [connStatus, setConnStatus] = useState<string | null>(null);
@@ -123,7 +133,9 @@ function Settings({ profile }: { profile?: string }): React.JSX.Element {
     setConnMode(conn.mode);
     setConnRemoteUrl(conn.remoteUrl);
     setConnHasApiKey(conn.hasApiKey);
-    setConnApiKey(conn.hasApiKey ? REMOTE_API_KEY_MASK : "");
+    const mask = conn.hasApiKey ? makeApiKeyMask(conn.apiKeyLength) : "";
+    setConnApiKeyMask(mask);
+    setConnApiKey(mask);
     setSshHost(conn.ssh?.host || "");
     setSshPort(conn.ssh?.port ? String(conn.ssh.port) : "");
     setSshUser(conn.ssh?.username || "");
@@ -204,13 +216,13 @@ function Settings({ profile }: { profile?: string }): React.JSX.Element {
   }
 
   function getConnectionApiKeyForSave(): string | undefined {
-    // Mask sentinel ("********") in the field means "the secret is still
-    // server-side and the user hasn't touched it" — always preserve the
-    // stored key. The old code wiped the key whenever the URL changed,
-    // so a one-character URL edit (fix typo, add /v1) silently dropped
-    // the saved credential. To clear the key, the user must explicitly
-    // erase the field.
-    if (connHasApiKey && connApiKey === REMOTE_API_KEY_MASK) {
+    // Mask sentinel in the field means "the secret is still server-side
+    // and the user hasn't touched it" — always preserve the stored key.
+    // The old code wiped the key whenever the URL changed, so a one-
+    // character URL edit (fix typo, add /v1) silently dropped the saved
+    // credential. To clear the key, the user must explicitly erase the
+    // field.
+    if (connHasApiKey && connApiKey === connApiKeyMask) {
       return undefined;
     }
     return connApiKey.trim();
@@ -236,7 +248,13 @@ function Settings({ profile }: { profile?: string }): React.JSX.Element {
       if (apiKey !== undefined) {
         const hasApiKey = apiKey.length > 0;
         setConnHasApiKey(hasApiKey);
-        if (hasApiKey) setConnApiKey(REMOTE_API_KEY_MASK);
+        if (hasApiKey) {
+          const mask = makeApiKeyMask(apiKey.length);
+          setConnApiKeyMask(mask);
+          setConnApiKey(mask);
+        } else {
+          setConnApiKeyMask("");
+        }
       }
     }
     setConnStatus("Saved");
@@ -281,6 +299,7 @@ function Settings({ profile }: { profile?: string }): React.JSX.Element {
     setConnMode("local");
     setConnRemoteUrl("");
     setConnApiKey("");
+    setConnApiKeyMask("");
     setConnHasApiKey(false);
     await window.hermesAPI.setConnectionConfig("local", "", "");
     setConnStatus(t("settings.switchedToLocal"));
@@ -609,7 +628,7 @@ function Settings({ profile }: { profile?: string }): React.JSX.Element {
                 value={connApiKey}
                 onChange={(e) => setConnApiKey(e.target.value)}
                 onFocus={(e) => {
-                  if (connApiKey === REMOTE_API_KEY_MASK) {
+                  if (connApiKey === connApiKeyMask) {
                     e.currentTarget.select();
                   }
                 }}

--- a/src/renderer/src/screens/Settings/Settings.tsx
+++ b/src/renderer/src/screens/Settings/Settings.tsx
@@ -77,7 +77,6 @@ function Settings({ profile }: { profile?: string }): React.JSX.Element {
   // Connection mode
   const [connMode, setConnMode] = useState<"local" | "remote" | "ssh">("local");
   const [connRemoteUrl, setConnRemoteUrl] = useState("");
-  const [connSavedRemoteUrl, setConnSavedRemoteUrl] = useState("");
   const [connApiKey, setConnApiKey] = useState("");
   const [connHasApiKey, setConnHasApiKey] = useState(false);
   const [connTesting, setConnTesting] = useState(false);
@@ -123,7 +122,6 @@ function Settings({ profile }: { profile?: string }): React.JSX.Element {
     setAppVersion(aVersion);
     setConnMode(conn.mode);
     setConnRemoteUrl(conn.remoteUrl);
-    setConnSavedRemoteUrl(conn.remoteUrl);
     setConnHasApiKey(conn.hasApiKey);
     setConnApiKey(conn.hasApiKey ? REMOTE_API_KEY_MASK : "");
     setSshHost(conn.ssh?.host || "");
@@ -206,8 +204,14 @@ function Settings({ profile }: { profile?: string }): React.JSX.Element {
   }
 
   function getConnectionApiKeyForSave(): string | undefined {
+    // Mask sentinel ("********") in the field means "the secret is still
+    // server-side and the user hasn't touched it" — always preserve the
+    // stored key. The old code wiped the key whenever the URL changed,
+    // so a one-character URL edit (fix typo, add /v1) silently dropped
+    // the saved credential. To clear the key, the user must explicitly
+    // erase the field.
     if (connHasApiKey && connApiKey === REMOTE_API_KEY_MASK) {
-      return connRemoteUrl === connSavedRemoteUrl ? undefined : "";
+      return undefined;
     }
     return connApiKey.trim();
   }
@@ -229,7 +233,6 @@ function Settings({ profile }: { profile?: string }): React.JSX.Element {
         connRemoteUrl,
         apiKey,
       );
-      setConnSavedRemoteUrl(connRemoteUrl);
       if (apiKey !== undefined) {
         const hasApiKey = apiKey.length > 0;
         setConnHasApiKey(hasApiKey);
@@ -277,7 +280,6 @@ function Settings({ profile }: { profile?: string }): React.JSX.Element {
   async function handleSwitchToLocal(): Promise<void> {
     setConnMode("local");
     setConnRemoteUrl("");
-    setConnSavedRemoteUrl("");
     setConnApiKey("");
     setConnHasApiKey(false);
     await window.hermesAPI.setConnectionConfig("local", "", "");

--- a/tests/connection-config-security.test.ts
+++ b/tests/connection-config-security.test.ts
@@ -55,6 +55,10 @@ describe("connection config secret exposure", () => {
       mode: "remote",
       remoteUrl: "https://hermes.example",
       hasApiKey: true,
+      // Length is intentionally exposed so the renderer can render a
+      // mask that matches the stored key's width. The secret itself
+      // must NOT be present — covered by the assertions below.
+      apiKeyLength: "remote-secret".length,
     });
     expect("apiKey" in publicConfig).toBe(false);
     expect(JSON.stringify(publicConfig)).not.toContain("remote-secret");

--- a/tests/remote-mode-url-and-spawn.test.ts
+++ b/tests/remote-mode-url-and-spawn.test.ts
@@ -92,7 +92,9 @@ import {
   normaliseRemoteUrl,
   startGateway,
   restartGateway,
+  testRemoteConnection,
 } from "../src/main/hermes";
+import http from "http";
 
 describe("normaliseRemoteUrl", () => {
   it("strips a trailing /v1 segment so callers don't double it", () => {
@@ -152,6 +154,39 @@ describe("normaliseRemoteUrl", () => {
     expect(normaliseRemoteUrl("")).toBe("");
     // @ts-expect-error — defending against the undefined case
     expect(normaliseRemoteUrl(undefined)).toBe("");
+  });
+});
+
+describe("testRemoteConnection URL probe", () => {
+  it("strips trailing /v1 before appending /health", async () => {
+    // Capture the URL handed to http.request by the health probe.
+    // Reported in #266: stale code path was building
+    // `http://host/v1/health` from a user-supplied `http://host/v1`,
+    // which 404s and produces the "Cannot reach remote Hermes" splash.
+    let capturedTarget: string | undefined;
+    const reqSpy = vi
+      .spyOn(http, "request")
+      .mockImplementation((target: unknown, ...rest: unknown[]) => {
+        capturedTarget = String(target);
+        // Find the response callback (last arg) and immediately fire it
+        // with a fake 200 so the promise resolves cleanly.
+        const cb = rest[rest.length - 1] as (res: unknown) => void;
+        cb({ statusCode: 200, resume: () => {} });
+        // Stub minimal request handle
+        return {
+          on: () => {},
+          end: () => {},
+          destroy: () => {},
+        } as unknown as ReturnType<typeof http.request>;
+      });
+
+    await testRemoteConnection("http://127.0.0.1:8642/v1");
+    expect(capturedTarget).toBe("http://127.0.0.1:8642/health");
+
+    await testRemoteConnection("http://127.0.0.1:8642/V1/");
+    expect(capturedTarget).toBe("http://127.0.0.1:8642/health");
+
+    reqSpy.mockRestore();
   });
 });
 

--- a/tests/remote-mode-url-and-spawn.test.ts
+++ b/tests/remote-mode-url-and-spawn.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi } from "vitest";
+
+/**
+ * Coverage for the two fixes in #266:
+ *
+ *   1. `normaliseRemoteUrl` strips trailing `/v1` and slashes so callers
+ *      that append `/v1/<path>` don't produce `/v1/v1/...` → 404.
+ *
+ *   2. `startGateway` and `restartGateway` refuse to spawn a local
+ *      hermes-agent when the connection is in remote/SSH mode — the
+ *      defensive net that catches IPC paths that don't explicitly gate
+ *      on `isRemoteMode()`.
+ */
+
+const { TEST_HOME, connModeRef, spawnSpy } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const path = require("path");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const os = require("os");
+  return {
+    TEST_HOME: path.join(os.tmpdir(), `hermes-remote-test-${Date.now()}`),
+    connModeRef: { mode: "local" as "local" | "remote" | "ssh" },
+    spawnSpy: vi.fn(() => ({
+      unref: () => {},
+      pid: 12345,
+      on: () => {},
+    })),
+  };
+});
+
+vi.mock("../src/main/installer", () => ({
+  HERMES_HOME: TEST_HOME,
+  HERMES_PYTHON: "/usr/bin/python3",
+  HERMES_REPO: "/dev/null",
+  hermesCliArgs: () => ["gateway"],
+  getEnhancedPath: () => process.env.PATH || "",
+}));
+
+vi.mock("../src/main/config", () => ({
+  getModelConfig: () => ({ model: "test-model", provider: "openrouter" }),
+  readEnv: () => ({}),
+  getConnectionConfig: () => ({
+    mode: connModeRef.mode,
+    remoteUrl: "http://example.com",
+    apiKey: "",
+    ssh: {
+      host: "",
+      port: 22,
+      username: "",
+      keyPath: "",
+      remotePort: 8642,
+      localPort: 18642,
+    },
+  }),
+}));
+
+vi.mock("../src/main/ssh-tunnel", () => ({
+  getSshTunnelUrl: () => "http://localhost:18642",
+  isSshTunnelActive: () => true,
+  isSshTunnelHealthy: () => Promise.resolve(true),
+  startSshTunnel: () => Promise.resolve(),
+}));
+
+vi.mock("../src/main/utils", () => ({
+  stripAnsi: (s: string) => s,
+  pidIsAliveAs: () => false,
+}));
+
+vi.mock("../src/main/models", () => ({
+  readModels: () => [],
+}));
+
+vi.mock("../src/main/process-options", () => ({
+  HIDDEN_SUBPROCESS_OPTIONS: {},
+}));
+
+// Spy on child_process.spawn so we can assert it isn't called when the
+// remote-mode guard fires.  When guards work correctly tests never
+// reach the spawn site; the unref/pid/on stubs are belt-and-braces.
+
+vi.mock("child_process", async () => {
+  const actual = await vi.importActual<typeof import("child_process")>(
+    "child_process",
+  );
+  return {
+    ...actual,
+    spawn: spawnSpy,
+  };
+});
+
+import {
+  normaliseRemoteUrl,
+  startGateway,
+  restartGateway,
+} from "../src/main/hermes";
+
+describe("normaliseRemoteUrl", () => {
+  it("strips a trailing /v1 segment so callers don't double it", () => {
+    expect(normaliseRemoteUrl("http://127.0.0.1:8642/v1")).toBe(
+      "http://127.0.0.1:8642",
+    );
+    expect(normaliseRemoteUrl("https://api.example.com/v1")).toBe(
+      "https://api.example.com",
+    );
+  });
+
+  it("strips trailing slashes", () => {
+    expect(normaliseRemoteUrl("http://127.0.0.1:8642/")).toBe(
+      "http://127.0.0.1:8642",
+    );
+    expect(normaliseRemoteUrl("http://127.0.0.1:8642///")).toBe(
+      "http://127.0.0.1:8642",
+    );
+  });
+
+  it("strips trailing /v1/ (slash-suffixed)", () => {
+    expect(normaliseRemoteUrl("http://127.0.0.1:8642/v1/")).toBe(
+      "http://127.0.0.1:8642",
+    );
+  });
+
+  it("is case-insensitive on the /v1 segment", () => {
+    expect(normaliseRemoteUrl("http://127.0.0.1:8642/V1")).toBe(
+      "http://127.0.0.1:8642",
+    );
+  });
+
+  it("trims whitespace", () => {
+    expect(normaliseRemoteUrl("  http://127.0.0.1:8642  ")).toBe(
+      "http://127.0.0.1:8642",
+    );
+  });
+
+  it("leaves a clean URL untouched", () => {
+    expect(normaliseRemoteUrl("http://127.0.0.1:8642")).toBe(
+      "http://127.0.0.1:8642",
+    );
+    expect(normaliseRemoteUrl("https://api.example.com")).toBe(
+      "https://api.example.com",
+    );
+  });
+
+  it("doesn't strip a `/v1` that isn't the trailing segment", () => {
+    // Pathological but valid — a host whose path contains v1 elsewhere
+    // should not be mangled.
+    expect(normaliseRemoteUrl("http://example.com/v1/foo")).toBe(
+      "http://example.com/v1/foo",
+    );
+  });
+
+  it("tolerates empty input", () => {
+    expect(normaliseRemoteUrl("")).toBe("");
+    // @ts-expect-error — defending against the undefined case
+    expect(normaliseRemoteUrl(undefined)).toBe("");
+  });
+});
+
+describe("startGateway / restartGateway in remote mode", () => {
+  it("startGateway refuses to spawn in remote mode", () => {
+    spawnSpy.mockClear();
+    connModeRef.mode = "remote";
+    const result = startGateway();
+    expect(result).toBe(false);
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  it("startGateway refuses to spawn in ssh mode", () => {
+    spawnSpy.mockClear();
+    connModeRef.mode = "ssh";
+    const result = startGateway();
+    expect(result).toBe(false);
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  it("restartGateway is a no-op in remote mode", () => {
+    spawnSpy.mockClear();
+    connModeRef.mode = "remote";
+    restartGateway();
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  it("restartGateway is a no-op in ssh mode", () => {
+    spawnSpy.mockClear();
+    connModeRef.mode = "ssh";
+    restartGateway();
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #266.

Reporter pasted the gateway URL with `/v1` ("…the gateway's curl examples show that form") and got a 404 wall. While auditing the same code path I found three related papercuts that together make remote mode brittle, so this PR bundles them.

## What changes

### 1. URL normalization
Trailing `/v1` and trailing slashes are now stripped from the user-supplied remote URL before any code path appends a sub-path. The desktop appends `/v1/chat/completions` itself, so leaving the user's `/v1` produced `/v1/v1/chat/completions` → 404. Three call sites had to be updated to go through the same `normaliseRemoteUrl` helper:

- `getApiUrl()` — chat requests
- `testRemoteConnection()` — health probe used by the splash screen ("Cannot reach remote Hermes")
- `resolveRemoteApiKey()` — URL equality check used when attaching the API key to health probes

### 2. Local-spawn leak in remote mode
Defensive `if (isRemoteMode()) return` guards inside `startGateway()` and `restartGateway()`. The renderer already gates these calls, but the main process has a handful of indirect callers (env-var save, model change, IPC handlers from older flows) — the inner guard catches them all and emits a single log line:

```
[gateway] startGateway() called in remote/SSH mode — refusing local spawn
```

Also fixed an operator-precedence bug in the `set-env` handler that was firing a gateway restart on `_TOKEN`/`HF_TOKEN` writes even when no local gateway existed. The `start-gateway` and `stop-gateway` IPC handlers are now explicit no-ops in remote mode (rather than relying on the inner guard for correctness).

### 3. Settings UX bugs uncovered by the test
While manually testing #266 I hit two adjacent issues in Settings → Connection:

- **Silent key wipe on URL edit.** The API-key input fills with a mask sentinel after save (the secret never leaves main). The save handler used to interpret "mask in field + URL changed" as "user wants to drop the key" — so fixing a typo in the URL silently wiped the saved credential. Mask in field now always means "preserve."
- **Mask width didn't match the real key.** A 43-char OpenRouter key was displayed as 8 dots, leading users to think the key was truncated. `PublicConnectionConfig` now exposes `apiKeyLength` (just the length, not the secret) so the mask matches the stored key's width (floored at 8, capped at 128).

## Tests

`tests/remote-mode-url-and-spawn.test.ts` — 13 cases covering URL normalization edge cases (trailing `/v1`, slashes, case, whitespace, mid-string `/v1`, empty input), `testRemoteConnection` health-probe URL, and `startGateway` / `restartGateway` no-op behavior in remote/SSH mode (asserted via a spied `child_process.spawn`).

`tests/connection-config-security.test.ts` updated to assert `apiKeyLength` is exposed but the secret itself never appears in the public config.

448/448 tests passing, typecheck clean.

## Manual verification

- Remote mode with `http://127.0.0.1:8642/v1`, `http://127.0.0.1:8642/V1/`, and `http://127.0.0.1:8642` — all connect cleanly.
- Edited the URL while the API-key field showed the mask; saved; verified `desktop.json` still contained the original key.
- API-key mask now renders 43 dots for a 43-char OpenRouter key.
- Switched between local and remote modes; no stray python.exe spawned (gateway PID stayed constant at the one I started manually).

## Test plan

- [ ] Configure remote mode with `http://<host>:8642/v1` and confirm chat works.
- [ ] Edit only the URL while the API-key field shows the mask; verify the saved key is preserved.
- [ ] Verify the mask in Settings matches the stored key's length.
- [ ] In remote mode, trigger anything that would normally restart the gateway (env change, model swap) — confirm no local python.exe is spawned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Out of scope

The issue body also mentions `[CRON] remote list failed: HTTP 404` from polling `/api/jobs`. I audited it and confirmed that current `hermes-agent` builds (verified locally) do expose `/api/jobs` — the 404 was specific to the reporter's older 0.14.0. Sessions reads a local SQLite and degrades cleanly; kanban is already gated with `isRemoteOnlyMode()`. So the only remaining edge case is a user pointing remote mode at an old agent or a non-Hermes OpenAI-compatible server, which felt like scope creep for this PR. Happy to open a follow-up if someone reports it on a current build.
