### PR TITLE
fix(setup): route the OpenAI provider through custom + explicit base_url

### DIFF
--- a/src/renderer/src/constants.ts
+++ b/src/renderer/src/constants.ts
@@ -116,8 +116,13 @@ export const PROVIDERS = {
       envKey: "OPENAI_API_KEY",
       url: "https://platform.openai.com/api-keys",
       placeholder: "sk-...",
-      configProvider: "openai",
-      baseUrl: "",
+      // Routed through the `custom` provider with an explicit base_url:
+      // hermes-agent's resolve_provider does not recognise a bare `openai`
+      // provider id (issue #294). The `custom` + api.openai.com path is
+      // accepted, and the OpenAI key is picked up via the known-host
+      // base-URL mapping.
+      configProvider: "custom",
+      baseUrl: "https://api.openai.com/v1",
       needsKey: true,
     },
     {


### PR DESCRIPTION
## Summary

A fresh install that picks **OpenAI** and enters an API key fails to start with:

> `Unknown provider 'openai'. Check 'hermes model' for available providers, or run 'hermes doctor' to diagnose config issues.`

Setup wrote `model.provider: openai`, but the gateway's `resolve_provider()` does not recognise a bare `openai` provider id — it is in neither `PROVIDER_REGISTRY` nor the `_PROVIDER_ALIASES` table it consults, so the config is rejected.

## Fix

Configure the OpenAI provider card to use the **`custom`** provider with an explicit `base_url` of `https://api.openai.com/v1`:

- `resolve_provider()` accepts `custom` unconditionally — no "Unknown provider".
- The OpenAI key still goes to `.env` as `OPENAI_API_KEY`, and `setModelConfig` picks it up via the existing known-host base-URL mapping (`api.openai.com` → `OPENAI_API_KEY`), writing `model.api_key` — the same path already used for DeepSeek/Groq/etc. custom hosts.

One-card, two-field change in `constants.ts`. The card still displays as "OpenAI" to the user.

## Notes

- Closes the reported setup flow. An existing config that already contains `model.provider: openai` would need setup re-run (or the complementary upstream fix that teaches `resolve_provider` the `openai` alias).
- The provider **dropdown** in the model picker still carries a bare `openai` value — a separate, lower-impact path not covered here.

Fixes #294.

## Test plan

- [x] `npm run typecheck` (web) passes.
- [ ] Fresh setup → pick OpenAI → enter key → gateway starts, no "Unknown provider".