### PR TITLE
Log the auto-updater lifecycle to a file (refs #271)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -32,6 +32,7 @@ import {
   readLogs,
   InstallProgress,
 } from "./installer";
+import { updaterLogger } from "./updater-log";
 import {
   isRemoteMode,
   isRemoteOnlyMode,
@@ -1401,6 +1402,9 @@ function setupUpdater(): void {
     autoUpdater: AppUpdater;
   };
 
+  // Log the updater's own lifecycle to <userData>/logs/updater.log so a
+  // failed update (e.g. issue #271) leaves something to diagnose.
+  autoUpdater.logger = updaterLogger;
   autoUpdater.autoDownload = false;
   autoUpdater.autoInstallOnAppQuit = true;
 
@@ -1446,6 +1450,11 @@ function setupUpdater(): void {
   });
 
   ipcMain.handle("install-update", () => {
+    // Bracket the suspect call: if the log shows this line but the app
+    // never relaunches, the failure is in quitAndInstall / the installer.
+    updaterLogger.info(
+      "Restart requested by user — calling quitAndInstall(isSilent=false, isForceRunAfter=true)",
+    );
     autoUpdater.quitAndInstall(false, true);
   });
 

--- a/src/main/updater-log.ts
+++ b/src/main/updater-log.ts
@@ -1,0 +1,63 @@
+/**
+ * A minimal file logger for electron-updater.
+ *
+ * The auto-updater previously ran with no logger, so a failed update — e.g.
+ * issue #271, "after upgrading, clicking Restart doesn't relaunch the app" —
+ * left no trace at all and was undiagnosable from a bug report. This writes
+ * electron-updater's own log lines to `<userData>/logs/updater.log` (and
+ * mirrors them to the main-process console), with no extra dependency.
+ *
+ * The object satisfies electron-updater's `Logger` interface.
+ */
+import { app } from "electron";
+import { appendFileSync, existsSync, mkdirSync, statSync, writeFileSync } from "fs";
+import { join } from "path";
+
+// Rotate (truncate) the log once it passes this size — updater sessions are
+// short, so keeping only the most recent activity is enough to diagnose.
+const MAX_BYTES = 512 * 1024;
+
+/** Resolve `<userData>/logs/updater.log`, creating the dir. Returns "" when
+ *  the path can't be resolved (e.g. no Electron runtime under unit tests). */
+function logFilePath(): string {
+  try {
+    const userData = app?.getPath?.("userData");
+    if (!userData) return "";
+    const dir = join(userData, "logs");
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    return join(dir, "updater.log");
+  } catch {
+    return "";
+  }
+}
+
+function write(level: string, message?: unknown): void {
+  const text =
+    typeof message === "string" ? message : JSON.stringify(message);
+  const tag = `[updater] ${text}`;
+  if (level === "error") console.error(tag);
+  else if (level === "warn") console.warn(tag);
+  else console.log(tag);
+
+  try {
+    const file = logFilePath();
+    if (!file) return;
+    if (existsSync(file) && statSync(file).size > MAX_BYTES) {
+      writeFileSync(file, "");
+    }
+    appendFileSync(
+      file,
+      `${new Date().toISOString()} [${level}] ${text}\n`,
+      "utf-8",
+    );
+  } catch {
+    /* logging must never throw */
+  }
+}
+
+export const updaterLogger = {
+  info: (message?: unknown): void => write("info", message),
+  warn: (message?: unknown): void => write("warn", message),
+  error: (message?: unknown): void => write("error", message),
+  debug: (message?: unknown): void => write("debug", message),
+};


### PR DESCRIPTION
Refs #271.

## Why

`autoUpdater` runs with **no logger set**. When an update fails — e.g. #271, *"after upgrading, clicking Restart doesn't relaunch the app"* — there is no trace anywhere, so the report is a single line with nothing actionable. This failure class is currently undiagnosable by design.

## What

- A minimal file logger (`src/main/updater-log.ts`) — **no new dependency** — wired to `autoUpdater.logger`. It writes electron-updater's own lifecycle lines (check / available / download progress / downloaded / quitAndInstall / errors) to **`<userData>/logs/updater.log`** and mirrors them to the main-process console. The file is truncated past 512 KB.
- The `install-update` IPC logs an explicit line right before `quitAndInstall`, so the log distinguishes *"Restart was clicked and quitAndInstall was reached"* from a failure earlier in the flow.

## What this is not

This does **not** fix #271. The auto-update path only runs in a packaged build, so the relaunch failure can't be reproduced from source. This PR is the prerequisite instrumentation — once it ships, the next occurrence (or a maintainer testing a release-to-release upgrade) produces `updater.log`, which can point at whether the failure is in `quitAndInstall`, the NSIS installer, or the post-install relaunch.

## Test plan

- [x] `npm run typecheck` clean
- [x] Full suite — 488 passed / 3 skipped, unchanged
- [x] Logger degrades safely with no Electron runtime (paths optional-chained) and never throws
- [ ] Live updater behaviour is packaged-build-only — not exercised by `npm run dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)