### PR TITLE
Sessions: auto-refresh the tab while it stays open (refs #322)

### DIFF
--- a/src/renderer/src/screens/Sessions/Sessions.test.tsx
+++ b/src/renderer/src/screens/Sessions/Sessions.test.tsx
@@ -1,0 +1,103 @@
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// useI18n needs an I18nProvider; the Sessions tab only uses `t` for labels,
+// so a pass-through mock keeps these tests focused on the refresh behaviour.
+vi.mock("../../components/useI18n", () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+    locale: "en",
+    setLocale: () => {},
+  }),
+}));
+
+import Sessions, { SESSIONS_REFRESH_MS } from "./Sessions";
+
+const baseProps = {
+  onResumeSession: (): void => {},
+  onNewChat: (): void => {},
+  currentSessionId: null,
+};
+
+function installHermesAPI(): {
+  listCachedSessions: ReturnType<typeof vi.fn>;
+  syncSessionCache: ReturnType<typeof vi.fn>;
+  searchSessions: ReturnType<typeof vi.fn>;
+} {
+  const api = {
+    listCachedSessions: vi.fn().mockResolvedValue([]),
+    syncSessionCache: vi.fn().mockResolvedValue([]),
+    searchSessions: vi.fn().mockResolvedValue([]),
+  };
+  Object.defineProperty(window, "hermesAPI", { configurable: true, value: api });
+  return api;
+}
+
+describe("Sessions tab live refresh (#322)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("re-syncs from state.db on an interval while the tab is visible", async () => {
+    const api = installHermesAPI();
+    render(<Sessions {...baseProps} visible={true} />);
+    await act(async () => {});
+
+    const afterMount = api.syncSessionCache.mock.calls.length;
+    expect(afterMount).toBeGreaterThan(0);
+
+    await act(async () => {
+      vi.advanceTimersByTime(SESSIONS_REFRESH_MS);
+    });
+    expect(api.syncSessionCache.mock.calls.length).toBe(afterMount + 1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(SESSIONS_REFRESH_MS);
+    });
+    expect(api.syncSessionCache.mock.calls.length).toBe(afterMount + 2);
+  });
+
+  it("runs no timer while the tab is hidden", async () => {
+    const api = installHermesAPI();
+    render(<Sessions {...baseProps} visible={false} />);
+    await act(async () => {});
+
+    const afterMount = api.syncSessionCache.mock.calls.length;
+    await act(async () => {
+      vi.advanceTimersByTime(SESSIONS_REFRESH_MS * 5);
+    });
+    expect(api.syncSessionCache.mock.calls.length).toBe(afterMount);
+  });
+
+  it("stops the timer once the tab becomes hidden", async () => {
+    const api = installHermesAPI();
+    const view = render(<Sessions {...baseProps} visible={true} />);
+    await act(async () => {});
+
+    await act(async () => {
+      view.rerender(<Sessions {...baseProps} visible={false} />);
+    });
+    const afterHide = api.syncSessionCache.mock.calls.length;
+
+    await act(async () => {
+      vi.advanceTimersByTime(SESSIONS_REFRESH_MS * 3);
+    });
+    expect(api.syncSessionCache.mock.calls.length).toBe(afterHide);
+  });
+
+  it("refreshes when the window regains focus", async () => {
+    const api = installHermesAPI();
+    render(<Sessions {...baseProps} visible={true} />);
+    await act(async () => {});
+
+    const afterMount = api.syncSessionCache.mock.calls.length;
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    expect(api.syncSessionCache.mock.calls.length).toBe(afterMount + 1);
+  });
+});

--- a/src/renderer/src/screens/Sessions/Sessions.tsx
+++ b/src/renderer/src/screens/Sessions/Sessions.tsx
@@ -148,6 +148,11 @@ const SessionCard = memo(function SessionCard({
   );
 });
 
+// How often the Sessions tab re-syncs from state.db while it is open, so
+// sessions created in the background (cron jobs, gateway platforms, another
+// device) surface without the user navigating away and back. (refs #322)
+export const SESSIONS_REFRESH_MS = 30_000;
+
 function Sessions({
   onResumeSession,
   onNewChat,
@@ -163,6 +168,13 @@ function Sessions({
   const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const searchRef = useRef<HTMLInputElement>(null);
 
+  // Quiet re-sync from state.db — refreshes the list WITHOUT flipping the
+  // loading state, so it can run on a timer or on focus with no spinner flash.
+  const refreshSessions = useCallback(async (): Promise<void> => {
+    const synced = await window.hermesAPI.syncSessionCache();
+    setSessions(synced.slice(0, 50));
+  }, []);
+
   const loadSessions = useCallback(async (): Promise<void> => {
     setLoading(true);
     const cached = await window.hermesAPI.listCachedSessions(50);
@@ -170,10 +182,9 @@ function Sessions({
       setSessions(cached);
       setLoading(false);
     }
-    const synced = await window.hermesAPI.syncSessionCache();
-    setSessions(synced.slice(0, 50));
+    await refreshSessions();
     setLoading(false);
-  }, []);
+  }, [refreshSessions]);
 
   useEffect(() => {
     loadSessions();
@@ -188,6 +199,26 @@ function Sessions({
       loadSessions();
     }
   }, [visible, loadSessions]);
+
+  // While the Sessions tab is actually showing, periodically re-sync so
+  // sessions created in the background — cron jobs, gateway platforms, or
+  // another device writing the same state.db — surface even if the user
+  // just leaves this tab open. Also refresh when the window regains focus.
+  // Gated on `visible`: no timer and no DB reads while another screen shows.
+  useEffect(() => {
+    if (!visible) return;
+    const timer = setInterval(() => {
+      void refreshSessions();
+    }, SESSIONS_REFRESH_MS);
+    const onFocus = (): void => {
+      void refreshSessions();
+    };
+    window.addEventListener("focus", onFocus);
+    return () => {
+      clearInterval(timer);
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [visible, refreshSessions]);
 
   useEffect(() => {
     if (searchTimer.current) clearTimeout(searchTimer.current);


### PR DESCRIPTION
Addresses the genuine part of #322.

## The report vs. the code

#322 reports "stale sessions shown for days" because `syncSessionCache()` is only called when the Sessions page mounts. The first half is accurate; the headline isn't:

`Sessions.tsx`'s `loadSessions()` runs both on mount **and on every becomes-visible transition**, and `syncSessionCache()` reads `state.db` directly (the cache file is just a fast first-paint buffer, not the source of truth). So you can't see stale data "for days" — *arriving* at the Sessions tab always triggers a fresh DB sync.

The **real** gap is narrower: if the user simply **leaves the Sessions tab open**, sessions created in the background — cron jobs, gateway platforms (Telegram/API), or another device writing the same `state.db` — won't appear, because nothing re-syncs until the next navigation.

## The fix

- New quiet `refreshSessions()` — re-syncs from `state.db` **without** flipping the loading state, so it can run unattended with no spinner flash. `loadSessions()` now delegates its DB sync to it.
- While the tab is `visible`: a 30s interval + a `window` `focus` listener call `refreshSessions()`.
- Both are **gated on `visible`** — no timer, no DB reads while another screen is showing.

This deliberately avoids the always-on **main-process** `setInterval` the issue proposed: that would query `state.db` forever even when the Sessions tab is never opened, for no benefit (the next open syncs anyway). Scoping the refresh to when the tab is actually shown gives the same result at zero idle cost.

## Test plan

- [x] `npm run typecheck` clean
- [x] New `src/renderer/src/screens/Sessions/Sessions.test.tsx` (4 cases): interval re-syncs while visible; no timer while hidden; timer stops when the tab becomes hidden; window focus refreshes.
- [x] Full suite: 492 passed / 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)