### PR TITLE
feat(providers): in-app OAuth sign-in for subscription providers

### DIFF
--- a/src/main/hermes-auth.ts
+++ b/src/main/hermes-auth.ts
@@ -1,0 +1,156 @@
+import { spawn, type ChildProcess } from "child_process";
+import { homedir } from "os";
+import {
+  HERMES_PYTHON,
+  HERMES_REPO,
+  HERMES_HOME,
+  hermesCliArgs,
+  getEnhancedPath,
+} from "./installer";
+import { HIDDEN_SUBPROCESS_OPTIONS } from "./process-options";
+import { stripAnsi } from "./utils";
+
+/**
+ * Provider identifiers that authenticate via an interactive OAuth flow
+ * (`hermes auth add <provider> --type oauth`) rather than a static API
+ * key. Mirrors hermes-agent's `_OAUTH_CAPABLE_PROVIDERS` set, minus the
+ * API-key-capable `anthropic`/`nous` which the desktop sets up through
+ * the normal key flow.
+ */
+export const OAUTH_LOGIN_PROVIDERS = [
+  "openai-codex",
+  "xai-oauth",
+  "qwen-oauth",
+  "google-gemini-cli",
+  "minimax-oauth",
+] as const;
+
+export type OAuthLoginProvider = (typeof OAUTH_LOGIN_PROVIDERS)[number];
+
+export function isOAuthLoginProvider(value: string): value is OAuthLoginProvider {
+  return (OAUTH_LOGIN_PROVIDERS as readonly string[]).includes(value);
+}
+
+export interface OAuthLoginResult {
+  success: boolean;
+  error?: string;
+}
+
+/**
+ * Parse a device-code login prompt out of the CLI's streamed output.
+ * The OpenAI Codex flow — unlike the browser-loopback providers —
+ * prints a URL to open and a short code to enter rather than opening a
+ * browser itself. Detecting both lets the desktop open the page and
+ * pre-copy the code so the user only has to paste.
+ *
+ * Returns null until both parts are present. Only an `https:` URL is
+ * accepted (the value is fed to `shell.openExternal`).
+ */
+export function detectDeviceCode(
+  text: string,
+): { url: string; code: string } | null {
+  const urlMatch = text.match(
+    /Open this URL in your browser:\s*\n\s*(https:\/\/\S+)/,
+  );
+  const codeMatch = text.match(/Enter this code:\s*\n\s*(\S+)/);
+  if (urlMatch && codeMatch) {
+    return { url: urlMatch[1], code: codeMatch[1] };
+  }
+  return null;
+}
+
+// Only one interactive login can run at a time — the renderer surfaces a
+// single modal. Tracked so the renderer can cancel a flow the user
+// abandoned (otherwise the CLI's loopback OAuth server lingers).
+let activeProc: ChildProcess | null = null;
+
+/**
+ * Run `hermes auth add <provider> --type oauth`, streaming the CLI's
+ * stdout/stderr line-by-line to `emit`. The CLI opens the system browser
+ * for the OAuth consent step and runs a localhost loopback server to
+ * catch the redirect; this function just supervises that subprocess.
+ *
+ * Resolves `{ success: true }` on exit code 0, `{ success: false, error }`
+ * otherwise (non-zero exit, spawn failure, or cancellation).
+ */
+export function runHermesAuthLogin(
+  provider: string,
+  emit: (chunk: string) => void,
+  profile?: string,
+): Promise<OAuthLoginResult> {
+  return new Promise((resolve) => {
+    if (!isOAuthLoginProvider(provider)) {
+      resolve({ success: false, error: `Unsupported OAuth provider: ${provider}` });
+      return;
+    }
+    if (activeProc) {
+      resolve({
+        success: false,
+        error: "Another sign-in is already in progress.",
+      });
+      return;
+    }
+
+    // `--type oauth` is explicit so the CLI never falls back to an
+    // interactive "API key or OAuth?" prompt on a stdin we've closed.
+    const subArgs =
+      profile && profile !== "default"
+        ? ["-p", profile, "auth", "add", provider, "--type", "oauth"]
+        : ["auth", "add", provider, "--type", "oauth"];
+
+    let proc: ChildProcess;
+    try {
+      proc = spawn(HERMES_PYTHON, hermesCliArgs(subArgs), {
+        cwd: HERMES_REPO,
+        env: {
+          ...process.env,
+          PATH: getEnhancedPath(),
+          HOME: homedir(),
+          HERMES_HOME,
+          TERM: "dumb",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+        ...HIDDEN_SUBPROCESS_OPTIONS,
+      });
+    } catch (err) {
+      resolve({ success: false, error: (err as Error).message });
+      return;
+    }
+
+    activeProc = proc;
+    let settled = false;
+    const finish = (result: OAuthLoginResult): void => {
+      if (settled) return;
+      settled = true;
+      activeProc = null;
+      resolve(result);
+    };
+
+    proc.stdout?.on("data", (data: Buffer) => emit(stripAnsi(data.toString())));
+    proc.stderr?.on("data", (data: Buffer) => emit(stripAnsi(data.toString())));
+
+    proc.on("error", (err) => {
+      finish({ success: false, error: `Failed to start sign-in: ${err.message}` });
+    });
+
+    proc.on("close", (code, signal) => {
+      if (code === 0) {
+        finish({ success: true });
+      } else if (signal) {
+        finish({ success: false, error: "Sign-in cancelled." });
+      } else {
+        finish({ success: false, error: `Sign-in exited with code ${code}.` });
+      }
+    });
+  });
+}
+
+/**
+ * Kill the in-flight login subprocess, if any. Used when the user closes
+ * the sign-in modal before the OAuth flow completes.
+ */
+export function cancelHermesAuthLogin(): boolean {
+  if (!activeProc) return false;
+  activeProc.kill();
+  return true;
+}

--- a/src/main/hermes-auth.ts
+++ b/src/main/hermes-auth.ts
@@ -49,10 +49,13 @@ export interface OAuthLoginResult {
 export function detectDeviceCode(
   text: string,
 ): { url: string; code: string } | null {
+  // `[^\S\n]*` is horizontal-whitespace-only — using `\s*` here would
+  // silently consume a blank line between the label and the value, making
+  // a false-positive match against the wrong line possible.
   const urlMatch = text.match(
-    /Open this URL in your browser:\s*\n\s*(https:\/\/\S+)/,
+    /Open this URL in your browser:[^\S\n]*\n[^\S\n]*(https:\/\/\S+)/,
   );
-  const codeMatch = text.match(/Enter this code:\s*\n\s*(\S+)/);
+  const codeMatch = text.match(/Enter this code:[^\S\n]*\n[^\S\n]*(\S+)/);
   if (urlMatch && codeMatch) {
     return { url: urlMatch[1], code: codeMatch[1] };
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,6 +6,7 @@ import {
   Menu,
   Notification,
   dialog,
+  clipboard,
 } from "electron";
 import { join } from "path";
 import { electronApp, optimizer, is } from "@electron-toolkit/utils";
@@ -32,6 +33,11 @@ import {
   readLogs,
   InstallProgress,
 } from "./installer";
+import {
+  runHermesAuthLogin,
+  cancelHermesAuthLogin,
+  detectDeviceCode,
+} from "./hermes-auth";
 import {
   isRemoteMode,
   isRemoteOnlyMode,
@@ -396,6 +402,39 @@ function setupIPC(): void {
       return { success: false, error: (err as Error).message };
     }
   });
+
+  // OAuth provider sign-in — spawns `hermes auth add <provider> --type
+  // oauth`, streaming the CLI's output to the renderer's sign-in modal.
+  ipcMain.handle(
+    "oauth-login",
+    (event, provider: string, profile?: string) => {
+      // Codex uses a device-code flow: it prints a URL + code instead
+      // of opening a browser. Watch the stream for that prompt, then
+      // open the page and pre-copy the code so the user just pastes.
+      let buffer = "";
+      let deviceHandled = false;
+      return runHermesAuthLogin(
+        provider,
+        (chunk) => {
+          event.sender.send("oauth-login-progress", chunk);
+          if (deviceHandled) return;
+          buffer += chunk;
+          const device = detectDeviceCode(buffer);
+          if (device) {
+            deviceHandled = true;
+            openExternalUrl(device.url);
+            clipboard.writeText(device.code);
+            event.sender.send(
+              "oauth-login-progress",
+              `\n→ Code ${device.code} copied to clipboard — opening browser...\n`,
+            );
+          }
+        },
+        profile,
+      );
+    },
+  );
+  ipcMain.handle("oauth-login-cancel", () => cancelHermesAuthLogin());
 
   // Configuration (profile-aware)
   ipcMain.handle("get-locale", () => getAppLocale());

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -416,6 +416,9 @@ function setupIPC(): void {
       return runHermesAuthLogin(
         provider,
         (chunk) => {
+          // The user can close the modal mid-flow before cancelHermesAuthLogin
+          // tears down the subprocess; any send on a destroyed sender throws.
+          if (event.sender.isDestroyed()) return;
           event.sender.send("oauth-login-progress", chunk);
           if (deviceHandled) return;
           buffer += chunk;

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -131,6 +131,14 @@ interface HermesAPI {
   checkOpenClaw: () => Promise<{ found: boolean; path: string | null }>;
   runClawMigrate: () => Promise<{ success: boolean; error?: string }>;
 
+  // OAuth provider sign-in
+  oauthLogin: (
+    provider: string,
+    profile?: string,
+  ) => Promise<{ success: boolean; error?: string }>;
+  cancelOAuthLogin: () => Promise<boolean>;
+  onOAuthLoginProgress: (callback: (chunk: string) => void) => () => void;
+
   getLocale: () => Promise<AppLocale>;
   setLocale: (locale: AppLocale) => Promise<AppLocale>;
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -68,6 +68,23 @@ const hermesAPI = {
   runClawMigrate: (): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke("run-claw-migrate"),
 
+  // OAuth provider sign-in
+  oauthLogin: (
+    provider: string,
+    profile?: string,
+  ): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke("oauth-login", provider, profile),
+  cancelOAuthLogin: (): Promise<boolean> =>
+    ipcRenderer.invoke("oauth-login-cancel"),
+  onOAuthLoginProgress: (callback: (chunk: string) => void): (() => void) => {
+    const handler = (
+      _event: Electron.IpcRendererEvent,
+      chunk: unknown,
+    ): void => callback(String(chunk));
+    ipcRenderer.on("oauth-login-progress", handler);
+    return () => ipcRenderer.removeListener("oauth-login-progress", handler);
+  },
+
   getLocale: (): Promise<AppLocale> => ipcRenderer.invoke("get-locale"),
   setLocale: (locale: AppLocale): Promise<AppLocale> =>
     ipcRenderer.invoke("set-locale", locale),

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -2249,6 +2249,40 @@ body {
   color: var(--text-muted);
 }
 
+.oauth-signin-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 8px;
+  align-self: flex-start;
+}
+
+.oauth-login-status {
+  font-size: 12px;
+  color: var(--text-muted);
+  margin: 0 0 10px;
+}
+
+/* Prominent outcome banner shown when the sign-in finishes — the raw
+   CLI log below stays append-only, so the result needs to stand out. */
+.oauth-login-result {
+  font-size: 13px;
+  font-weight: 600;
+  padding: 10px 12px;
+  border-radius: 8px;
+  margin: 0 0 10px;
+}
+
+.oauth-login-result-success {
+  color: var(--success, #2e7d32);
+  background: var(--success-bg, rgba(46, 125, 50, 0.12));
+}
+
+.oauth-login-result-error {
+  color: var(--danger, #e5484d);
+  background: var(--danger-bg, rgba(229, 72, 77, 0.12));
+}
+
 .settings-pool-entry {
   display: flex;
   align-items: center;

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -2274,13 +2274,13 @@ body {
 }
 
 .oauth-login-result-success {
-  color: var(--success, #2e7d32);
-  background: var(--success-bg, rgba(46, 125, 50, 0.12));
+  color: var(--success);
+  background: var(--success-bg);
 }
 
 .oauth-login-result-error {
-  color: var(--danger, #e5484d);
-  background: var(--danger-bg, rgba(229, 72, 77, 0.12));
+  color: var(--error);
+  background: var(--error-bg);
 }
 
 .settings-pool-entry {

--- a/src/renderer/src/components/OAuthLoginModal.tsx
+++ b/src/renderer/src/components/OAuthLoginModal.tsx
@@ -1,0 +1,123 @@
+import { useState, useEffect, useRef } from "react";
+import { X } from "../assets/icons";
+import { useI18n } from "./useI18n";
+
+interface OAuthLoginModalProps {
+  provider: string;
+  providerLabel: string;
+  profile?: string;
+  onClose: () => void;
+}
+
+type Status = "running" | "success" | "error";
+
+/**
+ * Drives an interactive OAuth sign-in for a subscription provider.
+ * Spawns `hermes auth add <provider> --type oauth` in the main process,
+ * streams the CLI output here, and reports success/failure. The CLI
+ * opens the system browser for the consent step.
+ */
+function OAuthLoginModal({
+  provider,
+  providerLabel,
+  profile,
+  onClose,
+}: OAuthLoginModalProps): React.JSX.Element {
+  const { t } = useI18n();
+  const [log, setLog] = useState("");
+  const [status, setStatus] = useState<Status>("running");
+  const [error, setError] = useState("");
+  const logRef = useRef<HTMLPreElement>(null);
+  // The login subprocess is single-flight in the main process. React
+  // StrictMode (dev) double-invokes effects, so guard against firing a
+  // second `oauthLogin` that would just bounce off that guard.
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    const cleanup = window.hermesAPI.onOAuthLoginProgress((chunk) => {
+      setLog((prev) => prev + chunk);
+    });
+    if (!startedRef.current) {
+      startedRef.current = true;
+      window.hermesAPI
+        .oauthLogin(provider, profile)
+        .then((res) => {
+          if (res.success) {
+            setStatus("success");
+          } else {
+            setStatus("error");
+            setError(res.error || t("providers.oauth.failed"));
+          }
+        })
+        .catch((err: unknown) => {
+          setStatus("error");
+          setError((err as Error)?.message || t("providers.oauth.failed"));
+        });
+    }
+    return cleanup;
+  }, [provider, profile, t]);
+
+  // Keep the streamed log scrolled to the newest line.
+  useEffect(() => {
+    if (logRef.current) {
+      logRef.current.scrollTop = logRef.current.scrollHeight;
+    }
+  }, [log]);
+
+  function handleClose(): void {
+    // Abandoning a flow mid-OAuth: tell main to kill the CLI subprocess
+    // so its loopback redirect server doesn't linger.
+    if (status === "running") {
+      void window.hermesAPI.cancelOAuthLogin();
+    }
+    onClose();
+  }
+
+  return (
+    <div className="models-modal-overlay" onClick={handleClose}>
+      <div className="models-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="models-modal-header">
+          <h2 className="models-modal-title">
+            {t("providers.oauth.signIn")} — {providerLabel}
+          </h2>
+          <button
+            className="btn-ghost"
+            onClick={handleClose}
+            aria-label={t("common.close")}
+          >
+            <X size={18} />
+          </button>
+        </div>
+        <div className="models-modal-body">
+          {status === "running" && (
+            <p className="oauth-login-status">
+              {t("providers.oauth.runningHint")}
+            </p>
+          )}
+          {status === "success" && (
+            <div className="oauth-login-result oauth-login-result-success">
+              ✓&nbsp;{t("providers.oauth.successHint")}
+            </div>
+          )}
+          {status === "error" && (
+            <div className="oauth-login-result oauth-login-result-error">
+              ✗&nbsp;{error}
+            </div>
+          )}
+          {log && (
+            <pre className="settings-hermes-doctor" ref={logRef}>
+              {log}
+            </pre>
+          )}
+        </div>
+        <div className="models-modal-footer">
+          <button className="btn btn-primary btn-sm" onClick={handleClose}>
+            {status === "running" ? t("common.cancel") : t("common.close")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default OAuthLoginModal;

--- a/src/renderer/src/constants.ts
+++ b/src/renderer/src/constants.ts
@@ -183,6 +183,36 @@ export const PROVIDERS = {
   ],
 };
 
+// Subscription / OAuth-plan providers — these authenticate through an
+// interactive browser login (`hermes auth add <id> --type oauth`) rather
+// than a static API key. The Providers screen renders a "Sign in" card
+// for each. Values must match hermes-agent's provider registry.
+export interface OAuthProviderDef {
+  id: string;
+  name: string;
+  desc: string;
+}
+
+export const OAUTH_PROVIDERS: OAuthProviderDef[] = [
+  {
+    id: "openai-codex",
+    name: "ChatGPT (Codex Plan)",
+    desc: "providers.oauth.codexDesc",
+  },
+  { id: "xai-oauth", name: "xAI Grok (OAuth)", desc: "providers.oauth.xaiDesc" },
+  { id: "qwen-oauth", name: "Qwen (OAuth)", desc: "providers.oauth.qwenDesc" },
+  {
+    id: "google-gemini-cli",
+    name: "Gemini (CLI OAuth)",
+    desc: "providers.oauth.geminiDesc",
+  },
+  {
+    id: "minimax-oauth",
+    name: "MiniMax (OAuth)",
+    desc: "providers.oauth.minimaxDesc",
+  },
+];
+
 export interface LocalPreset {
   id: string;
   name: string;

--- a/src/renderer/src/screens/Providers/Providers.tsx
+++ b/src/renderer/src/screens/Providers/Providers.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import { SETTINGS_SECTIONS, PROVIDERS } from "../../constants";
+import { SETTINGS_SECTIONS, PROVIDERS, OAUTH_PROVIDERS } from "../../constants";
 import { useI18n } from "../../components/useI18n";
 import BrandLogo from "../../components/common/BrandLogo";
 import { useDiscoveredModels } from "../../hooks/useDiscoveredModels";
+import OAuthLoginModal from "../../components/OAuthLoginModal";
+import { KeyRound } from "../../assets/icons";
 
 function Providers({
   profile,
@@ -33,6 +35,11 @@ function Providers({
   const [poolProvider, setPoolProvider] = useState("");
   const [poolNewKey, setPoolNewKey] = useState("");
   const [poolNewLabel, setPoolNewLabel] = useState("");
+
+  // OAuth sign-in modal — holds the provider def being authenticated.
+  const [oauthModal, setOauthModal] = useState<
+    (typeof OAUTH_PROVIDERS)[number] | null
+  >(null);
 
   // Per-key debounce timers for env auto-save on change. Previously env
   // values were persisted only on input blur, so users who clicked the
@@ -519,6 +526,42 @@ function Providers({
           </div>
         );
       })}
+
+      <div className="settings-section">
+        <div className="settings-section-title">
+          {t("providers.oauth.sectionTitle")}
+        </div>
+        <div className="settings-field-hint" style={{ marginBottom: 10 }}>
+          {t("providers.oauth.sectionHint")}
+        </div>
+        <div className="provider-keys-grid">
+          {OAUTH_PROVIDERS.map((p) => (
+            <div key={p.id} className="provider-key-card">
+              <div className="provider-key-card-head">
+                <BrandLogo provider={p.id} size={22} />
+                <span className="provider-key-card-title">{p.name}</span>
+              </div>
+              <div className="settings-field-hint">{t(p.desc)}</div>
+              <button
+                className="btn btn-secondary btn-sm oauth-signin-btn"
+                onClick={() => setOauthModal(p)}
+              >
+                <KeyRound size={14} />
+                {t("providers.oauth.signIn")}
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {oauthModal && (
+        <OAuthLoginModal
+          provider={oauthModal.id}
+          providerLabel={oauthModal.name}
+          profile={profile}
+          onClose={() => setOauthModal(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/renderer/src/screens/Providers/Providers.tsx
+++ b/src/renderer/src/screens/Providers/Providers.tsx
@@ -544,6 +544,7 @@ function Providers({
               <div className="settings-field-hint">{t(p.desc)}</div>
               <button
                 className="btn btn-secondary btn-sm oauth-signin-btn"
+                aria-label={`${t("providers.oauth.signIn")} — ${p.name}`}
                 onClick={() => setOauthModal(p)}
               >
                 <KeyRound size={14} />

--- a/src/shared/i18n/locales/en/providers.ts
+++ b/src/shared/i18n/locales/en/providers.ts
@@ -1,4 +1,18 @@
 export default {
   title: "Providers",
   subtitle: "Configure LLM providers, API keys, and credential pools",
+  oauth: {
+    sectionTitle: "Subscription / OAuth Plans",
+    sectionHint:
+      "Sign in with a provider subscription instead of an API key. Authorization happens in your browser.",
+    signIn: "Sign in",
+    runningHint: "Follow the steps below to finish signing in.",
+    successHint: "Signed in successfully. You can now select this provider.",
+    failed: "Sign-in failed.",
+    codexDesc: "Use your ChatGPT Codex plan",
+    xaiDesc: "Use your xAI Grok subscription",
+    qwenDesc: "Use your Qwen subscription",
+    geminiDesc: "Use your Google AI Pro / Gemini plan",
+    minimaxDesc: "Use your MiniMax subscription",
+  },
 } as const;

--- a/src/shared/i18n/locales/es/providers.ts
+++ b/src/shared/i18n/locales/es/providers.ts
@@ -1,4 +1,20 @@
 export default {
   title: "Proveedores",
   subtitle: "Configura proveedores de LLM, API keys y grupos de credenciales",
+  oauth: {
+    sectionTitle: "Suscripciones / Planes OAuth",
+    sectionHint:
+      "Inicia sesión con una suscripción del proveedor en lugar de una API key. La autorización se realiza en tu navegador.",
+    signIn: "Iniciar sesión",
+    runningHint:
+      "Sigue los pasos de abajo para completar el inicio de sesión.",
+    successHint:
+      "Sesión iniciada correctamente. Ya puedes seleccionar este proveedor.",
+    failed: "Error al iniciar sesión.",
+    codexDesc: "Usa tu plan ChatGPT Codex",
+    xaiDesc: "Usa tu suscripción de xAI Grok",
+    qwenDesc: "Usa tu suscripción de Qwen",
+    geminiDesc: "Usa tu plan Google AI Pro / Gemini",
+    minimaxDesc: "Usa tu suscripción de MiniMax",
+  },
 } as const;

--- a/src/shared/i18n/locales/id/providers.ts
+++ b/src/shared/i18n/locales/id/providers.ts
@@ -1,4 +1,19 @@
 export default {
   title: "Provider",
   subtitle: "Konfigurasikan provider LLM, API key, dan kumpulan kredensial",
+  oauth: {
+    sectionTitle: "Langganan / Paket OAuth",
+    sectionHint:
+      "Masuk dengan langganan provider alih-alih API key. Otorisasi dilakukan di browser Anda.",
+    signIn: "Masuk",
+    runningHint:
+      "Ikuti langkah-langkah di bawah untuk menyelesaikan proses masuk.",
+    successHint: "Berhasil masuk. Anda sekarang dapat memilih provider ini.",
+    failed: "Gagal masuk.",
+    codexDesc: "Gunakan paket ChatGPT Codex Anda",
+    xaiDesc: "Gunakan langganan xAI Grok Anda",
+    qwenDesc: "Gunakan langganan Qwen Anda",
+    geminiDesc: "Gunakan paket Google AI Pro / Gemini Anda",
+    minimaxDesc: "Gunakan langganan MiniMax Anda",
+  },
 } as const;

--- a/src/shared/i18n/locales/ja/providers.ts
+++ b/src/shared/i18n/locales/ja/providers.ts
@@ -1,4 +1,19 @@
 export default {
   title: "プロバイダ",
   subtitle: "LLM プロバイダ、API キー、認証情報プールを設定します",
+  oauth: {
+    sectionTitle: "サブスクリプション / OAuth プラン",
+    sectionHint:
+      "API キーの代わりにプロバイダのサブスクリプションでサインインします。認証はブラウザで行われます。",
+    signIn: "サインイン",
+    runningHint: "以下の手順に従ってサインインを完了してください。",
+    successHint:
+      "サインインに成功しました。このプロバイダを選択できます。",
+    failed: "サインインに失敗しました。",
+    codexDesc: "ChatGPT Codex プランを使用",
+    xaiDesc: "xAI Grok のサブスクリプションを使用",
+    qwenDesc: "Qwen のサブスクリプションを使用",
+    geminiDesc: "Google AI Pro / Gemini プランを使用",
+    minimaxDesc: "MiniMax のサブスクリプションを使用",
+  },
 } as const;

--- a/src/shared/i18n/locales/pt-BR/providers.ts
+++ b/src/shared/i18n/locales/pt-BR/providers.ts
@@ -1,4 +1,19 @@
 export default {
   title: "Provedores",
   subtitle: "Configure provedores de LLM, chaves de API e pools de credenciais",
+  oauth: {
+    sectionTitle: "Assinaturas / Planos OAuth",
+    sectionHint:
+      "Faça login com uma assinatura do provedor em vez de uma chave de API. A autorização acontece no navegador.",
+    signIn: "Entrar",
+    runningHint: "Siga os passos abaixo para concluir o login.",
+    successHint:
+      "Login efetuado com sucesso. Agora você pode selecionar este provedor.",
+    failed: "Falha no login.",
+    codexDesc: "Use seu plano ChatGPT Codex",
+    xaiDesc: "Use sua assinatura do xAI Grok",
+    qwenDesc: "Use sua assinatura do Qwen",
+    geminiDesc: "Use seu plano Google AI Pro / Gemini",
+    minimaxDesc: "Use sua assinatura do MiniMax",
+  },
 } as const;

--- a/src/shared/i18n/locales/pt-PT/providers.ts
+++ b/src/shared/i18n/locales/pt-PT/providers.ts
@@ -2,4 +2,19 @@ export default {
   title: "Fornecedores",
   subtitle:
     "Configure fornecedores de LLM, chaves de API e pools de credenciais",
+  oauth: {
+    sectionTitle: "Subscrições / Planos OAuth",
+    sectionHint:
+      "Inicie sessão com uma subscrição do fornecedor em vez de uma chave de API. A autorização é feita no navegador.",
+    signIn: "Iniciar sessão",
+    runningHint: "Siga os passos abaixo para concluir o início de sessão.",
+    successHint:
+      "Sessão iniciada com sucesso. Já pode seleccionar este fornecedor.",
+    failed: "Falha ao iniciar sessão.",
+    codexDesc: "Use o seu plano ChatGPT Codex",
+    xaiDesc: "Use a sua subscrição do xAI Grok",
+    qwenDesc: "Use a sua subscrição do Qwen",
+    geminiDesc: "Use o seu plano Google AI Pro / Gemini",
+    minimaxDesc: "Use a sua subscrição do MiniMax",
+  },
 } as const;

--- a/src/shared/i18n/locales/zh-CN/providers.ts
+++ b/src/shared/i18n/locales/zh-CN/providers.ts
@@ -1,4 +1,17 @@
 export default {
   title: "提供商",
   subtitle: "配置 LLM 提供商、API 密钥和凭据池",
+  oauth: {
+    sectionTitle: "订阅 / OAuth 套餐",
+    sectionHint: "使用提供商订阅而非 API 密钥登录。授权在浏览器中完成。",
+    signIn: "登录",
+    runningHint: "请按照下方步骤完成登录。",
+    successHint: "登录成功。现在可以选择此提供商。",
+    failed: "登录失败。",
+    codexDesc: "使用您的 ChatGPT Codex 套餐",
+    xaiDesc: "使用您的 xAI Grok 订阅",
+    qwenDesc: "使用您的 Qwen 订阅",
+    geminiDesc: "使用您的 Google AI Pro / Gemini 套餐",
+    minimaxDesc: "使用您的 MiniMax 订阅",
+  },
 } as const;

--- a/src/shared/i18n/locales/zh-TW/providers.ts
+++ b/src/shared/i18n/locales/zh-TW/providers.ts
@@ -1,4 +1,17 @@
 export default {
   title: "供應商",
   subtitle: "設定 LLM 供應商、API 金鑰和憑證池",
+  oauth: {
+    sectionTitle: "訂閱 / OAuth 方案",
+    sectionHint: "使用供應商訂閱而非 API 金鑰登入。授權在瀏覽器中完成。",
+    signIn: "登入",
+    runningHint: "請依照下方步驟完成登入。",
+    successHint: "登入成功。現在可以選擇此供應商。",
+    failed: "登入失敗。",
+    codexDesc: "使用您的 ChatGPT Codex 方案",
+    xaiDesc: "使用您的 xAI Grok 訂閱",
+    qwenDesc: "使用您的 Qwen 訂閱",
+    geminiDesc: "使用您的 Google AI Pro / Gemini 方案",
+    minimaxDesc: "使用您的 MiniMax 訂閱",
+  },
 } as const;

--- a/tests/hermes-auth.test.ts
+++ b/tests/hermes-auth.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventEmitter } from "events";
+
+/**
+ * Coverage for the in-app OAuth login feature (`src/main/hermes-auth.ts`):
+ *
+ *   - provider allowlist (`isOAuthLoginProvider`)
+ *   - `runHermesAuthLogin` spawns `hermes auth add <provider> --type
+ *     oauth`, streams output, and maps exit code → success/failure
+ *   - the single-flight guard rejects a second concurrent login
+ *   - `cancelHermesAuthLogin` kills the in-flight subprocess
+ */
+
+interface FakeProc extends EventEmitter {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: ReturnType<typeof vi.fn>;
+}
+
+const { spawnSpy, fakeProcs } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { EventEmitter: EE } = require("events");
+  const fakeProcs: FakeProc[] = [];
+  return {
+    fakeProcs,
+    spawnSpy: vi.fn(() => {
+      const proc = new EE() as FakeProc;
+      proc.stdout = new EE();
+      proc.stderr = new EE();
+      proc.kill = vi.fn();
+      fakeProcs.push(proc);
+      return proc;
+    }),
+  };
+});
+
+vi.mock("../src/main/installer", () => ({
+  HERMES_PYTHON: "/usr/bin/python3",
+  HERMES_REPO: "/tmp/hermes-repo",
+  HERMES_HOME: "/tmp/hermes-home",
+  hermesCliArgs: (args: string[]) => args,
+  getEnhancedPath: () => process.env.PATH || "",
+}));
+
+vi.mock("../src/main/process-options", () => ({
+  HIDDEN_SUBPROCESS_OPTIONS: {},
+}));
+
+vi.mock("../src/main/utils", () => ({
+  stripAnsi: (s: string) => s,
+}));
+
+// hermes-auth.ts only consumes `spawn` from child_process, so a minimal
+// replacement is enough. Both the named export and a `default` are
+// provided so the CJS↔ESM interop layer is satisfied.
+vi.mock("child_process", () => ({
+  spawn: spawnSpy,
+  default: { spawn: spawnSpy },
+}));
+
+import {
+  runHermesAuthLogin,
+  cancelHermesAuthLogin,
+  isOAuthLoginProvider,
+  detectDeviceCode,
+  OAUTH_LOGIN_PROVIDERS,
+} from "../src/main/hermes-auth";
+
+function lastProc(): FakeProc {
+  return fakeProcs[fakeProcs.length - 1];
+}
+
+describe("detectDeviceCode", () => {
+  // The exact shape the OpenAI Codex CLI prints.
+  const codexPrompt = [
+    "To continue, follow these steps:",
+    "",
+    "  1. Open this URL in your browser:",
+    "     https://auth.openai.com/codex/device",
+    "",
+    "  2. Enter this code:",
+    "     BVY0-XEPCD",
+    "",
+    "Waiting for sign-in... (press Ctrl+C to cancel)",
+  ].join("\n");
+
+  it("extracts the URL and code from a Codex device prompt", () => {
+    expect(detectDeviceCode(codexPrompt)).toEqual({
+      url: "https://auth.openai.com/codex/device",
+      code: "BVY0-XEPCD",
+    });
+  });
+
+  it("returns null until both URL and code are present", () => {
+    const partial = "  1. Open this URL in your browser:\n     https://auth.openai.com/codex/device\n";
+    expect(detectDeviceCode(partial)).toBeNull();
+    expect(detectDeviceCode("")).toBeNull();
+  });
+
+  it("ignores a non-https URL", () => {
+    const insecure = codexPrompt.replace("https://", "http://");
+    expect(detectDeviceCode(insecure)).toBeNull();
+  });
+
+  it("does not match browser-loopback provider output", () => {
+    // Gemini opens its own browser and has no device code — must not
+    // trigger the device-code path.
+    const gemini =
+      "Opening your browser to sign in to Google…\n" +
+      "If it does not open automatically, visit:\n" +
+      "  https://accounts.google.com/o/oauth2/v2/auth?client_id=x\n";
+    expect(detectDeviceCode(gemini)).toBeNull();
+  });
+});
+
+describe("isOAuthLoginProvider", () => {
+  it("accepts the five OAuth-capable providers", () => {
+    for (const p of OAUTH_LOGIN_PROVIDERS) {
+      expect(isOAuthLoginProvider(p)).toBe(true);
+    }
+  });
+
+  it("rejects API-key providers and unknown values", () => {
+    expect(isOAuthLoginProvider("openrouter")).toBe(false);
+    expect(isOAuthLoginProvider("anthropic")).toBe(false);
+    expect(isOAuthLoginProvider("kimi-coding")).toBe(false);
+    expect(isOAuthLoginProvider("")).toBe(false);
+  });
+});
+
+describe("runHermesAuthLogin", () => {
+  beforeEach(() => {
+    spawnSpy.mockClear();
+    fakeProcs.length = 0;
+  });
+
+  it("refuses an unsupported provider without spawning", async () => {
+    const result = await runHermesAuthLogin("openrouter", () => {});
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/unsupported/i);
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  it("spawns `auth add <provider> --type oauth` and streams output", async () => {
+    const chunks: string[] = [];
+    const promise = runHermesAuthLogin("google-gemini-cli", (c) =>
+      chunks.push(c),
+    );
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    const args = spawnSpy.mock.calls[0][1] as string[];
+    expect(args).toEqual([
+      "auth",
+      "add",
+      "google-gemini-cli",
+      "--type",
+      "oauth",
+    ]);
+
+    const proc = lastProc();
+    proc.stdout.emit("data", Buffer.from("Opening browser for sign-in...\n"));
+    proc.stderr.emit("data", Buffer.from("waiting for redirect\n"));
+    proc.emit("close", 0, null);
+
+    const result = await promise;
+    expect(result.success).toBe(true);
+    expect(chunks.join("")).toContain("Opening browser");
+    expect(chunks.join("")).toContain("waiting for redirect");
+  });
+
+  it("passes the profile flag when a named profile is given", async () => {
+    const promise = runHermesAuthLogin("xai-oauth", () => {}, "work");
+    const args = spawnSpy.mock.calls[0][1] as string[];
+    expect(args).toEqual([
+      "-p",
+      "work",
+      "auth",
+      "add",
+      "xai-oauth",
+      "--type",
+      "oauth",
+    ]);
+    lastProc().emit("close", 0, null);
+    await promise;
+  });
+
+  it("reports failure on a non-zero exit code", async () => {
+    const promise = runHermesAuthLogin("qwen-oauth", () => {});
+    lastProc().emit("close", 1, null);
+    const result = await promise;
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/code 1/);
+  });
+
+  it("reports cancellation when the process is killed by signal", async () => {
+    const promise = runHermesAuthLogin("minimax-oauth", () => {});
+    lastProc().emit("close", null, "SIGTERM");
+    const result = await promise;
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/cancelled/i);
+  });
+
+  it("rejects a second concurrent login while one is in flight", async () => {
+    const first = runHermesAuthLogin("openai-codex", () => {});
+    const second = await runHermesAuthLogin("xai-oauth", () => {});
+    expect(second.success).toBe(false);
+    expect(second.error).toMatch(/already in progress/i);
+    // Only the first login spawned a process.
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    lastProc().emit("close", 0, null);
+    await first;
+  });
+});
+
+describe("cancelHermesAuthLogin", () => {
+  beforeEach(() => {
+    spawnSpy.mockClear();
+    fakeProcs.length = 0;
+  });
+
+  it("returns false when no login is running", () => {
+    expect(cancelHermesAuthLogin()).toBe(false);
+  });
+
+  it("kills the in-flight subprocess and returns true", async () => {
+    const promise = runHermesAuthLogin("openai-codex", () => {});
+    const proc = lastProc();
+
+    expect(cancelHermesAuthLogin()).toBe(true);
+    expect(proc.kill).toHaveBeenCalled();
+
+    // Real kill would fire a close with a signal; emulate so the
+    // promise settles and the single-flight slot is released.
+    proc.emit("close", null, "SIGTERM");
+    await promise;
+    expect(cancelHermesAuthLogin()).toBe(false);
+  });
+});

--- a/tests/hermes-auth.test.ts
+++ b/tests/hermes-auth.test.ts
@@ -111,6 +111,31 @@ describe("detectDeviceCode", () => {
       "  https://accounts.google.com/o/oauth2/v2/auth?client_id=x\n";
     expect(detectDeviceCode(gemini)).toBeNull();
   });
+
+  it("does not silently consume a blank line between label and value", () => {
+    // A naive `\s*` for indentation would skip across the empty line and
+    // wrongly attach the wrong URL/code as the value (fathah's review on
+    // PR #280). Horizontal-whitespace-only stops at the linebreak.
+    const blankUrlGap = [
+      "  1. Open this URL in your browser:",
+      "",
+      "     https://attacker.example/phish",
+      "",
+      "  2. Enter this code:",
+      "     BVY0-XEPCD",
+    ].join("\n");
+    expect(detectDeviceCode(blankUrlGap)).toBeNull();
+
+    const blankCodeGap = [
+      "  1. Open this URL in your browser:",
+      "     https://auth.openai.com/codex/device",
+      "",
+      "  2. Enter this code:",
+      "",
+      "     BVY0-XEPCD",
+    ].join("\n");
+    expect(detectDeviceCode(blankCodeGap)).toBeNull();
+  });
 });
 
 describe("isOAuthLoginProvider", () => {


### PR DESCRIPTION
## Summary

Hermes Desktop can *select* OAuth/subscription providers (Codex, Gemini CLI, etc.) but had no way to *authenticate* them — users had to drop to a terminal and run `hermes auth add <provider>` by hand. This adds in-app sign-in.

## What it does

- New **"Subscription / OAuth Plans"** section on the Providers screen, with a **Sign in** card per provider: ChatGPT (Codex Plan), xAI Grok, Qwen, Gemini (CLI OAuth), MiniMax.
- Clicking **Sign in** opens a modal that spawns `hermes auth add <provider> --type oauth`, streams the CLI output live, and shows a prominent green ✓ / red ✗ outcome banner. Closing mid-flow kills the subprocess so its loopback redirect server doesn't linger.
- **Codex device-code helper:** Codex (unlike the browser-loopback providers) prints a URL + short code instead of opening a browser. The desktop detects that prompt, **opens the page automatically** and **copies the code to the clipboard**, adding a line to the log so the user knows. Detection is a pure, tested function keyed on the Codex prompt shape — it won't misfire for the browser-loopback providers or non-`https` URLs.

## Implementation

- `src/main/hermes-auth.ts` — spawn + stream + single-flight guard + cancel + `detectDeviceCode`.
- `oauth-login` / `oauth-login-cancel` IPC; preload surface.
- `OAuthLoginModal.tsx` on the Providers screen.
- i18n across all 8 locales.
- `tests/hermes-auth.test.ts` — 14 cases: provider allowlist, arg construction, profile flag, success/failure/cancel exit mapping, concurrent-login rejection, cancel, and device-code parsing.

## Manual testing

- **Codex** ✅ — device-code flow: page auto-opens, code pre-copied, green banner on completion.
- **Gemini (CLI OAuth)** ✅ — browser OAuth, credential added (`hermes auth list` confirms).
- **MiniMax** ✅ — browser OAuth, credential added.
- **xAI Grok** — flow launches the browser correctly; couldn't complete (no xAI subscription to test against).
- **Qwen** — surfaces a clear error: `hermes auth add qwen-oauth` requires the external Qwen CLI to be authenticated first (a hermes-agent requirement). The red banner shows it; left in the list since it works for users who *do* have the Qwen CLI.

`npm run typecheck` clean, `npm test` 502 passing.

## Known pre-existing item (not changed here)

`openai-codex` is in `PROVIDERS_WITHOUT_API_KEYS` (added by #102), so the install gate treats it as "configured" even with **no credential** — the only OAuth provider that bypasses the gate unauthenticated. The other four correctly gate on `hasOAuthCredentials`. Making this consistent (dropping `openai-codex` from that set so all five gate on real credentials) is a behaviour change to a merged PR and out of scope here — flagging for a maintainer call.

## Test plan

- [ ] Providers → "Subscription / OAuth Plans" → Sign in on each provider
- [ ] Codex: page opens, code is in clipboard, green banner on success
- [ ] Browser-loopback providers (Gemini/MiniMax/xAI): browser opens, green banner on success
- [ ] Close the modal mid-flow → no orphan `hermes`/python process
- [ ] Switch language → section + modal strings translate

🤖 Generated with [Claude Code](https://claude.com/claude-code)