### PR TITLE
Skills: surface install failures when the CLI exits 0 silently (closes #310)

### DIFF
--- a/src/main/skills.ts
+++ b/src/main/skills.ts
@@ -235,17 +235,75 @@ export function listBundledSkills(): SkillSearchResult[] {
   );
 }
 
+/**
+ * Failure markers seen in `hermes skills install/uninstall` stdout when the
+ * CLI exits 0 despite the operation having failed. Observed live against
+ * Hermes Agent v0.14.0 (2026.5.16) on 2026-05-22:
+ *
+ *   $ hermes skills install concept-diagram --yes
+ *   Resolving 'concept-diagram'...
+ *   No exact match for 'concept-diagram'. Did you mean one of these?
+ *     concept-diagrams - official/creative/concept-diagrams
+ *   $ echo $?    -> 0
+ *
+ * Without this classifier the desktop would trust the 0 exit and report
+ * a successful install, leaving the user with a button that flashed and
+ * did nothing (issue #310).
+ */
+const SKILL_CLI_FAILURE_MARKERS: readonly RegExp[] = [
+  /\bNo exact match for\b/,
+  /\bNo skill named\b/,
+  /^Error:/m,
+];
+
+export interface SkillCliResult {
+  success: boolean;
+  error?: string;
+}
+
+/**
+ * Classify the combined output of `hermes skills install/uninstall` after
+ * the subprocess has exited 0. The CLI exits 0 even on resolution failure
+ * (issue #310), so the exit code alone is not enough. When a known failure
+ * marker is present, surface the message (minus the leading
+ * "Resolving '...'" progress line) as `error` so the renderer can display
+ * it; otherwise treat the operation as successful.
+ *
+ * Pure — no I/O, no globals — so it is cheap to unit-test exhaustively.
+ */
+export function classifySkillCliOutput(
+  stdout: string,
+  stderr: string = "",
+): SkillCliResult {
+  const combined = `${stdout}\n${stderr}`;
+  if (SKILL_CLI_FAILURE_MARKERS.some((re) => re.test(combined))) {
+    return { success: false, error: extractSkillCliMessage(combined) };
+  }
+  return { success: true };
+}
+
+function extractSkillCliMessage(output: string): string {
+  // Strip the leading "Resolving '<name>'..." progress line — pure noise
+  // for the user. Keep the rest verbatim so suggestions like
+  // "Did you mean concept-diagrams" reach the renderer.
+  const lines = output
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0 && !/^Resolving '.*'\.\.\.$/.test(l));
+  return lines.join("\n").trim() || output.trim();
+}
+
 export function installSkill(
   identifier: string,
   profile?: string,
-): { success: boolean; error?: string } {
+): SkillCliResult {
   try {
     const args = hermesCliArgs(["skills", "install", identifier, "--yes"]);
     if (profile && profile !== "default") {
       args.splice(process.platform === "win32" ? 2 : 1, 0, "-p", profile);
     }
 
-    execFileSync(HERMES_PYTHON, args, {
+    const stdout = execFileSync(HERMES_PYTHON, args, {
       cwd: HERMES_REPO,
       env: {
         ...process.env,
@@ -257,25 +315,31 @@ export function installSkill(
       timeout: 60000,
       ...HIDDEN_SUBPROCESS_OPTIONS,
     });
-    return { success: true };
+    // Exit 0 alone is not proof of success — the CLI exits 0 on resolution
+    // failure too. Inspect the captured stdout for known failure markers
+    // (issue #310).
+    return classifySkillCliOutput(stdout?.toString() ?? "");
   } catch (err) {
-    const msg =
-      (err as { stderr?: Buffer }).stderr?.toString() || (err as Error).message;
-    return { success: false, error: msg.trim() };
+    const e = err as { stdout?: Buffer; stderr?: Buffer; message?: string };
+    const msg = (e.stderr?.toString() || e.message || "").trim();
+    return {
+      success: false,
+      error: msg || e.stdout?.toString().trim() || "Install failed.",
+    };
   }
 }
 
 export function uninstallSkill(
   name: string,
   profile?: string,
-): { success: boolean; error?: string } {
+): SkillCliResult {
   try {
     const args = hermesCliArgs(["skills", "uninstall", name]);
     if (profile && profile !== "default") {
       args.splice(process.platform === "win32" ? 2 : 1, 0, "-p", profile);
     }
 
-    execFileSync(HERMES_PYTHON, args, {
+    const stdout = execFileSync(HERMES_PYTHON, args, {
       cwd: HERMES_REPO,
       env: {
         ...process.env,
@@ -287,10 +351,15 @@ export function uninstallSkill(
       timeout: 30000,
       ...HIDDEN_SUBPROCESS_OPTIONS,
     });
-    return { success: true };
+    // Same exit-0-on-failure shape as install (#310) — classify the
+    // captured output before claiming success.
+    return classifySkillCliOutput(stdout?.toString() ?? "");
   } catch (err) {
-    const msg =
-      (err as { stderr?: Buffer }).stderr?.toString() || (err as Error).message;
-    return { success: false, error: msg.trim() };
+    const e = err as { stdout?: Buffer; stderr?: Buffer; message?: string };
+    const msg = (e.stderr?.toString() || e.message || "").trim();
+    return {
+      success: false,
+      error: msg || e.stdout?.toString().trim() || "Uninstall failed.",
+    };
   }
 }

--- a/src/renderer/src/screens/Skills/Skills.test.tsx
+++ b/src/renderer/src/screens/Skills/Skills.test.tsx
@@ -1,0 +1,141 @@
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// useI18n needs an I18nProvider; pass-through `t` keeps the test focused
+// on the install-click → IPC contract.
+vi.mock("../../components/useI18n", () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+    locale: "en",
+    setLocale: () => {},
+  }),
+}));
+
+// AgentMarkdown is only used in the (unrelated) detail panel.
+vi.mock("../../components/AgentMarkdown", () => ({
+  AgentMarkdown: ({ content }: { content: string }) => <pre>{content}</pre>,
+}));
+
+import Skills from "./Skills";
+
+describe("Skills.tsx — Install button (issue #310 diagnosis)", () => {
+  it("calls window.hermesAPI.installSkill(skill.name, profile) when Install is clicked on a Browse card", async () => {
+    const installSkill = vi.fn().mockResolvedValue({ success: true });
+    const listInstalledSkills = vi.fn().mockResolvedValue([]);
+    const listBundledSkills = vi.fn().mockResolvedValue([
+      {
+        name: "concept-diagram",
+        description: "draw diagrams",
+        category: "creative",
+        source: "bundled",
+        installed: false,
+      },
+    ]);
+    const getSkillContent = vi.fn().mockResolvedValue("");
+
+    Object.defineProperty(window, "hermesAPI", {
+      configurable: true,
+      value: {
+        installSkill,
+        listInstalledSkills,
+        listBundledSkills,
+        getSkillContent,
+      },
+    });
+
+    const view = render(<Skills />);
+
+    // Wait for both list-loads to resolve and the loading spinner to clear.
+    await waitFor(() => {
+      expect(listBundledSkills).toHaveBeenCalled();
+      expect(listInstalledSkills).toHaveBeenCalled();
+    });
+
+    // Default tab is "installed"; switch to Browse so the bundled card renders.
+    const tabs = view.container.querySelectorAll(".skills-tab");
+    const browseTab = tabs[1] as HTMLButtonElement;
+    expect(browseTab).toBeTruthy();
+    await act(async () => {
+      fireEvent.click(browseTab);
+    });
+
+    // Find the Install button on the bundled card.
+    let installBtn: HTMLButtonElement | null = null;
+    await waitFor(() => {
+      installBtn = view.container.querySelector(
+        ".skills-card-install-btn",
+      ) as HTMLButtonElement | null;
+      expect(installBtn).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.click(installBtn!);
+    });
+
+    // The proof: click reaches handleInstall, which calls the bridge method
+    // with the card's skill.name and the current profile (undefined here).
+    expect(installSkill).toHaveBeenCalledTimes(1);
+    expect(installSkill).toHaveBeenCalledWith("concept-diagram", undefined);
+  });
+
+  it("surfaces the CLI error in the UI when installSkill returns success:false (issue #310 fix)", async () => {
+    const cliMessage =
+      "No exact match for 'concept-diagram'. Did you mean one of these?\n" +
+      "concept-diagrams - official/creative/concept-diagrams";
+    const installSkill = vi
+      .fn()
+      .mockResolvedValue({ success: false, error: cliMessage });
+    const listInstalledSkills = vi.fn().mockResolvedValue([]);
+    const listBundledSkills = vi.fn().mockResolvedValue([
+      {
+        name: "concept-diagram",
+        description: "",
+        category: "creative",
+        source: "bundled",
+        installed: false,
+      },
+    ]);
+    const getSkillContent = vi.fn().mockResolvedValue("");
+
+    Object.defineProperty(window, "hermesAPI", {
+      configurable: true,
+      value: {
+        installSkill,
+        listInstalledSkills,
+        listBundledSkills,
+        getSkillContent,
+      },
+    });
+
+    const view = render(<Skills />);
+    await waitFor(() => expect(listBundledSkills).toHaveBeenCalled());
+
+    const browseTab = view.container.querySelectorAll(
+      ".skills-tab",
+    )[1] as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(browseTab);
+    });
+
+    let installBtn: HTMLButtonElement | null = null;
+    await waitFor(() => {
+      installBtn = view.container.querySelector(
+        ".skills-card-install-btn",
+      ) as HTMLButtonElement | null;
+      expect(installBtn).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.click(installBtn!);
+    });
+
+    // The CLI's failure message reaches the user via the .skills-error
+    // banner — no more "button flashed and nothing happened".
+    await waitFor(() => {
+      const banner = view.container.querySelector(".skills-error");
+      expect(banner).toBeTruthy();
+      expect(banner!.textContent).toContain("No exact match for");
+      expect(banner!.textContent).toContain("Did you mean");
+    });
+  });
+});

--- a/tests/skills-cli-output.test.ts
+++ b/tests/skills-cli-output.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { classifySkillCliOutput } from "../src/main/skills";
+
+/**
+ * Issue #310: `hermes skills install` exits 0 even when no skill was
+ * installed (resolution failure, unknown name, etc.) and prints the actual
+ * failure on stdout. Before this classifier the desktop trusted the 0 exit
+ * and reported `{success:true}` — leaving the user with a button that
+ * flashed and did nothing. These cases lock the classifier's behaviour
+ * against the CLI output captured live on 2026-05-22 (Hermes Agent
+ * v0.14.0).
+ */
+describe("classifySkillCliOutput", () => {
+  it("returns success on clean exit-0 output with no failure markers", () => {
+    expect(classifySkillCliOutput("Resolving 'demo'...\nInstalled.")).toEqual({
+      success: true,
+    });
+    expect(classifySkillCliOutput("")).toEqual({ success: true });
+  });
+
+  it("detects the ambiguous-short-name failure ('No exact match for ...')", () => {
+    const out =
+      "Resolving 'concept-diagram'...\n" +
+      "No exact match for 'concept-diagram'. Did you mean one of these?\n" +
+      "  concept-diagrams - official/creative/concept-diagrams\n";
+    const result = classifySkillCliOutput(out);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("No exact match for");
+    expect(result.error).toContain("Did you mean");
+    expect(result.error).toContain("concept-diagrams");
+    // The noisy "Resolving '...'..." progress line is stripped.
+    expect(result.error).not.toContain("Resolving");
+  });
+
+  it("detects the unknown-name failure ('Error: No skill named ... found')", () => {
+    const out =
+      "Resolving 'definitely-not-real'...\n" +
+      "Error: No skill named 'definitely-not-real' found in any source.\n";
+    const result = classifySkillCliOutput(out);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("No skill named");
+    expect(result.error).toContain("definitely-not-real");
+  });
+
+  it("treats a generic 'Error:' line as failure (defensive fallback)", () => {
+    const result = classifySkillCliOutput("Error: something else went wrong\n");
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("something else went wrong");
+  });
+
+  it("classifies failure markers on stderr too", () => {
+    const result = classifySkillCliOutput(
+      "",
+      "Error: stderr-only failure path\n",
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("stderr-only failure path");
+  });
+
+  it("does not false-flag a clean Resolving progress line as failure", () => {
+    expect(classifySkillCliOutput("Resolving 'x'...")).toEqual({
+      success: true,
+    });
+    expect(classifySkillCliOutput("Resolving 'x'...\nInstalled x.")).toEqual({
+      success: true,
+    });
+  });
+
+  it("falls back to the raw output if every line gets filtered as noise", () => {
+    // Pathological input: only the Resolving line is present and it
+    // contains a failure marker — extractSkillCliMessage's filter would
+    // otherwise produce an empty string.
+    const result = classifySkillCliOutput("Error:");
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Error:");
+  });
+});


### PR DESCRIPTION
Closes #310.

## TL;DR

`hermes skills install` exits 0 even when the resolver fails to find a matching skill — the actual failure is on stdout. The desktop's `installSkill` was trusting the exit code as the success signal, so failed installs returned `{success: true}`, the renderer skipped the error path, and the user saw a button that flashed and did nothing. This PR captures and classifies the CLI output so failures reach the user.

## Diagnosis — what's real vs. what isn't

The reporter ran detailed CDP instrumentation and concluded the click handler never reaches the `installSkill` IPC. Verified against the actual source and the running app — that conclusion is **incorrect** and is a measurement artifact:

- **`contextBridge` freezes the exposed bridge.** The preload uses `contextBridge.exposeInMainWorld("hermesAPI", ...)` and the main window has `contextIsolation:true, sandbox:true, nodeIntegration:false` — standard Electron hardening that deep-freezes the bridge object. The reporter's "Round 3" monkey-patch (`window.hermesAPI.X = wrapped`) was silently rejected, so their probe stayed empty regardless of whether the IPC fired. New `Skills.test.tsx` deterministically proves the click DOES reach `window.hermesAPI.installSkill(skill.name, profile)`.
- **Fiber walk for `skill` prop (Round 5)** — `skill` is a closure variable in the onClick lambda, not a prop, so it wouldn't appear on `memoizedProps` of any ancestor.
- **The reporter's Round 6 IS the smoking gun**: calling `installSkill('UNKNOWN', null)` directly from the console returns `{success: true}`. That's the actual bug — exit-0 fooling the desktop — and it's what this PR fixes.

The CLI behaviour was verified live on this machine against Hermes Agent v0.14.0 (2026-05-22):

```
$ hermes skills install concept-diagram --yes
Resolving 'concept-diagram'...
No exact match for 'concept-diagram'. Did you mean one of these?
  concept-diagrams - official/creative/concept-diagrams
$ echo $?     -> 0

$ hermes skills install definitely-not-a-real-skill-zzz --yes
Resolving 'definitely-not-a-real-skill-zzz'...
Error: No skill named 'definitely-not-a-real-skill-zzz' found in any source.
$ echo $?     -> 0
```

Two distinct, repeatable failure modes — both exit 0.

## The fix

New pure helper in `src/main/skills.ts`:

```ts
export function classifySkillCliOutput(stdout, stderr = "")
  : { success: boolean; error?: string }
```

It inspects the captured output for known failure markers (`No exact match for`, `No skill named`, and a `^Error:` safety net), strips the noisy `Resolving '...'` progress line, and returns `{success: false, error: <relevant message>}` when one matches. Both `installSkill` and `uninstallSkill` now capture `execFileSync`'s return value (previously discarded) and route it through the classifier.

The renderer's existing `setError(result.error)` path then surfaces the message in the `.skills-error` banner — the user sees *exactly* the CLI's "Did you mean concept-diagrams?" suggestion instead of a button that flashed and did nothing.

## Out of scope

- **The CLI's exit-code behaviour.** The real fix is upstream — `hermes skills install` should exit non-zero on resolution failure (or emit machine-readable status). Filed as NousResearch/hermes-agent#30631 and now in flight as NousResearch/hermes-agent#30633; this PR does not depend on it (defence-in-depth on the bridge layer regardless).
- **A possible disambiguation issue** between `listBundledSkills`'s `name` (read from SKILL.md frontmatter) and the CLI's canonical identifier — observable as `concept-diagram` (frontmatter) vs `concept-diagrams` (canonical). Surfacing the error is the immediate need; identifier-form changes can follow.

## Test plan

- [x] `npm run typecheck` clean
- [x] **7 unit tests** for `classifySkillCliOutput` — both observed failure modes, `^Error:` fallback, stderr-side classification, clean-output success, pathological all-noise input, no false-positives on the `Resolving` progress line.
- [x] **2 `Skills.tsx` component tests** — (a) clicking Install reaches `installSkill(skill.name, profile)` (refutes the reporter's misdiagnosis); (b) when the bridge returns `{success:false, error:"..."}` the message appears in the `.skills-error` banner.
- [x] **Live E2E under Electron** against the REAL CLI: an Electron-runtime harness called the real `installSkill` with both an unknown name and an ambiguous short name. Both returned `{success:false, error: <useful message>}` including `Did you mean ...` suggestions, instead of the prior silent `{success:true}`. Harness was temporary; not part of the diff.
- [x] Full suite: 496 passed / 3 skipped + 1 unrelated pre-existing flake (`locale-persistence.test.ts` "main process restarts" — times out under full-suite load, passes in isolation; verified independent of this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
