### PR TITLE
Kanban: surface real SSH errors instead of a misleading "unsupported mode" screen (refs #319)

### DIFF
--- a/src/main/kanban.ts
+++ b/src/main/kanban.ts
@@ -87,6 +87,14 @@ export interface KanbanResult<T = unknown> {
   data?: T;
   error?: string;
   stdout?: string;
+  /**
+   * Set only when the failure is the connection mode genuinely not
+   * supporting Kanban (plain remote HTTP). The renderer keys its
+   * "switch modes" screen off this flag — never off the error text —
+   * so a real SSH-Kanban failure surfaces its actual error instead of
+   * being mislabelled as a mode problem (issue #319).
+   */
+  unsupportedMode?: boolean;
 }
 
 const KANBAN_TIMEOUT_MS = 20000;
@@ -152,9 +160,10 @@ async function runKanban(
   });
 }
 
-function unsupportedInRemote<T>(): KanbanResult<T> {
+export function unsupportedInRemote<T>(): KanbanResult<T> {
   return {
     success: false,
+    unsupportedMode: true,
     error:
       "Kanban requires either a local Hermes install or SSH tunnel mode. " +
       "Plain remote (HTTP+API key) mode does not yet expose the kanban API. " +

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -546,7 +546,12 @@ interface HermesAPI {
   kanbanListBoards: (
     includeArchived?: boolean,
     profile?: string,
-  ) => Promise<{ success: boolean; data?: KanbanBoard[]; error?: string }>;
+  ) => Promise<{
+    success: boolean;
+    data?: KanbanBoard[];
+    error?: string;
+    unsupportedMode?: boolean;
+  }>;
   kanbanCurrentBoard: (
     profile?: string,
   ) => Promise<{ success: boolean; data?: string; error?: string }>;

--- a/src/renderer/src/screens/Kanban/Kanban.tsx
+++ b/src/renderer/src/screens/Kanban/Kanban.tsx
@@ -162,10 +162,12 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
           }),
         ]);
         if (!boardsRes.success) {
-          if (
-            boardsRes.error &&
-            boardsRes.error.toLowerCase().includes("remote")
-          ) {
+          // Only the genuine unsupported-mode result (plain remote HTTP)
+          // flips the "switch modes" screen. A real SSH-Kanban failure
+          // must surface its actual error rather than be mislabelled as a
+          // mode problem — its message can contain the word "remote"
+          // without the mode being unsupported (issue #319).
+          if (boardsRes.unsupportedMode) {
             setRemoteUnsupported(true);
             return;
           }

--- a/tests/kanban-unsupported.test.ts
+++ b/tests/kanban-unsupported.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { unsupportedInRemote } from "../src/main/kanban";
+
+// The Kanban screen must distinguish "this connection mode genuinely
+// doesn't support Kanban" from an operational failure (issue #319).
+// Only `unsupportedInRemote()` carries the `unsupportedMode` flag; the
+// renderer keys its "switch modes" screen off the flag, never off the
+// error text — so an SSH-Kanban failure whose message happens to contain
+// "remote" is no longer mislabelled as a mode problem.
+describe("unsupportedInRemote (issue #319)", () => {
+  it("flags the result as an unsupported connection mode", () => {
+    const res = unsupportedInRemote();
+    expect(res.success).toBe(false);
+    expect(res.unsupportedMode).toBe(true);
+    expect(res.error).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Refs #319 — *"Kanban can't be used, I'm already in SSH tunnel mode."*

## Diagnosis

The reporter is in SSH tunnel mode and sees Kanban's *"requires a local Hermes install or SSH tunnel mode"* screen — which lists SSH tunnel mode as **supported**. A contradiction.

Tracing it:

- **SSH-Kanban is wired correctly.** `kanban.ts`'s internal `runKanban()` routes through `sshRunKanban` when `mode === "ssh"`, and `isRemoteOnlyMode()` returns true *only* for plain remote HTTP (`mode === "remote"`) — not SSH. So SSH-Kanban is not "unsupported".
- **The defect is the renderer's classification.** `Kanban.tsx` decided whether to show the "switch modes" screen with `boardsRes.error.toLowerCase().includes("remote")` — a substring match. But `sshRunKanban`'s *own failure* messages contain the word "remote" (`"Remote kanban command failed"`, `"Failed to parse JSON from remote 'hermes kanban'"`). So **any genuine SSH-Kanban failure was mislabelled as an unsupported mode** — and the real error was discarded and replaced with the nonsensical "switch to SSH tunnel mode" message.

## The fix

Replace the substring heuristic with a **structured signal**: `KanbanResult` carries an `unsupportedMode` flag, set *only* by `unsupportedInRemote()` (the genuine plain-remote case). The renderer flips its "switch modes" screen off that flag, and shows the **actual error** for anything else.

## Honest scope

This fixes the **mislabelling** — #319's visible symptom. It does **not** fix whatever makes the reporter's SSH-Kanban command fail underneath; that failure is environment-specific. But it was *invisible* before — this PR makes it surface, which is the prerequisite to diagnosing it. Once this ships, the reporter will see the real error.

One plausible lead, if the surfaced error turns out to be "hermes CLI not found on the remote": that's #284 — already fixed by #305 (`buildRemoteHermesCmd` venv probe). This PR deliberately doesn't touch that.

## Test plan

- [x] `npm run typecheck` clean
- [x] Full suite — 489 passed / 3 skipped; new `tests/kanban-unsupported.test.ts` locks the `unsupportedMode` flag contract
- [x] Reviewed: `unsupportedInRemote()` is the only producer of the flag; ordinary `{success:false, error}` returns do not set it

🤖 Generated with [Claude Code](https://claude.com/claude-code)