### PR TITLE
Add SafeHouse Tool Bridge support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ sudo dnf install ./hermes-desktop-<version>.rpm
 - **Session management** — full-text search (SQLite FTS5), date-grouped history, resume and search across conversations
 - **Profile switching** — create, delete, and switch between separate Hermes environments with isolated config
 - **14 toolsets** — web, browser, terminal, file, code execution, vision, image gen, TTS, skills, memory, session search, clarify, delegation, MoA, and task planning
+- **SafeHouse Tool Bridge** — optional loopback-only SafeHouse Signal tool bridge support for approved local platform expert prompts
 - **Memory system** — view/edit memory entries, user profile memory, capacity tracking, and discoverable memory providers (Honcho, Hindsight, Mem0, RetainDB, Supermemory, ByteRover)
 - **Persona editor** — edit and reset your agent's SOUL.md personality
 - **Saved models** — CRUD management for model configurations across providers

--- a/docs/SAFEHOUSE_TOOL_BRIDGE.md
+++ b/docs/SAFEHOUSE_TOOL_BRIDGE.md
@@ -1,0 +1,47 @@
+# SafeHouse Tool Bridge
+
+Hermes Desktop can call the SafeHouse Signal local Tool Bridge directly from chat.
+
+Default bridge URL:
+
+```text
+http://127.0.0.1:57109
+```
+
+Optional override:
+
+```bash
+SAFEHOUSE_TOOL_BRIDGE_URL=http://127.0.0.1:57109 npm run dev
+```
+
+Only loopback HTTP(S) URLs are accepted. Remote bridge URLs are rejected so Desktop cannot accidentally send SafeHouse prompts or tool payloads to a non-local endpoint.
+
+## Endpoints
+
+- `GET /health`
+- `GET /tools`
+- `POST /tools/call`
+
+Desktop uses `GET /health` and `GET /tools` to show bridge status and tool count in chat. SafeHouse-specific plain-English prompts are routed deterministically to `POST /tools/call`.
+
+## Routed Prompts
+
+- `Summarize SafeHouse platform health` -> `safehouse.platform.status`
+- `Check API usage` -> `safehouse.api.usage.summary`
+- `What agents are failing?` -> `safehouse.agent.operations.summary`
+- `Check outbound queue` -> `safehouse.outbound.queue.summary`
+- `Draft a playbook recommendation` -> `safehouse.playbook.draft.recommendation`
+- `Can you replay failed queue items?` -> `safehouse.propose.queue.retry`
+- `Can you run a migration?` -> `safehouse.block.migration`
+
+Read-only routes call approved SafeHouse tools. Proposal-only routes return approval-required proposals. Blocked routes return policy blocks and never dispatch to Hermes or SafeHouse mutation paths.
+
+## Security Boundary
+
+- Desktop does not receive SafeHouse database credentials.
+- Desktop does not receive Supabase service-role keys.
+- Desktop does not store SafeHouse admin bearer tokens.
+- Mutations remain blocked or proposal-only.
+- The bridge must remain local-only.
+
+If the bridge is unavailable, Desktop shows an unavailable bridge result instead of inventing SafeHouse platform state.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -58,6 +58,13 @@ import {
   getRemoteAuthHeader,
 } from "./hermes";
 import {
+  askSafeHouseToolBridge,
+  callSafeHouseTool,
+  getSafeHouseToolBridgeHealth,
+  listSafeHouseTools,
+  routeSafeHousePrompt,
+} from "./safehouse-tools";
+import {
   startSshTunnel,
   stopSshTunnel,
   testSshConnection,
@@ -954,6 +961,33 @@ function setupIPC(): void {
       });
       Menu.buildFromTemplate(template).popup({ window: win });
     },
+  );
+
+  // SafeHouse local tool bridge — loopback-only HTTP bridge for approved
+  // SafeHouse platform tools. The bridge owns SafeHouse admin auth; Desktop
+  // never receives service-role keys or raw database credentials.
+  ipcMain.handle("safehouse-bridge-status", (_event, bridgeUrl?: string) =>
+    getSafeHouseToolBridgeHealth(bridgeUrl),
+  );
+  ipcMain.handle("safehouse-bridge-tools", (_event, bridgeUrl?: string) =>
+    listSafeHouseTools(bridgeUrl),
+  );
+  ipcMain.handle(
+    "safehouse-bridge-call",
+    (
+      _event,
+      tool: string,
+      input?: Record<string, unknown>,
+      bridgeUrl?: string,
+    ) => callSafeHouseTool(tool, input ?? {}, bridgeUrl),
+  );
+  ipcMain.handle("safehouse-route-prompt", (_event, prompt: string) =>
+    routeSafeHousePrompt(prompt),
+  );
+  ipcMain.handle(
+    "safehouse-ask",
+    (_event, prompt: string, bridgeUrl?: string) =>
+      askSafeHouseToolBridge(prompt, bridgeUrl),
   );
 
   // Attachment staging — for pasted blobs that have no filesystem origin.

--- a/src/main/safehouse-tools.ts
+++ b/src/main/safehouse-tools.ts
@@ -646,6 +646,8 @@ export function routeSafeHousePrompt(
     includesAny(text, [
       "what can you control",
       "what can you do",
+      "what are you blocked",
+      "blocked from doing",
       "list blocked actions",
       "blocked actions",
       "control",

--- a/src/main/safehouse-tools.ts
+++ b/src/main/safehouse-tools.ts
@@ -515,16 +515,35 @@ function arrayLines(value: unknown): string[] {
   return value.map((item) => `- ${String(item)}`);
 }
 
+function recordOrNull(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function extractGatewayRun(
+  result: Record<string, unknown>,
+): Record<string, unknown> | null {
+  const gateway = recordOrNull(result.gateway);
+  const data = recordOrNull(gateway?.data);
+  return recordOrNull(data?.run);
+}
+
 export function formatSafeHouseToolResponse(
   routeInfo: SafeHousePromptRoute,
   envelope: SafeHouseToolCallEnvelope,
 ): string {
-  const result = (envelope.result ?? {}) as Record<string, unknown>;
+  const bridgeResult = (envelope.result ?? {}) as Record<string, unknown>;
+  const gatewayRun = extractGatewayRun(bridgeResult);
+  const gatewayOutput = recordOrNull(gatewayRun?.output);
+  const result = gatewayOutput ?? bridgeResult;
   const summary =
     typeof result.summary === "string"
       ? result.summary
       : (envelope.error ?? "No summary returned.");
-  const status = String(result.status ?? envelope.status ?? "unknown");
+  const status = String(
+    result.status ?? bridgeResult.status ?? envelope.status ?? "unknown",
+  );
   const risks = arrayLines(result.risks ?? result.ingestion_risks);
   const actions = arrayLines(
     result.recommended_next_actions ?? result.safe_remediation_steps,
@@ -536,6 +555,14 @@ export function formatSafeHouseToolResponse(
       result.likely_causes,
   );
   const runtimeNotes = arrayLines(result.runtime_notes);
+  const schemaValid =
+    envelope.strict_json === true ||
+    bridgeResult.schema_valid === true ||
+    gatewayRun?.schema_valid === true;
+  const mutationPerformed =
+    envelope.mutation_performed === true ||
+    bridgeResult.mutation_performed === true;
+  const providerTruth = recordOrNull(gatewayRun?.provider_truth);
 
   const lines = [
     `### SafeHouse Tool Result`,
@@ -544,9 +571,18 @@ export function formatSafeHouseToolResponse(
     `- Source: ${envelope.source ?? "SafeHouse Tool Bridge"}`,
     `- Classification: ${envelope.classification ?? routeInfo.classification}`,
     `- Status: ${status}`,
+    ...(typeof gatewayRun?.run_id === "string"
+      ? [`- Run ID: \`${gatewayRun.run_id}\``]
+      : []),
+    ...(typeof gatewayRun?.runtime === "string"
+      ? [`- Runtime: ${gatewayRun.runtime}`]
+      : []),
+    ...(typeof providerTruth?.provider_mode === "string"
+      ? [`- Provider mode: ${providerTruth.provider_mode}`]
+      : []),
     `- Approval required: ${envelope.approval_required === true ? "yes" : "no"}`,
-    `- Mutation performed: ${envelope.mutation_performed === true ? "yes" : "no"}`,
-    `- Strict JSON: ${envelope.strict_json === true ? "yes" : "unknown"}`,
+    `- Mutation performed: ${mutationPerformed ? "yes" : "no"}`,
+    `- Strict JSON: ${schemaValid ? "yes" : "unknown"}`,
     "",
     summary,
   ];

--- a/src/main/safehouse-tools.ts
+++ b/src/main/safehouse-tools.ts
@@ -4,7 +4,11 @@ const BRIDGE_TIMEOUT_MS = 15_000;
 export interface SafeHouseTool {
   name: string;
   description: string;
-  classification: "read_only" | "proposal_only" | "blocked";
+  classification:
+    | "read_only"
+    | "local_safe_write"
+    | "proposal_only"
+    | "blocked";
   risk_level: string;
   approval_required: boolean;
   action: string;
@@ -39,7 +43,11 @@ export interface SafeHouseBridgeHealth {
 export interface SafeHousePromptRoute {
   tool: string;
   action: string;
-  classification: "read_only" | "proposal_only" | "blocked";
+  classification:
+    | "read_only"
+    | "local_safe_write"
+    | "proposal_only"
+    | "blocked";
   reason: string;
 }
 
@@ -47,13 +55,18 @@ export interface SafeHouseToolCallEnvelope {
   ok: boolean;
   tool?: string;
   action?: string;
-  classification?: "read_only" | "proposal_only" | "blocked";
+  classification?:
+    | "read_only"
+    | "local_safe_write"
+    | "proposal_only"
+    | "blocked";
   risk_level?: string;
   approval_required?: boolean;
   source?: string;
   status?: string;
   result?: Record<string, unknown>;
   mutation_performed?: boolean;
+  local_record_written?: boolean;
   strict_json?: boolean;
   error?: string;
 }
@@ -243,8 +256,10 @@ export function routeSafeHousePrompt(
   if (
     includesAny(text, [
       "docker prune",
+      "prune docker",
       "delete docker volume",
       "remove docker volume",
+      "delete database",
     ])
   ) {
     return route(
@@ -283,6 +298,20 @@ export function routeSafeHousePrompt(
       "production_deploy",
       "blocked",
       "Production deployment is blocked.",
+    );
+  }
+  if (
+    includesAny(text, [
+      "remove openclaw",
+      "disable openclaw",
+      "delete openclaw",
+    ])
+  ) {
+    return route(
+      "safehouse.block.openclaw_removal",
+      "openclaw_removal",
+      "blocked",
+      "OpenClaw removal is blocked.",
     );
   }
   if (includesAny(text, ["payment", "refund", "invoice", "billing mutation"])) {
@@ -342,6 +371,133 @@ export function routeSafeHousePrompt(
       "secret_access",
       "blocked",
       "Direct secret or DB access is blocked.",
+    );
+  }
+
+  if (includesAny(text, ["create a task", "add a task", "create ops card"])) {
+    return route(
+      "safehouse.ops.cards.create",
+      "ops_cards_create",
+      "local_safe_write",
+      "Create local SafeHouse operations card.",
+    );
+  }
+  if (
+    includesAny(text, [
+      "show operations board",
+      "show my operations board",
+      "list operations board",
+    ])
+  ) {
+    return route(
+      "safehouse.ops.cards.list",
+      "ops_cards_list",
+      "read_only",
+      "SafeHouse operations board.",
+    );
+  }
+  if (
+    includesAny(text, [
+      "what tasks are blocked",
+      "blocked tasks",
+      "what is blocked",
+    ])
+  ) {
+    return route(
+      "safehouse.ops.cards.summarize",
+      "ops_cards_summarize",
+      "read_only",
+      "SafeHouse operations board summary.",
+    );
+  }
+  if (includesAny(text, ["propose a skill", "create a skill", "add a skill"])) {
+    return route(
+      "safehouse.skills.propose",
+      "skills_propose",
+      "local_safe_write",
+      "Create local SafeHouse skill proposal.",
+    );
+  }
+  if (includesAny(text, ["what skills", "list skills", "skill registry"])) {
+    return route(
+      "safehouse.skills.list",
+      "skills_list",
+      "read_only",
+      "SafeHouse skill registry.",
+    );
+  }
+  if (
+    includesAny(text, [
+      "remember that",
+      "add this to platform memory",
+      "troubleshooting pattern",
+    ])
+  ) {
+    return route(
+      "safehouse.memory.candidates.propose",
+      "memory_candidates_propose",
+      "local_safe_write",
+      "Create reviewed memory candidate.",
+    );
+  }
+  if (
+    includesAny(text, [
+      "show memory candidates",
+      "what have you learned",
+      "review memory candidates",
+    ])
+  ) {
+    return route(
+      "safehouse.memory.candidates.list",
+      "memory_candidates_list",
+      "read_only",
+      "SafeHouse memory candidates.",
+    );
+  }
+  if (includesAny(text, ["check threat feeds", "threat feed freshness"])) {
+    return route(
+      "safehouse.watchdog.threat_feeds",
+      "watchdog_threat_feeds",
+      "read_only",
+      "Threat feed watchdog.",
+    );
+  }
+  if (
+    includesAny(text, [
+      "run all read-only watchdog",
+      "run all watchdog",
+      "run platform checks",
+    ])
+  ) {
+    return route(
+      "safehouse.watchdog.run_all_readonly",
+      "watchdog_run_all_readonly",
+      "read_only",
+      "Read-only watchdog checks.",
+    );
+  }
+  if (
+    includesAny(text, [
+      "spin up an agent",
+      "delegate a read-only check",
+      "delegate",
+    ])
+  ) {
+    return route(
+      "safehouse.agents.delegate_readonly",
+      "agents_delegate_readonly",
+      "local_safe_write",
+      "Create read-only delegation record.",
+    );
+  }
+  if (
+    includesAny(text, ["show sub-agent results", "show delegation results"])
+  ) {
+    return route(
+      "safehouse.agents.delegations.list",
+      "agent_delegations_list",
+      "read_only",
+      "Read-only delegation records.",
     );
   }
 
@@ -720,6 +876,10 @@ export function formatSafeHouseToolResponse(
   const mutationPerformed =
     envelope.mutation_performed === true ||
     bridgeResult.mutation_performed === true;
+  const localRecordWritten =
+    envelope.local_record_written === true ||
+    bridgeResult.local_record_written === true ||
+    result.local_record_written === true;
   const providerTruth = recordOrNull(gatewayRun?.provider_truth);
 
   const lines = [
@@ -740,6 +900,9 @@ export function formatSafeHouseToolResponse(
       : []),
     `- Approval required: ${envelope.approval_required === true ? "yes" : "no"}`,
     `- Mutation performed: ${mutationPerformed ? "yes" : "no"}`,
+    ...(localRecordWritten
+      ? ["- Local record written: yes", "- local_record_written: true"]
+      : []),
     `- Strict JSON: ${schemaValid ? "yes" : "unknown"}`,
     "",
     summary,

--- a/src/main/safehouse-tools.ts
+++ b/src/main/safehouse-tools.ts
@@ -106,14 +106,21 @@ export function redactSafeHouseBridgeValue(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(redactSafeHouseBridgeValue);
   if (value && typeof value === "object") {
     return Object.fromEntries(
-      Object.entries(value).map(([key, nested]) => [
-        key,
-        /(password|secret|token|service[_-]?role|api[_-]?key|authorization|cookie)/iu.test(
-          key,
-        )
-          ? "[redacted]"
-          : redactSafeHouseBridgeValue(nested),
-      ]),
+      Object.entries(value).map(([key, nested]) => {
+        const sensitiveKey =
+          /(password|secret|token|service[_-]?role|api[_-]?key|authorization|cookie)/iu.test(
+            key,
+          );
+        if (
+          sensitiveKey &&
+          nested !== false &&
+          nested !== null &&
+          nested !== undefined
+        ) {
+          return [key, "[redacted]"];
+        }
+        return [key, redactSafeHouseBridgeValue(nested)];
+      }),
     );
   }
   return value;
@@ -321,6 +328,9 @@ export function routeSafeHousePrompt(
     includesAny(text, [
       "direct db",
       "database credential",
+      "direct database",
+      "access database",
+      "database directly",
       "service role",
       "service-role",
       "show secret",
@@ -383,6 +393,133 @@ export function routeSafeHousePrompt(
 
   if (
     includesAny(text, [
+      "can you see",
+      "see the platform",
+      "what can you see",
+      "platform visibility",
+    ])
+  ) {
+    return route(
+      "safehouse.platform.visibility",
+      "platform_visibility",
+      "read_only",
+      "Platform visibility boundaries.",
+    );
+  }
+  if (
+    includesAny(text, [
+      "what modules",
+      "modules are",
+      "module map",
+      "modules can you inspect",
+      "can you inspect",
+      "inspect modules",
+    ])
+  ) {
+    return route(
+      "safehouse.platform.map",
+      "platform_map",
+      "read_only",
+      "SafeHouse module map.",
+    );
+  }
+  if (
+    includesAny(text, [
+      "admin pages",
+      "admin routes",
+      "admin route",
+      "admin menu",
+      "pages exist",
+    ])
+  ) {
+    return route(
+      "safehouse.admin.routes",
+      "admin_routes",
+      "read_only",
+      "SafeHouse admin route boundaries.",
+    );
+  }
+  if (
+    includesAny(text, [
+      "what is running locally",
+      "running locally",
+      "current runtime state",
+      "runtime snapshot",
+      "local ports",
+    ])
+  ) {
+    return route(
+      "safehouse.runtime.snapshot",
+      "runtime_snapshot",
+      "read_only",
+      "SafeHouse local runtime snapshot.",
+    );
+  }
+  if (
+    includesAny(text, [
+      "agent runs",
+      "runtime runs",
+      "recent runs",
+      "recent agent runtime",
+      "run records",
+    ])
+  ) {
+    return route(
+      "safehouse.agent.runs.recent",
+      "agent_runs_recent",
+      "read_only",
+      "Recent agent runtime state.",
+    );
+  }
+  if (
+    includesAny(text, [
+      "edge functions",
+      "functions are available",
+      "function status",
+      "available functions",
+    ])
+  ) {
+    return route(
+      "safehouse.edge.functions.status",
+      "edge_functions_status",
+      "read_only",
+      "Edge Function status summary.",
+    );
+  }
+  if (
+    includesAny(text, [
+      "what can you control",
+      "what can you do",
+      "list blocked actions",
+      "blocked actions",
+      "control",
+    ])
+  ) {
+    return route(
+      "safehouse.action.permissions",
+      "action_permissions",
+      "read_only",
+      "SafeHouse action permission boundaries.",
+    );
+  }
+  if (
+    includesAny(text, [
+      "what docs",
+      "docs should",
+      "documentation",
+      "docs define",
+      "read docs",
+    ])
+  ) {
+    return route(
+      "safehouse.docs.index",
+      "docs_index",
+      "read_only",
+      "SafeHouse docs index.",
+    );
+  }
+  if (
+    includesAny(text, [
       "extension store",
       "store readiness",
       "chrome store",
@@ -442,6 +579,8 @@ export function routeSafeHousePrompt(
       "agent failures",
       "agent operations",
       "agents failing",
+      "agents running",
+      "agents are running",
     ])
   ) {
     return route(
@@ -497,6 +636,8 @@ export function routeSafeHousePrompt(
       "platform health",
       "safehouse health",
       "summarize safehouse",
+      "what is broken",
+      "broken",
     ])
   ) {
     return route(
@@ -519,6 +660,22 @@ function recordOrNull(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : null;
+}
+
+function dataHighlights(value: unknown): string[] {
+  const data = recordOrNull(value);
+  if (!data) return [];
+  const lines: string[] = [];
+  for (const [key, nested] of Object.entries(data).slice(0, 8)) {
+    if (Array.isArray(nested)) {
+      lines.push(`- ${key}: ${nested.length} item(s)`);
+    } else if (nested && typeof nested === "object") {
+      lines.push(`- ${key}: ${Object.keys(nested).length} field(s)`);
+    } else {
+      lines.push(`- ${key}: ${String(nested)}`);
+    }
+  }
+  return lines;
 }
 
 function extractGatewayRun(
@@ -545,6 +702,7 @@ export function formatSafeHouseToolResponse(
     result.status ?? bridgeResult.status ?? envelope.status ?? "unknown",
   );
   const risks = arrayLines(result.risks ?? result.ingestion_risks);
+  const limitations = arrayLines(result.limitations);
   const actions = arrayLines(
     result.recommended_next_actions ?? result.safe_remediation_steps,
   );
@@ -588,7 +746,10 @@ export function formatSafeHouseToolResponse(
   ];
 
   if (findings.length) lines.push("", "**Findings**", ...findings);
+  const data = dataHighlights(result.data);
+  if (data.length) lines.push("", "**Tool data**", ...data);
   if (risks.length) lines.push("", "**Risks**", ...risks);
+  if (limitations.length) lines.push("", "**Limitations**", ...limitations);
   if (actions.length)
     lines.push("", "**Recommended next actions**", ...actions);
   if (runtimeNotes.length) lines.push("", "**Runtime notes**", ...runtimeNotes);

--- a/src/main/safehouse-tools.ts
+++ b/src/main/safehouse-tools.ts
@@ -1,0 +1,605 @@
+const DEFAULT_SAFEHOUSE_TOOL_BRIDGE_URL = "http://127.0.0.1:57109";
+const BRIDGE_TIMEOUT_MS = 15_000;
+
+export interface SafeHouseTool {
+  name: string;
+  description: string;
+  classification: "read_only" | "proposal_only" | "blocked";
+  risk_level: string;
+  approval_required: boolean;
+  action: string;
+  endpoint?: unknown;
+  input_schema?: unknown;
+  output_schema?: unknown;
+  safety_notes?: string[];
+}
+
+export interface SafeHouseToolManifest {
+  name: string;
+  version: string;
+  tools: SafeHouseTool[];
+  bridge?: Record<string, unknown>;
+}
+
+export interface SafeHouseBridgeHealth {
+  ok: boolean;
+  service?: string;
+  version?: string;
+  bind?: string;
+  mode?: string;
+  tools_count?: number;
+  mutations_blocked?: boolean;
+  direct_db_access?: boolean;
+  service_role_key_required?: boolean;
+  error?: string;
+  bridge_url: string;
+  local_only: boolean;
+}
+
+export interface SafeHousePromptRoute {
+  tool: string;
+  action: string;
+  classification: "read_only" | "proposal_only" | "blocked";
+  reason: string;
+}
+
+export interface SafeHouseToolCallEnvelope {
+  ok: boolean;
+  tool?: string;
+  action?: string;
+  classification?: "read_only" | "proposal_only" | "blocked";
+  risk_level?: string;
+  approval_required?: boolean;
+  source?: string;
+  status?: string;
+  result?: Record<string, unknown>;
+  mutation_performed?: boolean;
+  strict_json?: boolean;
+  error?: string;
+}
+
+export interface SafeHouseAskResult {
+  matched: boolean;
+  route: SafeHousePromptRoute | null;
+  response?: SafeHouseToolCallEnvelope;
+  markdown?: string;
+  error?: string;
+}
+
+function bridgeUrlFromEnv(): string {
+  return (
+    process.env.SAFEHOUSE_TOOL_BRIDGE_URL || DEFAULT_SAFEHOUSE_TOOL_BRIDGE_URL
+  );
+}
+
+export function isLoopbackBridgeUrl(rawUrl: string): boolean {
+  try {
+    const parsed = new URL(rawUrl);
+    const host = parsed.hostname.toLowerCase();
+    return (
+      (parsed.protocol === "http:" || parsed.protocol === "https:") &&
+      (host === "127.0.0.1" || host === "localhost" || host === "::1")
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function resolveSafeHouseBridgeUrl(rawUrl?: string): string {
+  const candidate = (rawUrl || bridgeUrlFromEnv()).trim().replace(/\/+$/, "");
+  if (!candidate) return DEFAULT_SAFEHOUSE_TOOL_BRIDGE_URL;
+  if (!isLoopbackBridgeUrl(candidate)) {
+    throw new Error(
+      "SafeHouse Tool Bridge URL must be a loopback HTTP(S) URL such as http://127.0.0.1:57109.",
+    );
+  }
+  return candidate;
+}
+
+export function redactSafeHouseBridgeValue(value: unknown): unknown {
+  if (typeof value === "string") {
+    return value
+      .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/giu, "Bearer [redacted]")
+      .replace(/sk-[A-Za-z0-9._-]+/giu, "sk-[redacted]")
+      .replace(/[\w.+-]+@[\w.-]+\.[a-z]{2,}/giu, "[redacted-email]");
+  }
+  if (Array.isArray(value)) return value.map(redactSafeHouseBridgeValue);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nested]) => [
+        key,
+        /(password|secret|token|service[_-]?role|api[_-]?key|authorization|cookie)/iu.test(
+          key,
+        )
+          ? "[redacted]"
+          : redactSafeHouseBridgeValue(nested),
+      ]),
+    );
+  }
+  return value;
+}
+
+async function fetchBridgeJson<T>(
+  path: string,
+  options: RequestInit = {},
+  rawUrl?: string,
+): Promise<T> {
+  const baseUrl = resolveSafeHouseBridgeUrl(rawUrl);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), BRIDGE_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${baseUrl}${path}`, {
+      ...options,
+      signal: controller.signal,
+      headers: {
+        "Content-Type": "application/json",
+        ...(options.headers ?? {}),
+      },
+    });
+    const text = await response.text();
+    let data: unknown = {};
+    try {
+      data = text ? JSON.parse(text) : {};
+    } catch {
+      data = { ok: false, error: "SafeHouse bridge returned non-JSON." };
+    }
+    if (!response.ok) {
+      const error =
+        typeof data === "object" &&
+        data &&
+        "error" in data &&
+        typeof (data as { error: unknown }).error === "string"
+          ? (data as { error: string }).error
+          : `SafeHouse bridge returned HTTP ${response.status}.`;
+      throw new Error(error);
+    }
+    return redactSafeHouseBridgeValue(data) as T;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function getSafeHouseToolBridgeHealth(
+  rawUrl?: string,
+): Promise<SafeHouseBridgeHealth> {
+  const bridgeUrl = resolveSafeHouseBridgeUrl(rawUrl);
+  try {
+    const health = await fetchBridgeJson<Record<string, unknown>>(
+      "/health",
+      {},
+      bridgeUrl,
+    );
+    return {
+      ...(health as Omit<SafeHouseBridgeHealth, "bridge_url" | "local_only">),
+      bridge_url: bridgeUrl,
+      local_only: true,
+      ok: health.ok === true,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      bridge_url: bridgeUrl,
+      local_only: true,
+      error:
+        error instanceof Error
+          ? String(redactSafeHouseBridgeValue(error.message))
+          : "SafeHouse bridge unavailable.",
+    };
+  }
+}
+
+export async function listSafeHouseTools(
+  rawUrl?: string,
+): Promise<SafeHouseToolManifest> {
+  return fetchBridgeJson<SafeHouseToolManifest>("/tools", {}, rawUrl);
+}
+
+export async function callSafeHouseTool(
+  tool: string,
+  input: Record<string, unknown> = {},
+  rawUrl?: string,
+): Promise<SafeHouseToolCallEnvelope> {
+  return fetchBridgeJson<SafeHouseToolCallEnvelope>(
+    "/tools/call",
+    {
+      method: "POST",
+      body: JSON.stringify(
+        redactSafeHouseBridgeValue({
+          tool,
+          ...input,
+        }),
+      ),
+    },
+    rawUrl,
+  );
+}
+
+function includesAny(text: string, terms: string[]): boolean {
+  return terms.some((term) => text.includes(term));
+}
+
+function route(
+  tool: string,
+  action: string,
+  classification: SafeHousePromptRoute["classification"],
+  reason: string,
+): SafeHousePromptRoute {
+  return { tool, action, classification, reason };
+}
+
+export function routeSafeHousePrompt(
+  prompt: string,
+): SafeHousePromptRoute | null {
+  const text = prompt.toLowerCase().replace(/\s+/g, " ").trim();
+  if (!text) return null;
+
+  if (
+    includesAny(text, [
+      "docker prune",
+      "delete docker volume",
+      "remove docker volume",
+    ])
+  ) {
+    return route(
+      "safehouse.block.docker_prune",
+      "docker_prune",
+      "blocked",
+      "Docker destructive request.",
+    );
+  }
+  if (
+    includesAny(text, [
+      "run migration",
+      "run a migration",
+      "apply migration",
+      "database migration",
+      "deploy migration",
+    ])
+  ) {
+    return route(
+      "safehouse.block.migration",
+      "migration",
+      "blocked",
+      "Migration/deploy command is blocked.",
+    );
+  }
+  if (
+    includesAny(text, [
+      "production deploy",
+      "deploy production",
+      "switch dns",
+      "dns cutover",
+    ])
+  ) {
+    return route(
+      "safehouse.block.production_deploy",
+      "production_deploy",
+      "blocked",
+      "Production deployment is blocked.",
+    );
+  }
+  if (includesAny(text, ["payment", "refund", "invoice", "billing mutation"])) {
+    return route(
+      "safehouse.block.payment_mutation",
+      "payment_mutation",
+      "blocked",
+      "Payment mutation is blocked.",
+    );
+  }
+  if (
+    includesAny(text, [
+      "account mutation",
+      "delete user",
+      "disable account",
+      "change account",
+    ])
+  ) {
+    return route(
+      "safehouse.block.account_mutation",
+      "account_mutation",
+      "blocked",
+      "Account mutation is blocked.",
+    );
+  }
+  if (includesAny(text, ["provision vpn", "wireguard", "vpn provisioning"])) {
+    return route(
+      "safehouse.block.vpn_provisioning",
+      "vpn_provisioning",
+      "blocked",
+      "VPN provisioning is blocked.",
+    );
+  }
+  if (includesAny(text, ["voice routing", "route voice", "call routing"])) {
+    return route(
+      "safehouse.block.voice_routing",
+      "voice_routing",
+      "blocked",
+      "Voice routing mutation is blocked.",
+    );
+  }
+  if (
+    includesAny(text, [
+      "direct db",
+      "database credential",
+      "service role",
+      "service-role",
+      "show secret",
+      "read secret",
+    ])
+  ) {
+    return route(
+      "safehouse.block.secret_access",
+      "secret_access",
+      "blocked",
+      "Direct secret or DB access is blocked.",
+    );
+  }
+
+  if (
+    includesAny(text, [
+      "replay failed queue",
+      "retry failed queue",
+      "replay queue",
+      "queue retry",
+    ])
+  ) {
+    return route(
+      "safehouse.propose.queue.retry",
+      "propose_queue_retry",
+      "proposal_only",
+      "Queue retry requires approval.",
+    );
+  }
+  if (includesAny(text, ["turn off feed", "disable feed", "enable feed"])) {
+    return route(
+      "safehouse.propose.feed.disable",
+      "propose_feed_disable",
+      "proposal_only",
+      "Feed state changes require approval.",
+    );
+  }
+  if (includesAny(text, ["update playbook", "change playbook"])) {
+    return route(
+      "safehouse.propose.playbook.update",
+      "propose_playbook_update",
+      "proposal_only",
+      "Playbook mutation requires approval.",
+    );
+  }
+  if (
+    includesAny(text, [
+      "change runtime setting",
+      "set hermes primary",
+      "runtime setting",
+    ])
+  ) {
+    return route(
+      "safehouse.propose.runtime.setting.change",
+      "propose_runtime_setting_change",
+      "proposal_only",
+      "Runtime setting changes require approval.",
+    );
+  }
+
+  if (
+    includesAny(text, [
+      "extension store",
+      "store readiness",
+      "chrome store",
+      "edge store",
+    ])
+  ) {
+    return route(
+      "safehouse.extension.store.readiness",
+      "extension_store_readiness",
+      "read_only",
+      "Extension/store readiness summary.",
+    );
+  }
+  if (includesAny(text, ["docker status", "local docker"])) {
+    return route(
+      "safehouse.docker.status",
+      "docker_status",
+      "read_only",
+      "Docker status summary.",
+    );
+  }
+  if (includesAny(text, ["local runtime", "runtime status", "local stack"])) {
+    return route(
+      "safehouse.local.runtime.status",
+      "local_runtime_status",
+      "read_only",
+      "Local runtime status summary.",
+    );
+  }
+  if (includesAny(text, ["openclaw status", "openclaw fallback"])) {
+    return route(
+      "safehouse.openclaw.status",
+      "openclaw_status",
+      "read_only",
+      "OpenClaw fallback status.",
+    );
+  }
+  if (includesAny(text, ["strict eval", "strict json", "model strict"])) {
+    return route(
+      "safehouse.hermes.strict.eval.status",
+      "hermes_strict_eval_status",
+      "read_only",
+      "Hermes strict eval status.",
+    );
+  }
+  if (includesAny(text, ["api usage", "cost risk", "provider usage"])) {
+    return route(
+      "safehouse.api.usage.summary",
+      "api_usage_summary",
+      "read_only",
+      "API usage summary.",
+    );
+  }
+  if (
+    includesAny(text, [
+      "agents are failing",
+      "agent failures",
+      "agent operations",
+      "agents failing",
+    ])
+  ) {
+    return route(
+      "safehouse.agent.operations.summary",
+      "agent_operations_summary",
+      "read_only",
+      "Agent operations summary.",
+    );
+  }
+  if (includesAny(text, ["run failure", "explain failure", "failed run"])) {
+    return route(
+      "safehouse.run.failure.explain",
+      "run_failure_explanation",
+      "read_only",
+      "Run failure explanation.",
+    );
+  }
+  if (
+    includesAny(text, ["feed health", "feed management", "ingestion health"])
+  ) {
+    return route(
+      "safehouse.feed.health.summary",
+      "feed_health_summary",
+      "read_only",
+      "Feed health summary.",
+    );
+  }
+  if (includesAny(text, ["outbound queue", "queue health", "stuck queue"])) {
+    return route(
+      "safehouse.outbound.queue.summary",
+      "outbound_queue_summary",
+      "read_only",
+      "Outbound queue summary.",
+    );
+  }
+  if (
+    includesAny(text, [
+      "draft a playbook",
+      "draft playbook",
+      "playbook recommendation",
+    ])
+  ) {
+    return route(
+      "safehouse.playbook.draft.recommendation",
+      "playbook_draft_recommendation",
+      "read_only",
+      "Draft playbook recommendation.",
+    );
+  }
+  if (
+    includesAny(text, [
+      "platform status",
+      "platform health",
+      "safehouse health",
+      "summarize safehouse",
+    ])
+  ) {
+    return route(
+      "safehouse.platform.status",
+      "platform_status",
+      "read_only",
+      "Platform status summary.",
+    );
+  }
+
+  return null;
+}
+
+function arrayLines(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => `- ${String(item)}`);
+}
+
+export function formatSafeHouseToolResponse(
+  routeInfo: SafeHousePromptRoute,
+  envelope: SafeHouseToolCallEnvelope,
+): string {
+  const result = (envelope.result ?? {}) as Record<string, unknown>;
+  const summary =
+    typeof result.summary === "string"
+      ? result.summary
+      : (envelope.error ?? "No summary returned.");
+  const status = String(result.status ?? envelope.status ?? "unknown");
+  const risks = arrayLines(result.risks ?? result.ingestion_risks);
+  const actions = arrayLines(
+    result.recommended_next_actions ?? result.safe_remediation_steps,
+  );
+  const findings = arrayLines(
+    result.key_findings ??
+      result.notable_findings ??
+      result.evidence ??
+      result.likely_causes,
+  );
+  const runtimeNotes = arrayLines(result.runtime_notes);
+
+  const lines = [
+    `### SafeHouse Tool Result`,
+    `- Tool: \`${envelope.tool ?? routeInfo.tool}\``,
+    `- Action: \`${envelope.action ?? routeInfo.action}\``,
+    `- Source: ${envelope.source ?? "SafeHouse Tool Bridge"}`,
+    `- Classification: ${envelope.classification ?? routeInfo.classification}`,
+    `- Status: ${status}`,
+    `- Approval required: ${envelope.approval_required === true ? "yes" : "no"}`,
+    `- Mutation performed: ${envelope.mutation_performed === true ? "yes" : "no"}`,
+    `- Strict JSON: ${envelope.strict_json === true ? "yes" : "unknown"}`,
+    "",
+    summary,
+  ];
+
+  if (findings.length) lines.push("", "**Findings**", ...findings);
+  if (risks.length) lines.push("", "**Risks**", ...risks);
+  if (actions.length)
+    lines.push("", "**Recommended next actions**", ...actions);
+  if (runtimeNotes.length) lines.push("", "**Runtime notes**", ...runtimeNotes);
+  if (routeInfo.classification === "blocked") {
+    lines.push(
+      "",
+      "**Blocked by policy. No SafeHouse mutation was dispatched.**",
+    );
+  }
+  if (routeInfo.classification === "proposal_only") {
+    lines.push(
+      "",
+      "**Proposal only. Human approval is required before any future execution.**",
+    );
+  }
+
+  return lines.join("\n");
+}
+
+export async function askSafeHouseToolBridge(
+  prompt: string,
+  rawUrl?: string,
+): Promise<SafeHouseAskResult> {
+  const routeInfo = routeSafeHousePrompt(prompt);
+  if (!routeInfo) return { matched: false, route: null };
+
+  try {
+    const response = await callSafeHouseTool(
+      routeInfo.tool,
+      { prompt, payload: { source: "hermes-desktop-chat" } },
+      rawUrl,
+    );
+    return {
+      matched: true,
+      route: routeInfo,
+      response,
+      markdown: formatSafeHouseToolResponse(routeInfo, response),
+    };
+  } catch (error) {
+    return {
+      matched: true,
+      route: routeInfo,
+      error:
+        error instanceof Error
+          ? String(redactSafeHouseBridgeValue(error.message))
+          : "SafeHouse bridge call failed.",
+      markdown: `### SafeHouse Tool Bridge Unavailable\n- Tool: \`${routeInfo.tool}\`\n- Classification: ${routeInfo.classification}\n- Mutation performed: no\n\n${error instanceof Error ? String(redactSafeHouseBridgeValue(error.message)) : "SafeHouse bridge call failed."}`,
+    };
+  }
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -64,7 +64,11 @@ interface SafeHouseToolBridgeStatus {
 interface SafeHouseToolEntry {
   name: string;
   description: string;
-  classification: "read_only" | "proposal_only" | "blocked";
+  classification:
+    | "read_only"
+    | "local_safe_write"
+    | "proposal_only"
+    | "blocked";
   risk_level: string;
   approval_required: boolean;
   action: string;
@@ -79,7 +83,11 @@ interface SafeHouseToolManifest {
 interface SafeHousePromptRoute {
   tool: string;
   action: string;
-  classification: "read_only" | "proposal_only" | "blocked";
+  classification:
+    | "read_only"
+    | "local_safe_write"
+    | "proposal_only"
+    | "blocked";
   reason: string;
 }
 
@@ -87,11 +95,16 @@ interface SafeHouseToolCallEnvelope {
   ok: boolean;
   tool?: string;
   action?: string;
-  classification?: "read_only" | "proposal_only" | "blocked";
+  classification?:
+    | "read_only"
+    | "local_safe_write"
+    | "proposal_only"
+    | "blocked";
   source?: string;
   status?: string;
   result?: Record<string, unknown>;
   mutation_performed?: boolean;
+  local_record_written?: boolean;
   strict_json?: boolean;
   error?: string;
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -49,6 +49,61 @@ interface CredentialPoolEntry {
   key?: string;
 }
 
+interface SafeHouseToolBridgeStatus {
+  ok: boolean;
+  bridge_url: string;
+  local_only: boolean;
+  service?: string;
+  version?: string;
+  mode?: string;
+  tools_count?: number;
+  mutations_blocked?: boolean;
+  error?: string;
+}
+
+interface SafeHouseToolEntry {
+  name: string;
+  description: string;
+  classification: "read_only" | "proposal_only" | "blocked";
+  risk_level: string;
+  approval_required: boolean;
+  action: string;
+}
+
+interface SafeHouseToolManifest {
+  name: string;
+  version: string;
+  tools: SafeHouseToolEntry[];
+}
+
+interface SafeHousePromptRoute {
+  tool: string;
+  action: string;
+  classification: "read_only" | "proposal_only" | "blocked";
+  reason: string;
+}
+
+interface SafeHouseToolCallEnvelope {
+  ok: boolean;
+  tool?: string;
+  action?: string;
+  classification?: "read_only" | "proposal_only" | "blocked";
+  source?: string;
+  status?: string;
+  result?: Record<string, unknown>;
+  mutation_performed?: boolean;
+  strict_json?: boolean;
+  error?: string;
+}
+
+interface SafeHouseAskResult {
+  matched: boolean;
+  route: SafeHousePromptRoute | null;
+  response?: Record<string, unknown>;
+  markdown?: string;
+  error?: string;
+}
+
 interface KanbanTask {
   id: string;
   title: string;
@@ -256,6 +311,22 @@ interface HermesAPI {
     name: string,
     labels: { open: string; saveAs: string },
   ) => void;
+  getSafeHouseToolBridgeStatus: (
+    bridgeUrl?: string,
+  ) => Promise<SafeHouseToolBridgeStatus>;
+  listSafeHouseTools: (bridgeUrl?: string) => Promise<SafeHouseToolManifest>;
+  callSafeHouseTool: (
+    tool: string,
+    input?: Record<string, unknown>,
+    bridgeUrl?: string,
+  ) => Promise<SafeHouseToolCallEnvelope>;
+  routeSafeHousePrompt: (
+    prompt: string,
+  ) => Promise<SafeHousePromptRoute | null>;
+  askSafeHouseToolBridge: (
+    prompt: string,
+    bridgeUrl?: string,
+  ) => Promise<SafeHouseAskResult>;
   getPathForFile: (file: File) => string;
   stageAttachment: (
     sessionId: string,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -265,6 +265,78 @@ const hermesAPI = {
     ipcRenderer.send("show-media-menu", src, name, labels);
   },
 
+  // SafeHouse Tool Bridge
+  getSafeHouseToolBridgeStatus: (
+    bridgeUrl?: string,
+  ): Promise<{
+    ok: boolean;
+    bridge_url: string;
+    local_only: boolean;
+    service?: string;
+    version?: string;
+    mode?: string;
+    tools_count?: number;
+    mutations_blocked?: boolean;
+    error?: string;
+  }> => ipcRenderer.invoke("safehouse-bridge-status", bridgeUrl),
+
+  listSafeHouseTools: (
+    bridgeUrl?: string,
+  ): Promise<{
+    name: string;
+    version: string;
+    tools: Array<{
+      name: string;
+      description: string;
+      classification: "read_only" | "proposal_only" | "blocked";
+      risk_level: string;
+      approval_required: boolean;
+      action: string;
+    }>;
+  }> => ipcRenderer.invoke("safehouse-bridge-tools", bridgeUrl),
+
+  callSafeHouseTool: (
+    tool: string,
+    input?: Record<string, unknown>,
+    bridgeUrl?: string,
+  ): Promise<{
+    ok: boolean;
+    tool?: string;
+    action?: string;
+    classification?: "read_only" | "proposal_only" | "blocked";
+    source?: string;
+    status?: string;
+    result?: Record<string, unknown>;
+    mutation_performed?: boolean;
+    strict_json?: boolean;
+    error?: string;
+  }> => ipcRenderer.invoke("safehouse-bridge-call", tool, input, bridgeUrl),
+
+  routeSafeHousePrompt: (
+    prompt: string,
+  ): Promise<{
+    tool: string;
+    action: string;
+    classification: "read_only" | "proposal_only" | "blocked";
+    reason: string;
+  } | null> => ipcRenderer.invoke("safehouse-route-prompt", prompt),
+
+  askSafeHouseToolBridge: (
+    prompt: string,
+    bridgeUrl?: string,
+  ): Promise<{
+    matched: boolean;
+    route: {
+      tool: string;
+      action: string;
+      classification: "read_only" | "proposal_only" | "blocked";
+      reason: string;
+    } | null;
+    response?: Record<string, unknown>;
+    markdown?: string;
+    error?: string;
+  }> => ipcRenderer.invoke("safehouse-ask", prompt, bridgeUrl),
+
   // Resolve the absolute filesystem path for a File coming from drag-drop
   // or the file picker.  Returns "" for blobs that have no origin path
   // (e.g. clipboard paste) — caller should stageAttachment for those.

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -288,7 +288,11 @@ const hermesAPI = {
     tools: Array<{
       name: string;
       description: string;
-      classification: "read_only" | "proposal_only" | "blocked";
+      classification:
+        | "read_only"
+        | "local_safe_write"
+        | "proposal_only"
+        | "blocked";
       risk_level: string;
       approval_required: boolean;
       action: string;
@@ -303,11 +307,16 @@ const hermesAPI = {
     ok: boolean;
     tool?: string;
     action?: string;
-    classification?: "read_only" | "proposal_only" | "blocked";
+    classification?:
+      | "read_only"
+      | "local_safe_write"
+      | "proposal_only"
+      | "blocked";
     source?: string;
     status?: string;
     result?: Record<string, unknown>;
     mutation_performed?: boolean;
+    local_record_written?: boolean;
     strict_json?: boolean;
     error?: string;
   }> => ipcRenderer.invoke("safehouse-bridge-call", tool, input, bridgeUrl),
@@ -317,7 +326,11 @@ const hermesAPI = {
   ): Promise<{
     tool: string;
     action: string;
-    classification: "read_only" | "proposal_only" | "blocked";
+    classification:
+      | "read_only"
+      | "local_safe_write"
+      | "proposal_only"
+      | "blocked";
     reason: string;
   } | null> => ipcRenderer.invoke("safehouse-route-prompt", prompt),
 
@@ -329,7 +342,11 @@ const hermesAPI = {
     route: {
       tool: string;
       action: string;
-      classification: "read_only" | "proposal_only" | "blocked";
+      classification:
+        | "read_only"
+        | "local_safe_write"
+        | "proposal_only"
+        | "blocked";
       reason: string;
     } | null;
     response?: Record<string, unknown>;

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1715,6 +1715,54 @@ body {
   flex-shrink: 0;
 }
 
+.safehouse-tool-bridge-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 28px;
+  margin-bottom: 10px;
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.safehouse-tool-bridge-status.connected {
+  border-color: rgba(34, 197, 94, 0.25);
+  background: var(--success-bg);
+}
+
+.safehouse-tool-bridge-status.offline {
+  border-color: rgba(245, 158, 11, 0.25);
+  background: var(--warning-bg);
+}
+
+.safehouse-tool-bridge-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--warning);
+  flex-shrink: 0;
+}
+
+.safehouse-tool-bridge-status.connected .safehouse-tool-bridge-dot {
+  background: var(--success);
+}
+
+.safehouse-tool-bridge-label {
+  color: var(--text-primary);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.safehouse-tool-bridge-detail {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .chat-input-wrapper {
   display: flex;
   align-items: flex-end;

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1763,6 +1763,228 @@ body {
   white-space: nowrap;
 }
 
+/* SafeHouse bridge-backed operator pages */
+.safehouse-bridge-page {
+  flex: 1;
+  overflow-y: auto;
+  padding: 32px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+}
+
+.safehouse-bridge-hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.safehouse-bridge-kicker {
+  color: var(--success);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 6px;
+}
+
+.safehouse-bridge-hero h1 {
+  font-size: 28px;
+  line-height: 1.15;
+  margin: 0 0 8px;
+}
+
+.safehouse-bridge-hero p,
+.safehouse-bridge-note,
+.safehouse-bridge-card-desc,
+.safehouse-bridge-tool-card p,
+.safehouse-bridge-boundaries p {
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.safehouse-bridge-status-card,
+.safehouse-bridge-draft,
+.safehouse-bridge-result-summary,
+.safehouse-bridge-boundaries {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-secondary);
+  padding: 16px;
+  margin-bottom: 16px;
+}
+
+.safehouse-bridge-status-card {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.safehouse-bridge-status-card.connected {
+  border-color: rgba(34, 197, 94, 0.28);
+  background: var(--success-bg);
+}
+
+.safehouse-bridge-status-card.offline {
+  border-color: rgba(245, 158, 11, 0.28);
+  background: var(--warning-bg);
+}
+
+.safehouse-bridge-status-card p {
+  margin: 4px 0 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.safehouse-bridge-status-grid,
+.safehouse-bridge-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.safehouse-bridge-status-grid span {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 4px 8px;
+  color: var(--text-secondary);
+  background: var(--bg-primary);
+  font-size: 12px;
+}
+
+.safehouse-bridge-error,
+.safehouse-bridge-empty,
+.safehouse-bridge-loading {
+  border-radius: var(--radius-md);
+  padding: 12px;
+  margin-bottom: 16px;
+  color: var(--text-secondary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+}
+
+.safehouse-bridge-error {
+  color: var(--error);
+  background: var(--error-bg);
+  border-color: rgba(239, 68, 68, 0.25);
+}
+
+.safehouse-bridge-draft {
+  display: grid;
+  gap: 10px;
+}
+
+.safehouse-bridge-draft h2,
+.safehouse-bridge-tool-group h2 {
+  font-size: 16px;
+  margin: 0;
+}
+
+.safehouse-bridge-textarea {
+  min-height: 84px;
+  resize: vertical;
+}
+
+.safehouse-bridge-card-grid,
+.safehouse-bridge-tool-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 12px;
+}
+
+.safehouse-bridge-card,
+.safehouse-bridge-tool-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
+  padding: 14px;
+}
+
+.safehouse-bridge-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.safehouse-bridge-card-header h3 {
+  font-size: 14px;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.safehouse-bridge-badge {
+  border-radius: 999px;
+  padding: 3px 8px;
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  background: var(--bg-primary);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.safehouse-bridge-badge.ok {
+  color: var(--success);
+  border-color: rgba(34, 197, 94, 0.3);
+  background: var(--success-bg);
+}
+
+.safehouse-bridge-badge.proposal {
+  color: var(--warning);
+  border-color: rgba(245, 158, 11, 0.3);
+  background: var(--warning-bg);
+}
+
+.safehouse-bridge-badge.blocked {
+  color: var(--error);
+  border-color: rgba(239, 68, 68, 0.3);
+  background: var(--error-bg);
+}
+
+.safehouse-bridge-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin: 12px 0;
+}
+
+.safehouse-bridge-meta div {
+  min-width: 0;
+}
+
+.safehouse-bridge-meta dt {
+  color: var(--text-muted);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.safehouse-bridge-meta dd {
+  margin: 2px 0 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.safehouse-bridge-tool-groups {
+  display: grid;
+  gap: 18px;
+}
+
+.safehouse-bridge-tool-card {
+  display: grid;
+  gap: 8px;
+}
+
+.safehouse-bridge-tool-card span {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
 .chat-input-wrapper {
   display: flex;
   align-items: flex-end;

--- a/src/renderer/src/components/SafeHouseBridgeOperatorPage.test.tsx
+++ b/src/renderer/src/components/SafeHouseBridgeOperatorPage.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import SafeHouseBridgeOperatorPage from "./SafeHouseBridgeOperatorPage";
+
+const bridgeStatus = {
+  ok: true,
+  connected: true,
+  url: "http://127.0.0.1:57109",
+  mode: "local_proof",
+  tool_count: 65,
+  local_only: true,
+};
+
+const bridgeTools = {
+  ok: true,
+  url: "http://127.0.0.1:57109",
+  mode: "local_proof",
+  tools: [
+    {
+      name: "safehouse.platform.visibility",
+      description: "Inspect SafeHouse platform visibility.",
+      classification: "read_only",
+    },
+    {
+      name: "safehouse.ops.cards.create",
+      description: "Create a SafeHouse operations card.",
+      classification: "local_safe_write",
+    },
+    {
+      name: "safehouse.propose.queue.retry",
+      description: "Draft a queue retry proposal.",
+      classification: "proposal_only",
+    },
+    {
+      name: "safehouse.block.migration",
+      description: "Block migration requests.",
+      classification: "blocked",
+    },
+  ],
+};
+
+function installBridgeApi(result: Record<string, unknown>): void {
+  Object.defineProperty(window, "hermesAPI", {
+    configurable: true,
+    value: {
+      getSafeHouseToolBridgeStatus: vi.fn().mockResolvedValue(bridgeStatus),
+      listSafeHouseTools: vi.fn().mockResolvedValue(bridgeTools),
+      callSafeHouseTool: vi.fn().mockResolvedValue(result),
+    },
+  });
+}
+
+describe("SafeHouseBridgeOperatorPage", () => {
+  it("renders SafeHouse operations board data in bridge mode", async () => {
+    installBridgeApi({
+      ok: true,
+      tool: "safehouse.ops.cards.list",
+      classification: "read_only",
+      status: "success",
+      result: {
+        cards: [
+          {
+            id: "card-1",
+            title: "Review threat feed failures",
+            status: "ready",
+            priority: "high",
+            risk_level: "low",
+          },
+        ],
+      },
+    });
+
+    render(<SafeHouseBridgeOperatorPage mode="kanban" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("SafeHouse Operations Board")).toBeTruthy();
+      expect(screen.getByText("Review threat feed failures")).toBeTruthy();
+    });
+
+    expect(screen.getByText("SafeHouse bridge mode")).toBeTruthy();
+    expect(screen.getByText("Bridge connected")).toBeTruthy();
+  });
+
+  it("groups SafeHouse tools by bridge safety class", async () => {
+    installBridgeApi({ ok: true });
+
+    render(<SafeHouseBridgeOperatorPage mode="tools" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("SafeHouse Tool Registry")).toBeTruthy();
+      expect(screen.getAllByText(/read only/i).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/local safe write/i).length).toBeGreaterThan(
+        0,
+      );
+      expect(screen.getAllByText(/proposal only/i).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/blocked/i).length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/renderer/src/components/SafeHouseBridgeOperatorPage.tsx
+++ b/src/renderer/src/components/SafeHouseBridgeOperatorPage.tsx
@@ -1,0 +1,647 @@
+import {
+  type ReactElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { Refresh } from "../assets/icons";
+
+type SafeHouseToolClass =
+  | "read_only"
+  | "local_safe_write"
+  | "proposal_only"
+  | "blocked";
+
+interface SafeHouseToolEntry {
+  name: string;
+  description: string;
+  classification: SafeHouseToolClass;
+  risk_level: string;
+  approval_required: boolean;
+  action: string;
+}
+
+interface SafeHouseBridgeStatus {
+  ok: boolean;
+  bridge_url: string;
+  local_only: boolean;
+  service?: string;
+  version?: string;
+  mode?: string;
+  tools_count?: number;
+  mutations_blocked?: boolean;
+  error?: string;
+}
+
+interface SafeHouseToolEnvelope {
+  ok: boolean;
+  tool?: string;
+  action?: string;
+  classification?: SafeHouseToolClass;
+  risk_level?: string;
+  approval_required?: boolean;
+  source?: string;
+  status?: string;
+  result?: Record<string, unknown>;
+  mutation_performed?: boolean;
+  local_record_written?: boolean;
+  strict_json?: boolean;
+  error?: string;
+}
+
+type SafeHouseBridgeMode =
+  | "kanban"
+  | "skills"
+  | "memory"
+  | "tools"
+  | "gateway"
+  | "watchdog";
+
+interface SafeHouseBridgeOperatorPageProps {
+  mode: SafeHouseBridgeMode;
+}
+
+const PAGE_CONFIG: Record<
+  SafeHouseBridgeMode,
+  { title: string; subtitle: string; primaryTool?: string; emptyText: string }
+> = {
+  kanban: {
+    title: "SafeHouse Operations Board",
+    subtitle:
+      "SafeHouse bridge mode for local ops cards. These are local control-plane records only.",
+    primaryTool: "safehouse.ops.cards.list",
+    emptyText: "No SafeHouse operations cards returned by the bridge.",
+  },
+  skills: {
+    title: "SafeHouse Skills Registry",
+    subtitle:
+      "SafeHouse bridge mode for proposed, approved, active, disabled, and rejected skills.",
+    primaryTool: "safehouse.skills.list",
+    emptyText: "No SafeHouse skills returned by the bridge.",
+  },
+  memory: {
+    title: "SafeHouse Memory Candidates",
+    subtitle:
+      "SafeHouse bridge mode for reviewed recursive-learning candidates. Secrets are blocked.",
+    primaryTool: "safehouse.memory.candidates.list",
+    emptyText: "No SafeHouse memory candidates returned by the bridge.",
+  },
+  tools: {
+    title: "SafeHouse Tool Registry",
+    subtitle:
+      "Loopback-only SafeHouse tool manifest grouped by read-only, local-safe-write, proposal-only, and blocked classes.",
+    emptyText: "No SafeHouse tools returned by the bridge.",
+  },
+  gateway: {
+    title: "SafeHouse Gateway",
+    subtitle:
+      "Bridge health, endpoint, tool count, and local-only safety posture for SafeHouse operator mode.",
+    emptyText: "SafeHouse bridge is offline or returned no status.",
+  },
+  watchdog: {
+    title: "SafeHouse Watchdog",
+    subtitle:
+      "Read-only watchdog summaries through the SafeHouse Tool Bridge. No remediation is executed here.",
+    primaryTool: "safehouse.watchdog.status",
+    emptyText: "No SafeHouse watchdog data returned by the bridge.",
+  },
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function prettyLabel(value: string): string {
+  return value.replace(/_/g, " ");
+}
+
+function statusClass(value?: string): string {
+  const normalized = value?.toLowerCase() ?? "";
+  if (normalized.includes("blocked") || normalized.includes("reject"))
+    return "blocked";
+  if (normalized.includes("active") || normalized.includes("approved"))
+    return "ok";
+  if (normalized.includes("proposal") || normalized.includes("proposed"))
+    return "proposal";
+  return "neutral";
+}
+
+function safeString(value: unknown, fallback = ""): string {
+  if (value === null || value === undefined) return fallback;
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean")
+    return String(value);
+  return fallback;
+}
+
+function itemTitle(record: Record<string, unknown>, fallback: string): string {
+  return (
+    safeString(record.title) ||
+    safeString(record.skill_name) ||
+    safeString(record.name) ||
+    safeString(record.check_name) ||
+    safeString(record.id) ||
+    fallback
+  );
+}
+
+function itemDescription(record: Record<string, unknown>): string {
+  return (
+    safeString(record.description) ||
+    safeString(record.content) ||
+    safeString(record.summary) ||
+    safeString(record.recommended_action) ||
+    safeString(record.result_summary) ||
+    ""
+  );
+}
+
+function collectResultItems(
+  mode: SafeHouseBridgeMode,
+  envelope: SafeHouseToolEnvelope | null,
+): Record<string, unknown>[] {
+  const result = asRecord(envelope?.result);
+  const data = asRecord(result?.data) ?? result;
+  if (!data) return [];
+
+  const preferredKeys: Record<SafeHouseBridgeMode, string[]> = {
+    kanban: ["cards", "operations_cards", "board"],
+    skills: ["skills"],
+    memory: ["memory_candidates", "candidates"],
+    tools: [],
+    gateway: [],
+    watchdog: ["checks", "last_run_checks"],
+  };
+
+  for (const key of preferredKeys[mode]) {
+    const value = data[key];
+    if (Array.isArray(value)) {
+      return value
+        .map(asRecord)
+        .filter((item): item is Record<string, unknown> => Boolean(item));
+    }
+    const record = asRecord(value);
+    if (record) {
+      return Object.entries(record).map(([name, nested]) => ({
+        name,
+        ...(asRecord(nested) ?? { value: nested }),
+      }));
+    }
+  }
+
+  for (const value of Object.values(data)) {
+    if (Array.isArray(value)) {
+      return value
+        .map(asRecord)
+        .filter((item): item is Record<string, unknown> => Boolean(item));
+    }
+  }
+
+  return [];
+}
+
+function resultSummary(envelope: SafeHouseToolEnvelope | null): string {
+  const result = asRecord(envelope?.result);
+  return (
+    safeString(result?.summary) ||
+    safeString(result?.status) ||
+    envelope?.error ||
+    "No summary returned."
+  );
+}
+
+function ToolClassBadge({
+  value,
+}: {
+  value?: SafeHouseToolClass | string;
+}): React.JSX.Element {
+  const label = value ? prettyLabel(String(value)) : "unknown";
+  return (
+    <span className={`safehouse-bridge-badge ${statusClass(label)}`}>
+      {label}
+    </span>
+  );
+}
+
+function ResultCard({
+  mode,
+  record,
+  onAction,
+  busy,
+}: {
+  mode: SafeHouseBridgeMode;
+  record: Record<string, unknown>;
+  onAction: (tool: string, input: Record<string, unknown>) => Promise<void>;
+  busy: string | null;
+}): React.JSX.Element {
+  const id = safeString(record.id);
+  const status = safeString(record.status);
+  const title = itemTitle(record, "SafeHouse record");
+  const description = itemDescription(record);
+  const metadata = [
+    ["id", id],
+    ["status", status],
+    ["priority", safeString(record.priority)],
+    ["risk", safeString(record.risk_level)],
+    ["source", safeString(record.source)],
+    ["updated", safeString(record.updated_at)],
+  ].filter(([, value]) => Boolean(value));
+
+  const actionButton = (
+    label: string,
+    tool: string,
+    input: Record<string, unknown>,
+    className = "btn btn-secondary btn-sm",
+  ): ReactElement => (
+    <button
+      className={className}
+      disabled={!id || busy === `${tool}:${id}`}
+      onClick={() => onAction(tool, input)}
+    >
+      {label}
+    </button>
+  );
+
+  return (
+    <article className="safehouse-bridge-card">
+      <div className="safehouse-bridge-card-header">
+        <h3>{title}</h3>
+        {status && (
+          <span className={`safehouse-bridge-badge ${statusClass(status)}`}>
+            {status}
+          </span>
+        )}
+      </div>
+      {description && (
+        <p className="safehouse-bridge-card-desc">{description}</p>
+      )}
+      {metadata.length > 0 && (
+        <dl className="safehouse-bridge-meta">
+          {metadata.map(([key, value]) => (
+            <div key={key}>
+              <dt>{key}</dt>
+              <dd>{value}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
+      {id && mode === "kanban" && (
+        <div className="safehouse-bridge-actions">
+          {actionButton("Move to review", "safehouse.ops.cards.update_status", {
+            card_id: id,
+            status: "review",
+          })}
+          {actionButton("Archive", "safehouse.ops.cards.archive", {
+            card_id: id,
+          })}
+        </div>
+      )}
+      {id && mode === "skills" && (
+        <div className="safehouse-bridge-actions">
+          {actionButton("Approve", "safehouse.skills.review", {
+            skill_id: id,
+            status: "approved",
+          })}
+          {actionButton("Reject", "safehouse.skills.review", {
+            skill_id: id,
+            status: "rejected",
+          })}
+          {actionButton("Propose activate", "safehouse.skills.activate", {
+            skill_id: id,
+          })}
+          {actionButton("Propose disable", "safehouse.skills.disable", {
+            skill_id: id,
+          })}
+        </div>
+      )}
+      {id && mode === "memory" && (
+        <div className="safehouse-bridge-actions">
+          {actionButton("Approve", "safehouse.memory.candidates.review", {
+            memory_id: id,
+            status: "approved",
+          })}
+          {actionButton("Reject", "safehouse.memory.candidates.review", {
+            memory_id: id,
+            status: "rejected",
+          })}
+        </div>
+      )}
+    </article>
+  );
+}
+
+export default function SafeHouseBridgeOperatorPage({
+  mode,
+}: SafeHouseBridgeOperatorPageProps): React.JSX.Element {
+  const config = PAGE_CONFIG[mode];
+  const [status, setStatus] = useState<SafeHouseBridgeStatus | null>(null);
+  const [tools, setTools] = useState<SafeHouseToolEntry[]>([]);
+  const [result, setResult] = useState<SafeHouseToolEnvelope | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState("");
+  const [draftTitle, setDraftTitle] = useState("");
+  const [draftBody, setDraftBody] = useState("");
+
+  const toolsByClass = useMemo(() => {
+    const groups: Record<SafeHouseToolClass, SafeHouseToolEntry[]> = {
+      read_only: [],
+      local_safe_write: [],
+      proposal_only: [],
+      blocked: [],
+    };
+    for (const tool of tools) groups[tool.classification]?.push(tool);
+    return groups;
+  }, [tools]);
+
+  const load = useCallback(async (): Promise<void> => {
+    setLoading(true);
+    setError("");
+    try {
+      const [bridgeStatus, manifest] = await Promise.all([
+        window.hermesAPI.getSafeHouseToolBridgeStatus(),
+        window.hermesAPI.listSafeHouseTools(),
+      ]);
+      setStatus(bridgeStatus as SafeHouseBridgeStatus);
+      setTools((manifest.tools ?? []) as SafeHouseToolEntry[]);
+      if (config.primaryTool && bridgeStatus.ok) {
+        const envelope = await window.hermesAPI.callSafeHouseTool(
+          config.primaryTool,
+          {},
+        );
+        setResult(envelope as SafeHouseToolEnvelope);
+      } else {
+        setResult(null);
+      }
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "SafeHouse bridge unavailable.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [config.primaryTool]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const runTool = useCallback(
+    async (tool: string, input: Record<string, unknown>): Promise<void> => {
+      const itemId = safeString(
+        input.card_id ?? input.skill_id ?? input.memory_id ?? input.id,
+        "new",
+      );
+      setBusy(`${tool}:${itemId}`);
+      setError("");
+      try {
+        const envelope = (await window.hermesAPI.callSafeHouseTool(
+          tool,
+          input,
+        )) as SafeHouseToolEnvelope;
+        setResult(envelope);
+        if (!envelope.ok) {
+          setError(envelope.error ?? `${tool} failed.`);
+        } else if (config.primaryTool) {
+          const refreshed = (await window.hermesAPI.callSafeHouseTool(
+            config.primaryTool,
+            {},
+          )) as SafeHouseToolEnvelope;
+          setResult(refreshed);
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : `${tool} failed.`);
+      } finally {
+        setBusy(null);
+      }
+    },
+    [config.primaryTool],
+  );
+
+  const submitDraft = async (): Promise<void> => {
+    const title = draftTitle.trim();
+    const body = draftBody.trim();
+    if (!title && mode !== "memory") return;
+    if (mode === "kanban") {
+      await runTool("safehouse.ops.cards.create", {
+        title,
+        description:
+          body || "Created from Hermes Desktop SafeHouse bridge mode.",
+        priority: "medium",
+        source: "hermes_desktop",
+        assigned_runtime: "hermes",
+        risk_level: "low",
+        approval_required: false,
+      });
+    }
+    if (mode === "skills") {
+      await runTool("safehouse.skills.propose", {
+        skill_name: title,
+        description:
+          body || "Proposed from Hermes Desktop SafeHouse bridge mode.",
+        source: "hermes_desktop",
+        risk_level: "read_only",
+        tool_scope: ["safehouse.watchdog.status"],
+        approval_required: true,
+      });
+    }
+    if (mode === "memory") {
+      await runTool("safehouse.memory.candidates.propose", {
+        memory_type: "operator_preference",
+        content: body || title,
+        source: "hermes_desktop",
+        confidence: 0.8,
+      });
+    }
+    setDraftTitle("");
+    setDraftBody("");
+  };
+
+  const items = collectResultItems(mode, result);
+
+  return (
+    <div className="safehouse-bridge-page">
+      <div className="safehouse-bridge-hero">
+        <div>
+          <div className="safehouse-bridge-kicker">SafeHouse bridge mode</div>
+          <h1>{config.title}</h1>
+          <p>{config.subtitle}</p>
+        </div>
+        <button
+          className="btn btn-secondary btn-sm"
+          onClick={load}
+          disabled={loading}
+        >
+          <Refresh size={13} />
+          Refresh
+        </button>
+      </div>
+
+      <div
+        className={`safehouse-bridge-status-card ${status?.ok ? "connected" : "offline"}`}
+      >
+        <div>
+          <strong>
+            {status?.ok ? "Bridge connected" : "Bridge unavailable"}
+          </strong>
+          <p>{status?.bridge_url ?? "http://127.0.0.1:57109"}</p>
+        </div>
+        <div className="safehouse-bridge-status-grid">
+          <span>{status?.tools_count ?? tools.length} tools</span>
+          <span>local only: {status?.local_only === false ? "no" : "yes"}</span>
+          <span>
+            mutations blocked:{" "}
+            {status?.mutations_blocked === false ? "no" : "yes"}
+          </span>
+        </div>
+      </div>
+
+      {error && <div className="safehouse-bridge-error">{error}</div>}
+      {loading && (
+        <div className="safehouse-bridge-loading">
+          Loading SafeHouse bridge data...
+        </div>
+      )}
+
+      {(mode === "kanban" || mode === "skills" || mode === "memory") &&
+        status?.ok && (
+          <div className="safehouse-bridge-draft">
+            <h2>
+              {mode === "kanban"
+                ? "Create local ops card"
+                : mode === "skills"
+                  ? "Propose skill"
+                  : "Propose memory candidate"}
+            </h2>
+            {mode !== "memory" && (
+              <input
+                className="input"
+                value={draftTitle}
+                onChange={(event) => setDraftTitle(event.target.value)}
+                placeholder={mode === "skills" ? "Skill name" : "Task title"}
+              />
+            )}
+            <textarea
+              className="input safehouse-bridge-textarea"
+              value={draftBody}
+              onChange={(event) => setDraftBody(event.target.value)}
+              placeholder={
+                mode === "memory"
+                  ? "Safe platform memory candidate. Do not paste secrets."
+                  : "Description"
+              }
+            />
+            <button
+              className="btn btn-primary btn-sm"
+              disabled={
+                Boolean(busy) || (!draftTitle.trim() && mode !== "memory")
+              }
+              onClick={submitDraft}
+            >
+              {mode === "kanban"
+                ? "Create card"
+                : mode === "skills"
+                  ? "Propose skill"
+                  : "Propose memory"}
+            </button>
+            <p className="safehouse-bridge-note">
+              Local-safe writes create SafeHouse control-plane records only.
+              They do not run migrations, deploy production, prune Docker,
+              expose secrets, or bypass approvals.
+            </p>
+          </div>
+        )}
+
+      {mode === "watchdog" && status?.ok && (
+        <div className="safehouse-bridge-actions">
+          <button
+            className="btn btn-secondary btn-sm"
+            disabled={Boolean(busy)}
+            onClick={() => runTool("safehouse.watchdog.run_all_readonly", {})}
+          >
+            Run all read-only watchdog checks
+          </button>
+        </div>
+      )}
+
+      {(mode === "tools" || mode === "gateway") && (
+        <div className="safehouse-bridge-tool-groups">
+          {(Object.keys(toolsByClass) as SafeHouseToolClass[]).map(
+            (classification) => (
+              <section
+                key={classification}
+                className="safehouse-bridge-tool-group"
+              >
+                <h2>
+                  {prettyLabel(classification)} (
+                  {toolsByClass[classification].length})
+                </h2>
+                <div className="safehouse-bridge-tool-list">
+                  {toolsByClass[classification].map((tool) => (
+                    <article
+                      key={tool.name}
+                      className="safehouse-bridge-tool-card"
+                    >
+                      <div className="safehouse-bridge-card-header">
+                        <h3>{tool.name}</h3>
+                        <ToolClassBadge value={tool.classification} />
+                      </div>
+                      <p>{tool.description}</p>
+                      <span>action: {tool.action}</span>
+                      <span>
+                        approval:{" "}
+                        {tool.approval_required ? "required" : "not required"}
+                      </span>
+                    </article>
+                  ))}
+                </div>
+              </section>
+            ),
+          )}
+        </div>
+      )}
+
+      {mode !== "tools" && mode !== "gateway" && (
+        <div className="safehouse-bridge-results">
+          <div className="safehouse-bridge-result-summary">
+            <strong>
+              {result?.tool ?? config.primaryTool ?? "SafeHouse bridge"}
+            </strong>
+            <p>{resultSummary(result)}</p>
+            {result?.classification && (
+              <ToolClassBadge value={result.classification} />
+            )}
+          </div>
+          {items.length === 0 && !loading ? (
+            <div className="safehouse-bridge-empty">{config.emptyText}</div>
+          ) : (
+            <div className="safehouse-bridge-card-grid">
+              {items.map((item, index) => (
+                <ResultCard
+                  key={safeString(item.id, `${mode}-${index}`)}
+                  mode={mode}
+                  record={item}
+                  onAction={runTool}
+                  busy={busy}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="safehouse-bridge-boundaries">
+        <strong>Safety boundaries</strong>
+        <p>
+          Desktop bridge mode never receives DB credentials, Supabase
+          service-role keys, production secrets, or destructive mutation
+          authority. Dangerous commands remain blocked by SafeHouse policy and
+          OpenClaw fallback remains preserved.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/src/screens/Chat/Chat.tsx
+++ b/src/renderer/src/screens/Chat/Chat.tsx
@@ -49,6 +49,13 @@ function Chat({
   // Working folder bound to this conversation (issue #27). Per-conversation,
   // held in memory; reset on session switch / new chat below.
   const [contextFolder, setContextFolder] = useState<string | null>(null);
+  const [safeHouseBridge, setSafeHouseBridge] = useState<{
+    ok: boolean;
+    bridgeUrl: string;
+    toolsCount: number;
+    mode: string;
+    error?: string;
+  } | null>(null);
   const dragCounter = useRef(0);
   const chatInputRef = useRef<ChatInputHandle>(null);
   const queueRef = useRef<QueuedMessage[]>([]);
@@ -59,6 +66,35 @@ function Chat({
     (async (): Promise<void> => {
       const flag = await window.hermesAPI.isRemoteMode();
       if (!cancelled) setRemoteMode(flag);
+    })();
+    return (): void => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async (): Promise<void> => {
+      const status = await window.hermesAPI.getSafeHouseToolBridgeStatus();
+      let toolsCount = status.tools_count ?? 0;
+      if (status.ok) {
+        try {
+          const manifest = await window.hermesAPI.listSafeHouseTools();
+          toolsCount = manifest.tools.length;
+        } catch {
+          // Health is enough to show the bridge is reachable; keep the
+          // health-reported count when the manifest request races startup.
+        }
+      }
+      if (!cancelled) {
+        setSafeHouseBridge({
+          ok: status.ok,
+          bridgeUrl: status.bridge_url,
+          toolsCount,
+          mode: status.mode || "unknown",
+          error: status.error,
+        });
+      }
     })();
     return (): void => {
       cancelled = true;
@@ -333,6 +369,23 @@ function Chat({
         </div>
       )}
       <div className="chat-input-area">
+        <div
+          className={`safehouse-tool-bridge-status ${
+            safeHouseBridge?.ok ? "connected" : "offline"
+          }`}
+          data-testid="safehouse-tool-bridge-status"
+          title={safeHouseBridge?.bridgeUrl}
+        >
+          <span className="safehouse-tool-bridge-dot" aria-hidden />
+          <span className="safehouse-tool-bridge-label">
+            SafeHouse tools {safeHouseBridge?.ok ? "connected" : "offline"}
+          </span>
+          <span className="safehouse-tool-bridge-detail">
+            {safeHouseBridge?.ok
+              ? `${safeHouseBridge.toolsCount} tools • ${safeHouseBridge.mode} • profile ${profile || "default"}`
+              : safeHouseBridge?.error || "Start http://127.0.0.1:57109"}
+          </span>
+        </div>
         <ChatInput
           ref={chatInputRef}
           isLoading={isLoading}

--- a/src/renderer/src/screens/Chat/hooks/useChatActions.ts
+++ b/src/renderer/src/screens/Chat/hooks/useChatActions.ts
@@ -119,12 +119,56 @@ export function useChatActions({
         return;
       }
 
+      const safeHouseRoute = text
+        ? await window.hermesAPI.routeSafeHousePrompt(text)
+        : null;
+      if (safeHouseRoute) {
+        setIsLoading(true);
+        pushUser(text, "user");
+        onSessionStarted?.();
+        try {
+          const result = await window.hermesAPI.askSafeHouseToolBridge(text);
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: `agent-safehouse-${Date.now()}`,
+              role: "agent",
+              content:
+                result.markdown ||
+                result.error ||
+                "SafeHouse tool bridge returned no displayable result.",
+            },
+          ]);
+        } catch (error) {
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: `agent-safehouse-error-${Date.now()}`,
+              role: "agent",
+              content: `SafeHouse Tool Bridge error: ${
+                error instanceof Error ? error.message : "unknown error"
+              }`,
+            },
+          ]);
+        } finally {
+          setIsLoading(false);
+        }
+        return;
+      }
+
       setIsLoading(true);
       pushUser(text, "user", attachments);
       onSessionStarted?.();
       await sendToAgent(text, attachments);
     },
-    [localCommands, pushUser, onSessionStarted, sendToAgent, setIsLoading],
+    [
+      localCommands,
+      pushUser,
+      onSessionStarted,
+      sendToAgent,
+      setIsLoading,
+      setMessages,
+    ],
   );
 
   const handleQuickAsk = useCallback(

--- a/src/renderer/src/screens/Layout/Layout.tsx
+++ b/src/renderer/src/screens/Layout/Layout.tsx
@@ -18,6 +18,7 @@ import Providers from "../Providers/Providers";
 import Schedules from "../Schedules/Schedules";
 import Kanban from "../Kanban/Kanban";
 import RemoteNotice from "../../components/RemoteNotice";
+import SafeHouseBridgeOperatorPage from "../../components/SafeHouseBridgeOperatorPage";
 import VerifyWarningBanner from "../../components/VerifyWarningBanner";
 import hermeslogo from "../../assets/hermes.png";
 import {
@@ -340,7 +341,7 @@ function Layout({
         {visitedViews.has("skills") && (
           <div style={paneStyle("skills")}>
             {remoteMode ? (
-              <RemoteNotice feature="Skills" />
+              <SafeHouseBridgeOperatorPage mode="skills" />
             ) : (
               <Skills profile={activeProfile} />
             )}
@@ -360,7 +361,7 @@ function Layout({
         {visitedViews.has("memory") && (
           <div style={paneStyle("memory")}>
             {remoteMode ? (
-              <RemoteNotice feature="Memory" />
+              <SafeHouseBridgeOperatorPage mode="memory" />
             ) : (
               <Memory profile={activeProfile} />
             )}
@@ -370,7 +371,7 @@ function Layout({
         {visitedViews.has("tools") && (
           <div style={paneStyle("tools")}>
             {remoteMode ? (
-              <RemoteNotice feature="Tools" />
+              <SafeHouseBridgeOperatorPage mode="tools" />
             ) : (
               <Tools profile={activeProfile} />
             )}
@@ -379,14 +380,18 @@ function Layout({
 
         {visitedViews.has("schedules") && (
           <div style={paneStyle("schedules")}>
-            <Schedules profile={activeProfile} />
+            {remoteMode ? (
+              <SafeHouseBridgeOperatorPage mode="watchdog" />
+            ) : (
+              <Schedules profile={activeProfile} />
+            )}
           </div>
         )}
 
         {visitedViews.has("kanban") && (
           <div style={paneStyle("kanban")}>
             {remoteMode ? (
-              <RemoteNotice feature="Kanban" />
+              <SafeHouseBridgeOperatorPage mode="kanban" />
             ) : (
               <Kanban profile={activeProfile} visible={view === "kanban"} />
             )}
@@ -396,7 +401,7 @@ function Layout({
         {visitedViews.has("gateway") && (
           <div style={paneStyle("gateway")}>
             {remoteMode ? (
-              <RemoteNotice feature="Gateway" />
+              <SafeHouseBridgeOperatorPage mode="gateway" />
             ) : (
               <Gateway profile={activeProfile} />
             )}

--- a/tests/ipc-handlers.test.ts
+++ b/tests/ipc-handlers.test.ts
@@ -65,6 +65,11 @@ describe("New IPC handlers from v0.8/v0.9 features", () => {
     "run-hermes-dump",
     "list-mcp-servers",
     "discover-memory-providers",
+    "safehouse-bridge-status",
+    "safehouse-bridge-tools",
+    "safehouse-bridge-call",
+    "safehouse-route-prompt",
+    "safehouse-ask",
   ];
 
   for (const ch of newChannels) {

--- a/tests/preload-api-surface.test.ts
+++ b/tests/preload-api-surface.test.ts
@@ -92,6 +92,19 @@ describe("New APIs from v0.8/v0.9 features", () => {
     expect(preloadMethods).toContain("discoverMemoryProviders");
     expect(typeMethods).toContain("discoverMemoryProviders");
   });
+
+  it("has SafeHouse Tool Bridge APIs", () => {
+    for (const method of [
+      "getSafeHouseToolBridgeStatus",
+      "listSafeHouseTools",
+      "callSafeHouseTool",
+      "routeSafeHousePrompt",
+      "askSafeHouseToolBridge",
+    ]) {
+      expect(preloadMethods).toContain(method);
+      expect(typeMethods).toContain(method);
+    }
+  });
 });
 
 // ─── Legacy APIs still present ──────────────────────────

--- a/tests/safehouse-tools.test.ts
+++ b/tests/safehouse-tools.test.ts
@@ -166,6 +166,9 @@ describe("SafeHouse Tool Bridge client", () => {
     expect(routeSafeHousePrompt("What can you control?")?.tool).toBe(
       "safehouse.action.permissions",
     );
+    expect(routeSafeHousePrompt("What are you blocked from doing?")?.tool).toBe(
+      "safehouse.action.permissions",
+    );
     expect(routeSafeHousePrompt("What is running locally?")?.tool).toBe(
       "safehouse.runtime.snapshot",
     );

--- a/tests/safehouse-tools.test.ts
+++ b/tests/safehouse-tools.test.ts
@@ -9,6 +9,7 @@ import {
   redactSafeHouseBridgeValue,
   resolveSafeHouseBridgeUrl,
   routeSafeHousePrompt,
+  formatSafeHouseToolResponse,
 } from "../src/main/safehouse-tools";
 
 const servers: http.Server[] = [];
@@ -182,6 +183,56 @@ describe("SafeHouse Tool Bridge client", () => {
     expect(result.response?.mutation_performed).toBe(false);
     expect(result.markdown).toContain("SafeHouse Tool Result");
     expect(result.markdown).toContain("Mutation performed: no");
+  });
+
+  it("renders live gateway-backed run output instead of the bridge envelope", () => {
+    const markdown = formatSafeHouseToolResponse(
+      {
+        tool: "safehouse.platform.status",
+        action: "platform_status",
+        classification: "read_only",
+        reason: "test",
+      },
+      {
+        ok: true,
+        tool: "safehouse.platform.status",
+        action: "platform_status",
+        classification: "read_only",
+        source: "safehouse_agent_runtime_gateway",
+        status: "completed",
+        result: {
+          ok: true,
+          status: "completed",
+          gateway: {
+            data: {
+              run: {
+                run_id: "run-123",
+                runtime: "hermes",
+                schema_valid: true,
+                output: {
+                  summary: "Live platform summary.",
+                  status: "degraded",
+                  key_findings: ["Gateway output rendered."],
+                  risks: ["Provider can be unavailable."],
+                  recommended_next_actions: ["Keep fallback available."],
+                  runtime_notes: ["No mutation."],
+                },
+                provider_truth: {
+                  provider_mode: "real_hermes_model",
+                },
+              },
+            },
+          },
+        },
+      },
+    );
+
+    expect(markdown).toContain("Live platform summary.");
+    expect(markdown).toContain("Run ID: `run-123`");
+    expect(markdown).toContain("Runtime: hermes");
+    expect(markdown).toContain("Provider mode: real_hermes_model");
+    expect(markdown).toContain("Strict JSON: yes");
+    expect(markdown).not.toContain("No summary returned");
   });
 
   it("renders blocked tool responses as policy-blocked with no mutation", async () => {

--- a/tests/safehouse-tools.test.ts
+++ b/tests/safehouse-tools.test.ts
@@ -184,6 +184,35 @@ describe("SafeHouse Tool Bridge client", () => {
     expect(
       routeSafeHousePrompt("Can you access the database directly?")?.tool,
     ).toBe("safehouse.block.secret_access");
+    expect(routeSafeHousePrompt("Show operations board.")?.tool).toBe(
+      "safehouse.ops.cards.list",
+    );
+    expect(
+      routeSafeHousePrompt("Create a task to review threat feed failures.")
+        ?.tool,
+    ).toBe("safehouse.ops.cards.create");
+    expect(
+      routeSafeHousePrompt(
+        "Propose a skill for checking extension store readiness.",
+      )?.tool,
+    ).toBe("safehouse.skills.propose");
+    expect(
+      routeSafeHousePrompt(
+        "Remember that GitHub Actions minutes must be conserved.",
+      )?.tool,
+    ).toBe("safehouse.memory.candidates.propose");
+    expect(
+      routeSafeHousePrompt("Run all read-only watchdog checks.")?.tool,
+    ).toBe("safehouse.watchdog.run_all_readonly");
+    expect(
+      routeSafeHousePrompt("Spin up an agent to inspect outbound queue.")?.tool,
+    ).toBe("safehouse.agents.delegate_readonly");
+    expect(routeSafeHousePrompt("Can you prune Docker?")?.tool).toBe(
+      "safehouse.block.docker_prune",
+    );
+    expect(routeSafeHousePrompt("Can you remove OpenClaw?")?.tool).toBe(
+      "safehouse.block.openclaw_removal",
+    );
     expect(routeSafeHousePrompt("write a poem")).toBeNull();
   });
 
@@ -287,6 +316,42 @@ describe("SafeHouse Tool Bridge client", () => {
     expect(markdown).toContain("visible_modules: 2 item(s)");
     expect(markdown).toContain("**Limitations**");
     expect(markdown).toContain("No direct DB console.");
+  });
+
+  it("renders local-safe operations tool responses", () => {
+    const markdown = formatSafeHouseToolResponse(
+      {
+        tool: "safehouse.ops.cards.create",
+        action: "ops_cards_create",
+        classification: "local_safe_write",
+        reason: "test",
+      },
+      {
+        ok: true,
+        tool: "safehouse.ops.cards.create",
+        action: "ops_cards_create",
+        classification: "local_safe_write",
+        source: "safehouse_ops_autopilot",
+        status: "completed",
+        result: {
+          summary: "Created local operations card.",
+          status: "healthy",
+          data: { card: { title: "Review threat feed failures" } },
+          risks: ["No execution authority."],
+          limitations: ["No production system changed."],
+          recommended_next_actions: ["Review card."],
+          local_record_written: true,
+          runtime_notes: ["platform_mutation=false"],
+        },
+        mutation_performed: false,
+        strict_json: true,
+      },
+    );
+
+    expect(markdown).toContain("Created local operations card.");
+    expect(markdown).toContain("Classification: local_safe_write");
+    expect(markdown).toContain("Mutation performed: no");
+    expect(markdown).toContain("local_record_written: true");
   });
 
   it("renders blocked tool responses as policy-blocked with no mutation", async () => {

--- a/tests/safehouse-tools.test.ts
+++ b/tests/safehouse-tools.test.ts
@@ -1,0 +1,212 @@
+import http from "http";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  askSafeHouseToolBridge,
+  callSafeHouseTool,
+  getSafeHouseToolBridgeHealth,
+  isLoopbackBridgeUrl,
+  listSafeHouseTools,
+  redactSafeHouseBridgeValue,
+  resolveSafeHouseBridgeUrl,
+  routeSafeHousePrompt,
+} from "../src/main/safehouse-tools";
+
+const servers: http.Server[] = [];
+
+async function startMockBridge(): Promise<{
+  url: string;
+  calls: Array<{ url: string; body: unknown }>;
+}> {
+  const calls: Array<{ url: string; body: unknown }> = [];
+  const server = http.createServer(async (req, res) => {
+    res.setHeader("Content-Type", "application/json");
+    if (req.method === "GET" && req.url === "/health") {
+      res.end(
+        JSON.stringify({
+          ok: true,
+          service: "safehouse-hermes-tool-bridge",
+          mode: "local_proof",
+          tools_count: 2,
+          mutations_blocked: true,
+          direct_db_access: false,
+          service_role_key_required: false,
+        }),
+      );
+      return;
+    }
+    if (req.method === "GET" && req.url === "/tools") {
+      res.end(
+        JSON.stringify({
+          name: "safehouse-signal-admin-tools",
+          version: "test",
+          tools: [
+            {
+              name: "safehouse.platform.status",
+              description: "Platform status",
+              classification: "read_only",
+              risk_level: "read_only",
+              approval_required: false,
+              action: "platform_status",
+            },
+            {
+              name: "safehouse.block.migration",
+              description: "Block migration",
+              classification: "blocked",
+              risk_level: "blocked",
+              approval_required: true,
+              action: "migration",
+            },
+          ],
+        }),
+      );
+      return;
+    }
+    if (req.method === "POST" && req.url === "/tools/call") {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) chunks.push(Buffer.from(chunk));
+      const body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      calls.push({ url: req.url, body });
+      const blocked = body.tool === "safehouse.block.migration";
+      res.end(
+        JSON.stringify({
+          ok: true,
+          tool: body.tool,
+          action: blocked ? "migration" : "platform_status",
+          classification: blocked ? "blocked" : "read_only",
+          source: blocked ? "policy_block" : "local_proof",
+          status: blocked ? "blocked" : "completed",
+          result: {
+            summary: blocked
+              ? "Migration is blocked by policy."
+              : "Platform status is available.",
+            status: blocked ? "blocked" : "unknown",
+            key_findings: ["Bridge call reached SafeHouse mock."],
+            risks: ["No mutation was performed."],
+            recommended_next_actions: ["Keep using approved tools."],
+            runtime_notes: ["test bridge"],
+          },
+          mutation_performed: false,
+          strict_json: true,
+        }),
+      );
+      return;
+    }
+    res.statusCode = 404;
+    res.end(JSON.stringify({ ok: false, error: "not found" }));
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  servers.push(server);
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("mock server did not bind");
+  }
+  return { url: `http://127.0.0.1:${address.port}`, calls };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    servers
+      .splice(0)
+      .map(
+        (server) =>
+          new Promise<void>((resolve) => server.close(() => resolve())),
+      ),
+  );
+});
+
+describe("SafeHouse Tool Bridge client", () => {
+  it("accepts loopback bridge URLs and rejects non-local URLs", () => {
+    expect(isLoopbackBridgeUrl("http://127.0.0.1:57109")).toBe(true);
+    expect(isLoopbackBridgeUrl("http://localhost:57109")).toBe(true);
+    expect(isLoopbackBridgeUrl("https://example.com/tools")).toBe(false);
+    expect(() =>
+      resolveSafeHouseBridgeUrl("https://example.com/tools"),
+    ).toThrow(/loopback/);
+  });
+
+  it("loads bridge health and tool manifest", async () => {
+    const bridge = await startMockBridge();
+    const health = await getSafeHouseToolBridgeHealth(bridge.url);
+    const manifest = await listSafeHouseTools(bridge.url);
+
+    expect(health.ok).toBe(true);
+    expect(health.bridge_url).toBe(bridge.url);
+    expect(health.mutations_blocked).toBe(true);
+    expect(manifest.tools).toHaveLength(2);
+  });
+
+  it("calls read-only tools without leaking secrets", async () => {
+    const bridge = await startMockBridge();
+    const result = await callSafeHouseTool(
+      "safehouse.platform.status",
+      {
+        prompt: "Summarize platform health",
+        token: "sk-test-secret",
+      },
+      bridge.url,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.classification).toBe("read_only");
+    expect(result.mutation_performed).toBe(false);
+    expect(JSON.stringify(result)).not.toContain("sk-test-secret");
+    expect(JSON.stringify(bridge.calls[0].body)).not.toContain(
+      "sk-test-secret",
+    );
+  });
+
+  it("routes plain-English SafeHouse prompts to approved tools", () => {
+    expect(
+      routeSafeHousePrompt("Summarize SafeHouse platform health")?.tool,
+    ).toBe("safehouse.platform.status");
+    expect(routeSafeHousePrompt("Check API usage")?.tool).toBe(
+      "safehouse.api.usage.summary",
+    );
+    expect(
+      routeSafeHousePrompt("Can you replay failed queue items?")?.tool,
+    ).toBe("safehouse.propose.queue.retry");
+    expect(routeSafeHousePrompt("Can you run a migration?")?.tool).toBe(
+      "safehouse.block.migration",
+    );
+    expect(routeSafeHousePrompt("write a poem")).toBeNull();
+  });
+
+  it("returns display markdown for routed bridge prompts", async () => {
+    const bridge = await startMockBridge();
+    const result = await askSafeHouseToolBridge(
+      "Summarize SafeHouse platform health",
+      bridge.url,
+    );
+
+    expect(result.matched).toBe(true);
+    expect(result.response?.mutation_performed).toBe(false);
+    expect(result.markdown).toContain("SafeHouse Tool Result");
+    expect(result.markdown).toContain("Mutation performed: no");
+  });
+
+  it("renders blocked tool responses as policy-blocked with no mutation", async () => {
+    const bridge = await startMockBridge();
+    const result = await askSafeHouseToolBridge(
+      "Can you run a migration?",
+      bridge.url,
+    );
+
+    expect(result.matched).toBe(true);
+    expect(result.route?.classification).toBe("blocked");
+    expect(result.response?.classification).toBe("blocked");
+    expect(result.response?.mutation_performed).toBe(false);
+    expect(result.markdown).toContain("Blocked by policy");
+  });
+
+  it("redacts secret-like fields from bridge values", () => {
+    expect(
+      redactSafeHouseBridgeValue({
+        authorization: "Bearer abc123",
+        nested: { api_key: "sk-test-secret" },
+      }),
+    ).toEqual({
+      authorization: "[redacted]",
+      nested: { api_key: "[redacted]" },
+    });
+  });
+});

--- a/tests/safehouse-tools.test.ts
+++ b/tests/safehouse-tools.test.ts
@@ -157,6 +157,18 @@ describe("SafeHouse Tool Bridge client", () => {
   });
 
   it("routes plain-English SafeHouse prompts to approved tools", () => {
+    expect(routeSafeHousePrompt("Can you see the platform?")?.tool).toBe(
+      "safehouse.platform.visibility",
+    );
+    expect(
+      routeSafeHousePrompt("What SafeHouse modules can you inspect?")?.tool,
+    ).toBe("safehouse.platform.map");
+    expect(routeSafeHousePrompt("What can you control?")?.tool).toBe(
+      "safehouse.action.permissions",
+    );
+    expect(routeSafeHousePrompt("What is running locally?")?.tool).toBe(
+      "safehouse.runtime.snapshot",
+    );
     expect(
       routeSafeHousePrompt("Summarize SafeHouse platform health")?.tool,
     ).toBe("safehouse.platform.status");
@@ -169,6 +181,9 @@ describe("SafeHouse Tool Bridge client", () => {
     expect(routeSafeHousePrompt("Can you run a migration?")?.tool).toBe(
       "safehouse.block.migration",
     );
+    expect(
+      routeSafeHousePrompt("Can you access the database directly?")?.tool,
+    ).toBe("safehouse.block.secret_access");
     expect(routeSafeHousePrompt("write a poem")).toBeNull();
   });
 
@@ -233,6 +248,45 @@ describe("SafeHouse Tool Bridge client", () => {
     expect(markdown).toContain("Provider mode: real_hermes_model");
     expect(markdown).toContain("Strict JSON: yes");
     expect(markdown).not.toContain("No summary returned");
+  });
+
+  it("renders visibility tool data and limitations", () => {
+    const markdown = formatSafeHouseToolResponse(
+      {
+        tool: "safehouse.platform.visibility",
+        action: "platform_visibility",
+        classification: "read_only",
+        reason: "test",
+      },
+      {
+        ok: true,
+        tool: "safehouse.platform.visibility",
+        action: "platform_visibility",
+        classification: "read_only",
+        source: "safehouse_tool_bridge_visibility",
+        status: "completed",
+        result: {
+          summary: "Hermes sees SafeHouse through approved tools.",
+          status: "healthy",
+          data: {
+            visible_modules: ["platform health", "agent runs"],
+            available_tools: ["safehouse.platform.map"],
+          },
+          risks: ["Visibility is bounded."],
+          limitations: ["No direct DB console."],
+          recommended_next_actions: ["Use safehouse.action.permissions."],
+          runtime_notes: ["mutation=false"],
+        },
+        mutation_performed: false,
+        strict_json: true,
+      },
+    );
+
+    expect(markdown).toContain("Hermes sees SafeHouse through approved tools.");
+    expect(markdown).toContain("**Tool data**");
+    expect(markdown).toContain("visible_modules: 2 item(s)");
+    expect(markdown).toContain("**Limitations**");
+    expect(markdown).toContain("No direct DB console.");
   });
 
   it("renders blocked tool responses as policy-blocked with no mutation", async () => {


### PR DESCRIPTION
- Adds loopback-only SafeHouse Tool Bridge support.
- Loads SafeHouse tools from GET /tools.
- Calls POST /tools/call.
- Routes SafeHouse prompts deterministically.
- Renders read-only, local-safe-write, proposal-only, and blocked results.
- Rejects unsafe non-loopback bridge URLs.
- No DB credentials, service-role key, secrets, or mutation authority added.
- Validation: lint, test, typecheck, build, git diff --check.