### PR TITLE
fix(windows): launch Python via pythonw.exe to suppress console flash (#342)

### DIFF
--- a/src/main/installer.ts
+++ b/src/main/installer.ts
@@ -120,8 +120,19 @@ export const HERMES_HOME =
   defaultHermesHome();
 export const HERMES_REPO = join(HERMES_HOME, "hermes-agent");
 export const HERMES_VENV = join(HERMES_REPO, "venv");
+// On Windows, use `pythonw.exe` (the GUI-subsystem interpreter that ships in
+// every venv) instead of `python.exe` so that subprocess spawns don't flash
+// a blank console window before `windowsHide: true` / CREATE_NO_WINDOW takes
+// effect. Issue #342: on every chat send the `sendMessageViaCli` fallback
+// path spawned `python.exe`, and the console appeared for a few hundred ms
+// despite `windowsHide: true` — a well-known race between console allocation
+// and CREATE_NO_WINDOW on console-subsystem child binaries. `pythonw.exe`
+// is linked as Windows subsystem, so the OS can never allocate a console
+// for it regardless of creation flags. It's a bit-identical interpreter
+// otherwise — same modules, same stdout/stderr behaviour over piped stdio
+// (which is what every call site here uses).
 export const HERMES_PYTHON = IS_WINDOWS
-  ? join(HERMES_VENV, "Scripts", "python.exe")
+  ? join(HERMES_VENV, "Scripts", "pythonw.exe")
   : join(HERMES_VENV, "bin", "python");
 export const HERMES_SCRIPT = IS_WINDOWS
   ? join(HERMES_VENV, "Scripts", "hermes.exe")

--- a/tests/installer-platform.test.ts
+++ b/tests/installer-platform.test.ts
@@ -20,7 +20,10 @@ describe("installer platform wiring", () => {
 
     if (process.platform === "win32") {
       expect(args).toEqual(["-m", "hermes_cli.main", "--version"]);
-      expect(HERMES_PYTHON).toMatch(/venv[\\/]Scripts[\\/]python\.exe$/);
+      // Use `pythonw.exe` (Windows-subsystem) instead of `python.exe` so
+      // child spawns don't flash a blank console window before
+      // `windowsHide`/CREATE_NO_WINDOW takes effect — see issue #342.
+      expect(HERMES_PYTHON).toMatch(/venv[\\/]Scripts[\\/]pythonw\.exe$/);
       expect(HERMES_SCRIPT).toMatch(/venv[\\/]Scripts[\\/]hermes\.exe$/);
       return;
     }


### PR DESCRIPTION
Closes #342. Adopts the "Suggested Fix A" from the reporter — credit to @Orangew5639 for an unusually thorough root-cause writeup.

## The bug

Every chat send on Windows v0.5.0 flashes a blank "Python" console window for a few hundred ms. Trigger: every `sendMessageViaCli` invocation spawns `python.exe` with `windowsHide: true`, and the flag has a documented race against console allocation on console-subsystem child binaries — the OS opens the console before `CREATE_NO_WINDOW` takes full effect. The flag *usually* works, which is why this doesn't reproduce universally, but it's intermittent enough to be a real UX papercut for affected users.

## The fix

One-line change in `src/main/installer.ts`: point `HERMES_PYTHON` at `pythonw.exe` on Windows instead of `python.exe`.

`pythonw.exe` is the same interpreter linked as Windows-subsystem rather than console-subsystem. The OS literally cannot allocate a console for it, regardless of any creation flags. It ships in every standard CPython venv alongside `python.exe`.

The swap is behaviour-preserving for this codebase because every `spawn` / `execFile` / `execFileSync` site uses `ignore` or piped stdio — `pythonw.exe` writes to piped stdout/stderr exactly the same way `python.exe` does. Nothing inherits stdio, nothing needs an interactive console.

This covers all affected entry points in one go, not just `sendMessageViaCli`: doctor, version probe, model discovery, skills install/uninstall/inspect, kanban CLI, hermes-auth OAuth login, cron jobs, profile management.

## Why this is the right fix

The reporter walked through the alternative (audit Electron/Node.js windowsHide implementation) and noted that even with a fixed `windowsHide`, you still get the race for console-subsystem children. `pythonw.exe` eliminates the class of bug rather than patching the one instance.

## Verification

- `npm run typecheck` — clean.
- `npm test` — **49 files / 577 passed / 3 skipped / 0 failures.**
- The existing gateway-PID-image check (`src/main/utils.ts:getProcessImageNameWin` / `profiles.ts:pidIsAliveAs(pid, ["python","pythonw"])`) already accepts either binary as a valid gateway image, so the long-running gateway path is unaffected.
- Updated `tests/installer-platform.test.ts` to assert `pythonw.exe` on win32 and document the rationale.