### PR TITLE
fix(chat): sync gateway session id on session switch

### DIFF
--- a/src/renderer/src/screens/Chat/Chat.tsx
+++ b/src/renderer/src/screens/Chat/Chat.tsx
@@ -79,6 +79,15 @@ function Chat({
     }
   }, [messages]);
 
+  // Sync the gateway session id when the parent swaps to a different session.
+  // Chat is not remounted on session switch, so a stale hermesSessionId from a
+  // previous conversation would otherwise survive — causing sends to resume,
+  // and the Clear button to delete, the WRONG session (issue #276).
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setHermesSessionId(sessionId);
+  }, [sessionId]);
+
   // Cmd/Ctrl+N → new chat
   useEffect(() => {
     function onKey(e: KeyboardEvent): void {


### PR DESCRIPTION
## Summary

`Chat` keeps a local `hermesSessionId` for the active gateway session. It was only reset when the message list emptied — **never synced when the parent swaps to a different session** (Chat is not remounted on a session switch). A stale id from a previous conversation therefore survived, so:

- the **Clear / delete** button deleted the *previously active* session instead of the one on screen, and
- a new message **resumed the wrong session**.

The fix adds an effect that syncs `hermesSessionId` to the `sessionId` prop whenever it changes.

Relates to #276.

## Test plan

- [x] Open chat A (send a message); open a different older session B from the list; click delete → **B** is deleted, A retained.
- [x] Open chat A; open session B; send a message → it continues **B**.
- [x] `npm run typecheck` (node + web) and `vitest` pass.