### PR TITLE
fix(chat): resume gateway sessions via X-Hermes-Session-Id header

### DIFF
--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -312,6 +312,14 @@ function sendMessageViaApi(
     "Content-Type": "application/json",
     ...getRemoteAuthHeader(),
   };
+  // Session continuity: the gateway resumes an existing session via the
+  // `X-Hermes-Session-Id` *request header* — the `session_id` body field
+  // above is not honoured. Without this header every request forks a new
+  // server-side session, fragmenting stored history and messageCount
+  // (issue #226). The gateway echoes the id back in the response header.
+  if (_resumeSessionId) {
+    headers["X-Hermes-Session-Id"] = _resumeSessionId;
+  }
   // Local API server key (API_SERVER_KEY in the profile's .env /
   // config.yaml) only applies in local mode — in remote/SSH mode the
   // remote endpoint's own auth header (set above) is authoritative and

--- a/tests/hermes-api.test.ts
+++ b/tests/hermes-api.test.ts
@@ -189,4 +189,51 @@ describe("sendMessageViaApi forwards resumeSessionId", () => {
 
     expect(parsed).not.toHaveProperty("session_id");
   });
+
+  it("sends the X-Hermes-Session-Id request header when resuming", async () => {
+    const testSessionId = "session-abc-123";
+
+    await sendMessage(
+      "hello",
+      {
+        onChunk: () => {},
+        onDone: () => {},
+        onError: () => {},
+      },
+      "default",
+      testSessionId,
+    );
+
+    const chatRequest = capturedRequests.find((r) =>
+      r.url.includes("/v1/chat/completions"),
+    );
+    expect(chatRequest).toBeDefined();
+    const headers = chatRequest!.options.headers as Record<string, string>;
+
+    // The gateway resumes an existing session from this request header;
+    // the session_id body field is ignored. Without it every request
+    // forks a new server-side session (issue #226).
+    expect(headers["X-Hermes-Session-Id"]).toBe(testSessionId);
+  });
+
+  it("omits the X-Hermes-Session-Id header for a fresh session", async () => {
+    await sendMessage(
+      "hello",
+      {
+        onChunk: () => {},
+        onDone: () => {},
+        onError: () => {},
+      },
+      "default",
+      undefined,
+    );
+
+    const chatRequest = capturedRequests.find((r) =>
+      r.url.includes("/v1/chat/completions"),
+    );
+    expect(chatRequest).toBeDefined();
+    const headers = chatRequest!.options.headers as Record<string, string>;
+
+    expect(headers).not.toHaveProperty("X-Hermes-Session-Id");
+  });
 });


### PR DESCRIPTION
## Summary

The gateway resumes an existing session from the **`X-Hermes-Session-Id` request header** — the `session_id` field in the request body is **ignored**. The desktop only sent the body field, so **every message forked a new server-side session**.

That single root cause produces every symptom in #226:

- **History lost on reopen** — reloading a session shows only the turns from when it was momentarily "current"; later turns forked into other sessions.
- **`messageCount` too low** — most sessions end up holding only a turn or two.
- **Sessions "missing"** — actually *proliferating*, roughly one per turn.

The fix sends the resume id as the `X-Hermes-Session-Id` request header in `sendMessageViaApi`. The gateway already echoes it back in the response header (which the desktop reads), so continuity is now stable.

This is hermes-agent's own documented mechanism — `gateway/run.py`'s api_server proxy client sets the same header, with the comment: *"The remote api_server can maintain session continuity via X-Hermes-Session-Id, so it loads its own history."*

## Verification

Direct probes against the local gateway:

- `POST /v1/chat/completions` with `session_id` in the **body** → a *new* `X-Hermes-Session-Id` on every call (forks).
- Same request with `X-Hermes-Session-Id` as a **request header** → the *same* id echoed back (resumes).

End-to-end in the app with the fix: a 4-turn conversation persisted as **one** session (8 messages appended under a single id), instead of four separate 2-message sessions.

Fixes #226.

## Test plan

- [x] New chat, multiple turns → all turns persist under one session id (verified in `state.db`).
- [x] Switch away and reopen the session → full history intact.
- [x] `npm run typecheck` and `vitest` pass.