### PR TITLE
feat(chat): right-click context menu (copy/paste/select-all + copy chat)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,6 +6,7 @@ import {
   Menu,
   Notification,
   dialog,
+  clipboard,
 } from "electron";
 import { join } from "path";
 import { electronApp, optimizer, is } from "@electron-toolkit/utils";
@@ -313,6 +314,37 @@ function createWindow(): void {
       hardenWebviewPreferences(webPreferences);
     },
   );
+
+  // Right-click context menu (issue #298): native Cut/Copy/Paste/Select All
+  // via Electron roles — they act on the focused field / selection and work
+  // across the whole app — plus two items to copy the whole conversation.
+  mainWindow.webContents.on("context-menu", (_event, params) => {
+    const { editFlags, isEditable } = params;
+    const template: Electron.MenuItemConstructorOptions[] = [];
+    if (isEditable) {
+      template.push({ role: "cut", enabled: editFlags.canCut });
+    }
+    template.push({ role: "copy", enabled: editFlags.canCopy });
+    if (isEditable) {
+      template.push({ role: "paste", enabled: editFlags.canPaste });
+    }
+    template.push(
+      { type: "separator" },
+      { role: "selectAll" },
+      { type: "separator" },
+      {
+        label: "Copy entire chat (text)",
+        click: () =>
+          mainWindow?.webContents.send("context-menu-copy-chat", "text"),
+      },
+      {
+        label: "Copy entire chat (Markdown)",
+        click: () =>
+          mainWindow?.webContents.send("context-menu-copy-chat", "markdown"),
+      },
+    );
+    Menu.buildFromTemplate(template).popup();
+  });
 
   if (is.dev && process.env["ELECTRON_RENDERER_URL"]) {
     mainWindow.loadURL(process.env["ELECTRON_RENDERER_URL"]);
@@ -713,6 +745,13 @@ function setupIPC(): void {
       currentChatAbort();
       currentChatAbort = null;
     }
+  });
+
+  // Renderer-driven clipboard write (issue #298 — "Copy entire chat").
+  // Routed through the main process so it doesn't depend on the renderer's
+  // document being focused, which the navigator.clipboard API requires.
+  ipcMain.handle("copy-to-clipboard", (_event, text: string) => {
+    clipboard.writeText(typeof text === "string" ? text : "");
   });
 
   // Attachment staging — for pasted blobs that have no filesystem origin.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -322,15 +322,31 @@ function createWindow(): void {
     const { editFlags, isEditable } = params;
     const template: Electron.MenuItemConstructorOptions[] = [];
     if (isEditable) {
-      template.push({ role: "cut", enabled: editFlags.canCut });
-    }
-    template.push({ role: "copy", enabled: editFlags.canCopy });
-    if (isEditable) {
-      template.push({ role: "paste", enabled: editFlags.canPaste });
+      template.push(
+        { role: "cut", enabled: editFlags.canCut },
+        { role: "copy", enabled: editFlags.canCopy },
+        { role: "paste", enabled: editFlags.canPaste },
+        { type: "separator" },
+        // The selectAll role scopes correctly to the focused input field.
+        { role: "selectAll" },
+      );
+    } else {
+      template.push(
+        { role: "copy", enabled: editFlags.canCopy },
+        { type: "separator" },
+        // The selectAll role would select the entire window for non-editable
+        // content — scope it to the message bubble under the cursor instead.
+        {
+          label: "Select All",
+          click: () =>
+            mainWindow?.webContents.send("context-menu-select-bubble", {
+              x: params.x,
+              y: params.y,
+            }),
+        },
+      );
     }
     template.push(
-      { type: "separator" },
-      { role: "selectAll" },
       { type: "separator" },
       {
         label: "Copy entire chat (text)",

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -201,6 +201,10 @@ interface HermesAPI {
     attachments?: Attachment[],
   ) => Promise<{ response: string; sessionId?: string }>;
   abortChat: () => Promise<void>;
+  copyToClipboard: (text: string) => Promise<void>;
+  onContextMenuCopyChat: (
+    callback: (format: "text" | "markdown") => void,
+  ) => () => void;
   getPathForFile: (file: File) => string;
   stageAttachment: (
     sessionId: string,

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -205,6 +205,9 @@ interface HermesAPI {
   onContextMenuCopyChat: (
     callback: (format: "text" | "markdown") => void,
   ) => () => void;
+  onContextMenuSelectBubble: (
+    callback: (point: { x: number; y: number }) => void,
+  ) => () => void;
   getPathForFile: (file: File) => string;
   stageAttachment: (
     sessionId: string,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -190,6 +190,9 @@ const hermesAPI = {
 
   abortChat: (): Promise<void> => ipcRenderer.invoke("abort-chat"),
 
+  copyToClipboard: (text: string): Promise<void> =>
+    ipcRenderer.invoke("copy-to-clipboard", text),
+
   // Resolve the absolute filesystem path for a File coming from drag-drop
   // or the file picker.  Returns "" for blobs that have no origin path
   // (e.g. clipboard paste) — caller should stageAttachment for those.
@@ -243,6 +246,18 @@ const hermesAPI = {
     ): void => callback(sessionId);
     ipcRenderer.on("chat-done", handler);
     return () => ipcRenderer.removeListener("chat-done", handler);
+  },
+
+  onContextMenuCopyChat: (
+    callback: (format: "text" | "markdown") => void,
+  ): (() => void) => {
+    const handler = (
+      _event: Electron.IpcRendererEvent,
+      format: "text" | "markdown",
+    ): void => callback(format);
+    ipcRenderer.on("context-menu-copy-chat", handler);
+    return () =>
+      ipcRenderer.removeListener("context-menu-copy-chat", handler);
   },
 
   onChatToolProgress: (callback: (tool: string) => void): (() => void) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -260,6 +260,18 @@ const hermesAPI = {
       ipcRenderer.removeListener("context-menu-copy-chat", handler);
   },
 
+  onContextMenuSelectBubble: (
+    callback: (point: { x: number; y: number }) => void,
+  ): (() => void) => {
+    const handler = (
+      _event: Electron.IpcRendererEvent,
+      point: { x: number; y: number },
+    ): void => callback(point);
+    ipcRenderer.on("context-menu-select-bubble", handler);
+    return () =>
+      ipcRenderer.removeListener("context-menu-select-bubble", handler);
+  },
+
   onChatToolProgress: (callback: (tool: string) => void): (() => void) => {
     const handler = (_event: Electron.IpcRendererEvent, tool: string): void =>
       callback(tool);

--- a/src/renderer/src/screens/Chat/Chat.tsx
+++ b/src/renderer/src/screens/Chat/Chat.tsx
@@ -11,6 +11,7 @@ import { useModelConfig } from "./hooks/useModelConfig";
 import { useFastMode } from "./hooks/useFastMode";
 import { useLocalCommands } from "./hooks/useLocalCommands";
 import { useI18n } from "../../components/useI18n";
+import { buildChatTranscript } from "./transcriptUtils";
 import type { ChatMessage, UsageState } from "./types";
 
 export type { ChatMessage } from "./types";
@@ -90,6 +91,21 @@ function Chat({
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [onNewChat]);
+
+  // "Copy entire chat" context-menu items (issue #298) — serialise the whole
+  // conversation in the requested format and copy it. A ref keeps the latest
+  // messages without re-registering the IPC listener on every chunk.
+  const messagesRef = useRef(messages);
+  useEffect(() => {
+    messagesRef.current = messages;
+  });
+  useEffect(() => {
+    return window.hermesAPI.onContextMenuCopyChat((format) => {
+      const msgs = messagesRef.current;
+      if (msgs.length === 0) return;
+      void window.hermesAPI.copyToClipboard(buildChatTranscript(msgs, format));
+    });
+  }, []);
 
   const addAgentMessage = useCallback(
     (content: string) => {

--- a/src/renderer/src/screens/Chat/Chat.tsx
+++ b/src/renderer/src/screens/Chat/Chat.tsx
@@ -107,6 +107,19 @@ function Chat({
     });
   }, []);
 
+  // "Select All" on a message (issue #298): the native selectAll role would
+  // select the entire window, so scope it to the .chat-bubble under the
+  // cursor — the user can then Copy that message.
+  useEffect(() => {
+    return window.hermesAPI.onContextMenuSelectBubble(({ x, y }) => {
+      const bubble = document.elementFromPoint(x, y)?.closest(".chat-bubble");
+      if (!bubble) return;
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.selectAllChildren(bubble);
+    });
+  }, []);
+
   const addAgentMessage = useCallback(
     (content: string) => {
       setMessages((prev) => [

--- a/src/renderer/src/screens/Chat/transcriptUtils.test.ts
+++ b/src/renderer/src/screens/Chat/transcriptUtils.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { buildChatTranscript } from "./transcriptUtils";
+import type { ChatMessage } from "./types";
+
+function msg(role: "user" | "agent", content: string): ChatMessage {
+  return { id: `${role}-${content}`, role, content };
+}
+
+describe("buildChatTranscript (issue #298)", () => {
+  it("returns an empty string for no messages", () => {
+    expect(buildChatTranscript([], "text")).toBe("");
+    expect(buildChatTranscript([], "markdown")).toBe("");
+  });
+
+  it("formats plain text with You / Hermes speakers", () => {
+    const out = buildChatTranscript(
+      [msg("user", "hi"), msg("agent", "hello there")],
+      "text",
+    );
+    expect(out).toBe("You: hi\n\nHermes: hello there");
+  });
+
+  it("formats markdown with bold speaker headers", () => {
+    const out = buildChatTranscript(
+      [msg("user", "hi"), msg("agent", "hello there")],
+      "markdown",
+    );
+    expect(out).toBe("**You:**\n\nhi\n\n**Hermes:**\n\nhello there");
+  });
+
+  it("trims surrounding whitespace from message content", () => {
+    expect(buildChatTranscript([msg("user", "  spaced  ")], "text")).toBe(
+      "You: spaced",
+    );
+  });
+
+  it("maps the agent role to Hermes and user to You", () => {
+    expect(buildChatTranscript([msg("agent", "x")], "text")).toBe("Hermes: x");
+    expect(buildChatTranscript([msg("user", "x")], "text")).toBe("You: x");
+  });
+});

--- a/src/renderer/src/screens/Chat/transcriptUtils.ts
+++ b/src/renderer/src/screens/Chat/transcriptUtils.ts
@@ -1,0 +1,26 @@
+import type { ChatMessage } from "./types";
+
+export type TranscriptFormat = "text" | "markdown";
+
+/**
+ * Serialise a conversation into a clipboard-ready transcript (issue #298).
+ *
+ * - `text`     → plain `You: …` / `Hermes: …` blocks.
+ * - `markdown` → `**You:**` / `**Hermes:**` headed blocks.
+ *
+ * Blocks are separated by a blank line. Exported for unit testing.
+ */
+export function buildChatTranscript(
+  messages: ChatMessage[],
+  format: TranscriptFormat,
+): string {
+  return messages
+    .map((m) => {
+      const speaker = m.role === "user" ? "You" : "Hermes";
+      const content = (m.content ?? "").trim();
+      return format === "markdown"
+        ? `**${speaker}:**\n\n${content}`
+        : `${speaker}: ${content}`;
+    })
+    .join("\n\n");
+}


### PR DESCRIPTION
## Summary

Adds a native right-click context menu to the desktop window — **Closes #298**.

- **Cut / Copy / Paste / Select All** via Electron menu roles — they act on the focused field or text selection and work across the whole app (chat input, message text, settings fields). Enabled state follows `editFlags` (Paste only when editable, Copy only with a selection, etc.).
- **Select All on a message** is scoped to the `.chat-bubble` under the cursor — the Electron `selectAll` role would otherwise select the *entire window* for non-editable content. In editable fields the role is kept (it scopes correctly there).
- **Copy entire chat (text)** and **Copy entire chat (Markdown)** — serialise the whole conversation and copy it. Routed through the main process so the clipboard write doesn't depend on renderer document focus.

`buildChatTranscript()` is a pure, unit-tested helper.

## Implementation

- `index.ts` — `webContents.on("context-menu", …)` builds the menu; `copy-to-clipboard` IPC handler.
- `preload` — `copyToClipboard`, `onContextMenuCopyChat`, `onContextMenuSelectBubble`.
- `Chat/transcriptUtils.ts` — `buildChatTranscript()` + tests.
- `Chat.tsx` — listeners for the copy-chat and select-bubble events.

## Test plan

- [x] `npm run typecheck` (node + web) and `vitest` pass (incl. 5 new `transcriptUtils` tests).
- [x] Right-click in chat input → Cut/Copy/Paste/Select All; on a message → Copy/Select All; selection-aware enabled state — verified live.
- [x] "Select All" on a message scopes to that message, not the window — verified live.
- [x] "Copy entire chat" (text / Markdown) → correct formats — verified live.