### PR TITLE
fix(installer): ignore empty OpenClaw dir stubs in migration detector

### DIFF
--- a/src/main/installer.ts
+++ b/src/main/installer.ts
@@ -324,10 +324,34 @@ export function runHermesDoctor(): string {
 
 const OPENCLAW_DIR_NAMES = [".openclaw", ".clawdbot", ".moldbot"];
 
-export function checkOpenClawExists(): { found: boolean; path: string | null } {
+// hermes-desktop itself creates ~/.openclaw/claw3d/ as a stub when preparing
+// Claw3D settings (see claw3d.ts:writeClaw3dSettings), so a bare `existsSync`
+// check would surface that empty stub as a "real" OpenClaw install and
+// prompt the user to migrate from themselves. Require at least one regular
+// file anywhere in the tree so empty scaffolding doesn't trigger the banner.
+function dirContainsAnyFile(dir: string, maxDepth = 3): boolean {
+  try {
+    const entries = readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isFile()) return true;
+      if (entry.isDirectory() && maxDepth > 0) {
+        if (dirContainsAnyFile(join(dir, entry.name), maxDepth - 1)) {
+          return true;
+        }
+      }
+    }
+  } catch {
+    // unreadable → treat as empty
+  }
+  return false;
+}
+
+export function checkOpenClawExists(
+  home: string = homedir(),
+): { found: boolean; path: string | null } {
   for (const name of OPENCLAW_DIR_NAMES) {
-    const dir = join(homedir(), name);
-    if (existsSync(dir)) {
+    const dir = join(home, name);
+    if (existsSync(dir) && dirContainsAnyFile(dir)) {
       return { found: true, path: dir };
     }
   }

--- a/tests/installer-utils.test.ts
+++ b/tests/installer-utils.test.ts
@@ -3,6 +3,25 @@ import { join } from "path";
 import { existsSync, readFileSync, mkdirSync, writeFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
 
+// installer.ts transitively imports modules that pull in `electron` at value
+// scope (askpass.ts, sudoCreds.ts). Loading the real package in a plain
+// Node/vitest environment fails ("Electron failed to install correctly"),
+// which breaks every test that dynamically imports the installer module.
+// Provide a minimal stub so the import resolves.
+vi.mock("electron", () => ({
+  BrowserWindow: class {
+    static getAllWindows(): unknown[] {
+      return [];
+    }
+  },
+  ipcMain: {
+    on: (): void => {},
+    handle: (): void => {},
+    removeHandler: (): void => {},
+    removeAllListeners: (): void => {},
+  },
+}));
+
 // We test the extracted pure functions by importing them.
 // Some functions depend on HERMES_HOME — we mock the module-level constants.
 
@@ -254,6 +273,47 @@ describe("Hermes auth credential discovery", () => {
     writeFileSync(join(TEST_DIR, "auth.json"), "{not-json");
     const malformed = await importInstallerWithHome(TEST_DIR);
     expect(malformed.hasHermesAuthCredential("openai-codex")).toBe(false);
+  });
+});
+
+// ─── OpenClaw detector ─────────────────────────────────
+
+describe("checkOpenClawExists", () => {
+  it("ignores an empty .openclaw directory (self-created stub)", async () => {
+    // Mirrors the real-world case where hermes-desktop's own Claw3D settings
+    // helper has mkdirSync'd ~/.openclaw/claw3d/ without writing any files.
+    mkdirSync(join(TEST_DIR, ".openclaw", "claw3d"), { recursive: true });
+    const { checkOpenClawExists } = await import("../src/main/installer");
+    expect(checkOpenClawExists(TEST_DIR)).toEqual({ found: false, path: null });
+  });
+
+  it("detects a populated .openclaw directory", async () => {
+    const dir = join(TEST_DIR, ".openclaw");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "openclaw.json"), "{}");
+    const { checkOpenClawExists } = await import("../src/main/installer");
+    expect(checkOpenClawExists(TEST_DIR)).toEqual({ found: true, path: dir });
+  });
+
+  it("detects files nested under subdirectories", async () => {
+    const dir = join(TEST_DIR, ".openclaw");
+    mkdirSync(join(dir, "skills", "my-skill"), { recursive: true });
+    writeFileSync(join(dir, "skills", "my-skill", "SKILL.md"), "hi");
+    const { checkOpenClawExists } = await import("../src/main/installer");
+    expect(checkOpenClawExists(TEST_DIR)).toEqual({ found: true, path: dir });
+  });
+
+  it("returns not-found when no candidate directory exists", async () => {
+    const { checkOpenClawExists } = await import("../src/main/installer");
+    expect(checkOpenClawExists(TEST_DIR)).toEqual({ found: false, path: null });
+  });
+
+  it("falls back to legacy .clawdbot and .moldbot names", async () => {
+    const dir = join(TEST_DIR, ".clawdbot");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "clawdbot.json"), "{}");
+    const { checkOpenClawExists } = await import("../src/main/installer");
+    expect(checkOpenClawExists(TEST_DIR)).toEqual({ found: true, path: dir });
   });
 });
 


### PR DESCRIPTION
## Summary

The Settings page shows an **OpenClaw Installation Detected** banner offering to migrate config/keys/sessions/skills from `~/.openclaw/` into `~/.hermes/`. The detector at `checkOpenClawExists` only checked `existsSync(dir)`, so it would surface a self-created empty stub as a real install.

The stub comes from hermes-desktop itself: [`src/main/claw3d.ts:184`](https://github.com/fathah/hermes-desktop/blob/main/src/main/claw3d.ts#L184) calls `mkdirSync(~/.openclaw/claw3d, { recursive: true })` while preparing Claw3D settings. If the settings file is never written (or later removed), an empty `~/.openclaw/claw3d/` directory remains and the banner offers to migrate from it — i.e. from yourself.

## Change

- `checkOpenClawExists` now requires at least one regular file anywhere in the candidate tree before reporting `found: true`. Empty scaffolding is ignored.
- Added an optional `home` parameter so the detector can be unit-tested against a tmpdir.
- Tests cover: empty dir ignored, populated dir detected, file nested under a subdir detected, missing dir not-found, legacy `.clawdbot` / `.moldbot` names still work.

## Incidental: test infra

`tests/installer-utils.test.ts` now mocks `electron`. Dynamic re-imports of `installer.ts` transitively load `askpass.ts` / `sudoCreds.ts`, which `import { BrowserWindow, ipcMain } from "electron"` at value scope. In a plain Node/vitest environment this fails with `Electron failed to install correctly`, which had already been breaking the three pre-existing `hasHermesAuthCredential` tests. The mock fixes both my new tests and those.

## Test plan
- [x] `npx vitest run tests/installer-utils.test.ts` — 21/21 pass
- [x] `npm run typecheck` — clean
- [x] Repro on this machine: empty `~/.openclaw/claw3d/` stub no longer triggers the Settings banner; populating it with any file restores detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)