### PR TITLE
Start Hermes Office with the desktop's configured model (#256)

### DIFF
--- a/src/main/claw3d.ts
+++ b/src/main/claw3d.ts
@@ -11,7 +11,11 @@ import { homedir } from "os";
 import { createConnection } from "net";
 import { getEnhancedPath, HERMES_HOME } from "./installer";
 import { stripAnsi, safeWriteFile } from "./utils";
-import { getApiServerKey, getConnectionConfig } from "./config";
+import {
+  getApiServerKey,
+  getConnectionConfig,
+  getModelConfig,
+} from "./config";
 import http from "http";
 
 const HERMES_OFFICE_REPO = "https://github.com/fathah/hermes-office";
@@ -240,6 +244,48 @@ export function getClaw3dWsUrl(): string {
 }
 
 /**
+ * The model Hermes Office should default to. Office runs against the same
+ * gateway as the desktop chat, so it should use the same configured model
+ * rather than a generic `hermes` agent the user never selected (issue
+ * #256). Falls back to `hermes` only when no model is configured.
+ */
+function resolveOfficeModel(): string {
+  try {
+    const model = getModelConfig().model?.trim();
+    if (model) return model;
+  } catch {
+    /* no model configured — fall through to the default */
+  }
+  return "hermes";
+}
+
+/**
+ * Build the `.env` Hermes Desktop writes into the hermes-office directory.
+ * Exported so the contents (notably `HERMES_MODEL`, issue #256) can be
+ * unit tested without a live Office install.
+ */
+export function buildOfficeEnv(opts: {
+  port: number;
+  url: string;
+  apiKey: string;
+  model: string;
+}): string {
+  return [
+    "# Auto-configured by Hermes Desktop",
+    `PORT=${opts.port}`,
+    `HOST=127.0.0.1`,
+    `NEXT_PUBLIC_GATEWAY_URL=${opts.url}`,
+    `CLAW3D_GATEWAY_URL=${opts.url}`,
+    `CLAW3D_GATEWAY_TOKEN=${opts.apiKey}`,
+    `HERMES_API_KEY=${opts.apiKey}`,
+    `HERMES_ADAPTER_PORT=18789`,
+    `HERMES_MODEL=${opts.model || "hermes"}`,
+    `HERMES_AGENT_NAME=Hermes`,
+    "",
+  ].join("\n");
+}
+
+/**
  * Write Claw3D settings to ~/.openclaw/claw3d/settings.json
  * and .env in the claw3d directory so onboarding is skipped.
  */
@@ -276,21 +322,15 @@ function writeClaw3dSettings(wsUrl?: string): void {
   try {
     if (existsSync(HERMES_OFFICE_DIR)) {
       const envPath = join(HERMES_OFFICE_DIR, ".env");
-      const port = getSavedPort();
-      const envContent = [
-        "# Auto-configured by Hermes Desktop",
-        `PORT=${port}`,
-        `HOST=127.0.0.1`,
-        `NEXT_PUBLIC_GATEWAY_URL=${url}`,
-        `CLAW3D_GATEWAY_URL=${url}`,
-        `CLAW3D_GATEWAY_TOKEN=${apiKey}`,
-        `HERMES_API_KEY=${apiKey}`,
-        `HERMES_ADAPTER_PORT=18789`,
-        `HERMES_MODEL=hermes`,
-        `HERMES_AGENT_NAME=Hermes`,
-        "",
-      ].join("\n");
-      safeWriteFile(envPath, envContent);
+      safeWriteFile(
+        envPath,
+        buildOfficeEnv({
+          port: getSavedPort(),
+          url,
+          apiKey,
+          model: resolveOfficeModel(),
+        }),
+      );
     }
   } catch {
     /* non-fatal */
@@ -860,6 +900,11 @@ export function startAll(): { success: boolean; error?: string } {
   }
 
   const port = getSavedPort();
+
+  // Refresh the `.env` before the processes read it, so Office always
+  // starts against the current port/URL and the desktop's configured
+  // model rather than a value frozen at first setup (issue #256).
+  writeClaw3dSettings();
 
   // Start dev server
   const devOk = startDevServer();

--- a/tests/office-env.test.ts
+++ b/tests/office-env.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { buildOfficeEnv } from "../src/main/claw3d";
+
+// Hermes Desktop writes the hermes-office `.env`. It used to hardcode
+// `HERMES_MODEL=hermes`, so Office ignored the user's configured model
+// (issue #256). The model is now passed through.
+describe("buildOfficeEnv (issue #256)", () => {
+  it("writes the configured model into HERMES_MODEL", () => {
+    const env = buildOfficeEnv({
+      port: 5179,
+      url: "ws://127.0.0.1:8642",
+      apiKey: "",
+      model: "grok-4.3",
+    });
+    expect(env).toContain("HERMES_MODEL=grok-4.3");
+    expect(env).not.toContain("HERMES_MODEL=hermes");
+  });
+
+  it("falls back to `hermes` when no model is configured", () => {
+    const env = buildOfficeEnv({
+      port: 5179,
+      url: "ws://x",
+      apiKey: "",
+      model: "",
+    });
+    expect(env).toContain("HERMES_MODEL=hermes");
+  });
+
+  it("carries the port and gateway URL through", () => {
+    const env = buildOfficeEnv({
+      port: 1234,
+      url: "ws://gw.test",
+      apiKey: "",
+      model: "m",
+    });
+    expect(env).toContain("PORT=1234");
+    expect(env).toContain("NEXT_PUBLIC_GATEWAY_URL=ws://gw.test");
+    expect(env).toContain("CLAW3D_GATEWAY_URL=ws://gw.test");
+  });
+
+  it("threads the gateway API key into CLAW3D_GATEWAY_TOKEN and HERMES_API_KEY (#297)", () => {
+    const env = buildOfficeEnv({
+      port: 5179,
+      url: "ws://x",
+      apiKey: "secret-key-123",
+      model: "hermes",
+    });
+    expect(env).toContain("CLAW3D_GATEWAY_TOKEN=secret-key-123");
+    expect(env).toContain("HERMES_API_KEY=secret-key-123");
+  });
+
+  it("emits empty token/key fields when the gateway has no API_SERVER_KEY", () => {
+    const env = buildOfficeEnv({
+      port: 5179,
+      url: "ws://x",
+      apiKey: "",
+      model: "hermes",
+    });
+    expect(env).toContain("CLAW3D_GATEWAY_TOKEN=");
+    expect(env).toContain("HERMES_API_KEY=");
+  });
+});


### PR DESCRIPTION
Addresses the **model half** of #256.

## The bug

`writeClaw3dSettings()` in `src/main/claw3d.ts` generates the `hermes-office/.env` and **hardcoded the model**:

```js
`HERMES_MODEL=hermes`,
```

So Hermes Office always ran a generic `hermes` agent, ignoring whatever model the desktop chat is configured with. When the desktop is set to (say) Grok or a Codex model, Office silently uses something else — which the reporter notes can surface as `AggregateError` / model-mismatch failures.

## The fix

- **Write the configured model.** `writeClaw3dSettings()` now resolves the model via `getModelConfig()` and writes it into the Office `.env`. Falls back to `hermes` only when no model is configured.
- **Refresh the `.env` on start.** Previously it was written only at first setup / port change / wsUrl change — so an existing Office install kept whatever model was frozen in at setup time, forever. `startAll()` now rewrites the `.env` before launching the processes, so existing installs pick up the right model on the next Office start, and a later desktop model change is reflected on the next Office restart.
- **Testable.** The `.env` builder is extracted into an exported `buildOfficeEnv()` with unit tests covering the `HERMES_MODEL` handling.

## Scope

This is the **model** half of #256 only. The other half — Office UI not following the desktop language — belongs to the separate `fathah/hermes-office` frontend (it has no i18n system); the desktop can't translate it. That's flagged on the issue.

## Test plan

- [x] `npm run typecheck` clean
- [x] `tests/office-env.test.ts` (3 new) + existing `claw3d` tests pass
- [x] Live: with the desktop model set to `gpt-5.5`, Stop→Start Office — `~/.hermes/hermes-office/.env` rewrites to `HERMES_MODEL=gpt-5.5`, and Office's model selector then shows `hermes/gpt-5.5` instead of the generic `hermes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)