### PR TITLE
feat(chat): queue follow-up messages typed while the agent is busy

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1657,6 +1657,29 @@ body {
   background: #dc2626;
 }
 
+/* Send button shown while the agent is busy — queues a follow-up rather
+   than sending immediately, so it reads as secondary, not a primary send. */
+.chat-queue-btn {
+  background: transparent;
+  border: 1px solid var(--accent);
+  color: var(--accent);
+}
+
+.chat-queue-btn:hover:not(:disabled) {
+  background: var(--accent);
+  color: #fff;
+}
+
+/* "N queued for next turn" hint above the input. */
+.chat-queue-indicator {
+  font-size: 12px;
+  color: var(--text-secondary);
+  padding: 4px 10px;
+  margin-bottom: 6px;
+  background: var(--accent-subtle);
+  border-radius: var(--radius-md);
+}
+
 .chat-btw-btn {
   width: 34px;
   height: 34px;

--- a/src/renderer/src/screens/Chat/Chat.tsx
+++ b/src/renderer/src/screens/Chat/Chat.tsx
@@ -12,8 +12,14 @@ import { useFastMode } from "./hooks/useFastMode";
 import { useLocalCommands } from "./hooks/useLocalCommands";
 import { useI18n } from "../../components/useI18n";
 import type { ChatMessage, UsageState } from "./types";
+import type { Attachment } from "../../../../shared/attachments";
 
 export type { ChatMessage } from "./types";
+
+interface QueuedMessage {
+  text: string;
+  attachments: Attachment[];
+}
 
 interface ChatProps {
   messages: ChatMessage[];
@@ -41,6 +47,23 @@ function Chat({
   const [remoteMode, setRemoteMode] = useState(false);
   const dragCounter = useRef(0);
   const chatInputRef = useRef<ChatInputHandle>(null);
+  // Follow-up messages typed while the agent is busy. They send automatically,
+  // one per turn, once the current turn finishes.
+  const queueRef = useRef<QueuedMessage[]>([]);
+  const [queuedCount, setQueuedCount] = useState(0);
+
+  const handleEnqueue = useCallback(
+    (text: string, attachments: Attachment[]) => {
+      queueRef.current.push({ text, attachments });
+      setQueuedCount(queueRef.current.length);
+    },
+    [],
+  );
+
+  const clearQueue = useCallback(() => {
+    queueRef.current = [];
+    setQueuedCount(0);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -115,7 +138,8 @@ function Chat({
     setHermesSessionId(null);
     setUsage(null);
     setToolProgress(null);
-  }, [isLoading, hermesSessionId, sessionId, setMessages]);
+    clearQueue();
+  }, [isLoading, hermesSessionId, sessionId, setMessages, clearQueue]);
 
   const localCommands = useLocalCommands({
     profile,
@@ -137,6 +161,23 @@ function Chat({
     chatInputRef,
     localCommands,
   });
+  const { handleSend } = actions;
+
+  // Drain the follow-up queue: once a turn finishes, send the next queued
+  // message as a fresh turn. One item per completion; the chain continues
+  // until the queue empties.
+  useEffect(() => {
+    if (isLoading || queueRef.current.length === 0) return;
+    const next = queueRef.current.shift();
+    setQueuedCount(queueRef.current.length);
+    if (next) void handleSend(next.text, next.attachments);
+  }, [isLoading, handleSend]);
+
+  // Stop = stop everything: abort the current turn and drop queued follow-ups.
+  function handleAbort(): void {
+    clearQueue();
+    actions.handleAbort();
+  }
 
   const handleSuggestion = useCallback((text: string) => {
     chatInputRef.current?.setText(text);
@@ -231,9 +272,11 @@ function Chat({
           hasSession={!!hermesSessionId}
           sessionId={hermesSessionId}
           remoteMode={remoteMode}
+          queuedCount={queuedCount}
           onSubmit={actions.handleSend}
+          onEnqueue={handleEnqueue}
           onQuickAsk={actions.handleQuickAsk}
-          onAbort={actions.handleAbort}
+          onAbort={handleAbort}
         />
         <ModelPicker
           currentModel={modelConfig.currentModel}

--- a/src/renderer/src/screens/Chat/ChatInput.tsx
+++ b/src/renderer/src/screens/Chat/ChatInput.tsx
@@ -33,7 +33,11 @@ interface ChatInputProps {
   hasSession: boolean;
   sessionId?: string | null;
   remoteMode?: boolean;
+  /** Number of messages waiting to send after the current turn finishes. */
+  queuedCount?: number;
   onSubmit: (text: string, attachments: Attachment[]) => void;
+  /** Called instead of onSubmit when the agent is busy — queues a follow-up. */
+  onEnqueue: (text: string, attachments: Attachment[]) => void;
   onQuickAsk: (text: string, attachments: Attachment[]) => void;
   onAbort: () => void;
 }
@@ -45,7 +49,9 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
       hasSession,
       sessionId,
       remoteMode,
+      queuedCount = 0,
       onSubmit,
+      onEnqueue,
       onQuickAsk,
       onAbort,
     },
@@ -210,11 +216,17 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
     function handleSend(): void {
       const text = input.trim();
       const hasPayload = text.length > 0 || attachments.length > 0;
-      if (!hasPayload || isLoading) return;
+      if (!hasPayload) return;
       setSlashMenuOpen(false);
       const sendAttachments = attachments;
       clearAfterSend(text);
-      onSubmit(text, sendAttachments);
+      // While the agent is busy, queue the message instead of dropping it —
+      // it sends automatically once the current turn finishes.
+      if (isLoading) {
+        onEnqueue(text, sendAttachments);
+      } else {
+        onSubmit(text, sendAttachments);
+      }
     }
 
     function handleQuickAsk(): void {
@@ -382,6 +394,11 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
             )}
           </div>
         )}
+        {queuedCount > 0 && (
+          <div className="chat-queue-indicator" role="status">
+            {t("chat.queued", { count: queuedCount })}
+          </div>
+        )}
         <div className="chat-input-wrapper">
           <input
             ref={fileInputRef}
@@ -412,13 +429,26 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
             autoFocus
           />
           {isLoading ? (
-            <button
-              className="chat-send-btn chat-stop-btn"
-              onClick={onAbort}
-              title={t("common.stop")}
-            >
-              <Stop size={14} />
-            </button>
+            <>
+              {(input.trim().length > 0 || attachments.length > 0) && (
+                <button
+                  className="chat-send-btn chat-queue-btn"
+                  onClick={handleSend}
+                  title={t("chat.queueForNext")}
+                  aria-label={t("chat.queueForNext")}
+                  type="button"
+                >
+                  <Send size={16} />
+                </button>
+              )}
+              <button
+                className="chat-send-btn chat-stop-btn"
+                onClick={onAbort}
+                title={t("common.stop")}
+              >
+                <Stop size={14} />
+              </button>
+            </>
           ) : (
             <>
               {input.trim() && hasSession && (

--- a/src/shared/i18n/locales/en/chat.ts
+++ b/src/shared/i18n/locales/en/chat.ts
@@ -8,6 +8,8 @@ export default {
   quickAskTitle:
     "Quick Ask (/btw) — side question that won't affect conversation context",
   send: "Send",
+  queueForNext: "Queue — sends after the current turn finishes",
+  queued: "{{count}} queued for next turn",
   custom: "Custom",
   typeModelName: "Type model name...",
   emptyTitle: "How can I help you today?",

--- a/src/shared/i18n/locales/ja/chat.ts
+++ b/src/shared/i18n/locales/ja/chat.ts
@@ -7,6 +7,8 @@ export default {
   typeMessage: "メッセージを入力...（Shift+Enter で改行）",
   quickAskTitle: "Quick Ask (/btw) — 会話コンテキストに影響しないサイド質問",
   send: "送信",
+  queueForNext: "キューに追加 — 現在のターン完了後に送信",
+  queued: "{{count}} 件キュー中",
   custom: "カスタム",
   typeModelName: "モデル名を入力...",
   emptyTitle: "今日はどんなお手伝いを？",


### PR DESCRIPTION
## Problem

While a turn is in flight, the chat input drops anything you submit — `handleSend` early-returns on `isLoading`, so pressing Enter mid-run does nothing. There is no way to line up a follow-up; you have to wait for the agent to finish before you can type your next instruction.

## What this does

Adds a **client-side follow-up queue**:

- **`ChatInput`** stays usable while the agent runs. Enter / the send button now **enqueue** the message instead of dropping it. While busy, the send button renders as a secondary (outlined) "queue" button next to Stop, with a `Queue — sends after the current turn finishes` tooltip.
- **`Chat`** drains the queue one item per turn: when a turn finishes, the next queued message sends automatically as a fresh turn. Multiple follow-ups chain until the queue empties.
- A **`{n} queued for next turn`** indicator above the input shows pending follow-ups.
- **Stop** (abort) clears the queue — stop means stop everything.
- **New chat / clear** also clears the queue.

The queue lives entirely in the renderer. No gateway, IPC, or protocol changes — it works in both local and remote modes.

## Why client-side

The desktop app talks to the agent over the stateless OpenAI-compatible `/v1/chat/completions` endpoint, which has no mid-run steering primitive. A renderer-side queue delivers the "type your next prompt while it works" UX without needing a new transport. Delivery is next-turn rather than mid-stream injection.

## Notes

- New i18n keys (`chat.queueForNext`, `chat.queued`) added to `en` and `ja`; other locales fall back to `en`.
- `chat.queued` uses i18next `{{count}}` interpolation.

## Testing

- `npm run typecheck` — pass
- `npm run lint` — no new errors/warnings from these changes
- `npm test` — 488 passed / 3 skipped, 39 files
- `npm run build:mac` — packages cleanly
