### PR TITLE
SSH tunnel: probe venv (un-dotted) and ~/.local/bin for remote hermes CLI (closes #284)

### DIFF
--- a/src/main/ssh-remote.ts
+++ b/src/main/ssh-remote.ts
@@ -1887,11 +1887,25 @@ export async function sshListCachedSessions(
 // Probe the well-known venv install paths first; fall back to bare `hermes`
 // on PATH only if none of those exist, preserving the old behavior for
 // non-installer deployments.
-function buildRemoteHermesCmd(args: string[], extraShell = ""): string {
+//
+// Each install base is probed with both `.venv` and `venv` — the venv
+// directory name is not fixed, and an install that uses the un-dotted
+// `venv` was otherwise invisible even when fully working (issue #284).
+// `~/.local/bin/hermes` is also probed, where `pip install --user` flows
+// place a wrapper. `command -v hermes` alone is not enough: the desktop's
+// non-interactive SSH does not source `~/.profile`/`~/.bashrc`, so any
+// PATH additions made there are not visible.
+//
+// Exported for unit testing the probe list without a live remote host.
+export function buildRemoteHermesCmd(args: string[], extraShell = ""): string {
   const candidates = [
     "$HOME/hermes-agent/.venv/bin/hermes",
+    "$HOME/hermes-agent/venv/bin/hermes",
     "$HOME/.hermes/hermes-agent/.venv/bin/hermes",
+    "$HOME/.hermes/hermes-agent/venv/bin/hermes",
     "/opt/hermes/hermes-agent/.venv/bin/hermes",
+    "/opt/hermes/hermes-agent/venv/bin/hermes",
+    "$HOME/.local/bin/hermes",
   ];
   const quotedArgs = args.map((a) => shellQuote(a)).join(" ");
   const probe = candidates

--- a/tests/ssh-remote.test.ts
+++ b/tests/ssh-remote.test.ts
@@ -4,6 +4,7 @@ import {
   buildGatewayStartCommand,
   buildGatewayStopCommand,
   buildGatewayStatusCommand,
+  buildRemoteHermesCmd,
 } from "../src/main/ssh-remote";
 import type { SshConfig } from "../src/main/ssh-tunnel";
 
@@ -72,5 +73,32 @@ describe("ssh gateway commands (issue #285)", () => {
     expect(cmd).toContain("systemctl is-active hermes.service");
     expect(cmd).toContain("gateway.pid");
     expect(systemdBranch(cmd)).not.toContain("gateway.pid");
+  });
+});
+
+describe("buildRemoteHermesCmd venv probe (issue #284)", () => {
+  const cmd = buildRemoteHermesCmd(["--version"]);
+
+  it("probes both .venv and venv for every install base", () => {
+    for (const base of [
+      "$HOME/hermes-agent",
+      "$HOME/.hermes/hermes-agent",
+      "/opt/hermes/hermes-agent",
+    ]) {
+      expect(cmd).toContain(`${base}/.venv/bin/hermes`);
+      expect(cmd).toContain(`${base}/venv/bin/hermes`);
+    }
+  });
+
+  it("probes ~/.local/bin where pip --user installs a wrapper", () => {
+    expect(cmd).toContain("$HOME/.local/bin/hermes");
+  });
+
+  it("does not probe the /usr/local/bin sudo-wrapper it deliberately bypasses", () => {
+    expect(cmd).not.toContain("/usr/local/bin/hermes");
+  });
+
+  it("still falls back to bare hermes on PATH", () => {
+    expect(cmd).toContain("command -v hermes");
   });
 });


### PR DESCRIPTION
Closes #284.

## The bug

In SSH tunnel mode the desktop locates the remote `hermes` CLI via `buildRemoteHermesCmd`, which probed only `.venv` install paths:

```ts
const candidates = [
  "$HOME/hermes-agent/.venv/bin/hermes",
  "$HOME/.hermes/hermes-agent/.venv/bin/hermes",
  "/opt/hermes/hermes-agent/.venv/bin/hermes",
];
```

A remote whose virtualenv directory is `venv` (no dot) is missed entirely — even when `hermes` runs fine from an interactive shell. The `command -v hermes` fallback doesn't save it either: the desktop's non-interactive SSH doesn't source `~/.profile` / `~/.bashrc`, so `PATH` additions made there are invisible.

Symptoms (from the report — thanks @daveonkels for the precise diagnosis):
- Settings → Debug Dump fails with *"hermes CLI not found on remote PATH or in any known venv location"*.
- The Kanban tab shows *"Kanban requires … SSH tunnel mode"* — misleading, since SSH tunnel mode **is** active and the tunnel works; the real failure is the probe.

## The fix

Probe each install base with **both** `.venv` and `venv`, and add `~/.local/bin/hermes` where `pip install --user` flows place a wrapper:

```ts
const candidates = [
  "$HOME/hermes-agent/.venv/bin/hermes",
  "$HOME/hermes-agent/venv/bin/hermes",
  "$HOME/.hermes/hermes-agent/.venv/bin/hermes",
  "$HOME/.hermes/hermes-agent/venv/bin/hermes",
  "/opt/hermes/hermes-agent/.venv/bin/hermes",
  "/opt/hermes/hermes-agent/venv/bin/hermes",
  "$HOME/.local/bin/hermes",
];
```

Each candidate is a cheap `[ -x path ]` test, so the extra entries cost nothing. `/usr/local/bin/hermes` is still deliberately **not** probed — that's the sudo-wrapper the function exists to bypass (see its header comment). `buildRemoteHermesCmd` is now exported so the probe list can be unit tested without a live host.

## Testing

- [x] `npm run typecheck` — clean
- [x] Full suite — 492 passed / 3 skipped; 4 new tests in `tests/ssh-remote.test.ts` assert both venv spellings + `~/.local/bin` are probed and `/usr/local/bin` is not
- [x] No VPS needed — `buildRemoteHermesCmd` is a pure command-string builder; the fix only widens an existing `[ -x … ]` probe list

## Not in this PR

The reporter also notes the Kanban tab's copy is misleading when the real fault is the remote probe. That's a separate renderer-copy change in `screens/Kanban/*` — left out to keep this fix focused; happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)