### PR TITLE
Render agent-generated media in chat (closes #299)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,6 +15,7 @@ import icon from "../../resources/icon.png?asset";
 import type { Attachment } from "../shared/attachments";
 import { stageAttachment, clearStagedAttachments } from "./attachment-staging";
 import { discoverProviderModels } from "./model-discovery";
+import { readMediaAsDataUrl, saveMedia } from "./media";
 import {
   checkInstallStatus,
   verifyInstall,
@@ -852,6 +853,14 @@ function setupIPC(): void {
   ipcMain.handle("copy-to-clipboard", (_event, text: string) => {
     clipboard.writeText(typeof text === "string" ? text : "");
   });
+
+  // Media — render agent-generated images and save them to disk (#299).
+  ipcMain.handle("read-media-file", (_event, filePath: string) =>
+    readMediaAsDataUrl(filePath),
+  );
+  ipcMain.handle("save-media-file", (event, src: string, name: string) =>
+    saveMedia(src, name, BrowserWindow.fromWebContents(event.sender)),
+  );
 
   // Attachment staging — for pasted blobs that have no filesystem origin.
   ipcMain.handle(

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -865,6 +865,50 @@ function setupIPC(): void {
     mediaFileExists(filePath),
   );
 
+  // Native right-click menu for a rendered media element (#299): "Open"
+  // hands the file to the OS default handler (or a web URL to the browser),
+  // "Save as…" writes a copy elsewhere. Labels are passed in from the
+  // renderer so the menu honours the active UI locale.
+  ipcMain.on(
+    "show-media-menu",
+    (
+      event,
+      src: string,
+      name: string,
+      labels: { open: string; saveAs: string },
+    ) => {
+      const win = BrowserWindow.fromWebContents(event.sender);
+      if (!win || !src) return;
+      const isUrl = /^https?:\/\//i.test(src);
+      const isData = src.startsWith("data:");
+      const template: Electron.MenuItemConstructorOptions[] = [];
+      // "Open" needs a real target — a local file or a web URL. A data:
+      // URL is inline bytes with nothing to hand to the OS, so it is
+      // save-only.
+      if (!isData) {
+        template.push({
+          label: labels.open,
+          click: () => {
+            if (isUrl) {
+              openExternalUrl(src);
+            } else {
+              shell.openPath(src).then((err) => {
+                if (err) console.error("[media] open failed:", err);
+              });
+            }
+          },
+        });
+      }
+      template.push({
+        label: labels.saveAs,
+        click: () => {
+          void saveMedia(src, name, win);
+        },
+      });
+      Menu.buildFromTemplate(template).popup({ window: win });
+    },
+  );
+
   // Attachment staging — for pasted blobs that have no filesystem origin.
   ipcMain.handle(
     "stage-attachment",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,7 +15,7 @@ import icon from "../../resources/icon.png?asset";
 import type { Attachment } from "../shared/attachments";
 import { stageAttachment, clearStagedAttachments } from "./attachment-staging";
 import { discoverProviderModels } from "./model-discovery";
-import { readMediaAsDataUrl, saveMedia } from "./media";
+import { readMediaAsDataUrl, saveMedia, mediaFileExists } from "./media";
 import {
   checkInstallStatus,
   verifyInstall,
@@ -860,6 +860,9 @@ function setupIPC(): void {
   );
   ipcMain.handle("save-media-file", (event, src: string, name: string) =>
     saveMedia(src, name, BrowserWindow.fromWebContents(event.sender)),
+  );
+  ipcMain.handle("media-file-exists", (_event, filePath: string) =>
+    mediaFileExists(filePath),
   );
 
   // Attachment staging — for pasted blobs that have no filesystem origin.

--- a/src/main/media.ts
+++ b/src/main/media.ts
@@ -1,0 +1,87 @@
+/**
+ * Main-process helpers for rendering and saving agent-generated media
+ * (issue #299). The agent delivers files via `MEDIA:` tokens; the renderer
+ * resolves local paths to data URLs through `readMediaAsDataUrl`, and lets
+ * the user save any media (data URL / http(s) URL / local path) to disk
+ * via `saveMedia`.
+ */
+
+import {
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  copyFileSync,
+  statSync,
+} from "fs";
+import { extname } from "path";
+import { BrowserWindow, dialog } from "electron";
+
+const MAX_MEDIA_BYTES = 25 * 1024 * 1024;
+
+const MIME_BY_EXT: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+  ".bmp": "image/bmp",
+  ".avif": "image/avif",
+};
+
+/**
+ * Read a local image file and return it as a `data:` URL. Returns null when
+ * the file is missing, not an image, too large, or unreadable.
+ */
+export function readMediaAsDataUrl(filePath: string): string | null {
+  try {
+    if (!filePath || !existsSync(filePath)) return null;
+    const ext = extname(filePath).toLowerCase();
+    const mime = MIME_BY_EXT[ext];
+    if (!mime) return null;
+    if (statSync(filePath).size > MAX_MEDIA_BYTES) return null;
+    const base64 = readFileSync(filePath).toString("base64");
+    return `data:${mime};base64,${base64}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Prompt the user for a destination and write `src` there. `src` may be a
+ * `data:` URL, an http(s) URL, or a local filesystem path. Returns true on
+ * success, false when canceled or on any error.
+ */
+export async function saveMedia(
+  src: string,
+  suggestedName: string,
+  win: BrowserWindow | null,
+): Promise<boolean> {
+  try {
+    const result = win
+      ? await dialog.showSaveDialog(win, { defaultPath: suggestedName })
+      : await dialog.showSaveDialog({ defaultPath: suggestedName });
+    if (result.canceled || !result.filePath) return false;
+    const dest = result.filePath;
+
+    if (src.startsWith("data:")) {
+      const comma = src.indexOf(",");
+      if (comma === -1) return false;
+      writeFileSync(dest, Buffer.from(src.slice(comma + 1), "base64"));
+      return true;
+    }
+
+    if (/^https?:\/\//i.test(src)) {
+      const response = await fetch(src);
+      if (!response.ok) return false;
+      const buffer = Buffer.from(await response.arrayBuffer());
+      writeFileSync(dest, buffer);
+      return true;
+    }
+
+    copyFileSync(src, dest);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/main/media.ts
+++ b/src/main/media.ts
@@ -48,6 +48,21 @@ export function readMediaAsDataUrl(filePath: string): string | null {
 }
 
 /**
+ * True only when `filePath` points at an existing regular file. Used to
+ * verify a bare (untagged) path the agent mentioned really is a delivered
+ * file before the renderer treats it as media (issue #299).
+ */
+export function mediaFileExists(filePath: string): boolean {
+  try {
+    return (
+      !!filePath && existsSync(filePath) && statSync(filePath).isFile()
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Prompt the user for a destination and write `src` there. `src` may be a
  * `data:` URL, an http(s) URL, or a local filesystem path. Returns true on
  * success, false when canceled or on any error.

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -225,6 +225,8 @@ interface HermesAPI {
   onContextMenuSelectBubble: (
     callback: (point: { x: number; y: number }) => void,
   ) => () => void;
+  readMediaFile: (filePath: string) => Promise<string | null>;
+  saveMediaFile: (src: string, name: string) => Promise<boolean>;
   getPathForFile: (file: File) => string;
   stageAttachment: (
     sessionId: string,

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -228,6 +228,11 @@ interface HermesAPI {
   readMediaFile: (filePath: string) => Promise<string | null>;
   saveMediaFile: (src: string, name: string) => Promise<boolean>;
   mediaFileExists: (filePath: string) => Promise<boolean>;
+  showMediaMenu: (
+    src: string,
+    name: string,
+    labels: { open: string; saveAs: string },
+  ) => void;
   getPathForFile: (file: File) => string;
   stageAttachment: (
     sessionId: string,

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -227,6 +227,7 @@ interface HermesAPI {
   ) => () => void;
   readMediaFile: (filePath: string) => Promise<string | null>;
   saveMediaFile: (src: string, name: string) => Promise<boolean>;
+  mediaFileExists: (filePath: string) => Promise<boolean>;
   getPathForFile: (file: File) => string;
   stageAttachment: (
     sessionId: string,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -227,6 +227,12 @@ const hermesAPI = {
   copyToClipboard: (text: string): Promise<void> =>
     ipcRenderer.invoke("copy-to-clipboard", text),
 
+  // Media (agent-generated images / files — issue #299)
+  readMediaFile: (filePath: string): Promise<string | null> =>
+    ipcRenderer.invoke("read-media-file", filePath),
+  saveMediaFile: (src: string, name: string): Promise<boolean> =>
+    ipcRenderer.invoke("save-media-file", src, name),
+
   // Resolve the absolute filesystem path for a File coming from drag-drop
   // or the file picker.  Returns "" for blobs that have no origin path
   // (e.g. clipboard paste) — caller should stageAttachment for those.

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -234,6 +234,13 @@ const hermesAPI = {
     ipcRenderer.invoke("save-media-file", src, name),
   mediaFileExists: (filePath: string): Promise<boolean> =>
     ipcRenderer.invoke("media-file-exists", filePath),
+  showMediaMenu: (
+    src: string,
+    name: string,
+    labels: { open: string; saveAs: string },
+  ): void => {
+    ipcRenderer.send("show-media-menu", src, name, labels);
+  },
 
   // Resolve the absolute filesystem path for a File coming from drag-drop
   // or the file picker.  Returns "" for blobs that have no origin path

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -232,6 +232,8 @@ const hermesAPI = {
     ipcRenderer.invoke("read-media-file", filePath),
   saveMediaFile: (src: string, name: string): Promise<boolean> =>
     ipcRenderer.invoke("save-media-file", src, name),
+  mediaFileExists: (filePath: string): Promise<boolean> =>
+    ipcRenderer.invoke("media-file-exists", filePath),
 
   // Resolve the absolute filesystem path for a File coming from drag-drop
   // or the file picker.  Returns "" for blobs that have no origin path

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1960,6 +1960,25 @@ body {
   z-index: 201;
 }
 
+/* Lightbox action buttons — light-on-dark so they read on the backdrop. */
+.chat-image-preview-btn {
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.chat-image-preview-btn:hover {
+  background: rgba(255, 255, 255, 0.22);
+}
+
 /* ── Agent-generated media (issue #299) ─────────────── */
 
 .chat-media-image {

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1950,6 +1950,50 @@ body {
   cursor: default;
 }
 
+.chat-image-preview-actions {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  z-index: 201;
+}
+
+/* ── Agent-generated media (issue #299) ─────────────── */
+
+.chat-media-image {
+  max-width: 100%;
+  max-height: 320px;
+  border-radius: 8px;
+  cursor: pointer;
+  display: block;
+  margin: 6px 0;
+}
+
+.chat-media-loading,
+.chat-media-error {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.chat-media-error {
+  color: var(--warning, #d08770);
+}
+
+.chat-media-file {
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: transparent;
+  cursor: pointer;
+  font-size: 13px;
+}
+
 /* ── Slash Command Menu ─────────────────────────────── */
 
 .slash-menu {

--- a/src/renderer/src/components/AgentMarkdown.tsx
+++ b/src/renderer/src/components/AgentMarkdown.tsx
@@ -3,6 +3,8 @@ import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { Copy } from "lucide-react";
 import { useI18n } from "./useI18n";
+import { MediaImage } from "./MediaImage";
+import { describeImageSrc } from "../screens/Chat/mediaUtils";
 
 // Lazy-load the heavy syntax highlighter — only imported when a code block renders
 let _highlighterMod: typeof import("react-syntax-highlighter") | null = null;
@@ -153,6 +155,10 @@ const AgentMarkdown = memo(function AgentMarkdown({
             {children}
           </a>
         ),
+        img: ({ src }) =>
+          typeof src === "string" && src.length > 0 ? (
+            <MediaImage token={describeImageSrc(src)} />
+          ) : null,
         code: ({ className, children, ...props }) => {
           const isInline =
             !className &&

--- a/src/renderer/src/components/MediaImage.tsx
+++ b/src/renderer/src/components/MediaImage.tsx
@@ -80,7 +80,7 @@ export function MediaImage({
             onClick={(e) => e.stopPropagation()}
           >
             <button
-              className="chat-media-file"
+              className="chat-image-preview-btn"
               onClick={() =>
                 window.hermesAPI.saveMediaFile(token.src, token.name)
               }
@@ -89,7 +89,7 @@ export function MediaImage({
               Save image
             </button>
             <button
-              className="chat-media-file"
+              className="chat-image-preview-btn"
               onClick={() => setZoomed(false)}
               aria-label="Close"
             >

--- a/src/renderer/src/components/MediaImage.tsx
+++ b/src/renderer/src/components/MediaImage.tsx
@@ -1,0 +1,105 @@
+import { useState, useEffect } from "react";
+import { Download, X } from "lucide-react";
+import type { MediaToken } from "../screens/Chat/mediaUtils";
+
+/**
+ * Renders an agent-delivered image (issue #299). Data URLs and http(s)
+ * URLs render directly; local filesystem paths are resolved to a data URL
+ * through the main process. Clicking the image opens a zoom/lightbox
+ * overlay with a "Save image" action.
+ */
+export function MediaImage({
+  token,
+}: {
+  token: MediaToken;
+}): React.JSX.Element {
+  const isDirect =
+    token.src.startsWith("data:") || /^https?:\/\//i.test(token.src);
+  const [resolved, setResolved] = useState<string | null>(
+    isDirect ? token.src : null,
+  );
+  const [failed, setFailed] = useState(false);
+  const [zoomed, setZoomed] = useState(false);
+
+  useEffect(() => {
+    if (isDirect) return;
+    let cancelled = false;
+    window.hermesAPI
+      .readMediaFile(token.src)
+      .then((dataUrl) => {
+        if (cancelled) return;
+        if (dataUrl) setResolved(dataUrl);
+        else setFailed(true);
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token.src, isDirect]);
+
+  if (failed) {
+    return (
+      <span className="chat-media-error">
+        ⚠ Could not load {token.name}
+      </span>
+    );
+  }
+
+  if (!resolved) {
+    return (
+      <span className="chat-media-loading">Loading {token.name}…</span>
+    );
+  }
+
+  return (
+    <>
+      <img
+        className="chat-media-image"
+        src={resolved}
+        alt={token.name}
+        onClick={() => setZoomed(true)}
+        onError={() => setFailed(true)}
+      />
+      {zoomed && (
+        <div
+          className="chat-image-preview-backdrop"
+          role="dialog"
+          aria-modal="true"
+          onClick={() => setZoomed(false)}
+        >
+          <img
+            className="chat-image-preview-image"
+            src={resolved}
+            alt={token.name}
+            onClick={(e) => e.stopPropagation()}
+          />
+          <div
+            className="chat-image-preview-actions"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              className="chat-media-file"
+              onClick={() =>
+                window.hermesAPI.saveMediaFile(token.src, token.name)
+              }
+            >
+              <Download size={14} />
+              Save image
+            </button>
+            <button
+              className="chat-media-file"
+              onClick={() => setZoomed(false)}
+              aria-label="Close"
+            >
+              <X size={14} />
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+export default MediaImage;

--- a/src/renderer/src/components/MediaImage.tsx
+++ b/src/renderer/src/components/MediaImage.tsx
@@ -1,6 +1,27 @@
 import { useState, useEffect } from "react";
 import { Download, X } from "lucide-react";
 import type { MediaToken } from "../screens/Chat/mediaUtils";
+import { useI18n } from "./useI18n";
+
+/**
+ * Returns an `onContextMenu` handler that opens a native right-click menu
+ * for a media element — "Open" (hands the file to the OS default handler,
+ * or a web URL to the browser) and "Save as…". The labels are resolved
+ * through i18n here so the native menu matches the active UI locale, since
+ * the menu itself is built in the main process (issue #299).
+ */
+function useMediaContextMenu(
+  token: MediaToken,
+): (event: React.MouseEvent) => void {
+  const { t } = useI18n();
+  return (event) => {
+    event.preventDefault();
+    window.hermesAPI.showMediaMenu(token.src, token.name, {
+      open: t("chat.media.open"),
+      saveAs: t("chat.media.saveAs"),
+    });
+  };
+}
 
 /**
  * Renders an agent-delivered image (issue #299). Data URLs and http(s)
@@ -20,6 +41,7 @@ export function MediaImage({
   );
   const [failed, setFailed] = useState(false);
   const [zoomed, setZoomed] = useState(false);
+  const onContextMenu = useMediaContextMenu(token);
 
   useEffect(() => {
     if (isDirect) return;
@@ -60,6 +82,7 @@ export function MediaImage({
         src={resolved}
         alt={token.name}
         onClick={() => setZoomed(true)}
+        onContextMenu={onContextMenu}
         onError={() => setFailed(true)}
       />
       {zoomed && (
@@ -74,6 +97,7 @@ export function MediaImage({
             src={resolved}
             alt={token.name}
             onClick={(e) => e.stopPropagation()}
+            onContextMenu={onContextMenu}
           />
           <div
             className="chat-image-preview-actions"
@@ -108,12 +132,14 @@ export function DownloadChip({
 }: {
   token: MediaToken;
 }): React.JSX.Element {
+  const onContextMenu = useMediaContextMenu(token);
   return (
     <button
       className="chat-media-file"
       onClick={() =>
         window.hermesAPI.saveMediaFile(token.src, token.name)
       }
+      onContextMenu={onContextMenu}
     >
       <Download size={14} />
       {token.name}

--- a/src/renderer/src/components/MediaImage.tsx
+++ b/src/renderer/src/components/MediaImage.tsx
@@ -102,4 +102,69 @@ export function MediaImage({
   );
 }
 
+/** A compact, clickable chip for non-image media — saves the file. */
+export function DownloadChip({
+  token,
+}: {
+  token: MediaToken;
+}): React.JSX.Element {
+  return (
+    <button
+      className="chat-media-file"
+      onClick={() =>
+        window.hermesAPI.saveMediaFile(token.src, token.name)
+      }
+    >
+      <Download size={14} />
+      {token.name}
+    </button>
+  );
+}
+
+/**
+ * Renders one media segment (issue #299). Explicit `MEDIA:` tokens are
+ * trusted and shown eagerly; a bare-path candidate is first verified to
+ * point at a real file — until then, and if verification fails, its
+ * original text is shown verbatim, so a path merely mentioned in prose is
+ * never turned into media.
+ */
+export function MediaSegmentView({
+  token,
+  raw,
+  source,
+}: {
+  token: MediaToken;
+  raw: string;
+  source: "media-token" | "bare-path";
+}): React.JSX.Element {
+  const [verified, setVerified] = useState<boolean | null>(
+    source === "media-token" ? true : null,
+  );
+
+  useEffect(() => {
+    // Only an inferred local path needs verifying; explicit tokens and
+    // URLs are trusted as-is.
+    if (source !== "bare-path" || token.isUrl) return;
+    let cancelled = false;
+    window.hermesAPI
+      .mediaFileExists(token.src)
+      .then((ok) => {
+        if (!cancelled) setVerified(ok);
+      })
+      .catch(() => {
+        if (!cancelled) setVerified(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [source, token.src, token.isUrl]);
+
+  if (verified !== true) return <>{raw}</>;
+  return token.isImage ? (
+    <MediaImage token={token} />
+  ) : (
+    <DownloadChip token={token} />
+  );
+}
+
 export default MediaImage;

--- a/src/renderer/src/screens/Chat/MessageRow.tsx
+++ b/src/renderer/src/screens/Chat/MessageRow.tsx
@@ -1,8 +1,11 @@
 import { memo, useState } from "react";
+import { Download } from "lucide-react";
 import icon from "../../assets/icon.png";
 import { AgentMarkdown } from "../../components/AgentMarkdown";
 import { AttachmentChip } from "../../components/AttachmentChip";
+import { MediaImage } from "../../components/MediaImage";
 import { useI18n } from "../../components/useI18n";
+import { parseMediaTokens } from "./mediaUtils";
 import type { Attachment, ChatBubbleMessage, ChatMessage } from "./types";
 
 export const APPROVAL_RE =
@@ -88,7 +91,29 @@ export const MessageRow = memo(function MessageRow({
         )}
         {msg.content &&
           (msg.role === "agent" ? (
-            <AgentMarkdown>{msg.content}</AgentMarkdown>
+            parseMediaTokens(msg.content).map((segment, i) => {
+              if (segment.type === "text") {
+                return segment.value.trim() ? (
+                  <AgentMarkdown key={i}>{segment.value}</AgentMarkdown>
+                ) : null;
+              }
+              const { token } = segment;
+              if (token.isImage) {
+                return <MediaImage key={i} token={token} />;
+              }
+              return (
+                <button
+                  key={i}
+                  className="chat-media-file"
+                  onClick={() =>
+                    window.hermesAPI.saveMediaFile(token.src, token.name)
+                  }
+                >
+                  <Download size={14} />
+                  {token.name}
+                </button>
+              );
+            })
           ) : (
             msg.content
           ))}

--- a/src/renderer/src/screens/Chat/MessageRow.tsx
+++ b/src/renderer/src/screens/Chat/MessageRow.tsx
@@ -1,9 +1,8 @@
 import { memo, useState } from "react";
-import { Download } from "lucide-react";
 import icon from "../../assets/icon.png";
 import { AgentMarkdown } from "../../components/AgentMarkdown";
 import { AttachmentChip } from "../../components/AttachmentChip";
-import { MediaImage } from "../../components/MediaImage";
+import { MediaSegmentView } from "../../components/MediaImage";
 import { useI18n } from "../../components/useI18n";
 import { parseMediaTokens } from "./mediaUtils";
 import type { Attachment, ChatBubbleMessage, ChatMessage } from "./types";
@@ -91,29 +90,20 @@ export const MessageRow = memo(function MessageRow({
         )}
         {msg.content &&
           (msg.role === "agent" ? (
-            parseMediaTokens(msg.content).map((segment, i) => {
-              if (segment.type === "text") {
-                return segment.value.trim() ? (
+            parseMediaTokens(msg.content).map((segment, i) =>
+              segment.type === "text" ? (
+                segment.value.trim() ? (
                   <AgentMarkdown key={i}>{segment.value}</AgentMarkdown>
-                ) : null;
-              }
-              const { token } = segment;
-              if (token.isImage) {
-                return <MediaImage key={i} token={token} />;
-              }
-              return (
-                <button
+                ) : null
+              ) : (
+                <MediaSegmentView
                   key={i}
-                  className="chat-media-file"
-                  onClick={() =>
-                    window.hermesAPI.saveMediaFile(token.src, token.name)
-                  }
-                >
-                  <Download size={14} />
-                  {token.name}
-                </button>
-              );
-            })
+                  token={segment.token}
+                  raw={segment.raw}
+                  source={segment.source}
+                />
+              ),
+            )
           ) : (
             msg.content
           ))}

--- a/src/renderer/src/screens/Chat/mediaUtils.test.ts
+++ b/src/renderer/src/screens/Chat/mediaUtils.test.ts
@@ -3,7 +3,17 @@ import {
   parseMediaTokens,
   hasMediaTokens,
   describeImageSrc,
+  type MediaSegment,
 } from "./mediaUtils";
+
+/** Find the first media segment, or fail the assertion if there is none. */
+function media(segs: MediaSegment[]): Extract<MediaSegment, { type: "media" }> {
+  const hit = segs.find((s) => s.type === "media");
+  if (!hit || hit.type !== "media") {
+    throw new Error("expected a media segment, got none");
+  }
+  return hit;
+}
 
 describe("parseMediaTokens (issue #299)", () => {
   it("returns a single text segment when there is nothing to extract", () => {
@@ -36,10 +46,15 @@ describe("parseMediaTokens (issue #299)", () => {
 
   it("strips trailing punctuation from a bare MEDIA: token", () => {
     const segs = parseMediaTokens("see MEDIA:/tmp/out.png.");
-    const media = segs.find((s) => s.type === "media");
-    expect((media as { token: { src: string } }).token.src).toBe(
-      "/tmp/out.png",
-    );
+    expect(media(segs).token.src).toBe("/tmp/out.png");
+  });
+
+  it("honours a quoted MEDIA: token containing spaces", () => {
+    const segs = parseMediaTokens('MEDIA:"C:\\My Folder\\a file.pdf"');
+    expect(media(segs).token).toMatchObject({
+      src: "C:\\My Folder\\a file.pdf",
+      name: "a file.pdf",
+    });
   });
 
   // ── Whole-line bare paths ──────────────────────────────
@@ -47,7 +62,7 @@ describe("parseMediaTokens (issue #299)", () => {
     const segs = parseMediaTokens(
       "Criei o PDF aqui:\n\nC:\\Users\\pmos6\\proverbios.pdf\n\nInclui 10.",
     );
-    expect(segs.find((s) => s.type === "media")).toMatchObject({
+    expect(media(segs)).toMatchObject({
       type: "media",
       source: "bare-path",
       raw: "C:\\Users\\pmos6\\proverbios.pdf",
@@ -57,7 +72,7 @@ describe("parseMediaTokens (issue #299)", () => {
 
   it("detects a whole-line POSIX path", () => {
     const segs = parseMediaTokens("Done:\n/home/me/out.png");
-    expect(segs.find((s) => s.type === "media")).toMatchObject({
+    expect(media(segs)).toMatchObject({
       source: "bare-path",
       token: { src: "/home/me/out.png", isImage: true },
     });
@@ -72,9 +87,52 @@ describe("parseMediaTokens (issue #299)", () => {
     });
   });
 
-  // ── False-positive guards ──────────────────────────────
-  it("does NOT detect a path mentioned mid-sentence", () => {
+  // ── Inline bare paths (mid-sentence) ───────────────────
+  it("detects an inline absolute path mentioned mid-sentence", () => {
     const segs = parseMediaTokens("I saved it to C:\\Users\\me\\x.pdf today.");
+    expect(segs[0]).toEqual({ type: "text", value: "I saved it to " });
+    expect(media(segs)).toMatchObject({
+      type: "media",
+      source: "bare-path",
+      raw: "C:\\Users\\me\\x.pdf",
+      token: { src: "C:\\Users\\me\\x.pdf", isImage: false },
+    });
+    expect(segs[segs.length - 1]).toEqual({ type: "text", value: " today." });
+  });
+
+  it("detects an inline POSIX absolute path", () => {
+    const segs = parseMediaTokens("Generated at /home/me/out.png — enjoy.");
+    expect(media(segs)).toMatchObject({
+      source: "bare-path",
+      token: { src: "/home/me/out.png", isImage: true },
+    });
+  });
+
+  it("excludes trailing punctuation from an inline path", () => {
+    const segs = parseMediaTokens("The chart is at C:\\d\\chart.png, see above.");
+    expect(media(segs).token.src).toBe("C:\\d\\chart.png");
+    expect(media(segs).raw).toBe("C:\\d\\chart.png");
+  });
+
+  it("keeps the matched path as `raw` so it can be shown verbatim", () => {
+    // `raw` is what MediaSegmentView renders until the file is verified.
+    const segs = parseMediaTokens("file: /var/data/report.csv done");
+    expect(media(segs).raw).toBe("/var/data/report.csv");
+  });
+
+  // ── False-positive guards ──────────────────────────────
+  it("does NOT start an inline match mid-token", () => {
+    const segs = parseMediaTokens("fooC:\\Users\\me\\x.pdf");
+    expect(segs.every((s) => s.type === "text")).toBe(true);
+  });
+
+  it("does NOT match an inline http URL as a path", () => {
+    const segs = parseMediaTokens("See https://example.com/pic.png for more.");
+    expect(segs.every((s) => s.type === "text")).toBe(true);
+  });
+
+  it("does NOT match an inline relative path", () => {
+    const segs = parseMediaTokens("Check output/cat.png please.");
     expect(segs.every((s) => s.type === "text")).toBe(true);
   });
 
@@ -82,6 +140,11 @@ describe("parseMediaTokens (issue #299)", () => {
     const segs = parseMediaTokens(
       "Example:\n```\nC:\\Users\\me\\x.png\n```\ndone",
     );
+    expect(segs.every((s) => s.type === "text")).toBe(true);
+  });
+
+  it("does NOT detect a path inside an inline code span", () => {
+    const segs = parseMediaTokens("Run `C:\\tmp\\x.png` to see it.");
     expect(segs.every((s) => s.type === "text")).toBe(true);
   });
 
@@ -95,13 +158,28 @@ describe("parseMediaTokens (issue #299)", () => {
     expect(segs.every((s) => s.type === "text")).toBe(true);
   });
 
+  it("does NOT match a bare path with an unknown extension", () => {
+    const segs = parseMediaTokens("Config at C:\\app\\settings.ini reloaded.");
+    expect(segs.every((s) => s.type === "text")).toBe(true);
+  });
+
   // ── Misc ───────────────────────────────────────────────
   it("does not double-count a MEDIA: token as a bare path", () => {
-    const media = parseMediaTokens("MEDIA:/tmp/a.png").filter(
+    const hits = parseMediaTokens("MEDIA:/tmp/a.png").filter(
       (s) => s.type === "media",
     );
-    expect(media).toHaveLength(1);
-    expect(media[0]).toMatchObject({ source: "media-token" });
+    expect(hits).toHaveLength(1);
+    expect(hits[0]).toMatchObject({ source: "media-token" });
+  });
+
+  it("detects several inline paths in one reply", () => {
+    const segs = parseMediaTokens(
+      "First /home/a/one.png and then /home/b/two.pdf are ready.",
+    );
+    const hits = segs.filter((s) => s.type === "media");
+    expect(hits).toHaveLength(2);
+    expect(hits.every((h) => h.type === "media" && h.source === "bare-path"))
+      .toBe(true);
   });
 
   it("keeps text after a token", () => {
@@ -114,6 +192,7 @@ describe("parseMediaTokens (issue #299)", () => {
 
   it("hasMediaTokens detects explicit tokens only", () => {
     expect(hasMediaTokens("MEDIA:/tmp/a.png")).toBe(true);
+    expect(hasMediaTokens("see /tmp/a.png")).toBe(false);
     expect(hasMediaTokens("no media")).toBe(false);
   });
 

--- a/src/renderer/src/screens/Chat/mediaUtils.test.ts
+++ b/src/renderer/src/screens/Chat/mediaUtils.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseMediaTokens,
+  hasMediaTokens,
+  describeImageSrc,
+} from "./mediaUtils";
+
+describe("parseMediaTokens (issue #299)", () => {
+  it("returns a single text segment when there is no MEDIA token", () => {
+    expect(parseMediaTokens("just a normal reply")).toEqual([
+      { type: "text", value: "just a normal reply" },
+    ]);
+  });
+
+  it("extracts a Windows-path MEDIA token", () => {
+    const segs = parseMediaTokens(
+      "Here it is:\n\nMEDIA:C:\\Users\\pmos6\\generated_cat_beach.png",
+    );
+    expect(segs).toHaveLength(2);
+    expect(segs[0]).toEqual({ type: "text", value: "Here it is:\n\n" });
+    expect(segs[1]).toEqual({
+      type: "media",
+      token: {
+        src: "C:\\Users\\pmos6\\generated_cat_beach.png",
+        isUrl: false,
+        isImage: true,
+        name: "generated_cat_beach.png",
+      },
+    });
+  });
+
+  it("extracts a POSIX-path MEDIA token", () => {
+    const segs = parseMediaTokens("MEDIA:/tmp/red_circle.svg");
+    expect(segs[0]).toMatchObject({
+      type: "media",
+      token: { src: "/tmp/red_circle.svg", isImage: true, isUrl: false },
+    });
+  });
+
+  it("extracts an https MEDIA token and marks it a URL", () => {
+    const segs = parseMediaTokens("MEDIA:https://example.com/pic.jpg");
+    expect(segs[0]).toMatchObject({
+      type: "media",
+      token: { src: "https://example.com/pic.jpg", isUrl: true, isImage: true },
+    });
+  });
+
+  it("handles a quoted path containing spaces", () => {
+    const segs = parseMediaTokens('MEDIA:"C:\\My Pics\\a b.png"');
+    expect(segs[0]).toMatchObject({
+      type: "media",
+      token: { src: "C:\\My Pics\\a b.png", isImage: true },
+    });
+  });
+
+  it("strips trailing sentence punctuation from a bare token", () => {
+    const segs = parseMediaTokens("see MEDIA:/tmp/out.png.");
+    expect((segs[1] as { token: { src: string } }).token.src).toBe(
+      "/tmp/out.png",
+    );
+  });
+
+  it("flags a non-image media file", () => {
+    const segs = parseMediaTokens("MEDIA:/tmp/clip.mp4");
+    expect((segs[0] as { token: { isImage: boolean } }).token.isImage).toBe(
+      false,
+    );
+  });
+
+  it("keeps text after a token", () => {
+    const segs = parseMediaTokens("MEDIA:/tmp/a.png\n\nEnjoy!");
+    expect(segs[segs.length - 1]).toEqual({
+      type: "text",
+      value: "\n\nEnjoy!",
+    });
+  });
+
+  it("hasMediaTokens detects presence", () => {
+    expect(hasMediaTokens("MEDIA:/tmp/a.png")).toBe(true);
+    expect(hasMediaTokens("no media here")).toBe(false);
+  });
+
+  it("describeImageSrc classifies a plain image src", () => {
+    expect(describeImageSrc("https://x.test/p.png")).toMatchObject({
+      isUrl: true,
+      isImage: true,
+      name: "p.png",
+    });
+  });
+});

--- a/src/renderer/src/screens/Chat/mediaUtils.test.ts
+++ b/src/renderer/src/screens/Chat/mediaUtils.test.ts
@@ -6,65 +6,102 @@ import {
 } from "./mediaUtils";
 
 describe("parseMediaTokens (issue #299)", () => {
-  it("returns a single text segment when there is no MEDIA token", () => {
+  it("returns a single text segment when there is nothing to extract", () => {
     expect(parseMediaTokens("just a normal reply")).toEqual([
       { type: "text", value: "just a normal reply" },
     ]);
   });
 
-  it("extracts a Windows-path MEDIA token", () => {
+  // ── Explicit MEDIA: tokens ─────────────────────────────
+  it("extracts an explicit MEDIA: token (Windows path)", () => {
     const segs = parseMediaTokens(
-      "Here it is:\n\nMEDIA:C:\\Users\\pmos6\\generated_cat_beach.png",
+      "Here it is:\n\nMEDIA:C:\\Users\\pmos6\\cat.png",
     );
-    expect(segs).toHaveLength(2);
     expect(segs[0]).toEqual({ type: "text", value: "Here it is:\n\n" });
-    expect(segs[1]).toEqual({
+    expect(segs[1]).toMatchObject({
       type: "media",
-      token: {
-        src: "C:\\Users\\pmos6\\generated_cat_beach.png",
-        isUrl: false,
-        isImage: true,
-        name: "generated_cat_beach.png",
-      },
+      source: "media-token",
+      token: { src: "C:\\Users\\pmos6\\cat.png", isImage: true, isUrl: false },
     });
   });
 
-  it("extracts a POSIX-path MEDIA token", () => {
-    const segs = parseMediaTokens("MEDIA:/tmp/red_circle.svg");
+  it("extracts a MEDIA: https token as a URL", () => {
+    const segs = parseMediaTokens("MEDIA:https://x.test/p.jpg");
     expect(segs[0]).toMatchObject({
       type: "media",
-      token: { src: "/tmp/red_circle.svg", isImage: true, isUrl: false },
+      source: "media-token",
+      token: { isUrl: true, isImage: true },
     });
   });
 
-  it("extracts an https MEDIA token and marks it a URL", () => {
-    const segs = parseMediaTokens("MEDIA:https://example.com/pic.jpg");
-    expect(segs[0]).toMatchObject({
-      type: "media",
-      token: { src: "https://example.com/pic.jpg", isUrl: true, isImage: true },
-    });
-  });
-
-  it("handles a quoted path containing spaces", () => {
-    const segs = parseMediaTokens('MEDIA:"C:\\My Pics\\a b.png"');
-    expect(segs[0]).toMatchObject({
-      type: "media",
-      token: { src: "C:\\My Pics\\a b.png", isImage: true },
-    });
-  });
-
-  it("strips trailing sentence punctuation from a bare token", () => {
+  it("strips trailing punctuation from a bare MEDIA: token", () => {
     const segs = parseMediaTokens("see MEDIA:/tmp/out.png.");
-    expect((segs[1] as { token: { src: string } }).token.src).toBe(
+    const media = segs.find((s) => s.type === "media");
+    expect((media as { token: { src: string } }).token.src).toBe(
       "/tmp/out.png",
     );
   });
 
-  it("flags a non-image media file", () => {
-    const segs = parseMediaTokens("MEDIA:/tmp/clip.mp4");
-    expect((segs[0] as { token: { isImage: boolean } }).token.isImage).toBe(
-      false,
+  // ── Whole-line bare paths ──────────────────────────────
+  it("detects a whole-line bare absolute path (Windows, non-image)", () => {
+    const segs = parseMediaTokens(
+      "Criei o PDF aqui:\n\nC:\\Users\\pmos6\\proverbios.pdf\n\nInclui 10.",
     );
+    expect(segs.find((s) => s.type === "media")).toMatchObject({
+      type: "media",
+      source: "bare-path",
+      raw: "C:\\Users\\pmos6\\proverbios.pdf",
+      token: { src: "C:\\Users\\pmos6\\proverbios.pdf", isImage: false },
+    });
+  });
+
+  it("detects a whole-line POSIX path", () => {
+    const segs = parseMediaTokens("Done:\n/home/me/out.png");
+    expect(segs.find((s) => s.type === "media")).toMatchObject({
+      source: "bare-path",
+      token: { src: "/home/me/out.png", isImage: true },
+    });
+  });
+
+  it("tolerates spaces inside a whole-line path", () => {
+    const segs = parseMediaTokens("C:\\My Folder\\a file.pdf");
+    expect(segs[0]).toMatchObject({
+      type: "media",
+      source: "bare-path",
+      token: { src: "C:\\My Folder\\a file.pdf", name: "a file.pdf" },
+    });
+  });
+
+  // ── False-positive guards ──────────────────────────────
+  it("does NOT detect a path mentioned mid-sentence", () => {
+    const segs = parseMediaTokens("I saved it to C:\\Users\\me\\x.pdf today.");
+    expect(segs.every((s) => s.type === "text")).toBe(true);
+  });
+
+  it("does NOT detect a path inside a fenced code block", () => {
+    const segs = parseMediaTokens(
+      "Example:\n```\nC:\\Users\\me\\x.png\n```\ndone",
+    );
+    expect(segs.every((s) => s.type === "text")).toBe(true);
+  });
+
+  it("does NOT treat a bare URL line as a path", () => {
+    const segs = parseMediaTokens("https://example.com/pic.png");
+    expect(segs.every((s) => s.type === "text")).toBe(true);
+  });
+
+  it("does NOT detect a relative path line", () => {
+    const segs = parseMediaTokens("output/cat.png");
+    expect(segs.every((s) => s.type === "text")).toBe(true);
+  });
+
+  // ── Misc ───────────────────────────────────────────────
+  it("does not double-count a MEDIA: token as a bare path", () => {
+    const media = parseMediaTokens("MEDIA:/tmp/a.png").filter(
+      (s) => s.type === "media",
+    );
+    expect(media).toHaveLength(1);
+    expect(media[0]).toMatchObject({ source: "media-token" });
   });
 
   it("keeps text after a token", () => {
@@ -75,12 +112,12 @@ describe("parseMediaTokens (issue #299)", () => {
     });
   });
 
-  it("hasMediaTokens detects presence", () => {
+  it("hasMediaTokens detects explicit tokens only", () => {
     expect(hasMediaTokens("MEDIA:/tmp/a.png")).toBe(true);
-    expect(hasMediaTokens("no media here")).toBe(false);
+    expect(hasMediaTokens("no media")).toBe(false);
   });
 
-  it("describeImageSrc classifies a plain image src", () => {
+  it("describeImageSrc classifies a plain src", () => {
     expect(describeImageSrc("https://x.test/p.png")).toMatchObject({
       isUrl: true,
       isImage: true,

--- a/src/renderer/src/screens/Chat/mediaUtils.ts
+++ b/src/renderer/src/screens/Chat/mediaUtils.ts
@@ -1,23 +1,25 @@
 /**
  * Parsing for agent-delivered media (issue #299).
  *
- * Two signals are recognised in agent responses:
+ * Three signals are recognised in agent responses:
  *
  *  1. Explicit `MEDIA:<path-or-url>` tokens — hermes-agent's delivery
  *     protocol. Trusted: rendered eagerly.
- *  2. A line whose *entire* trimmed content is an absolute file path with a
- *     known extension — the agent often just states the path it created
- *     instead of emitting a MEDIA: tag. Treated as a *candidate*: the
- *     renderer verifies the file exists before showing it, and lines inside
- *     ``` fences are skipped, so paths in code examples are left alone.
+ *  2. An inline absolute file path with a known extension, anywhere in the
+ *     text. Treated as a *candidate* — the renderer verifies the file
+ *     exists before showing it, so a path merely named in prose only turns
+ *     into media when it really points at a reachable file.
+ *  3. A whole line that is exactly an absolute path — also covers paths
+ *     containing spaces, which the inline (no-whitespace) form cannot.
  *
- * hermes-agent's own MEDIA: regexes are POSIX-only (paths must start with
- * `/` or `~/`); this parser also accepts Windows drive / UNC paths.
+ * Care taken against false positives: the inline matcher is anchored so it
+ * cannot start mid-token or inside a URL, and matches inside ``` fenced or
+ * `inline` code are skipped.
  */
 
 const IMAGE_EXT = /\.(png|jpe?g|gif|webp|svg|bmp|avif)$/i;
 
-// Extensions recognised in a bare (untagged) path line.
+// Extensions recognised in a bare (untagged) path.
 const BARE_PATH_EXT =
   "png|jpe?g|gif|webp|svg|bmp|avif|pdf|txt|md|csv|json|docx?|xlsx?|pptx?|" +
   "odt|rtf|zip|tar|gz|mp4|mov|webm|mkv|avi|mp3|wav|ogg|opus|m4a|flac";
@@ -26,9 +28,20 @@ const BARE_PATH_EXT =
 const MEDIA_RE =
   /MEDIA:[ \t]*(?:`([^`\n]+)`|"([^"\n]+)"|'([^'\n]+)'|(\S+))/g;
 
-// A whole line that is exactly an absolute path ending in a known extension.
-// Applied to the trimmed line, so spaces inside the path are tolerated. The
-// `^` anchor keeps it from matching URLs (which start with a scheme).
+// Inline bare absolute path (no whitespace in the path). The negative
+// lookbehind blocks matches that start mid-token or inside a URL (`://`);
+// the lookahead requires the extension to be followed by whitespace,
+// sentence punctuation, or end-of-string.
+const INLINE_PATH_RE = new RegExp(
+  String.raw`(?<![\w/\\.:])((?:[A-Za-z]:[\\/]|\\\\|/|~[\\/])\S*?\.(?:` +
+    BARE_PATH_EXT +
+    String.raw`))(?=[\s).,;:!?\]}>"']|$)`,
+  "gi",
+);
+
+// A whole trimmed line that is exactly an absolute path; covers paths with
+// spaces. The `^` anchor keeps it from matching URLs (which start with a
+// scheme rather than a drive letter / slash).
 const ABS_PATH_LINE_RE = new RegExp(
   `^(?:[A-Za-z]:[\\\\/]|\\\\\\\\|/|~[\\\\/]).*\\.(?:${BARE_PATH_EXT})$`,
   "i",
@@ -58,6 +71,14 @@ export type MediaSegment =
       source: "media-token" | "bare-path";
     };
 
+interface Hit {
+  start: number;
+  end: number;
+  token: MediaToken;
+  raw: string;
+  source: "media-token" | "bare-path";
+}
+
 function toToken(raw: string, wasQuoted: boolean): MediaToken | null {
   let src = raw.trim();
   // Bare MEDIA: tokens may swallow trailing sentence punctuation.
@@ -68,12 +89,27 @@ function toToken(raw: string, wasQuoted: boolean): MediaToken | null {
   return { src, isUrl, isImage: IMAGE_EXT.test(src), name };
 }
 
-interface Hit {
-  start: number;
-  end: number;
-  token: MediaToken;
-  raw: string;
-  source: "media-token" | "bare-path";
+/** Char ranges of ``` fenced blocks and `inline` code spans. */
+function codeRanges(content: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  let m: RegExpExecArray | null;
+  const fenced = /```[\s\S]*?```/g;
+  while ((m = fenced.exec(content)) !== null) {
+    ranges.push([m.index, m.index + m[0].length]);
+  }
+  const inline = /`[^`\n]+`/g;
+  while ((m = inline.exec(content)) !== null) {
+    ranges.push([m.index, m.index + m[0].length]);
+  }
+  return ranges;
+}
+
+function inCode(index: number, ranges: Array<[number, number]>): boolean {
+  return ranges.some(([s, e]) => index >= s && index < e);
+}
+
+function overlaps(start: number, end: number, hits: Hit[]): boolean {
+  return hits.some((h) => start < h.end && end > h.start);
 }
 
 /**
@@ -81,12 +117,14 @@ interface Hit {
  * rendered as markdown; media segments as inline images or download chips.
  */
 export function parseMediaTokens(content: string): MediaSegment[] {
+  const code = codeRanges(content);
   const hits: Hit[] = [];
+  let m: RegExpExecArray | null;
 
   // 1) Explicit MEDIA: tokens.
   MEDIA_RE.lastIndex = 0;
-  let m: RegExpExecArray | null;
   while ((m = MEDIA_RE.exec(content)) !== null) {
+    if (inCode(m.index, code)) continue;
     const quoted = m[1] ?? m[2] ?? m[3];
     const token = toToken(quoted ?? m[4] ?? "", quoted !== undefined);
     if (!token) continue;
@@ -99,25 +137,32 @@ export function parseMediaTokens(content: string): MediaSegment[] {
     });
   }
 
-  // 2) Whole-line bare absolute paths, skipping ``` fenced code.
+  // 2) Inline bare absolute paths (no whitespace).
+  INLINE_PATH_RE.lastIndex = 0;
+  while ((m = INLINE_PATH_RE.exec(content)) !== null) {
+    const start = m.index;
+    const end = start + m[0].length;
+    if (inCode(start, code) || overlaps(start, end, hits)) continue;
+    const token = toToken(m[1], true);
+    if (token) {
+      hits.push({ start, end, token, raw: m[1], source: "bare-path" });
+    }
+  }
+
+  // 3) Whole-line bare paths (covers paths containing spaces).
   let offset = 0;
-  let inFence = false;
   for (const line of content.split("\n")) {
     const lineStart = offset;
     offset += line.length + 1; // include the consumed "\n"
     const trimmed = line.trim();
-    if (/^```/.test(trimmed)) {
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence || !trimmed || !ABS_PATH_LINE_RE.test(trimmed)) continue;
+    if (!trimmed || !ABS_PATH_LINE_RE.test(trimmed)) continue;
     const start = lineStart + line.indexOf(trimmed);
     const end = start + trimmed.length;
-    // Don't double-count a path already inside a MEDIA: token.
-    if (hits.some((h) => start < h.end && end > h.start)) continue;
+    if (inCode(start, code) || overlaps(start, end, hits)) continue;
     const token = toToken(trimmed, true);
-    if (!token) continue;
-    hits.push({ start, end, token, raw: trimmed, source: "bare-path" });
+    if (token) {
+      hits.push({ start, end, token, raw: trimmed, source: "bare-path" });
+    }
   }
 
   hits.sort((a, b) => a.start - b.start);

--- a/src/renderer/src/screens/Chat/mediaUtils.ts
+++ b/src/renderer/src/screens/Chat/mediaUtils.ts
@@ -1,0 +1,86 @@
+/**
+ * Parsing for hermes-agent's `MEDIA:` delivery protocol (issue #299).
+ *
+ * The agent emits `MEDIA:<path-or-url>` tokens inline in its responses to
+ * deliver generated files (images, audio, …). Messaging-platform adapters
+ * turn those into native attachments; the desktop must do the same.
+ *
+ * hermes-agent's own regexes are POSIX-leaning (paths must start with `/`
+ * or `~/`), so a generated Windows path like `MEDIA:C:\Users\me\cat.png`
+ * is not matched upstream. This parser is deliberately more permissive: a
+ * token is `MEDIA:` followed by either a quoted string or an unquoted run
+ * of non-whitespace, covering Windows paths, POSIX paths and URLs.
+ */
+
+const IMAGE_EXT = /\.(png|jpe?g|gif|webp|svg|bmp|avif)$/i;
+
+// MEDIA: + optional whitespace + (backtick/double/single quoted) | (bare run)
+const MEDIA_RE =
+  /MEDIA:[ \t]*(?:`([^`\n]+)`|"([^"\n]+)"|'([^'\n]+)'|(\S+))/g;
+
+export interface MediaToken {
+  /** The resolved path or URL. */
+  src: string;
+  /** True when `src` is an http(s) URL rather than a local path. */
+  isUrl: boolean;
+  /** True when the file extension looks like a displayable image. */
+  isImage: boolean;
+  /** Last path/URL segment, for download filenames and alt text. */
+  name: string;
+}
+
+export type MediaSegment =
+  | { type: "text"; value: string }
+  | { type: "media"; token: MediaToken };
+
+function toToken(raw: string, wasQuoted: boolean): MediaToken | null {
+  let src = raw.trim();
+  // Bare tokens may swallow trailing sentence punctuation — strip it.
+  if (!wasQuoted) src = src.replace(/[).,;:!?\]}]+$/, "");
+  if (!src) return null;
+  const isUrl = /^https?:\/\//i.test(src);
+  const name = src.split(/[\\/]/).filter(Boolean).pop() || src;
+  return { src, isUrl, isImage: IMAGE_EXT.test(src), name };
+}
+
+/**
+ * Split agent content into ordered text / media segments. Text segments
+ * are rendered as markdown; media segments as inline images (or chips).
+ */
+export function parseMediaTokens(content: string): MediaSegment[] {
+  const segments: MediaSegment[] = [];
+  let lastIndex = 0;
+  let m: RegExpExecArray | null;
+  MEDIA_RE.lastIndex = 0;
+  while ((m = MEDIA_RE.exec(content)) !== null) {
+    const quoted = m[1] ?? m[2] ?? m[3];
+    const token = toToken(quoted ?? m[4] ?? "", quoted !== undefined);
+    if (!token) continue;
+    if (m.index > lastIndex) {
+      segments.push({
+        type: "text",
+        value: content.slice(lastIndex, m.index),
+      });
+    }
+    segments.push({ type: "media", token });
+    lastIndex = m.index + m[0].length;
+  }
+  if (lastIndex < content.length) {
+    segments.push({ type: "text", value: content.slice(lastIndex) });
+  }
+  return segments;
+}
+
+/** True when `content` contains at least one MEDIA: token. */
+export function hasMediaTokens(content: string): boolean {
+  MEDIA_RE.lastIndex = 0;
+  return MEDIA_RE.test(content);
+}
+
+/** Classify a plain image src (used by the markdown `img` override). */
+export function describeImageSrc(src: string): MediaToken {
+  const trimmed = src.trim();
+  const isUrl = /^https?:\/\//i.test(trimmed);
+  const name = trimmed.split(/[\\/]/).filter(Boolean).pop() || trimmed;
+  return { src: trimmed, isUrl, isImage: true, name };
+}

--- a/src/renderer/src/screens/Chat/mediaUtils.ts
+++ b/src/renderer/src/screens/Chat/mediaUtils.ts
@@ -1,29 +1,45 @@
 /**
- * Parsing for hermes-agent's `MEDIA:` delivery protocol (issue #299).
+ * Parsing for agent-delivered media (issue #299).
  *
- * The agent emits `MEDIA:<path-or-url>` tokens inline in its responses to
- * deliver generated files (images, audio, …). Messaging-platform adapters
- * turn those into native attachments; the desktop must do the same.
+ * Two signals are recognised in agent responses:
  *
- * hermes-agent's own regexes are POSIX-leaning (paths must start with `/`
- * or `~/`), so a generated Windows path like `MEDIA:C:\Users\me\cat.png`
- * is not matched upstream. This parser is deliberately more permissive: a
- * token is `MEDIA:` followed by either a quoted string or an unquoted run
- * of non-whitespace, covering Windows paths, POSIX paths and URLs.
+ *  1. Explicit `MEDIA:<path-or-url>` tokens — hermes-agent's delivery
+ *     protocol. Trusted: rendered eagerly.
+ *  2. A line whose *entire* trimmed content is an absolute file path with a
+ *     known extension — the agent often just states the path it created
+ *     instead of emitting a MEDIA: tag. Treated as a *candidate*: the
+ *     renderer verifies the file exists before showing it, and lines inside
+ *     ``` fences are skipped, so paths in code examples are left alone.
+ *
+ * hermes-agent's own MEDIA: regexes are POSIX-only (paths must start with
+ * `/` or `~/`); this parser also accepts Windows drive / UNC paths.
  */
 
 const IMAGE_EXT = /\.(png|jpe?g|gif|webp|svg|bmp|avif)$/i;
 
-// MEDIA: + optional whitespace + (backtick/double/single quoted) | (bare run)
+// Extensions recognised in a bare (untagged) path line.
+const BARE_PATH_EXT =
+  "png|jpe?g|gif|webp|svg|bmp|avif|pdf|txt|md|csv|json|docx?|xlsx?|pptx?|" +
+  "odt|rtf|zip|tar|gz|mp4|mov|webm|mkv|avi|mp3|wav|ogg|opus|m4a|flac";
+
+// MEDIA: + optional whitespace + (quoted) | (bare non-whitespace run).
 const MEDIA_RE =
   /MEDIA:[ \t]*(?:`([^`\n]+)`|"([^"\n]+)"|'([^'\n]+)'|(\S+))/g;
+
+// A whole line that is exactly an absolute path ending in a known extension.
+// Applied to the trimmed line, so spaces inside the path are tolerated. The
+// `^` anchor keeps it from matching URLs (which start with a scheme).
+const ABS_PATH_LINE_RE = new RegExp(
+  `^(?:[A-Za-z]:[\\\\/]|\\\\\\\\|/|~[\\\\/]).*\\.(?:${BARE_PATH_EXT})$`,
+  "i",
+);
 
 export interface MediaToken {
   /** The resolved path or URL. */
   src: string;
   /** True when `src` is an http(s) URL rather than a local path. */
   isUrl: boolean;
-  /** True when the file extension looks like a displayable image. */
+  /** True when the extension looks like a displayable image. */
   isImage: boolean;
   /** Last path/URL segment, for download filenames and alt text. */
   name: string;
@@ -31,11 +47,20 @@ export interface MediaToken {
 
 export type MediaSegment =
   | { type: "text"; value: string }
-  | { type: "media"; token: MediaToken };
+  | {
+      type: "media";
+      token: MediaToken;
+      /** Exact original text this segment replaced. Rendered verbatim when
+       *  a bare-path candidate turns out not to be a real file. */
+      raw: string;
+      /** `media-token` — explicit MEDIA: tag, rendered eagerly.
+       *  `bare-path` — inferred path, rendered only once verified to exist. */
+      source: "media-token" | "bare-path";
+    };
 
 function toToken(raw: string, wasQuoted: boolean): MediaToken | null {
   let src = raw.trim();
-  // Bare tokens may swallow trailing sentence punctuation — strip it.
+  // Bare MEDIA: tokens may swallow trailing sentence punctuation.
   if (!wasQuoted) src = src.replace(/[).,;:!?\]}]+$/, "");
   if (!src) return null;
   const isUrl = /^https?:\/\//i.test(src);
@@ -43,35 +68,81 @@ function toToken(raw: string, wasQuoted: boolean): MediaToken | null {
   return { src, isUrl, isImage: IMAGE_EXT.test(src), name };
 }
 
+interface Hit {
+  start: number;
+  end: number;
+  token: MediaToken;
+  raw: string;
+  source: "media-token" | "bare-path";
+}
+
 /**
- * Split agent content into ordered text / media segments. Text segments
- * are rendered as markdown; media segments as inline images (or chips).
+ * Split agent content into ordered text / media segments. Text segments are
+ * rendered as markdown; media segments as inline images or download chips.
  */
 export function parseMediaTokens(content: string): MediaSegment[] {
-  const segments: MediaSegment[] = [];
-  let lastIndex = 0;
-  let m: RegExpExecArray | null;
+  const hits: Hit[] = [];
+
+  // 1) Explicit MEDIA: tokens.
   MEDIA_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
   while ((m = MEDIA_RE.exec(content)) !== null) {
     const quoted = m[1] ?? m[2] ?? m[3];
     const token = toToken(quoted ?? m[4] ?? "", quoted !== undefined);
     if (!token) continue;
-    if (m.index > lastIndex) {
-      segments.push({
-        type: "text",
-        value: content.slice(lastIndex, m.index),
-      });
-    }
-    segments.push({ type: "media", token });
-    lastIndex = m.index + m[0].length;
+    hits.push({
+      start: m.index,
+      end: m.index + m[0].length,
+      token,
+      raw: m[0],
+      source: "media-token",
+    });
   }
-  if (lastIndex < content.length) {
-    segments.push({ type: "text", value: content.slice(lastIndex) });
+
+  // 2) Whole-line bare absolute paths, skipping ``` fenced code.
+  let offset = 0;
+  let inFence = false;
+  for (const line of content.split("\n")) {
+    const lineStart = offset;
+    offset += line.length + 1; // include the consumed "\n"
+    const trimmed = line.trim();
+    if (/^```/.test(trimmed)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence || !trimmed || !ABS_PATH_LINE_RE.test(trimmed)) continue;
+    const start = lineStart + line.indexOf(trimmed);
+    const end = start + trimmed.length;
+    // Don't double-count a path already inside a MEDIA: token.
+    if (hits.some((h) => start < h.end && end > h.start)) continue;
+    const token = toToken(trimmed, true);
+    if (!token) continue;
+    hits.push({ start, end, token, raw: trimmed, source: "bare-path" });
+  }
+
+  hits.sort((a, b) => a.start - b.start);
+
+  const segments: MediaSegment[] = [];
+  let last = 0;
+  for (const h of hits) {
+    if (h.start > last) {
+      segments.push({ type: "text", value: content.slice(last, h.start) });
+    }
+    segments.push({
+      type: "media",
+      token: h.token,
+      raw: h.raw,
+      source: h.source,
+    });
+    last = h.end;
+  }
+  if (last < content.length) {
+    segments.push({ type: "text", value: content.slice(last) });
   }
   return segments;
 }
 
-/** True when `content` contains at least one MEDIA: token. */
+/** True when `content` contains at least one explicit MEDIA: token. */
 export function hasMediaTokens(content: string): boolean {
   MEDIA_RE.lastIndex = 0;
   return MEDIA_RE.test(content);

--- a/src/shared/i18n/locales/en/chat.ts
+++ b/src/shared/i18n/locales/en/chat.ts
@@ -51,6 +51,10 @@ export default {
   categoryTools: "Tools",
   categoryInfo: "Info",
   noUsageData: "No usage data yet. Send a message first.",
+  media: {
+    open: "Open",
+    saveAs: "Save as…",
+  },
   commands: {
     new: "Start a new chat",
     clear: "Clear conversation history",

--- a/src/shared/i18n/locales/es/chat.ts
+++ b/src/shared/i18n/locales/es/chat.ts
@@ -48,6 +48,10 @@ export default {
   categoryTools: "Herramientas",
   categoryInfo: "Información",
   noUsageData: "Todavía no hay datos de uso. Envía primero un mensaje.",
+  media: {
+    open: "Abrir",
+    saveAs: "Guardar como…",
+  },
   commands: {
     new: "Iniciar un nuevo chat",
     clear: "Borrar el historial de la conversación",

--- a/src/shared/i18n/locales/id/chat.ts
+++ b/src/shared/i18n/locales/id/chat.ts
@@ -48,6 +48,10 @@ export default {
   categoryTools: "Alat",
   categoryInfo: "Info",
   noUsageData: "Belum ada data penggunaan. Kirim pesan terlebih dahulu.",
+  media: {
+    open: "Buka",
+    saveAs: "Simpan sebagai…",
+  },
   commands: {
     new: "Mulai chat baru",
     clear: "Bersihkan riwayat percakapan",

--- a/src/shared/i18n/locales/ja/chat.ts
+++ b/src/shared/i18n/locales/ja/chat.ts
@@ -47,6 +47,10 @@ export default {
   categoryInfo: "情報",
   noUsageData:
     "まだ使用データがありません。まずメッセージを送ってみてください。",
+  media: {
+    open: "開く",
+    saveAs: "名前を付けて保存…",
+  },
   commands: {
     new: "新しいチャットを開始",
     clear: "会話履歴をクリア",

--- a/src/shared/i18n/locales/pt-BR/chat.ts
+++ b/src/shared/i18n/locales/pt-BR/chat.ts
@@ -48,6 +48,10 @@ export default {
   categoryTools: "Ferramentas",
   categoryInfo: "Informação",
   noUsageData: "Nenhum dado de uso ainda. Envie uma mensagem primeiro.",
+  media: {
+    open: "Abrir",
+    saveAs: "Salvar como…",
+  },
   commands: {
     new: "Iniciar um novo chat",
     clear: "Limpar o histórico da conversa",

--- a/src/shared/i18n/locales/pt-PT/chat.ts
+++ b/src/shared/i18n/locales/pt-PT/chat.ts
@@ -48,6 +48,10 @@ export default {
   categoryTools: "Ferramentas",
   categoryInfo: "Informação",
   noUsageData: "Ainda sem dados de utilização. Envie uma mensagem primeiro.",
+  media: {
+    open: "Abrir",
+    saveAs: "Guardar como…",
+  },
   commands: {
     new: "Iniciar um novo chat",
     clear: "Limpar o histórico da conversa",

--- a/src/shared/i18n/locales/zh-CN/chat.ts
+++ b/src/shared/i18n/locales/zh-CN/chat.ts
@@ -44,6 +44,10 @@ export default {
   categoryTools: "工具",
   categoryInfo: "信息",
   noUsageData: "暂无使用数据。请先发送一条消息。",
+  media: {
+    open: "打开",
+    saveAs: "另存为…",
+  },
   commands: {
     new: "开始新对话",
     clear: "清空对话历史",

--- a/src/shared/i18n/locales/zh-TW/chat.ts
+++ b/src/shared/i18n/locales/zh-TW/chat.ts
@@ -34,6 +34,10 @@ export default {
   categoryTools: "工具",
   categoryInfo: "資訊",
   noUsageData: "目前沒有使用資料。請先傳送一則訊息。",
+  media: {
+    open: "開啟",
+    saveAs: "另存新檔…",
+  },
   commands: {
     new: "開始新對話",
     clear: "清除對話歷史",


### PR DESCRIPTION
## Summary

Closes #299. The agent delivers generated files (images, PDFs, etc.) but the desktop app rendered the delivery path as literal text. This PR makes that media appear inline in the chat.

**Detection** — three signals in an agent reply are recognised:
1. **`MEDIA:<path-or-url>` tokens** — hermes-agent's explicit delivery protocol. Trusted, rendered eagerly. Quoted forms (backtick / single / double) handle paths with spaces.
2. **Inline bare absolute paths** — an absolute path with a known extension named anywhere in the prose. The matcher is anchored: a negative lookbehind blocks matches that start mid-token or inside a URL, the extension must be followed by whitespace/sentence punctuation, and matches inside fenced or inline code are skipped.
3. **Whole-line bare paths** — a line that is exactly an absolute path, which also covers paths containing spaces.
4. Markdown image syntax (`![alt](src)`) is rendered too, via an `img` override.

**False-positive safety** — every *inferred* bare path (inline or whole-line) is verified to point at a real, reachable file (`mediaFileExists` IPC) before it is rendered as media. Until verified — and if verification fails — the original text is shown verbatim, so a path merely mentioned in prose never silently becomes media. Explicit `MEDIA:` tokens and URLs are trusted as-is.

**Rendering**
- Images render inline (size-capped), click to open a zoom/lightbox with Save and close actions.
- Non-image media renders as a compact download chip.
- Local paths are resolved to data URLs through the main process; a 25 MB guard applies.

**Right-click menu** — images, the lightbox image, and download chips now have a native context menu: **Open** (local file → OS default handler; web URL → browser) and **Save as…** (data: URLs are save-only). Labels go through i18n — new `chat.media.*` keys for all eight locales.

## Notes

- Detection covers both whole-line *and* inline path mentions; there is no assumption that the agent always places a filename on its own line.
- The new right-click menu and the generic copy/paste context menu (separate PR #301) are independent. When both land, whichever merges second should add a one-line guard so the media menu wins on media elements — flagged here for the reviewer.

## Test plan

- [x] `npm run typecheck` clean
- [x] Full test suite — 513 passed / 3 skipped; `mediaUtils` parser has 25 unit tests
- [x] Live: image renders inline, lightbox + save work
- [x] Live: bare PDF path renders as a download chip
- [x] Live: inline path mention detected when the file exists
- [x] Live: right-click Open / Save as on images and download chips

🤖 Generated with [Claude Code](https://claude.com/claude-code)