### PR TITLE
fix(installer): cap getHermesVersion wait so a stuck flag can't leak intervals

### DIFF
--- a/src/main/installer.ts
+++ b/src/main/installer.ts
@@ -399,10 +399,19 @@ export async function getHermesVersion(): Promise<string | null> {
   if (_cachedVersion !== null) return _cachedVersion;
   if (!existsSync(HERMES_PYTHON) || !existsSync(HERMES_SCRIPT)) return null;
   if (_versionFetching) {
-    // Wait for in-flight fetch
+    // Wait for the in-flight fetch but cap the wait. The execFile below
+    // has a 15s timeout and its callback unconditionally clears
+    // `_versionFetching`, so under normal failure paths the poll
+    // unblocks on its own. Pathological cases (callback never invoked,
+    // worker killed mid-callback, async exception in handler) would
+    // otherwise leak a 100 ms interval per caller forever. Cap at 20s
+    // — comfortably above the execFile timeout — and resolve with
+    // whatever `_cachedVersion` happens to be (typically `null`),
+    // which matches the same return shape callers already handle.
     return new Promise((resolve) => {
+      const startedAt = Date.now();
       const check = setInterval(() => {
-        if (!_versionFetching) {
+        if (!_versionFetching || Date.now() - startedAt > 20_000) {
           clearInterval(check);
           resolve(_cachedVersion);
         }


### PR DESCRIPTION
## What

`getHermesVersion()` (`src/main/installer.ts:398`) short-circuits when a fetch is in flight and polls every 100 ms via `setInterval` until `_versionFetching` flips back to `false`:

```ts
if (_versionFetching) {
  return new Promise((resolve) => {
    const check = setInterval(() => {
      if (!_versionFetching) {
        clearInterval(check);
        resolve(_cachedVersion);
      }
    }, 100);
  });
}
```

There's no timeout on that wait.

## Why this matters

The `execFile` below has a 15 s timeout and its callback unconditionally clears `_versionFetching`, so under normal failure paths every waiter eventually unblocks — fine.

Pathological cases break the invariant:

- `execFile` callback never runs (worker process killed mid-callback, async exception in the callback chain that escapes Node's normal flow, host OS suspending the Electron main thread long enough that the internal timeout doesn't fire).
- Any future refactor that touches the callback and forgets to reset the flag in some branch.

In any of those, the flag stays stuck `true`. Every subsequent caller of `getHermesVersion()` then leaks its own 100 ms interval forever. Over the lifetime of a long-running desktop session this shows up as steadily climbing main-process CPU and event-loop pressure (each leaked interval fires 10×/s, so leaking N waiters adds 100·N timer wakeups per second).

## Fix

Cap the wait at 20 s — comfortably above the `execFile` 15 s timeout — and resolve with whatever `_cachedVersion` is at that point. That's almost always `null`, which callers already handle as "version unknown". 4-line change.

```ts
const startedAt = Date.now();
const check = setInterval(() => {
  if (!_versionFetching || Date.now() - startedAt > 20_000) {
    clearInterval(check);
    resolve(_cachedVersion);
  }
}, 100);
```

## Verification
- `npm run typecheck` passes
- No behaviour change on the happy path; only adds a fallback exit for the stuck-flag case
