### PR TITLE
ci: add GitHub Actions workflow for typecheck + tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+# Runs the type checker and test suite on every PR and on pushes to main,
+# so broken code is caught before it merges. Mirrors the Node version and
+# install step already used by release.yml.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# A newer commit on the same ref supersedes an in-flight run.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      # Lint is informational for now — the codebase has a large backlog of
+      # prettier/line-ending warnings (no errors). Surfaced but not gating,
+      # so a warning backlog doesn't block merges.
+      - name: Lint
+        run: npm run lint
+        continue-on-error: true


### PR DESCRIPTION
## Summary

Adds a CI workflow that runs **typecheck + tests** on every PR and on pushes to `main`. Closes #278.

Until now nothing ran a PR's suite automatically — a PR's `MERGEABLE / CLEAN` badge only means *no git conflict*, not *the code compiles or tests pass*. As a result, broken changes reached `main` unnoticed:

- three failing tests merged in (a duplicate provider option + a test mock missing a method) — fixed in #277;
- a PR that imported a non-existent file (`en/kanban.ts`) sat looking mergeable because it had no conflict.

CI makes "does it compile / do tests pass" automatic and visible on every PR.

## What it runs

`.github/workflows/ci.yml` — on `pull_request` and `push` to `main`:

- `npm ci` (Node 22 — matches `release.yml`)
- `npm run typecheck` (node + web)
- `npm test` (Vitest)
- `npm run lint` — **non-gating** (`continue-on-error`). The codebase has a large prettier/line-ending warning backlog (0 errors); lint is surfaced as annotations but doesn't block merges, so the backlog can be cleared separately without holding up CI adoption.

Includes a `concurrency` group so a newer push supersedes an in-flight run.

## Verification

Already exercised end-to-end on a real `ubuntu-latest` runner (via a throwaway PR on my fork) — **all steps green**: checkout, Node setup, `npm ci` (incl. the `better-sqlite3` native rebuild), typecheck, test, lint. So this should go green on its own PR here too.

`main` is currently green (typecheck clean, 488 tests passing) — so adopting CI now won't immediately flag a red baseline.

## Note

A CI workflow was briefly attempted before in #78, but its author self-closed it within ~20 minutes (it ran while `main` had failing tests, so it went red on pre-existing breakage — not a maintainer rejection). With #277 having fixed those, CI now starts from a green baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)