### PR TITLE
fix(ipc): guard chat-send callbacks against destroyed renderer sender

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -651,16 +651,35 @@ function setupIPC(): void {
         },
       );
 
+      // Streaming sends to `event.sender` will throw "Object has been
+      // destroyed" if the renderer WebContents goes away mid-response
+      // (window closed, reloaded, navigated away). Guard every send so a
+      // dead sender doesn't crash the IPC handler, and abort the in-flight
+      // chat the first time we see one — there's nobody listening anymore.
+      const safeSend = (channel: string, payload: unknown): boolean => {
+        if (event.sender.isDestroyed()) return false;
+        try {
+          event.sender.send(channel, payload);
+          return true;
+        } catch {
+          return false;
+        }
+      };
+
       const handle = await sendMessage(
         message,
         {
           onChunk: (chunk) => {
             fullResponse += chunk;
-            event.sender.send("chat-chunk", chunk);
+            if (!safeSend("chat-chunk", chunk) && currentChatAbort) {
+              // Renderer is gone — stop generating and resolve with what we
+              // have so the awaiting promise doesn't leak.
+              currentChatAbort();
+            }
           },
           onDone: (sessionId) => {
             currentChatAbort = null;
-            event.sender.send("chat-done", sessionId || "");
+            safeSend("chat-done", sessionId || "");
             resolveChat({ response: fullResponse, sessionId });
             // Desktop notification when window is not focused and response took >10s
             if (
@@ -680,7 +699,7 @@ function setupIPC(): void {
           },
           onError: (error) => {
             currentChatAbort = null;
-            event.sender.send("chat-error", error);
+            safeSend("chat-error", error);
             rejectChat(new Error(error));
             // Notify on error too if window not focused
             if (mainWindow && !mainWindow.isFocused()) {
@@ -691,10 +710,10 @@ function setupIPC(): void {
             }
           },
           onToolProgress: (tool) => {
-            event.sender.send("chat-tool-progress", tool);
+            safeSend("chat-tool-progress", tool);
           },
           onUsage: (usage) => {
-            event.sender.send("chat-usage", usage);
+            safeSend("chat-usage", usage);
           },
         },
         profile,


### PR DESCRIPTION
## What

The `chat-send` IPC handler's streaming callbacks call `event.sender.send(...)` without checking whether the renderer WebContents is still alive:

```ts
onChunk: (chunk) => {
  fullResponse += chunk;
  event.sender.send("chat-chunk", chunk);   // ← throws if window closed
},
onDone: (sessionId) => {
  event.sender.send("chat-done", sessionId || "");
  ...
},
onError: (error) => {
  event.sender.send("chat-error", error);
  ...
},
onToolProgress: (tool) => {
  event.sender.send("chat-tool-progress", tool);
},
onUsage: (usage) => {
  event.sender.send("chat-usage", usage);
},
```

## Repro

1. Send a prompt that streams a long-ish response (anything ≥ a second of generation works).
2. Close the chat window — or reload it with ⌘R / Ctrl+R — before generation finishes.
3. Next chunk hits the destroyed sender, Electron throws `Error: Object has been destroyed`.

The throw escapes the streaming callback. The IPC handler crashes. The awaiting `promise` never resolves or rejects (leaks). And worse: nothing aborts the in-flight generation, so we keep paying upstream tokens for a chat with no listener.

## Fix

Wrap every send in a `safeSend()` helper that:
1. Pre-checks `event.sender.isDestroyed()`.
2. try/catches the `send()` call as belt-and-braces (the renderer can die between the check and the send).
3. Returns `false` when the renderer is gone so callers can react.

For `onChunk` specifically, a `false` return now triggers `currentChatAbort()` — first chunk that fails to deliver tears down the upstream generation. The other callbacks just stop emitting; `onDone` / `onError` still resolve/reject the local promise so the handler unwinds.

```ts
const safeSend = (channel: string, payload: unknown): boolean => {
  if (event.sender.isDestroyed()) return false;
  try {
    event.sender.send(channel, payload);
    return true;
  } catch {
    return false;
  }
};
```

## Verification
- `npm run typecheck` passes
- No behaviour change when the sender is alive — every previous send-then-side-effect order is preserved
- Manual: open Hermes, send "explain quicksort in 500 words", close the window 2s in. Before this fix the main-process console logs `Object has been destroyed`; after, nothing
