### PR TITLE
Add i18n to the Kanban screen (en + pt-PT)

### DIFF
--- a/src/renderer/src/screens/Kanban/Kanban.tsx
+++ b/src/renderer/src/screens/Kanban/Kanban.tsx
@@ -11,6 +11,7 @@ import {
   RotateCcw,
   Sparkles,
 } from "../../assets/icons";
+import { useI18n } from "../../components/useI18n";
 
 interface KanbanProps {
   profile?: string;
@@ -89,13 +90,14 @@ interface KanbanTaskDetail {
   latest_summary: string | null;
 }
 
-const COLUMNS: { key: string; label: string }[] = [
-  { key: "triage", label: "Triage" },
-  { key: "todo", label: "To-do" },
-  { key: "ready", label: "Ready" },
-  { key: "running", label: "Running" },
-  { key: "blocked", label: "Blocked" },
-  { key: "done", label: "Done" },
+// Column order. Labels are resolved at render via `kanban.status.<key>`.
+const COLUMNS: { key: string }[] = [
+  { key: "triage" },
+  { key: "todo" },
+  { key: "ready" },
+  { key: "running" },
+  { key: "blocked" },
+  { key: "done" },
 ];
 
 const POLL_INTERVAL_MS = 6000;
@@ -135,6 +137,7 @@ function ageLabel(createdAt: number | null): string {
 }
 
 function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
+  const { t } = useI18n();
   const [boards, setBoards] = useState<KanbanBoard[]>([]);
   const [tasks, setTasks] = useState<KanbanTask[]>([]);
   const [loading, setLoading] = useState(true);
@@ -215,7 +218,7 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
             setRemoteUnsupported(true);
             return;
           }
-          setError(boardsRes.error || "Failed to load boards");
+          setError(boardsRes.error || t("kanban.errLoadBoards"));
           return;
         }
         // HQ availability: we treat the board as available whenever the SSH
@@ -247,7 +250,7 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
           setTasks(hqTasks);
         } else {
           if (!tasksRes.success) {
-            setError(tasksRes.error || "Failed to load tasks");
+            setError(tasksRes.error || t("kanban.errLoadTasks"));
             return;
           }
           setTasks(tasksRes.data || []);
@@ -259,7 +262,7 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
         if (!silent) setLoading(false);
       }
     },
-    [profile, activeBoardSlug],
+    [profile, activeBoardSlug, t],
   );
 
   useEffect(() => {
@@ -352,7 +355,7 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
     let workspaceArg: string | undefined;
     if (newWorkspace === "dir") {
       if (!newWorkspaceDir) {
-        setError("Pick a workspace folder first.");
+        setError(t("kanban.errPickFolder"));
         return;
       }
       workspaceArg = `dir:${newWorkspaceDir}`;
@@ -373,7 +376,7 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
     );
     setActionBusy(null);
     if (!res.success) {
-      setError(res.error || "Failed to create task");
+      setError(res.error || t("kanban.errCreateTask"));
       return;
     }
     setShowCreate(false);
@@ -394,7 +397,7 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
     const res = await window.hermesAPI.kanbanSwitchBoard(slug, profile);
     setActionBusy(null);
     if (!res.success) {
-      setError(res.error || "Failed to switch board");
+      setError(res.error || t("kanban.errSwitchBoard"));
       return;
     }
     setActiveBoardSlug(slug);
@@ -412,7 +415,7 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
     );
     setActionBusy(null);
     if (!res.success) {
-      setError(res.error || "Failed to create board");
+      setError(res.error || t("kanban.errCreateBoard"));
       return;
     }
     setShowNewBoard(false);
@@ -432,7 +435,7 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
         profile,
       );
     } else if (target === "blocked") {
-      const reason = window.prompt("Reason for blocking?") || "";
+      const reason = window.prompt(t("kanban.blockReasonPrompt")) || "";
       res = await window.hermesAPI.kanbanBlockTask(
         task.id,
         reason || undefined,
@@ -443,13 +446,16 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
     } else {
       setActionBusy(null);
       setError(
-        `Cannot move ${task.status} → ${target} from the desktop. Use the agent or CLI.`,
+        t("kanban.moveNotAllowed", {
+          from: t(`kanban.status.${task.status}`),
+          to: t(`kanban.status.${target}`),
+        }),
       );
       return;
     }
     setActionBusy(null);
     if (!res.success) {
-      setError(res.error || "Failed to move task");
+      setError(res.error || t("kanban.errMoveTask"));
       return;
     }
     loadAll(true);
@@ -460,7 +466,7 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
     const res = await window.hermesAPI.kanbanSpecifyTask(task.id, profile);
     setActionBusy(null);
     if (!res.success) {
-      setError(res.error || "Failed to specify task");
+      setError(res.error || t("kanban.errSpecify"));
       return;
     }
     loadAll(true);
@@ -481,18 +487,20 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
   async function handleDrop(task: KanbanTask, target: string): Promise<void> {
     if (!isValidDragTransition(task.status, target)) return;
     if (target === "done") {
-      if (!window.confirm(`Mark "${task.title}" as done?`)) return;
+      if (!window.confirm(t("kanban.confirmMarkDone", { title: task.title })))
+        return;
     }
     await handleMove(task, target);
   }
 
   async function handleArchive(task: KanbanTask): Promise<void> {
-    if (!window.confirm(`Archive "${task.title}"?`)) return;
+    if (!window.confirm(t("kanban.confirmArchive", { title: task.title })))
+      return;
     setActionBusy(task.id);
     const res = await window.hermesAPI.kanbanArchiveTask(task.id, profile);
     setActionBusy(null);
     if (!res.success) {
-      setError(res.error || "Failed to archive task");
+      setError(res.error || t("kanban.errArchive"));
       return;
     }
     if (detailTaskId === task.id) setDetailTaskId(null);
@@ -507,7 +515,7 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
       profile,
     );
     setActionBusy(null);
-    if (!res.success) setError(res.error || "Failed to reclaim");
+    if (!res.success) setError(res.error || t("kanban.errReclaim"));
     else loadAll(true);
   }
 
@@ -516,7 +524,7 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
     const res = await window.hermesAPI.kanbanDispatchOnce(false, profile);
     setActionBusy(null);
     if (!res.success) {
-      setError(res.error || "Dispatch failed");
+      setError(res.error || t("kanban.errDispatch"));
       return;
     }
     loadAll(true);
@@ -527,12 +535,10 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
       <div className="kanban-container">
         <div className="kanban-empty">
           <p className="schedules-empty-text">
-            Kanban requires a local Hermes install or SSH tunnel mode.
+            {t("kanban.remoteUnsupportedTitle")}
           </p>
           <p className="schedules-empty-hint">
-            Plain remote (HTTP + API key) mode does not yet expose the kanban
-            API. Switch to local or SSH tunnel mode in Settings to manage the
-            board.
+            {t("kanban.remoteUnsupportedHint")}
           </p>
         </div>
       </div>
@@ -553,11 +559,8 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
     <div className="kanban-container">
       <div className="kanban-header">
         <div>
-          <h2 className="schedules-title">Kanban</h2>
-          <p className="schedules-subtitle">
-            Durable multi-agent board for tasks the agent can pick up and finish
-            on its own.
-          </p>
+          <h2 className="schedules-title">{t("kanban.title")}</h2>
+          <p className="schedules-subtitle">{t("kanban.subtitle")}</p>
         </div>
         <div className="schedules-header-actions">
           <button
@@ -566,7 +569,7 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
             disabled={actionBusy !== null}
           >
             <Refresh size={14} />
-            Refresh
+            {t("kanban.refresh")}
           </button>
           {!isHqActive && (
             <>
@@ -574,17 +577,17 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
                 className="btn btn-secondary"
                 onClick={handleDispatch}
                 disabled={actionBusy !== null}
-                data-tooltip="Run one dispatcher pass — promote ready tasks and spawn workers"
+                data-tooltip={t("kanban.dispatchTooltip")}
               >
                 <Zap size={14} />
-                Dispatch
+                {t("kanban.dispatch")}
               </button>
               <button
                 className="btn btn-primary"
                 onClick={() => setShowCreate(true)}
               >
                 <Plus size={14} />
-                New task
+                {t("kanban.newTask")}
               </button>
             </>
           )}
@@ -634,7 +637,7 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
               onClick={() => setShowNewBoard(true)}
             >
               <Plus size={12} />
-              New board
+              {t("kanban.newBoard")}
             </button>
           )}
         </div>
@@ -695,7 +698,9 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
               }}
             >
               <div className="kanban-column-header">
-                <span className="kanban-column-title">{col.label}</span>
+                <span className="kanban-column-title">
+                  {t(`kanban.status.${col.key}`)}
+                </span>
                 <span className="kanban-column-count">{colTasks.length}</span>
               </div>
               <div className="kanban-column-body">
@@ -753,8 +758,8 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
                         {!isHqActive && task.status === "triage" && (
                           <button
                             className="btn-ghost kanban-card-action"
-                            data-tooltip="Specify (expand spec → to-do)"
-                            title="Specify (expand spec → to-do)"
+                            data-tooltip={t("kanban.cardSpecify")}
+                            title={t("kanban.cardSpecify")}
                             onClick={(e) => {
                               e.stopPropagation();
                               handleSpecify(task);
@@ -767,8 +772,8 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
                         {!isHqActive && task.status === "ready" && (
                           <button
                             className="btn-ghost kanban-card-action"
-                            data-tooltip="Mark done"
-                            title="Mark done"
+                            data-tooltip={t("kanban.cardMarkDone")}
+                            title={t("kanban.cardMarkDone")}
                             onClick={(e) => {
                               e.stopPropagation();
                               handleMove(task, "done");
@@ -781,8 +786,8 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
                         {!isHqActive && task.status === "running" && (
                           <button
                             className="btn-ghost kanban-card-action"
-                            data-tooltip="Reclaim worker"
-                            title="Reclaim worker"
+                            data-tooltip={t("kanban.cardReclaim")}
+                            title={t("kanban.cardReclaim")}
                             onClick={(e) => {
                               e.stopPropagation();
                               handleReclaim(task);
@@ -795,8 +800,8 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
                         {!isHqActive && task.status === "blocked" && (
                           <button
                             className="btn-ghost kanban-card-action"
-                            data-tooltip="Unblock"
-                            title="Unblock"
+                            data-tooltip={t("kanban.cardUnblock")}
+                            title={t("kanban.cardUnblock")}
                             onClick={(e) => {
                               e.stopPropagation();
                               handleMove(task, "ready");
@@ -811,8 +816,8 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
                             task.status === "ready") && (
                             <button
                               className="btn-ghost kanban-card-action"
-                              data-tooltip="Block"
-                              title="Block"
+                              data-tooltip={t("kanban.cardBlock")}
+                              title={t("kanban.cardBlock")}
                               onClick={(e) => {
                                 e.stopPropagation();
                                 handleMove(task, "blocked");
@@ -825,8 +830,8 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
                         {!isHqActive && (
                           <button
                             className="btn-ghost kanban-card-action kanban-card-action-danger"
-                            data-tooltip="Archive"
-                            title="Archive"
+                            data-tooltip={t("kanban.cardArchive")}
+                            title={t("kanban.cardArchive")}
                             onClick={(e) => {
                               e.stopPropagation();
                               handleArchive(task);
@@ -853,7 +858,7 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
         >
           <div className="schedules-modal" onClick={(e) => e.stopPropagation()}>
             <div className="schedules-modal-header">
-              <span>New kanban task</span>
+              <span>{t("kanban.createTitle")}</span>
               <button
                 className="btn-ghost"
                 onClick={() => setShowCreate(false)}
@@ -863,29 +868,33 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
             </div>
             <div className="schedules-modal-body">
               <div className="schedules-field">
-                <label className="schedules-field-label">Title</label>
+                <label className="schedules-field-label">
+                  {t("kanban.fieldTitle")}
+                </label>
                 <input
                   className="input"
                   type="text"
                   value={newTitle}
                   onChange={(e) => setNewTitle(e.target.value)}
-                  placeholder="What needs to be done?"
+                  placeholder={t("kanban.titlePlaceholder")}
                   autoFocus
                 />
               </div>
               <div className="schedules-field">
-                <label className="schedules-field-label">Body (optional)</label>
+                <label className="schedules-field-label">
+                  {t("kanban.fieldBody")}
+                </label>
                 <textarea
                   className="input schedules-textarea"
                   rows={4}
                   value={newBody}
                   onChange={(e) => setNewBody(e.target.value)}
-                  placeholder="Context, acceptance criteria, links…"
+                  placeholder={t("kanban.bodyPlaceholder")}
                 />
               </div>
               <div className="schedules-field">
                 <label className="schedules-field-label">
-                  Assignee profile
+                  {t("kanban.fieldAssignee")}
                 </label>
                 <select
                   className="input"
@@ -893,7 +902,7 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
                   value={newAssignee}
                   onChange={(e) => setNewAssignee(e.target.value)}
                 >
-                  <option value="">— Triage (no assignee)</option>
+                  <option value="">{t("kanban.assigneeNone")}</option>
                   {profileOptions.map((name) => (
                     <option key={name} value={name}>
                       {name}
@@ -902,30 +911,38 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
                 </select>
               </div>
               <div className="schedules-field">
-                <label className="schedules-field-label">Priority</label>
+                <label className="schedules-field-label">
+                  {t("kanban.fieldPriority")}
+                </label>
                 <select
                   className="input"
                   aria-label="Priority"
                   value={newPriority}
                   onChange={(e) => setNewPriority(e.target.value)}
                 >
-                  <option value="0">Normal (0)</option>
-                  <option value="1">Low (P2)</option>
-                  <option value="5">High (P1)</option>
-                  <option value="10">Urgent (P0)</option>
+                  <option value="0">{t("kanban.priorityNormal")}</option>
+                  <option value="1">{t("kanban.priorityLow")}</option>
+                  <option value="5">{t("kanban.priorityHigh")}</option>
+                  <option value="10">{t("kanban.priorityUrgent")}</option>
                 </select>
               </div>
               <div className="schedules-field">
-                <label className="schedules-field-label">Workspace</label>
+                <label className="schedules-field-label">
+                  {t("kanban.fieldWorkspace")}
+                </label>
                 <select
                   className="input"
                   aria-label="Workspace"
                   value={newWorkspace}
                   onChange={(e) => setNewWorkspace(e.target.value)}
                 >
-                  <option value="scratch">Scratch (temp dir)</option>
-                  <option value="worktree">Worktree (current repo)</option>
-                  <option value="dir">Choose folder…</option>
+                  <option value="scratch">
+                    {t("kanban.workspaceScratch")}
+                  </option>
+                  <option value="worktree">
+                    {t("kanban.workspaceWorktree")}
+                  </option>
+                  <option value="dir">{t("kanban.workspaceChoose")}</option>
                 </select>
                 {newWorkspace === "dir" && (
                   <div className="kanban-folder-picker">
@@ -934,7 +951,7 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
                       type="text"
                       value={newWorkspaceDir}
                       onChange={(e) => setNewWorkspaceDir(e.target.value)}
-                      placeholder="No folder selected"
+                      placeholder={t("kanban.workspaceNoFolder")}
                       readOnly
                     />
                     <button
@@ -942,7 +959,7 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
                       className="btn btn-secondary"
                       onClick={handlePickWorkspaceFolder}
                     >
-                      Browse…
+                      {t("kanban.browse")}
                     </button>
                   </div>
                 )}
@@ -954,10 +971,7 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
                     checked={newTriage}
                     onChange={(e) => setNewTriage(e.target.checked)}
                   />
-                  <span>
-                    Park in triage (a specifier expands the spec before
-                    promoting to to-do)
-                  </span>
+                  <span>{t("kanban.triageCheckbox")}</span>
                 </label>
               </div>
             </div>
@@ -966,14 +980,16 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
                 className="btn btn-secondary"
                 onClick={() => setShowCreate(false)}
               >
-                Cancel
+                {t("common.cancel")}
               </button>
               <button
                 className="btn btn-primary"
                 onClick={handleCreate}
                 disabled={!newTitle.trim() || actionBusy === "create"}
               >
-                {actionBusy === "create" ? "Creating…" : "Create task"}
+                {actionBusy === "create"
+                  ? t("kanban.creating")
+                  : t("kanban.create")}
               </button>
             </div>
           </div>
@@ -987,7 +1003,7 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
         >
           <div className="schedules-modal" onClick={(e) => e.stopPropagation()}>
             <div className="schedules-modal-header">
-              <span>New board</span>
+              <span>{t("kanban.newBoardTitle")}</span>
               <button
                 className="btn-ghost"
                 onClick={() => setShowNewBoard(false)}
@@ -997,26 +1013,28 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
             </div>
             <div className="schedules-modal-body">
               <div className="schedules-field">
-                <label className="schedules-field-label">Slug</label>
+                <label className="schedules-field-label">
+                  {t("kanban.fieldSlug")}
+                </label>
                 <input
                   className="input"
                   type="text"
                   value={newBoardSlug}
                   onChange={(e) => setNewBoardSlug(e.target.value)}
-                  placeholder="kebab-case, e.g. atm10-server"
+                  placeholder={t("kanban.slugPlaceholder")}
                   autoFocus
                 />
               </div>
               <div className="schedules-field">
                 <label className="schedules-field-label">
-                  Display name (optional)
+                  {t("kanban.fieldDisplayName")}
                 </label>
                 <input
                   className="input"
                   type="text"
                   value={newBoardName}
                   onChange={(e) => setNewBoardName(e.target.value)}
-                  placeholder="ATM10 Server"
+                  placeholder={t("kanban.displayNamePlaceholder")}
                 />
               </div>
             </div>
@@ -1025,14 +1043,16 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
                 className="btn btn-secondary"
                 onClick={() => setShowNewBoard(false)}
               >
-                Cancel
+                {t("common.cancel")}
               </button>
               <button
                 className="btn btn-primary"
                 onClick={handleCreateBoard}
                 disabled={!newBoardSlug.trim() || actionBusy === "board-create"}
               >
-                {actionBusy === "board-create" ? "Creating…" : "Create board"}
+                {actionBusy === "board-create"
+                  ? t("kanban.creating")
+                  : t("kanban.createBoard")}
               </button>
             </div>
           </div>
@@ -1049,7 +1069,7 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
             onClick={(e) => e.stopPropagation()}
           >
             <div className="schedules-modal-header">
-              <span>{detail?.task.title || "Task"}</span>
+              <span>{detail?.task.title || t("kanban.detailFallbackTitle")}</span>
               <button
                 className="btn-ghost"
                 title="Close task details"
@@ -1063,7 +1083,9 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
               {detail && (
                 <>
                   <div className="kanban-detail-meta">
-                    <span className="kanban-pill">{detail.task.status}</span>
+                    <span className="kanban-pill">
+                      {t(`kanban.status.${detail.task.status}`)}
+                    </span>
                     {detail.task.assignee && (
                       <span className="kanban-pill">
                         @{detail.task.assignee}
@@ -1078,7 +1100,7 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
                   </div>
                   {detail.task.body && (
                     <div className="kanban-detail-section">
-                      <label>Body</label>
+                      <label>{t("kanban.detailBody")}</label>
                       <pre className="kanban-detail-pre">
                         {detail.task.body}
                       </pre>
@@ -1086,7 +1108,7 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
                   )}
                   {detail.latest_summary && (
                     <div className="kanban-detail-section">
-                      <label>Latest run summary</label>
+                      <label>{t("kanban.detailSummary")}</label>
                       <pre className="kanban-detail-pre">
                         {detail.latest_summary}
                       </pre>
@@ -1094,7 +1116,7 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
                   )}
                   {detail.task.result && (
                     <div className="kanban-detail-section">
-                      <label>Result</label>
+                      <label>{t("kanban.detailResult")}</label>
                       <pre className="kanban-detail-pre">
                         {detail.task.result}
                       </pre>
@@ -1102,11 +1124,15 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
                   )}
                   {detail.comments.length > 0 && (
                     <div className="kanban-detail-section">
-                      <label>Comments ({detail.comments.length})</label>
+                      <label>
+                        {t("kanban.detailComments", {
+                          count: detail.comments.length,
+                        })}
+                      </label>
                       {detail.comments.map((c) => (
                         <div key={c.id} className="kanban-comment">
                           <div className="kanban-comment-author">
-                            {c.author || "anon"}
+                            {c.author || t("kanban.commentAnon")}
                           </div>
                           <div className="kanban-comment-body">{c.body}</div>
                         </div>
@@ -1115,7 +1141,11 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
                   )}
                   {detail.events.length > 0 && (
                     <div className="kanban-detail-section">
-                      <label>Events ({detail.events.length})</label>
+                      <label>
+                        {t("kanban.detailEvents", {
+                          count: detail.events.length,
+                        })}
+                      </label>
                       <div className="kanban-events">
                         {detail.events
                           .slice(-12)

--- a/src/shared/i18n/index.ts
+++ b/src/shared/i18n/index.ts
@@ -26,6 +26,7 @@ import soulEn from "./locales/en/soul";
 import memoryEn from "./locales/en/memory";
 import installEn from "./locales/en/install";
 import constantsEn from "./locales/en/constants";
+import kanbanEn from "./locales/en/kanban";
 import commonEs from "./locales/es/common";
 import navigationEs from "./locales/es/navigation";
 import welcomeEs from "./locales/es/welcome";
@@ -166,6 +167,7 @@ import soulPtPt from "./locales/pt-PT/soul";
 import memoryPtPt from "./locales/pt-PT/memory";
 import installPtPt from "./locales/pt-PT/install";
 import constantsPtPt from "./locales/pt-PT/constants";
+import kanbanPtPt from "./locales/pt-PT/kanban";
 
 export const resources = {
   en: {
@@ -190,6 +192,7 @@ export const resources = {
       memory: memoryEn,
       install: installEn,
       constants: constantsEn,
+      kanban: kanbanEn,
     },
   },
   es: {
@@ -334,6 +337,7 @@ export const resources = {
       memory: memoryPtPt,
       install: installPtPt,
       constants: constantsPtPt,
+      kanban: kanbanPtPt,
     },
   },
   ja: {

--- a/src/shared/i18n/locales/en/kanban.ts
+++ b/src/shared/i18n/locales/en/kanban.ts
@@ -1,0 +1,98 @@
+export default {
+  title: "Kanban",
+  subtitle:
+    "Durable multi-agent board for tasks the agent can pick up and finish on its own.",
+
+  // Header actions
+  refresh: "Refresh",
+  dispatch: "Dispatch",
+  dispatchTooltip:
+    "Run one dispatcher pass — promote ready tasks and spawn workers",
+  newTask: "New task",
+  newBoard: "New board",
+
+  // Remote-mode unsupported notice
+  remoteUnsupportedTitle:
+    "Kanban requires a local Hermes install or SSH tunnel mode.",
+  remoteUnsupportedHint:
+    "Plain remote (HTTP + API key) mode does not yet expose the kanban API. Switch to local or SSH tunnel mode in Settings to manage the board.",
+
+  // Column / task statuses
+  status: {
+    triage: "Triage",
+    todo: "To-do",
+    ready: "Ready",
+    running: "Running",
+    blocked: "Blocked",
+    done: "Done",
+  },
+
+  // Card action tooltips
+  cardSpecify: "Specify (expand spec → to-do)",
+  cardMarkDone: "Mark done",
+  cardReclaim: "Reclaim worker",
+  cardUnblock: "Unblock",
+  cardBlock: "Block",
+  cardArchive: "Archive",
+
+  // Create-task modal
+  createTitle: "New kanban task",
+  fieldTitle: "Title",
+  titlePlaceholder: "What needs to be done?",
+  fieldBody: "Body (optional)",
+  bodyPlaceholder: "Context, acceptance criteria, links…",
+  fieldAssignee: "Assignee profile",
+  assigneeNone: "— Triage (no assignee)",
+  fieldPriority: "Priority",
+  priorityNormal: "Normal (0)",
+  priorityLow: "Low (P2)",
+  priorityHigh: "High (P1)",
+  priorityUrgent: "Urgent (P0)",
+  fieldWorkspace: "Workspace",
+  workspaceScratch: "Scratch (temp dir)",
+  workspaceWorktree: "Worktree (current repo)",
+  workspaceChoose: "Choose folder…",
+  workspaceNoFolder: "No folder selected",
+  browse: "Browse…",
+  triageCheckbox:
+    "Park in triage (a specifier expands the spec before promoting to to-do)",
+  create: "Create task",
+  creating: "Creating…",
+
+  // New-board modal
+  newBoardTitle: "New board",
+  fieldSlug: "Slug",
+  slugPlaceholder: "kebab-case, e.g. atm10-server",
+  fieldDisplayName: "Display name (optional)",
+  displayNamePlaceholder: "ATM10 Server",
+  createBoard: "Create board",
+
+  // Task-detail modal
+  detailFallbackTitle: "Task",
+  detailBody: "Body",
+  detailSummary: "Latest run summary",
+  detailResult: "Result",
+  detailComments: "Comments ({{count}})",
+  detailEvents: "Events ({{count}})",
+  commentAnon: "anon",
+
+  // Prompts / confirmations
+  blockReasonPrompt: "Reason for blocking?",
+  confirmMarkDone: 'Mark "{{title}}" as done?',
+  confirmArchive: 'Archive "{{title}}"?',
+
+  // Errors
+  moveNotAllowed:
+    "Cannot move {{from}} → {{to}} from the desktop. Use the agent or CLI.",
+  errLoadBoards: "Failed to load boards",
+  errLoadTasks: "Failed to load tasks",
+  errMoveTask: "Failed to move task",
+  errPickFolder: "Pick a workspace folder first.",
+  errCreateTask: "Failed to create task",
+  errSwitchBoard: "Failed to switch board",
+  errCreateBoard: "Failed to create board",
+  errSpecify: "Failed to specify task",
+  errArchive: "Failed to archive task",
+  errReclaim: "Failed to reclaim",
+  errDispatch: "Dispatch failed",
+} as const;

--- a/src/shared/i18n/locales/pt-PT/kanban.ts
+++ b/src/shared/i18n/locales/pt-PT/kanban.ts
@@ -1,0 +1,98 @@
+export default {
+  title: "Kanban",
+  subtitle:
+    "Quadro multi-agente durável para tarefas que o agente pode escolher e concluir autonomamente.",
+
+  // Header actions
+  refresh: "Actualizar",
+  dispatch: "Despachar",
+  dispatchTooltip:
+    "Executar uma passagem do despachante — promover tarefas prontas e iniciar trabalhadores",
+  newTask: "Nova tarefa",
+  newBoard: "Novo quadro",
+
+  // Remote-mode unsupported notice
+  remoteUnsupportedTitle:
+    "O Kanban requer uma instalação local do Hermes ou o modo de túnel SSH.",
+  remoteUnsupportedHint:
+    "O modo remoto simples (HTTP + chave de API) ainda não expõe a API do kanban. Mude para o modo local ou de túnel SSH nas Definições para gerir o quadro.",
+
+  // Column / task statuses
+  status: {
+    triage: "Triagem",
+    todo: "Por fazer",
+    ready: "Pronto",
+    running: "Em execução",
+    blocked: "Bloqueado",
+    done: "Concluído",
+  },
+
+  // Card action tooltips
+  cardSpecify: "Especificar (expandir especificação → por fazer)",
+  cardMarkDone: "Marcar como concluída",
+  cardReclaim: "Recuperar worker",
+  cardUnblock: "Desbloquear",
+  cardBlock: "Bloquear",
+  cardArchive: "Arquivar",
+
+  // Create-task modal
+  createTitle: "Nova tarefa kanban",
+  fieldTitle: "Título",
+  titlePlaceholder: "O que precisa de ser feito?",
+  fieldBody: "Corpo (opcional)",
+  bodyPlaceholder: "Contexto, critérios de aceitação, ligações…",
+  fieldAssignee: "Perfil responsável",
+  assigneeNone: "— Triagem (sem responsável)",
+  fieldPriority: "Prioridade",
+  priorityNormal: "Normal (0)",
+  priorityLow: "Baixa (P2)",
+  priorityHigh: "Alta (P1)",
+  priorityUrgent: "Urgente (P0)",
+  fieldWorkspace: "Espaço de trabalho",
+  workspaceScratch: "Temporário (pasta temp)",
+  workspaceWorktree: "Worktree (repositório actual)",
+  workspaceChoose: "Escolher pasta…",
+  workspaceNoFolder: "Nenhuma pasta seleccionada",
+  browse: "navegar…",
+  triageCheckbox:
+    "Estacionar em triagem (um especificador expande a especificação antes de a promover para «Por fazer»)",
+  create: "Criar tarefa",
+  creating: "A criar…",
+
+  // New-board modal
+  newBoardTitle: "Novo quadro",
+  fieldSlug: "Slug",
+  slugPlaceholder: "kebab-case, ex.: atm10-server",
+  fieldDisplayName: "Nome (opcional)",
+  displayNamePlaceholder: "ATM10 Server",
+  createBoard: "Criar quadro",
+
+  // Task-detail modal
+  detailFallbackTitle: "Tarefa",
+  detailBody: "Corpo",
+  detailSummary: "Resumo da última execução",
+  detailResult: "Resultado",
+  detailComments: "Comentários ({{count}})",
+  detailEvents: "Eventos ({{count}})",
+  commentAnon: "anónimo",
+
+  // Prompts / confirmations
+  blockReasonPrompt: "Motivo do bloqueio?",
+  confirmMarkDone: 'Marcar "{{title}}" como concluída?',
+  confirmArchive: 'Arquivar "{{title}}"?',
+
+  // Errors
+  moveNotAllowed:
+    "Não é possível mover {{from}} → {{to}} a partir da aplicação. Use o agente ou a CLI.",
+  errLoadBoards: "Falha ao carregar os quadros",
+  errLoadTasks: "Falha ao carregar as tarefas",
+  errMoveTask: "Falha ao mover a tarefa",
+  errPickFolder: "Escolha primeiro uma pasta de espaço de trabalho.",
+  errCreateTask: "Falha ao criar a tarefa",
+  errSwitchBoard: "Falha ao mudar de quadro",
+  errCreateBoard: "Falha ao criar o quadro",
+  errSpecify: "Falha ao especificar a tarefa",
+  errArchive: "Falha ao arquivar a tarefa",
+  errReclaim: "Falha ao recuperar",
+  errDispatch: "Falha no despacho",
+} as const;


### PR DESCRIPTION
## Summary

The Kanban screen was the one screen with **no internationalization** — `Kanban.tsx` didn't import `useI18n` and every user-facing string was hardcoded English, so it stayed English regardless of the selected language.

This adds a `kanban` translation namespace and routes the screen through it.

- New `kanban` namespace — `en/kanban.ts` (the source) and `pt-PT/kanban.ts`.
- Wired into the shared i18n `resources` for `en` and `pt-PT`.
- `Kanban.tsx` refactored — `useI18n` added, all ~57 strings resolved via `t()` (column/status labels, card tooltips, the create-task and new-board modals, the task-detail modal, prompts, confirmations, errors).
- Interpolated strings use `{{count}}` / `{{title}}` / `{{from}}`+`{{to}}` placeholders.

## Scope

- Only **en + pt-PT** are translated. The other six locales (es, id, ja, pt-BR, zh-CN, zh-TW) **fall back to English** via the existing `t()` resolver (`translated ?? fallback ?? key`) — nothing breaks; they can be added in follow-up PRs. This is deliberate: no unreviewed machine translations are shipped.
- The pt-PT translation was reviewed by a native speaker.
- Compact codes are intentionally **not** localized — priority tags (`P0`/`P1`/`P2`) and relative-age units (`5s`/`3m`/`2h`/`4d`).
- Cancel buttons reuse the existing `common.cancel` key.

## Test plan

- [x] `npm run typecheck` clean
- [x] Full test suite green (488 passed / 3 skipped)
- [x] i18n resolves: `kanban` namespace loads for en + pt-PT; missing locales fall back to English

🤖 Generated with [Claude Code](https://claude.com/claude-code)