### PR TITLE
feat(models): model autocomplete for OAuth/subscription providers

### DIFF
--- a/src/main/model-discovery.ts
+++ b/src/main/model-discovery.ts
@@ -14,8 +14,15 @@
 import http from "http";
 import https from "https";
 import { URL } from "url";
+import { execFile } from "child_process";
 import { readEnv } from "./config";
-import { expectedEnvKeyForModel } from "./installer";
+import {
+  expectedEnvKeyForModel,
+  HERMES_PYTHON,
+  HERMES_REPO,
+  HERMES_HOME,
+  getEnhancedPath,
+} from "./installer";
 
 /** Canonical inference base URL for each named provider, mirroring
  *  hermes-agent's PROVIDER_REGISTRY defaults.  Only the providers whose
@@ -38,20 +45,111 @@ const PROVIDER_BASE_URLS: Record<string, string> = {
 
 /** Providers whose `/models` we never call — either they don't expose it,
  *  use a different protocol, or rely on OAuth credentials we can't
- *  reproduce from a static env var. */
+ *  reproduce from a static env var. The OAuth providers below are handled
+ *  separately via `discoverOAuthModels`, so they're not listed here. */
 const NON_DISCOVERABLE_PROVIDERS = new Set<string>([
   "auto",
   "custom",
   "nous",
   "google",
   "xai",
-  "openai-codex",
-  "xai-oauth",
-  "qwen-oauth",
   "qwen",
   "minimax",
   "kimi-coding",
 ]);
+
+/** OAuth/subscription providers — no static-key `/v1/models` endpoint.
+ *  Their model lists come from hermes-agent's `provider_model_ids`
+ *  (live + account-aware for Codex), reached via a short Python call. */
+const OAUTH_DISCOVERY_PROVIDERS = new Set<string>([
+  "openai-codex",
+  "xai-oauth",
+  "qwen-oauth",
+  "google-gemini-cli",
+  "minimax-oauth",
+]);
+
+/** Curated fallback model lists, mirrored from hermes-agent's
+ *  `hermes_cli/models.py` (`_PROVIDER_MODELS`) and `codex_models.py`
+ *  (`DEFAULT_CODEX_MODELS`). Used only when the Python call below is
+ *  unavailable (agent not installed, import error, timeout). The live
+ *  call is always preferred — these will drift as new models ship. */
+const OAUTH_PROVIDER_CURATED: Record<string, string[]> = {
+  "openai-codex": [
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.3-codex",
+    "gpt-5.3-codex-spark",
+    "gpt-5.2-codex",
+    "gpt-5.1-codex-max",
+    "gpt-5.1-codex-mini",
+  ],
+  "xai-oauth": [
+    "grok-4.3",
+    "grok-4.20-0309-reasoning",
+    "grok-4.20-0309-non-reasoning",
+    "grok-4.20-multi-agent-0309",
+  ],
+  "google-gemini-cli": [
+    "gemini-3.1-pro-preview",
+    "gemini-3-pro-preview",
+    "gemini-3-flash-preview",
+  ],
+  "minimax-oauth": ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"],
+  "qwen-oauth": [],
+};
+
+// One-liner that prints hermes-agent's model list for a provider as a
+// JSON array. `provider_model_ids` does the heavy lifting — curated
+// lists for most, plus a live account-aware query for openai-codex.
+const PROVIDER_MODELS_SNIPPET =
+  "import json,sys; from hermes_cli.models import provider_model_ids; " +
+  "print(json.dumps(list(provider_model_ids(sys.argv[1]))))";
+
+/** Ask hermes-agent's `provider_model_ids` for a provider's models by
+ *  running a short Python snippet against the bundled venv. Returns the
+ *  parsed list, or null on any failure (so the caller can fall back). */
+function runProviderModelIdsPython(
+  provider: string,
+): Promise<string[] | null> {
+  return new Promise((resolve) => {
+    execFile(
+      HERMES_PYTHON,
+      ["-c", PROVIDER_MODELS_SNIPPET, provider],
+      {
+        cwd: HERMES_REPO,
+        env: { ...process.env, PATH: getEnhancedPath(), HERMES_HOME },
+        timeout: 20_000,
+        windowsHide: true,
+      },
+      (err, stdout) => {
+        if (err) {
+          resolve(null);
+          return;
+        }
+        try {
+          const parsed: unknown = JSON.parse(String(stdout).trim());
+          if (Array.isArray(parsed)) {
+            resolve(parsed.filter((x): x is string => typeof x === "string"));
+            return;
+          }
+        } catch {
+          /* unparseable — fall through */
+        }
+        resolve(null);
+      },
+    );
+  });
+}
+
+/** Resolve an OAuth provider's models: hermes-agent's live list first,
+ *  curated fallback when that's unavailable. */
+async function discoverOAuthModels(provider: string): Promise<string[]> {
+  const live = await runProviderModelIdsPython(provider);
+  if (live && live.length > 0) return uniqueSorted(live);
+  return OAUTH_PROVIDER_CURATED[provider] ?? [];
+}
 
 // In-memory result cache to avoid hammering the provider on every keystroke.
 interface CacheEntry {
@@ -220,6 +318,17 @@ export async function discoverProviderModels(
   profile: string | undefined,
 ): Promise<DiscoverModelsResult> {
   const lowerProvider = (provider || "").trim().toLowerCase();
+
+  // OAuth/subscription providers don't have a static-key /v1/models
+  // endpoint — route them through hermes-agent's provider_model_ids.
+  if (OAUTH_DISCOVERY_PROVIDERS.has(lowerProvider)) {
+    const hit = fromCache(lowerProvider, "");
+    if (hit) return { models: hit, status: "ok", cached: true };
+    const models = await discoverOAuthModels(lowerProvider);
+    setCache(lowerProvider, "", models);
+    return { models, status: "ok", cached: false };
+  }
+
   if (!lowerProvider || NON_DISCOVERABLE_PROVIDERS.has(lowerProvider)) {
     // For "custom", caller must pass baseUrl explicitly — fall through
     // and the canonicalBaseUrl() check below will redirect to that path.

--- a/tests/model-discovery.test.ts
+++ b/tests/model-discovery.test.ts
@@ -99,7 +99,9 @@ describe("model-discovery", () => {
 
   it("returns status=unsupported for known no-discovery providers", async () => {
     const { discoverProviderModels } = await loadDiscovery();
-    for (const provider of ["nous", "google", "xai", "openai-codex", "qwen-oauth"]) {
+    // openai-codex / qwen-oauth are no longer here — OAuth providers are
+    // discovered via hermes-agent's provider_model_ids instead.
+    for (const provider of ["nous", "google", "xai"]) {
       const result = await discoverProviderModels(provider, undefined, "sk-x", undefined);
       expect(result.status).toBe("unsupported");
       expect(result.models).toEqual([]);

--- a/tests/oauth-model-discovery.test.ts
+++ b/tests/oauth-model-discovery.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Coverage for OAuth/subscription-provider model discovery.
+ *
+ * These providers have no static-key `/v1/models` endpoint, so the
+ * desktop asks hermes-agent's `provider_model_ids` via a short Python
+ * call. When that's unavailable it falls back to a curated list mirrored
+ * from the agent. Both paths are exercised here with a mocked
+ * `child_process.execFile`.
+ */
+
+const { execFileSpy, behavior } = vi.hoisted(() => {
+  const behavior: { err: Error | null; stdout: string } = {
+    err: null,
+    stdout: "",
+  };
+  return {
+    behavior,
+    execFileSpy: vi.fn(
+      (
+        _file: unknown,
+        _args: unknown,
+        _opts: unknown,
+        cb: (e: Error | null, out: string, errOut: string) => void,
+      ) => {
+        cb(behavior.err, behavior.stdout, "");
+      },
+    ),
+  };
+});
+
+vi.mock("child_process", () => ({
+  execFile: execFileSpy,
+  default: { execFile: execFileSpy },
+}));
+
+vi.mock("../src/main/installer", () => ({
+  expectedEnvKeyForModel: () => "",
+  HERMES_PYTHON: "/usr/bin/python3",
+  HERMES_REPO: "/tmp/hermes-repo",
+  HERMES_HOME: "/tmp/hermes-home",
+  getEnhancedPath: () => process.env.PATH || "",
+}));
+
+vi.mock("../src/main/config", () => ({
+  readEnv: () => ({}),
+}));
+
+import {
+  discoverProviderModels,
+  _clearCache,
+} from "../src/main/model-discovery";
+
+describe("OAuth provider model discovery", () => {
+  beforeEach(() => {
+    _clearCache();
+    execFileSpy.mockClear();
+    behavior.err = null;
+    behavior.stdout = "";
+  });
+
+  it("returns the live provider_model_ids list for an OAuth provider", async () => {
+    behavior.stdout = '["gpt-5.5", "gpt-5.3-codex", "gpt-5.2-codex"]';
+    const result = await discoverProviderModels(
+      "openai-codex",
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(result.status).toBe("ok");
+    // sorted + de-duped
+    expect(result.models).toEqual([
+      "gpt-5.2-codex",
+      "gpt-5.3-codex",
+      "gpt-5.5",
+    ]);
+    // the python call carried the provider as the snippet's argv
+    const call = execFileSpy.mock.calls[0];
+    expect((call[1] as string[])[(call[1] as string[]).length - 1]).toBe(
+      "openai-codex",
+    );
+  });
+
+  it("falls back to the curated list when the Python call fails", async () => {
+    behavior.err = new Error("python: command not found");
+    const result = await discoverProviderModels(
+      "openai-codex",
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(result.status).toBe("ok");
+    expect(result.models).toContain("gpt-5.3-codex");
+    expect(result.models.length).toBeGreaterThan(0);
+  });
+
+  it("falls back when stdout is not a JSON array", async () => {
+    behavior.stdout = "Traceback (most recent call last):\n  ImportError";
+    const result = await discoverProviderModels(
+      "xai-oauth",
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(result.models).toContain("grok-4.3");
+  });
+
+  it("falls back when the live list comes back empty", async () => {
+    behavior.stdout = "[]";
+    const result = await discoverProviderModels(
+      "google-gemini-cli",
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(result.models).toContain("gemini-3-pro-preview");
+  });
+
+  it("caches the result so a second call skips the Python spawn", async () => {
+    behavior.stdout = '["gpt-5.5"]';
+    const first = await discoverProviderModels(
+      "openai-codex",
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(first.cached).toBe(false);
+    const second = await discoverProviderModels(
+      "openai-codex",
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(second.cached).toBe(true);
+    expect(second.models).toEqual(["gpt-5.5"]);
+    expect(execFileSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

#267 added live model discovery for API-key providers (hitting their `/v1/models` endpoint). OAuth/subscription providers — Codex, Gemini CLI, xAI Grok, Qwen, MiniMax — were excluded: they have no static-key `/v1/models` endpoint, so the Add/Edit model dialog gave no autocomplete for them.

This fills that gap.

## How

hermes-agent's `hermes_cli/models.py::provider_model_ids()` already has the right data — curated lists for most, plus a **live, account-aware** query for `openai-codex` via the OAuth token. But it's exposed through no CLI command or HTTP endpoint (`hermes model` is interactive-only; the API server's `/v1/models` returns only `hermes-agent`; the published catalog covers ~2 providers). So:

1. **Primary:** run a short Python snippet against the bundled venv —
   `python -c "...provider_model_ids(sys.argv[1])..." <provider>` — and use whatever it returns.
2. **Fallback:** a curated list mirrored from the agent, used only when the Python call fails (agent not installed, import error, timeout). The live call always wins.

The renderer is unchanged — `useDiscoveredModels` already calls discovery generically; only the main-process router needed an OAuth branch.

## Verified

- **Codex** — live account-aware query, 6 models for the test account ✅
- **xAI Grok** — live (via the `models.dev` cache), 15 models ✅
- **MiniMax** — curated, 2 models ✅
- **Gemini CLI** — 3 models. This is faithfully what `provider_model_ids("google-gemini-cli")` returns — hermes-agent hardcodes a 3-entry list with no live query (unlike Codex). Not a desktop bug; tracked upstream at NousResearch/hermes-agent#29282.
- **Qwen** — 0 models. `qwen-oauth` isn't in hermes-agent's catalog at all — also #29282.

The desktop relays `provider_model_ids` verbatim, so it auto-improves the moment hermes-agent enriches those lists — no desktop change needed.

## Tests

`tests/oauth-model-discovery.test.ts` — 5 cases: live list, three fallback paths (spawn error, unparseable output, empty list), and result caching. `model-discovery.test.ts`'s "unsupported" case updated since `openai-codex`/`qwen-oauth` are now discoverable.

`npm run typecheck` clean, `npm test` 493 passing.

## Test plan

- [ ] Models → Add Model → Provider = ChatGPT (Codex Plan) → Model ID autocompletes
- [ ] Same for Gemini (CLI OAuth), MiniMax (OAuth), xAI Grok (OAuth)
- [ ] First query per provider may take ~1-2s (Python spawn); repeats are cached 5 min
- [ ] Uninstalled/unreachable agent → falls back to curated lists, no error surfaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)