### PR TITLE
feat(build): add portable Windows build target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,7 @@ jobs:
         run: npm run build
 
       - name: Package Windows artifacts
-        run: npx electron-builder --win nsis --x64 --publish never
+        run: npx electron-builder --win nsis portable --x64 --publish never
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -13,6 +13,11 @@ asarUnpack:
   - resources/**
 win:
   executableName: hermes-agent
+  target:
+    - nsis
+    - portable
+portable:
+  artifactName: ${name}-${version}-portable.${ext}
 nsis:
   artifactName: ${name}-${version}-setup.${ext}
   shortcutName: ${productName}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1387,8 +1387,15 @@ function setupUpdater(): void {
   // IPC handlers must always be registered to avoid invoke errors
   ipcMain.handle("get-app-version", () => app.getVersion());
 
-  if (!app.isPackaged) {
-    // Skip auto-update in dev mode
+  // Portable Windows builds set PORTABLE_EXECUTABLE_DIR. They have no
+  // install location for electron-updater to replace in place, so an
+  // update check just fails and surfaces a spurious "Update failed".
+  // Skip the updater for them (users update by downloading a new
+  // portable .exe), same as dev mode.
+  const isPortableBuild = !!process.env.PORTABLE_EXECUTABLE_DIR;
+
+  if (!app.isPackaged || isPortableBuild) {
+    // Skip auto-update in dev mode and portable builds
     ipcMain.handle("check-for-updates", async () => null);
     ipcMain.handle("download-update", () => true);
     ipcMain.handle("install-update", () => {});


### PR DESCRIPTION
## Summary

Hermes Desktop for Windows ships only as an NSIS installer. This adds a **portable** target, so the release also produces `hermes-desktop-<version>-portable.exe` — a standalone binary that runs with no installation (no installer, no admin prompt). Addresses #125.

## Changes

- **`electron-builder.yml`** — `win.target` is now `[nsis, portable]`, plus a `portable.artifactName`.
- **`release.yml`** — the Windows job ran `--win nsis`, which would have *overridden* the new target and never built it. Changed to `--win nsis portable`. The existing `dist/*.exe` upload glob already captures the portable artifact.
- **`index.ts`** — skip the auto-updater for portable builds. `electron-updater` can only service the NSIS install (it replaces `setup.exe` in place); a portable `.exe` has no install location, so the update check fails and the app shows a spurious red **"Update failed"**. Portable builds set `PORTABLE_EXECUTABLE_DIR`, so they now take the same no-op updater path as dev mode. Users update a portable build by downloading a newer portable `.exe`.

## Scope — honest note on data location

This makes the **binary** install-free. It does **not** make the app's *data* portable: `HERMES_HOME` still resolves to `%LOCALAPPDATA%\hermes` — it does not follow `PORTABLE_EXECUTABLE_DIR`, so config, sessions, and the bundled hermes-agent install stay in `%LOCALAPPDATA%`, not next to the executable.

So this delivers "run without installing," **not** "self-contained on a USB stick." True data-portability is a separate, larger change — and a debatable one, since the hermes-agent install under `HERMES_HOME` is multi-GB. (The original issue's "saves data alongside the executable" wording overstates what a bare `portable` target does; flagging that explicitly so expectations are right.)

## Verification

Built locally on Windows (`electron-builder --win portable`) — produces `hermes-desktop-0.4.5-portable.exe` cleanly. Launched it: app runs normally (chat, navigation), and with the updater fix the **"Update failed" banner no longer appears**.

`npm run typecheck` clean, `npm test` 488 passing.

## Test plan

- [x] `electron-builder --win nsis portable` produces both `*-setup.exe` and `*-portable.exe`
- [x] Portable `.exe` launches with no installer / no admin prompt
- [x] No "Update failed" banner in the portable build
- [ ] NSIS installer build unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)