### PR TITLE
fix(tests): repair the three failing tests on main

### DIFF
--- a/src/renderer/src/constants.ts
+++ b/src/renderer/src/constants.ts
@@ -44,7 +44,8 @@ export const PROVIDERS = {
     { value: "minimax", label: "MiniMax" },
     { value: "nous", label: "constants.nousName" },
     // Subscription / OAuth plans
-    { value: "openai-codex", label: "ChatGPT (Codex Plan)" },
+    // openai-codex is listed once above (first-party group) via #102 —
+    // not repeated here to avoid a duplicate <option> value.
     { value: "xai-oauth", label: "xAI Grok (OAuth)" },
     { value: "qwen-oauth", label: "Qwen (OAuth)" },
     { value: "google-gemini-cli", label: "Gemini (CLI OAuth)" },

--- a/tests/sessions-delete-session.test.ts
+++ b/tests/sessions-delete-session.test.ts
@@ -194,6 +194,14 @@ vi.mock("better-sqlite3", () => {
       return new FakeStatement(sql, this.store, this.readonlyMode);
     }
 
+    // better-sqlite3's `transaction(fn)` returns a callable that runs
+    // `fn` inside a transaction. The fake doesn't need real atomicity —
+    // a synchronous passthrough is enough for deleteSession's two-step
+    // delete. Previously absent, which broke deleteSession's tests.
+    transaction<T extends (...args: never[]) => unknown>(fn: T): T {
+      return ((...args: never[]) => fn(...args)) as T;
+    }
+
     close(): void {
       /* no-op */
     }


### PR DESCRIPTION
## Summary

`main` currently has **three failing tests**. Each was "merged red" — the PR that introduced it shipped a failing test, and with no CI running PR suites, nothing caught it.

```
× constants.test.ts  › PROVIDERS › no duplicate option values
× sessions-delete-session.test.ts › deleteSession › deletes the session and all its messages
× sessions-delete-session.test.ts › deleteSession › does nothing when deleting a non-existent session
```

## Fixes

### 1. Duplicate `openai-codex` provider option

#102 and #262 each independently added an `openai-codex` entry to `PROVIDERS.options`, so the provider dropdown now lists it **twice** (once as "OpenAI Codex", once as "ChatGPT (Codex Plan)"). #102's own `no duplicate option values` test catches it — it just never ran again after #262 merged.

Removed the duplicate. Kept #102's entry — its label is the translatable i18n key `constants.openaiCodexName` (vs the other's hardcoded English string), and it's consistent with the `labels` map, which already only has that one.

> Minor note for the maintainer, not changed here: `openai-codex` is an OAuth/subscription provider, so it may belong under the "Subscription / OAuth plans" group rather than "first-party API providers" where #102 placed it. Moving it is a judgement call — left as-is.

### 2. `deleteSession` tests — incomplete DB mock

`deleteSession` correctly wraps its two deletes in `db.transaction(...)` (valid better-sqlite3). The test's `FakeDatabase` mock implemented `exec`/`prepare`/`close` but **not `transaction`**, so the tests threw `TypeError: db.transaction is not a function`. Added a passthrough `transaction` to the mock. **Source code is correct and unchanged** — this is a test-only fix.

## Result

`npm test` → **468 passing, 3 skipped, 0 failing** (was 3 failing). Typecheck clean.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — full suite green

## Worth raising separately

All three of these reached `main` because the repo has **no CI** to run the test suite on PRs. A minimal GitHub Actions workflow (`npm run typecheck && npm test` on PRs) would have blocked every one of them. Happy to open that as a separate PR if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)