### PR TITLE
Sessions: read the active profile's state.db, not the root one (refs #311)

### DIFF
--- a/src/main/session-cache.ts
+++ b/src/main/session-cache.ts
@@ -1,14 +1,28 @@
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
-import { HERMES_HOME } from "./installer";
-import { safeWriteFile } from "./utils";
+import {
+  profileHome,
+  getActiveProfileNameSync,
+  activeStateDbPath,
+  safeWriteFile,
+} from "./utils";
 import Database from "better-sqlite3";
 import { t } from "../shared/i18n";
 import { getAppLocale } from "./locale";
 
-const CACHE_DIR = join(HERMES_HOME, "desktop");
-const CACHE_FILE = join(CACHE_DIR, "sessions.json");
-const DB_PATH = join(HERMES_HOME, "state.db");
+/**
+ * The session cache lives alongside its own profile's data so profiles
+ * don't share a single cache file. The default profile keeps
+ * ~/.hermes/desktop/sessions.json; named profiles use
+ * ~/.hermes/profiles/<name>/desktop/sessions.json (issue #311).
+ */
+function cacheFilePath(): string {
+  return join(
+    profileHome(getActiveProfileNameSync()),
+    "desktop",
+    "sessions.json",
+  );
+}
 
 export interface CachedSession {
   id: string;
@@ -56,9 +70,10 @@ function generateTitle(message: string): string {
 }
 
 function readCache(): CacheData {
+  const file = cacheFilePath();
   try {
-    if (!existsSync(CACHE_FILE)) return { sessions: [], lastSync: 0 };
-    return JSON.parse(readFileSync(CACHE_FILE, "utf-8"));
+    if (!existsSync(file)) return { sessions: [], lastSync: 0 };
+    return JSON.parse(readFileSync(file, "utf-8"));
   } catch {
     return { sessions: [], lastSync: 0 };
   }
@@ -66,15 +81,16 @@ function readCache(): CacheData {
 
 function writeCache(data: CacheData): void {
   try {
-    safeWriteFile(CACHE_FILE, JSON.stringify(data));
+    safeWriteFile(cacheFilePath(), JSON.stringify(data));
   } catch {
     // non-fatal
   }
 }
 
 function getDb(): Database.Database | null {
-  if (!existsSync(DB_PATH)) return null;
-  return new Database(DB_PATH, { readonly: true });
+  const dbPath = activeStateDbPath();
+  if (!existsSync(dbPath)) return null;
+  return new Database(dbPath, { readonly: true });
 }
 
 // Sync from hermes DB to local cache — only fetches new/updated sessions

--- a/src/main/sessions.ts
+++ b/src/main/sessions.ts
@@ -1,12 +1,9 @@
 import Database from "better-sqlite3";
-import { join } from "path";
 import { existsSync } from "fs";
-import { HERMES_HOME } from "./installer";
+import { activeStateDbPath } from "./utils";
 import type { Attachment } from "../shared/attachments";
 import { isImageMime } from "../shared/attachments";
 import { removeSessionFromCache } from "./session-cache";
-
-const DB_PATH = join(HERMES_HOME, "state.db");
 
 // Sentinel prefix used by hermes-agent's hermes_state.py to mark
 // JSON-encoded multimodal content in the messages.content column.
@@ -122,8 +119,11 @@ export interface SearchResult {
 }
 
 function getDb(readonly = true): Database.Database | null {
-  if (!existsSync(DB_PATH)) return null;
-  return new Database(DB_PATH, readonly ? { readonly: true } : {});
+  // Open the active profile's session DB — named profiles keep their
+  // sessions under ~/.hermes/profiles/<name>/state.db (issue #311).
+  const dbPath = activeStateDbPath();
+  if (!existsSync(dbPath)) return null;
+  return new Database(dbPath, readonly ? { readonly: true } : {});
 }
 
 export function listSessions(limit = 30, offset = 0): SessionSummary[] {

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -166,6 +166,17 @@ export function getActiveProfileNameSync(): string {
 }
 
 /**
+ * Resolve the session database for the currently active profile. The
+ * default profile uses ~/.hermes/state.db; named profiles use
+ * ~/.hermes/profiles/<name>/state.db. The desktop's Sessions feature
+ * used to read the root state.db unconditionally, so named-profile users
+ * saw an empty or wrong session list (issue #311).
+ */
+export function activeStateDbPath(): string {
+  return join(profileHome(getActiveProfileNameSync()), "state.db");
+}
+
+/**
  * Escape special regex characters in a string so it can be
  * safely interpolated into a RegExp constructor.
  */

--- a/tests/profile-validation.test.ts
+++ b/tests/profile-validation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { join } from "path";
+import { mkdirSync, writeFileSync } from "fs";
 
 const { TEST_HOME } = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -23,6 +24,7 @@ import {
   isValidProfileName,
   normalizeProfileName,
   profileHome,
+  activeStateDbPath,
   PROFILE_NAME_ERROR,
 } from "../src/main/utils";
 
@@ -62,5 +64,16 @@ describe("profile name validation", () => {
       join(TEST_HOME, "profiles", "work_1-prod"),
     );
     expect(() => profileHome("../outside")).toThrow(PROFILE_NAME_ERROR);
+  });
+
+  it("resolves the active profile's session DB path (issue #311)", () => {
+    mkdirSync(TEST_HOME, { recursive: true });
+    // No active_profile file → default profile → root state.db.
+    expect(activeStateDbPath()).toBe(join(TEST_HOME, "state.db"));
+    // Named active profile → profiles/<name>/state.db, not the root db.
+    writeFileSync(join(TEST_HOME, "active_profile"), "work_1-prod");
+    expect(activeStateDbPath()).toBe(
+      join(TEST_HOME, "profiles", "work_1-prod", "state.db"),
+    );
   });
 });


### PR DESCRIPTION
Addresses the **Sessions-tab facet of #311** (the reporter's hypothesis #2 — confirmed against the code).

## The bug

`sessions.ts` and `session-cache.ts` both hardcoded the database path:

```ts
const DB_PATH = join(HERMES_HOME, "state.db");   // root db, always
```

No profile awareness — `listSessions`, `searchSessions`, `getSessionMessages`, `deleteSession`, and the cache sync all opened `HERMES_HOME/state.db`. But a non-default profile keeps its sessions under `HERMES_HOME/profiles/<name>/state.db`. So on any named profile the Sessions tab showed the **default** profile's sessions — or an empty list when the root db doesn't exist at all (exactly the reporter's Windows case: 7 profiles, none `default`).

## The fix

- New shared helper `activeStateDbPath()` in `utils.ts` — `profileHome(getActiveProfileNameSync()) + "state.db"`. `sessions.ts` and `session-cache.ts` both resolve their db through it.
- The session **cache file** is moved per-profile too — `profiles/<name>/desktop/sessions.json` — so the fast-path cached list no longer mixes profiles.
- The **default** profile keeps its existing root paths (`profileHome("default") === HERMES_HOME`), so this is backward compatible — existing installs are unaffected.

No IPC / preload / renderer changes: the Sessions screen is already fully main-side-driven, so internal active-profile resolution (the same pattern `checkInstallStatus` / `getModelConfig` already use) is sufficient.

## Scope

This fixes the **Sessions feature reading the wrong db**. It does **not** fix #311's headline chat/session *bleed on profile switch* — that's caused by the gateway being profile-blind (`NousResearch/hermes-agent#29535`, upstream) and is out of scope here.

The `profiles/<name>/state.db` layout was also confirmed against hermes-agent's source: `SessionDB` resolves its path as `get_hermes_home() / "state.db"` (`acp_adapter/session.py`, `hermes_cli/doctor.py`), and a named profile's `HERMES_HOME` is `<root>/profiles/<name>` (`hermes_constants.py`, `AGENTS.md`).

## Test plan

- [x] `npm run typecheck` clean
- [x] New test in `tests/profile-validation.test.ts` — `activeStateDbPath()` resolves the root db for `default` and `profiles/<name>/state.db` for a named profile
- [x] Full suite: 488 passed / 3 skipped + 1 unrelated pre-existing flake — `locale-persistence.test.ts` "main process restarts" times out at 5s under full-suite load; **verified it fails identically on clean `main` with these changes stashed** (it passes in isolation). Not caused by this PR.

### Functional verification (real Electron runtime, real `better-sqlite3`)

The actual `sessions.ts` / `session-cache.ts` / `utils.ts` modules were exercised inside the Electron runtime against real on-disk dbs. Fixture: `profiles/work/state.db` = a WAL-safe clone of the real root db (21 sessions) **plus one sentinel session present only in the work-profile db**, so the result unambiguously shows which db was opened.

| Scenario | `activeStateDbPath()` | `listSessions()` | Sentinel | `getSessionMessages` | FTS search |
|---|---|---|---|---|---|
| No `active_profile` (default) | root `state.db` | 21 | not found ✓ | 0 ✓ | 0 hits ✓ |
| `active_profile=work` | `profiles/work/state.db` | **22** | **found** ✓ | **2 msgs** ✓ | **2 hits** ✓ |
| `active_profile` removed (regression) | root `state.db` | 21 | not found ✓ | 0 ✓ | 0 hits ✓ |

The per-profile session cache landed at `profiles/work/desktop/sessions.json` (with the sentinel); the default-profile cache did **not** pick it up — confirming caches stay isolated per profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)