### PR TITLE
Confirm before installing + adopt an existing install (closes #272)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -18,6 +18,9 @@ import {
   checkInstallStatus,
   verifyInstall,
   runInstall,
+  inspectInstallTarget,
+  validateHermesHome,
+  setHermesHomeOverride,
   getHermesVersion,
   clearVersionCache,
   runHermesDoctor,
@@ -339,6 +342,22 @@ function setupIPC(): void {
       return { success: false, error: (err as Error).message };
     }
   });
+
+  // Pre-install inspection + "use an existing installation" (issue #272).
+  ipcMain.handle("inspect-install-target", () => inspectInstallTarget());
+  ipcMain.handle("validate-hermes-home", (_event, dir: string) =>
+    validateHermesHome(dir),
+  );
+  ipcMain.handle("adopt-hermes-home", (_event, dir: string) => {
+    if (!validateHermesHome(dir)) return false;
+    // Persist the choice only. HERMES_HOME is resolved once at module
+    // load, so the override takes effect on the next launch — the renderer
+    // asks the user to restart. (An app-driven relaunch is unreliable
+    // under the dev server, which is torn down with the process.)
+    setHermesHomeOverride(dir);
+    return true;
+  });
+  ipcMain.handle("quit-app", () => app.quit());
 
   // Hermes engine info
   ipcMain.handle("get-hermes-version", async () => {

--- a/src/main/installer.ts
+++ b/src/main/installer.ts
@@ -9,7 +9,7 @@ import {
 import { join, delimiter } from "path";
 import { homedir, tmpdir } from "os";
 import { randomBytes } from "crypto";
-import type { BrowserWindow } from "electron";
+import { app, type BrowserWindow } from "electron";
 import {
   getConnectionConfig,
   getModelConfig,
@@ -66,8 +66,58 @@ function defaultHermesHome(): string {
   return localApp ?? homeDot;
 }
 
+// A Hermes home the user explicitly pointed the app at via the "use an
+// existing installation" flow (issue #272). Persisted in the desktop's own
+// userData dir — outside any Hermes home — so it can be read here, before
+// HERMES_HOME is resolved. Strictly additive: with no override file the
+// behaviour is identical to before.
+function hermesHomeOverrideFile(): string {
+  // `app` is undefined outside an Electron runtime (e.g. unit tests) —
+  // optional-chain it so module load degrades to "no override" instead of
+  // throwing.
+  const userData = app?.getPath?.("userData");
+  return userData ? join(userData, "hermes-home.json") : "";
+}
+
+function readHermesHomeOverride(): string {
+  try {
+    const file = hermesHomeOverrideFile();
+    if (!file || !existsSync(file)) return "";
+    const parsed = JSON.parse(readFileSync(file, "utf-8")) as {
+      hermesHome?: unknown;
+    };
+    const p =
+      typeof parsed.hermesHome === "string" ? parsed.hermesHome.trim() : "";
+    // Ignore a stale override whose directory no longer exists.
+    return p && existsSync(p) ? p : "";
+  } catch {
+    return "";
+  }
+}
+
+/** Persist (when `home` is set) or clear (when "") the Hermes home override. */
+export function setHermesHomeOverride(home: string): void {
+  try {
+    const file = hermesHomeOverrideFile();
+    if (!file) return;
+    if (!home.trim()) {
+      if (existsSync(file)) unlinkSync(file);
+      return;
+    }
+    writeFileSync(
+      file,
+      JSON.stringify({ hermesHome: home.trim() }, null, 2),
+      "utf-8",
+    );
+  } catch {
+    /* best effort — a failed write just means no override next launch */
+  }
+}
+
 export const HERMES_HOME =
-  process.env.HERMES_HOME?.trim() || defaultHermesHome();
+  process.env.HERMES_HOME?.trim() ||
+  readHermesHomeOverride() ||
+  defaultHermesHome();
 export const HERMES_REPO = join(HERMES_HOME, "hermes-agent");
 export const HERMES_VENV = join(HERMES_REPO, "venv");
 export const HERMES_PYTHON = IS_WINDOWS
@@ -79,6 +129,19 @@ export const HERMES_SCRIPT = IS_WINDOWS
 export const HERMES_ENV_FILE = join(HERMES_HOME, ".env");
 export const HERMES_CONFIG_FILE = join(HERMES_HOME, "config.yaml");
 export const HERMES_AUTH_FILE = join(HERMES_HOME, "auth.json");
+
+/** The Python + hermes-script paths for a Hermes install rooted at `home`,
+ *  in the layout the desktop's own installer produces. */
+function installBinariesFor(home: string): { python: string; script: string } {
+  const repo = join(home, "hermes-agent");
+  const venv = join(repo, "venv");
+  return IS_WINDOWS
+    ? {
+        python: join(venv, "Scripts", "python.exe"),
+        script: join(venv, "Scripts", "hermes.exe"),
+      }
+    : { python: join(venv, "bin", "python"), script: join(repo, "hermes") };
+}
 
 export function hermesCliArgs(args: string[] = []): string[] {
   if (process.platform === "win32") {
@@ -298,6 +361,54 @@ function envHasUsableValue(
     }
   }
   return false;
+}
+
+// ── Pre-install inspection (issue #272) ──────────────────────────────────────
+
+export type InstallTargetState = "fresh" | "update" | "replace";
+
+export interface InstallTargetInfo {
+  /** Where the desktop will install — shown to the user before they commit. */
+  hermesHome: string;
+  repoPath: string;
+  /** What the installer will do to `repoPath`:
+   *  - `fresh`   — nothing is there; a clean install.
+   *  - `update`  — a valid git checkout; install.sh/ps1 updates it in place.
+   *  - `replace` — a directory is there but not a valid checkout, so the
+   *                install script deletes and re-clones it. */
+  state: InstallTargetState;
+}
+
+/** Classify what the installer will do to the target directory. Pure — the
+ *  filesystem probing lives in `inspectInstallTarget`. */
+export function classifyInstallTarget(
+  repoExists: boolean,
+  repoIsGitRepo: boolean,
+): InstallTargetState {
+  if (!repoExists) return "fresh";
+  return repoIsGitRepo ? "update" : "replace";
+}
+
+/** Inspect the install target so the renderer can warn before installing. */
+export function inspectInstallTarget(): InstallTargetInfo {
+  const repoExists = existsSync(HERMES_REPO);
+  const repoIsGitRepo = repoExists && existsSync(join(HERMES_REPO, ".git"));
+  return {
+    hermesHome: HERMES_HOME,
+    repoPath: HERMES_REPO,
+    state: classifyInstallTarget(repoExists, repoIsGitRepo),
+  };
+}
+
+/** True when `dir` is a Hermes home the desktop can drive as-is — it must
+ *  contain a `hermes-agent` install with the venv binaries in the layout the
+ *  desktop expects. A hand-rolled install with a different layout fails here
+ *  rather than being silently adopted into a broken state (issue #272). */
+export function validateHermesHome(dir: string): boolean {
+  const home = dir?.trim();
+  if (!home || !existsSync(home)) return false;
+  const { python, script } = installBinariesFor(home);
+  return existsSync(python) && existsSync(script);
 }
 
 export function checkInstallStatus(): InstallStatus {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -117,6 +117,14 @@ interface HermesAPI {
   checkInstall: () => Promise<InstallStatus>;
   verifyInstall: () => Promise<boolean>;
   startInstall: () => Promise<{ success: boolean; error?: string }>;
+  inspectInstallTarget: () => Promise<{
+    hermesHome: string;
+    repoPath: string;
+    state: "fresh" | "update" | "replace";
+  }>;
+  validateHermesHome: (dir: string) => Promise<boolean>;
+  adoptHermesHome: (dir: string) => Promise<boolean>;
+  quitApp: () => Promise<void>;
   onInstallProgress: (
     callback: (progress: InstallProgress) => void,
   ) => () => void;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -26,6 +26,21 @@ const hermesAPI = {
   startInstall: (): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke("start-install"),
 
+  // Pre-install inspection + "use an existing installation" (issue #272)
+  inspectInstallTarget: (): Promise<{
+    hermesHome: string;
+    repoPath: string;
+    state: "fresh" | "update" | "replace";
+  }> => ipcRenderer.invoke("inspect-install-target"),
+
+  validateHermesHome: (dir: string): Promise<boolean> =>
+    ipcRenderer.invoke("validate-hermes-home", dir),
+
+  adoptHermesHome: (dir: string): Promise<boolean> =>
+    ipcRenderer.invoke("adopt-hermes-home", dir),
+
+  quitApp: (): Promise<void> => ipcRenderer.invoke("quit-app"),
+
   onInstallProgress: (
     callback: (progress: {
       step: number;

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -159,6 +159,7 @@ function App(): React.JSX.Element {
           <Install
             onComplete={handleInstallComplete}
             onFailed={handleInstallFailed}
+            onCancel={() => setScreen("welcome")}
           />
         );
       case "setup":

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -589,6 +589,77 @@ body {
   gap: 10px;
 }
 
+/* Pre-install confirmation (issue #272) */
+.install-confirm {
+  width: 100%;
+  max-width: 620px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-top: 12px;
+}
+
+.install-confirm-location {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.install-confirm-label {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.install-confirm-path {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 10px 12px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-primary);
+  word-break: break-all;
+  -webkit-user-select: text;
+  user-select: text;
+}
+
+.install-confirm-state {
+  font-size: 14px;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.install-confirm-state--replace {
+  padding: 10px 12px;
+  background: var(--warning-bg);
+  border: 1px solid var(--warning);
+  border-radius: var(--radius-md);
+}
+
+.install-confirm-note,
+.install-confirm-hint {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.install-confirm-hint {
+  color: var(--text-muted);
+}
+
+.install-confirm-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.install-confirm-error {
+  font-size: 13px;
+  color: var(--error);
+  margin: 0;
+}
+
 .verify-warning-banner {
   display: flex;
   align-items: center;

--- a/src/renderer/src/screens/Install/Install.tsx
+++ b/src/renderer/src/screens/Install/Install.tsx
@@ -12,13 +12,32 @@ interface InstallProgress {
   log: string;
 }
 
+interface InstallTarget {
+  hermesHome: string;
+  repoPath: string;
+  state: "fresh" | "update" | "replace";
+}
+
 interface InstallProps {
   onComplete: () => void;
   onFailed: (error: string) => void;
+  onCancel: () => void;
 }
 
-function Install({ onComplete, onFailed }: InstallProps): React.JSX.Element {
+function Install({
+  onComplete,
+  onFailed,
+  onCancel,
+}: InstallProps): React.JSX.Element {
   const { t } = useI18n();
+  // Gate the install behind an explicit confirmation so it can't run
+  // silently and surprise a user who already has Hermes installed (#272).
+  const [phase, setPhase] = useState<"confirm" | "running">("confirm");
+  const [target, setTarget] = useState<InstallTarget | null>(null);
+  const [useExistingError, setUseExistingError] = useState<string | null>(null);
+  // Set once the user adopts an existing install — the new location only
+  // applies on the next launch, so we ask them to restart.
+  const [adopted, setAdopted] = useState(false);
   const [progress, setProgress] = useState<InstallProgress>({
     step: 0,
     totalSteps: 7,
@@ -31,7 +50,26 @@ function Install({ onComplete, onFailed }: InstallProps): React.JSX.Element {
   const [copied, setCopied] = useState(false);
   const logRef = useRef<HTMLDivElement>(null);
 
+  // Inspect what the installer will do to the target directory, so the
+  // confirmation can say exactly what to expect (fresh / update / replace).
   useEffect(() => {
+    let mounted = true;
+    window.hermesAPI
+      .inspectInstallTarget()
+      .then((info) => {
+        if (mounted) setTarget(info);
+      })
+      .catch(() => {
+        /* leave target null — the confirmation falls back to generic copy */
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  // The install itself runs only once the user confirms.
+  useEffect(() => {
+    if (phase !== "running") return;
     let isMounted = true;
     const cleanup = window.hermesAPI.onInstallProgress((p) => {
       if (isMounted) setProgress(p);
@@ -56,7 +94,7 @@ function Install({ onComplete, onFailed }: InstallProps): React.JSX.Element {
       isMounted = false;
       cleanup();
     };
-  }, []);
+  }, [phase]);
 
   useEffect(() => {
     if (logRef.current) {
@@ -71,10 +109,112 @@ function Install({ onComplete, onFailed }: InstallProps): React.JSX.Element {
     setTimeout(() => setCopied(false), 2000);
   }
 
+  // "Use an existing installation": let the user point the app at a Hermes
+  // install it didn't auto-detect. A valid pick is persisted; the app must
+  // restart to adopt it (#272).
+  async function handleUseExisting(): Promise<void> {
+    setUseExistingError(null);
+    const dir = await window.hermesAPI.selectFolder();
+    if (!dir) return;
+    const ok = await window.hermesAPI.validateHermesHome(dir);
+    if (!ok) {
+      setUseExistingError(t("install.useExistingInvalid"));
+      return;
+    }
+    const saved = await window.hermesAPI.adoptHermesHome(dir);
+    if (saved) {
+      setAdopted(true);
+    } else {
+      // Lost a race (dir changed between validate and adopt).
+      setUseExistingError(t("install.useExistingInvalid"));
+    }
+  }
+
   const percent =
     progress.totalSteps > 0
       ? Math.round((progress.step / progress.totalSteps) * 100)
       : 0;
+
+  if (phase === "confirm") {
+    // After adopting an existing install, the choice only applies on the
+    // next launch — ask the user to restart.
+    if (adopted) {
+      return (
+        <div className="screen install-screen">
+          <h1 className="install-title">{t("install.confirmTitle")}</h1>
+          <div className="install-confirm">
+            <p className="install-confirm-state">
+              {t("install.useExistingDone")}
+            </p>
+            <div className="install-confirm-actions">
+              <button
+                className="btn btn-primary"
+                onClick={() => window.hermesAPI.quitApp()}
+              >
+                {t("install.useExistingQuitBtn")}
+              </button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    const stateMessage =
+      target?.state === "update"
+        ? t("install.confirmUpdate")
+        : target?.state === "replace"
+          ? t("install.confirmReplace")
+          : t("install.confirmFresh");
+
+    return (
+      <div className="screen install-screen">
+        <h1 className="install-title">{t("install.confirmTitle")}</h1>
+
+        <div className="install-confirm">
+          <div className="install-confirm-location">
+            <span className="install-confirm-label">
+              {t("install.confirmLocationLabel")}
+            </span>
+            <code className="install-confirm-path">
+              {target?.repoPath || "…"}
+            </code>
+          </div>
+
+          <p
+            className={`install-confirm-state install-confirm-state--${
+              target?.state ?? "fresh"
+            }`}
+          >
+            {stateMessage}
+          </p>
+          <p className="install-confirm-note">
+            {t("install.confirmNotInherited")}
+          </p>
+
+          <div className="install-confirm-actions">
+            <button
+              className="btn btn-primary"
+              onClick={() => setPhase("running")}
+            >
+              {t("install.confirmInstallBtn")}
+            </button>
+            <button className="btn btn-secondary" onClick={handleUseExisting}>
+              {t("install.useExistingBtn")}
+            </button>
+            <button className="btn btn-secondary" onClick={onCancel}>
+              {t("common.cancel")}
+            </button>
+          </div>
+          <p className="install-confirm-hint">
+            {t("install.useExistingHint")}
+          </p>
+          {useExistingError && (
+            <p className="install-confirm-error">{useExistingError}</p>
+          )}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="screen install-screen">

--- a/src/shared/i18n/locales/en/install.ts
+++ b/src/shared/i18n/locales/en/install.ts
@@ -12,4 +12,22 @@ export default {
   stepLabel: "Step {{step}}/{{total}}: {{title}}",
   waitingToStart: "Waiting to start...",
   continueToSetup: "Continue to Setup",
+  confirmTitle: "Before installing",
+  confirmLocationLabel: "Hermes will be installed at:",
+  confirmFresh:
+    "No existing installation was found here — a fresh copy will be set up.",
+  confirmUpdate:
+    "An existing Hermes installation is here — it will be updated to the latest version.",
+  confirmReplace:
+    "A folder exists here but isn't a valid Hermes installation — installing will delete and replace it.",
+  confirmNotInherited:
+    "If you installed Hermes somewhere else, or via the command line, it won't be carried over.",
+  confirmInstallBtn: "Install Hermes",
+  useExistingBtn: "Use an existing installation",
+  useExistingHint:
+    "Select the folder that holds your existing Hermes installation (the one containing the hermes-agent folder).",
+  useExistingInvalid: "No usable Hermes installation was found in that folder.",
+  useExistingDone:
+    "Existing installation set — quit and reopen Hermes to apply it.",
+  useExistingQuitBtn: "Quit Hermes",
 } as const;

--- a/src/shared/i18n/locales/es/install.ts
+++ b/src/shared/i18n/locales/es/install.ts
@@ -12,4 +12,23 @@ export default {
   stepLabel: "Paso {{step}}/{{total}}: {{title}}",
   waitingToStart: "Esperando para iniciar...",
   continueToSetup: "Continuar con la configuración",
+  confirmTitle: "Antes de instalar",
+  confirmLocationLabel: "Hermes se instalará en:",
+  confirmFresh:
+    "No se encontró ninguna instalación existente aquí — se configurará una copia nueva.",
+  confirmUpdate:
+    "Aquí hay una instalación de Hermes existente — se actualizará a la última versión.",
+  confirmReplace:
+    "Existe una carpeta aquí, pero no es una instalación válida de Hermes — instalar la eliminará y la reemplazará.",
+  confirmNotInherited:
+    "Si instalaste Hermes en otro lugar, o mediante la línea de comandos, no se conservará.",
+  confirmInstallBtn: "Instalar Hermes",
+  useExistingBtn: "Usar una instalación existente",
+  useExistingHint:
+    "Selecciona la carpeta que contiene tu instalación de Hermes existente (la que contiene la carpeta hermes-agent).",
+  useExistingInvalid:
+    "No se encontró una instalación de Hermes utilizable en esa carpeta.",
+  useExistingDone:
+    "Instalación existente establecida — cierra y vuelve a abrir Hermes para aplicarla.",
+  useExistingQuitBtn: "Salir de Hermes",
 } as const;

--- a/src/shared/i18n/locales/id/install.ts
+++ b/src/shared/i18n/locales/id/install.ts
@@ -12,4 +12,23 @@ export default {
   stepLabel: "Langkah {{step}}/{{total}}: {{title}}",
   waitingToStart: "Menunggu untuk mulai...",
   continueToSetup: "Lanjut ke Setup",
+  confirmTitle: "Sebelum memasang",
+  confirmLocationLabel: "Hermes akan dipasang di:",
+  confirmFresh:
+    "Tidak ada pemasangan yang ditemukan di sini — salinan baru akan disiapkan.",
+  confirmUpdate:
+    "Ada pemasangan Hermes di sini — akan diperbarui ke versi terbaru.",
+  confirmReplace:
+    "Ada folder di sini tetapi bukan pemasangan Hermes yang valid — memasang akan menghapus dan menggantinya.",
+  confirmNotInherited:
+    "Jika Anda memasang Hermes di tempat lain, atau melalui baris perintah, itu tidak akan dibawa serta.",
+  confirmInstallBtn: "Pasang Hermes",
+  useExistingBtn: "Gunakan pemasangan yang sudah ada",
+  useExistingHint:
+    "Pilih folder yang berisi pemasangan Hermes Anda yang sudah ada (folder yang memuat folder hermes-agent).",
+  useExistingInvalid:
+    "Tidak ada pemasangan Hermes yang dapat digunakan di folder itu.",
+  useExistingDone:
+    "Pemasangan yang ada telah diatur — tutup dan buka kembali Hermes untuk menerapkannya.",
+  useExistingQuitBtn: "Keluar dari Hermes",
 } as const;

--- a/src/shared/i18n/locales/ja/install.ts
+++ b/src/shared/i18n/locales/ja/install.ts
@@ -12,4 +12,23 @@ export default {
   stepLabel: "ステップ {{step}}/{{total}}：{{title}}",
   waitingToStart: "開始待機中...",
   continueToSetup: "セットアップへ進む",
+  confirmTitle: "インストール前の確認",
+  confirmLocationLabel: "Hermes のインストール先:",
+  confirmFresh:
+    "ここに既存のインストールは見つかりませんでした。新しくインストールされます。",
+  confirmUpdate:
+    "ここに既存の Hermes インストールがあります。最新バージョンに更新されます。",
+  confirmReplace:
+    "ここにフォルダがありますが、有効な Hermes インストールではありません。インストールすると削除されて置き換えられます。",
+  confirmNotInherited:
+    "Hermes を別の場所、またはコマンドラインでインストールした場合、それは引き継がれません。",
+  confirmInstallBtn: "Hermes をインストール",
+  useExistingBtn: "既存のインストールを使用",
+  useExistingHint:
+    "既存の Hermes インストールが含まれるフォルダ（hermes-agent フォルダを含むフォルダ）を選択してください。",
+  useExistingInvalid:
+    "そのフォルダで使用可能な Hermes インストールが見つかりませんでした。",
+  useExistingDone:
+    "既存のインストールを設定しました。Hermes を終了して再度開くと適用されます。",
+  useExistingQuitBtn: "Hermes を終了",
 } as const;

--- a/src/shared/i18n/locales/pt-BR/install.ts
+++ b/src/shared/i18n/locales/pt-BR/install.ts
@@ -12,4 +12,23 @@ export default {
   stepLabel: "Passo {{step}}/{{total}}: {{title}}",
   waitingToStart: "Aguardando para iniciar...",
   continueToSetup: "Continuar para a Configuração",
+  confirmTitle: "Antes de instalar",
+  confirmLocationLabel: "O Hermes será instalado em:",
+  confirmFresh:
+    "Nenhuma instalação existente foi encontrada aqui — uma cópia nova será configurada.",
+  confirmUpdate:
+    "Há uma instalação do Hermes aqui — ela será atualizada para a versão mais recente.",
+  confirmReplace:
+    "Existe uma pasta aqui, mas não é uma instalação válida do Hermes — instalar irá excluí-la e substituí-la.",
+  confirmNotInherited:
+    "Se você instalou o Hermes em outro lugar, ou pela linha de comando, ela não será aproveitada.",
+  confirmInstallBtn: "Instalar o Hermes",
+  useExistingBtn: "Usar uma instalação existente",
+  useExistingHint:
+    "Selecione a pasta que contém sua instalação existente do Hermes (a pasta que contém a pasta hermes-agent).",
+  useExistingInvalid:
+    "Nenhuma instalação utilizável do Hermes foi encontrada nessa pasta.",
+  useExistingDone:
+    "Instalação existente definida — feche e reabra o Hermes para aplicá-la.",
+  useExistingQuitBtn: "Sair do Hermes",
 } as const;

--- a/src/shared/i18n/locales/pt-PT/install.ts
+++ b/src/shared/i18n/locales/pt-PT/install.ts
@@ -12,4 +12,23 @@ export default {
   stepLabel: "Passo {{step}}/{{total}}: {{title}}",
   waitingToStart: "A aguardar para iniciar...",
   continueToSetup: "Continuar para a Configuração",
+  confirmTitle: "Antes de instalar",
+  confirmLocationLabel: "O Hermes será instalado em:",
+  confirmFresh:
+    "Não foi encontrada nenhuma instalação existente aqui — será configurada uma cópia nova.",
+  confirmUpdate:
+    "Existe aqui uma instalação do Hermes — será actualizada para a versão mais recente.",
+  confirmReplace:
+    "Existe aqui uma pasta, mas não é uma instalação válida do Hermes — instalar irá eliminá-la e substituí-la.",
+  confirmNotInherited:
+    "Se instalou o Hermes noutro local, ou através da linha de comandos, essa instalação não será aproveitada.",
+  confirmInstallBtn: "Instalar o Hermes",
+  useExistingBtn: "Usar uma instalação existente",
+  useExistingHint:
+    "Seleccione a pasta que contém a sua instalação existente do Hermes (a pasta que contém a pasta hermes-agent).",
+  useExistingInvalid:
+    "Não foi encontrada nenhuma instalação do Hermes utilizável nessa pasta.",
+  useExistingDone:
+    "Instalação existente definida — feche e reabra o Hermes para a aplicar.",
+  useExistingQuitBtn: "Sair do Hermes",
 } as const;

--- a/src/shared/i18n/locales/zh-CN/install.ts
+++ b/src/shared/i18n/locales/zh-CN/install.ts
@@ -11,4 +11,19 @@ export default {
   stepLabel: "步骤 {{step}}/{{total}}：{{title}}",
   waitingToStart: "等待开始...",
   continueToSetup: "继续前往设置",
+  confirmTitle: "安装前确认",
+  confirmLocationLabel: "Hermes 将安装到：",
+  confirmFresh: "此处未找到现有安装 — 将进行全新安装。",
+  confirmUpdate: "此处已有 Hermes 安装 — 将更新到最新版本。",
+  confirmReplace:
+    "此处存在一个文件夹，但不是有效的 Hermes 安装 — 安装将删除并替换它。",
+  confirmNotInherited:
+    "如果你在其他位置或通过命令行安装过 Hermes，那些安装不会被沿用。",
+  confirmInstallBtn: "安装 Hermes",
+  useExistingBtn: "使用现有安装",
+  useExistingHint:
+    "选择包含你现有 Hermes 安装的文件夹（即包含 hermes-agent 文件夹的那个）。",
+  useExistingInvalid: "在该文件夹中未找到可用的 Hermes 安装。",
+  useExistingDone: "已设置现有安装 — 退出并重新打开 Hermes 以应用。",
+  useExistingQuitBtn: "退出 Hermes",
 } as const;

--- a/src/shared/i18n/locales/zh-TW/install.ts
+++ b/src/shared/i18n/locales/zh-TW/install.ts
@@ -11,4 +11,19 @@ export default {
   stepLabel: "步驟 {{step}}/{{total}}：{{title}}",
   waitingToStart: "等待開始...",
   continueToSetup: "繼續前往設定",
+  confirmTitle: "安裝前確認",
+  confirmLocationLabel: "Hermes 將安裝到：",
+  confirmFresh: "此處未找到現有安裝 — 將進行全新安裝。",
+  confirmUpdate: "此處已有 Hermes 安裝 — 將更新到最新版本。",
+  confirmReplace:
+    "此處存在一個資料夾，但不是有效的 Hermes 安裝 — 安裝將刪除並取代它。",
+  confirmNotInherited:
+    "如果你在其他位置或透過命令列安裝過 Hermes，那些安裝不會被沿用。",
+  confirmInstallBtn: "安裝 Hermes",
+  useExistingBtn: "使用現有安裝",
+  useExistingHint:
+    "選擇包含你現有 Hermes 安裝的資料夾（即包含 hermes-agent 資料夾的那個）。",
+  useExistingInvalid: "在該資料夾中未找到可用的 Hermes 安裝。",
+  useExistingDone: "已設定現有安裝 — 結束並重新開啟 Hermes 以套用。",
+  useExistingQuitBtn: "結束 Hermes",
 } as const;

--- a/tests/installer-target.test.ts
+++ b/tests/installer-target.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { classifyInstallTarget } from "../src/main/installer";
+
+// Pre-install inspection (issue #272): classify what the installer will do
+// to the target `hermes-agent` directory so the renderer can warn first.
+describe("classifyInstallTarget", () => {
+  it("reports a fresh install when nothing is at the target", () => {
+    expect(classifyInstallTarget(false, false)).toBe("fresh");
+    // repoIsGitRepo is meaningless when the directory doesn't exist.
+    expect(classifyInstallTarget(false, true)).toBe("fresh");
+  });
+
+  it("reports an in-place update for an existing valid git checkout", () => {
+    expect(classifyInstallTarget(true, true)).toBe("update");
+  });
+
+  it("reports a destructive replace when the dir is not a git repo", () => {
+    // install.sh / install.ps1 delete-and-reclone a non-repo directory.
+    expect(classifyInstallTarget(true, false)).toBe("replace");
+  });
+});


### PR DESCRIPTION
Closes #272.

## Problem

The Install screen called `startInstall()` automatically on mount — the install ran with **no confirmation**. A user who already had Hermes installed could be blindsided: their existing install gets updated in place (or, if the `hermes-agent` directory isn't a clean git checkout, the upstream `install` script deletes and re-clones it), and an install located elsewhere or set up via the CLI is silently not carried over. The reporter of #272 asked for exactly this: a check, and a way to keep an existing install.

## What this adds

A confirmation step before the install runs:

- **It says what will happen.** The main process inspects the target `hermes-agent` directory and the renderer shows the specific outcome:
  - *fresh* — nothing there, a clean install;
  - *update* — a valid git checkout, updated in place;
  - *replace* — ⚠️ a directory exists but isn't a valid checkout, so the install script will delete and re-clone it.
  - Plus a note that an install elsewhere / via the CLI won't be carried over.
- **"Use an existing installation"** — point the app at a Hermes home it didn't auto-detect. The pick is validated (must contain a usable `hermes-agent` venv) and persisted as a `HERMES_HOME` override in the desktop's `userData` dir. The app applies it on the next launch and asks the user to restart.
  - `HERMES_HOME` resolution is **strictly additive**: `env HERMES_HOME → override file → default`. With no override file the behaviour is byte-for-byte unchanged.
  - A restart prompt is used rather than an app-driven relaunch — `app.relaunch()` is unreliable under the dev server, and "restart to apply a location change" is a normal, predictable UX in dev and production alike.
- **"Cancel"** returns to the Welcome screen.

## Notes

- `classifyInstallTarget` (fresh/update/replace) has unit tests.
- `app` access during `HERMES_HOME` resolution is optional-chained, so `installer.ts` still loads under unit tests (no Electron runtime).
- New i18n keys added for all eight locales.

## Test plan

- [x] `npm run typecheck` clean
- [x] Full suite — 491 passed / 3 skipped; 3 new `classifyInstallTarget` tests; the 11 existing installer-importing test files still pass
- [x] Live: confirm screen shows the correct state (verified the *update* case)
- [x] Live: "Use an existing installation" — validation rejects a folder with no usable install; a valid pick is persisted and applied after restart
- [x] Live: "Cancel" returns to Welcome

🤖 Generated with [Claude Code](https://claude.com/claude-code)