### PR TITLE
Route SSH-mode gateway ops through systemd when hermes.service exists (#285)

### DIFF
--- a/src/main/ssh-remote.ts
+++ b/src/main/ssh-remote.ts
@@ -1329,17 +1329,92 @@ export async function sshDeleteProfile(
 }
 
 // ── Gateway ───────────────────────────────────────────────────────────────────
+//
+// In SSH mode the remote gateway may be owned by a systemd `hermes.service`
+// unit — the standard VPS installer sets this up. Starting our own detached
+// `nohup` gateway then strands that unit in a restart crash-loop (issue
+// #285). Each operation below therefore asks the remote, in a single shell
+// `if`, whether such a unit is installed and routes the request through
+// systemd when it is — one SSH round-trip, atomic decision. The command
+// strings are built by the exported helpers below so they can be unit
+// tested without a live host.
+
+/**
+ * Shell test that succeeds when a systemd `hermes.service` unit file is
+ * installed on the remote. Safe on hosts without systemd: a missing
+ * `systemctl` yields empty output, so the test simply fails and callers
+ * fall back to the plain (`nohup` / pidfile) path.
+ */
+const SYSTEMD_HERMES_UNIT_TEST =
+  "systemctl list-unit-files hermes.service 2>/dev/null | " +
+  "grep -q '^hermes\\.service'";
+
+/**
+ * Command to start the remote gateway (issue #285). When a systemd
+ * `hermes.service` exists it owns the lifecycle, so the request is handed
+ * to systemd — `hermes.service` is a system unit, so `sudo` is tried first,
+ * then a direct call for when the SSH user is root. If neither works the
+ * command does nothing on purpose: an unmanaged `nohup` orphan that
+ * crash-loops the systemd unit is worse than a gateway that simply did not
+ * start (the status check will then report it as down). The detached
+ * `nohup` start is used only when there is no unit to collide with.
+ */
+export function buildGatewayStartCommand(): string {
+  return (
+    `if ${SYSTEMD_HERMES_UNIT_TEST}; then ` +
+    `sudo -n systemctl start hermes.service 2>/dev/null || ` +
+    `systemctl start hermes.service 2>/dev/null || true; ` +
+    `else ` +
+    `(nohup hermes gateway start > $HOME/.hermes/gateway.log 2>&1 &); ` +
+    `fi`
+  );
+}
+
+/**
+ * Command to stop the remote gateway (issue #285). Routed through systemd
+ * when a `hermes.service` unit exists, so the unit is left cleanly inactive
+ * rather than the desktop killing a process systemd would just restart;
+ * otherwise it falls back to `hermes gateway stop` and, last resort, the
+ * recorded pid.
+ */
+export function buildGatewayStopCommand(): string {
+  return (
+    `if ${SYSTEMD_HERMES_UNIT_TEST}; then ` +
+    `sudo -n systemctl stop hermes.service 2>/dev/null || ` +
+    `systemctl stop hermes.service 2>/dev/null || true; ` +
+    `else ` +
+    `hermes gateway stop 2>/dev/null || ` +
+    `(if [ -f $HOME/.hermes/gateway.pid ]; then ` +
+    `pid=$(python3 -c "import json; d=json.load(open('$HOME/.hermes/gateway.pid')); print(d['pid'] if isinstance(d,dict) else d)" 2>/dev/null); ` +
+    `[ -n "$pid" ] && kill $pid 2>/dev/null; fi); true; ` +
+    `fi`
+  );
+}
+
+/**
+ * Command to report remote gateway state (issue #285). For a systemd-managed
+ * gateway this is the unit's `is-active` state (`active` when up); otherwise
+ * it is a liveness check on the recorded pid. Prints `active` or `running`
+ * when up, anything else when not.
+ */
+export function buildGatewayStatusCommand(): string {
+  return (
+    `if ${SYSTEMD_HERMES_UNIT_TEST}; then ` +
+    `systemctl is-active hermes.service 2>/dev/null || true; ` +
+    `else ` +
+    `if [ -f $HOME/.hermes/gateway.pid ]; then ` +
+    `pid=$(python3 -c "import json,sys; d=json.load(open('$HOME/.hermes/gateway.pid')); print(d.get('pid',d) if isinstance(d,dict) else d)" 2>/dev/null || cat $HOME/.hermes/gateway.pid); ` +
+    `kill -0 $pid 2>/dev/null && echo "running" || echo "stopped"; ` +
+    `else echo "stopped"; fi; ` +
+    `fi`
+  );
+}
 
 export async function sshGatewayStatus(config: SshConfig): Promise<boolean> {
   try {
-    const out = await sshExec(
-      config,
-      `if [ -f $HOME/.hermes/gateway.pid ]; then ` +
-        `pid=$(python3 -c "import json,sys; d=json.load(open('$HOME/.hermes/gateway.pid')); print(d.get('pid',d) if isinstance(d,dict) else d)" 2>/dev/null || cat $HOME/.hermes/gateway.pid); ` +
-        `kill -0 $pid 2>/dev/null && echo "running" || echo "stopped"; ` +
-        `else echo "stopped"; fi`,
-    );
-    return out.trim() === "running";
+    const out = await sshExec(config, buildGatewayStatusCommand());
+    const state = out.trim();
+    return state === "running" || state === "active";
   } catch {
     return false;
   }
@@ -1347,10 +1422,7 @@ export async function sshGatewayStatus(config: SshConfig): Promise<boolean> {
 
 export async function sshStartGateway(config: SshConfig): Promise<void> {
   try {
-    await sshExec(
-      config,
-      `nohup hermes gateway start > $HOME/.hermes/gateway.log 2>&1 &`,
-    );
+    await sshExec(config, buildGatewayStartCommand());
   } catch {
     // best effort
   }
@@ -1358,13 +1430,7 @@ export async function sshStartGateway(config: SshConfig): Promise<void> {
 
 export async function sshStopGateway(config: SshConfig): Promise<void> {
   try {
-    await sshExec(
-      config,
-      `hermes gateway stop 2>/dev/null || ` +
-        `(if [ -f $HOME/.hermes/gateway.pid ]; then ` +
-        `pid=$(python3 -c "import json; d=json.load(open('$HOME/.hermes/gateway.pid')); print(d['pid'] if isinstance(d,dict) else d)" 2>/dev/null); ` +
-        `[ -n "$pid" ] && kill $pid 2>/dev/null; fi); true`,
-    );
+    await sshExec(config, buildGatewayStopCommand());
   } catch {
     // best effort
   }

--- a/tests/ssh-remote.test.ts
+++ b/tests/ssh-remote.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { sshSetConfigValue } from "../src/main/ssh-remote";
+import {
+  sshSetConfigValue,
+  buildGatewayStartCommand,
+  buildGatewayStopCommand,
+  buildGatewayStatusCommand,
+} from "../src/main/ssh-remote";
 import type { SshConfig } from "../src/main/ssh-tunnel";
+
+/** The `then` clause of the leading `if` — the systemd-managed branch. */
+function systemdBranch(command: string): string {
+  return command.slice(command.indexOf("then"), command.indexOf("else"));
+}
 
 const sshConfig: SshConfig = {
   host: "example.test",
@@ -25,4 +35,42 @@ describe("ssh remote config writes", () => {
       ).rejects.toThrow("Config value contains illegal characters");
     },
   );
+});
+
+describe("ssh gateway commands (issue #285)", () => {
+  it("detects a systemd hermes.service unit before acting", () => {
+    for (const cmd of [
+      buildGatewayStartCommand(),
+      buildGatewayStopCommand(),
+      buildGatewayStatusCommand(),
+    ]) {
+      expect(cmd).toContain("systemctl list-unit-files hermes.service");
+      expect(cmd.indexOf("if ")).toBeLessThan(cmd.indexOf("else"));
+    }
+  });
+
+  it("start prefers systemd, falling back to nohup only without a unit", () => {
+    const cmd = buildGatewayStartCommand();
+    expect(cmd).toContain("systemctl start hermes.service");
+    expect(cmd).toContain("sudo -n systemctl start hermes.service");
+    // The nohup fallback must live in the else branch — never alongside
+    // systemd, where it would strand the unit in a restart crash-loop.
+    expect(cmd).toContain("nohup hermes gateway start");
+    expect(systemdBranch(cmd)).not.toContain("nohup");
+  });
+
+  it("stop routes through systemd, else hermes gateway stop", () => {
+    const cmd = buildGatewayStopCommand();
+    expect(cmd).toContain("systemctl stop hermes.service");
+    expect(cmd).toContain("hermes gateway stop");
+    expect(systemdBranch(cmd)).not.toContain("hermes gateway stop");
+    expect(systemdBranch(cmd)).not.toContain("kill");
+  });
+
+  it("status reports the systemd unit state when managed", () => {
+    const cmd = buildGatewayStatusCommand();
+    expect(cmd).toContain("systemctl is-active hermes.service");
+    expect(cmd).toContain("gateway.pid");
+    expect(systemdBranch(cmd)).not.toContain("gateway.pid");
+  });
 });


### PR DESCRIPTION
Addresses #285.

## The bug

In SSH mode, `sshStartGateway` unconditionally ran:

```sh
nohup hermes gateway start > $HOME/.hermes/gateway.log 2>&1 &
```

That spawns a detached gateway **outside any systemd cgroup**. On a VPS provisioned with the standard `hermes.service` unit, the orphan grabs the gateway lock, so the unit's own start attempts exit 1 and systemd crash-loops it every ~10s indefinitely — with no in-app signal, since the orphan genuinely *is* running. `sshStopGateway` and `sshGatewayStatus` were equally systemd-blind, so the three operations disagreed on which gateway they were managing.

Full diagnosis and repro are in #285 (thanks @andreab67 for the detailed report).

## The fix

Detect a systemd `hermes.service` on the remote and route **start / stop / status** through systemd when one is present. Detection + action happen in a single shell `if`, so the decision is atomic and costs only one SSH round-trip — no extra calls, no client-side caching.

- **start / stop** — try `sudo -n systemctl …` first, then a direct `systemctl …` (the SSH user may be root).
- **No `nohup` fallback once systemd is detected.** This is deliberate, and differs from the fix sketch in the issue: if `systemctl` can't be reached (non-root, no passwordless sudo) the start command does *nothing*. An unmanaged orphan that crash-loops the unit is worse than a gateway that simply didn't start — and the status check then honestly reports it down. `rm -f gateway.pid && nohup …` would also risk two gateways racing the API port.
- **Hosts without systemd** keep the original `nohup` / pidfile path unchanged — a missing `systemctl` makes the detection test fail, so they fall straight through.
- `status` reports the unit's `is-active` state when systemd-managed, the pidfile liveness check otherwise.

The shell command strings are built by exported helpers (`buildGateway{Start,Stop,Status}Command`) so the systemd-vs-plain branching is unit tested without a live host.

## Testing

- [x] `npm run typecheck` — clean
- [x] Full test suite — 492 passed / 3 skipped; 4 new tests in `tests/ssh-remote.test.ts` cover the command-string branching (notably: the `nohup` fallback is asserted *absent* from the systemd branch)
- [ ] **Not yet verified against a real systemd VPS.** I don't have an Ubuntu host with `hermes.service` installed. @andreab67 — you have the exact repro environment; could you check this branch resolves the crash-loop? Draft until then.

## Follow-up (not in this PR)

The renderer companion noted in #285 — surfacing systemd unit status (active / failed / not-installed) in `screens/Gateway/*` when SSH mode is active — is left for a separate change to keep this PR focused on the lifecycle collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)