### PR TITLE
chat: media-render follow-ups from #303 (memoize, stable keys, non-image src routing)

### DIFF
--- a/src/renderer/src/components/AgentMarkdown.tsx
+++ b/src/renderer/src/components/AgentMarkdown.tsx
@@ -3,7 +3,7 @@ import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { Copy } from "lucide-react";
 import { useI18n } from "./useI18n";
-import { MediaImage } from "./MediaImage";
+import { MediaImage, DownloadChip } from "./MediaImage";
 import { describeImageSrc } from "../screens/Chat/mediaUtils";
 
 // Lazy-load the heavy syntax highlighter — only imported when a code block renders
@@ -155,10 +155,18 @@ const AgentMarkdown = memo(function AgentMarkdown({
             {children}
           </a>
         ),
-        img: ({ src }) =>
-          typeof src === "string" && src.length > 0 ? (
-            <MediaImage token={describeImageSrc(src)} />
-          ) : null,
+        img: ({ src }) => {
+          if (typeof src !== "string" || src.length === 0) return null;
+          // ![alt](file.pdf) parses as a markdown image but isn't an image —
+          // route those to the download chip instead of letting MediaImage
+          // try to load a non-image MIME and fail. (Follow-up from #303.)
+          const token = describeImageSrc(src);
+          return token.isImage ? (
+            <MediaImage token={token} />
+          ) : (
+            <DownloadChip token={token} />
+          );
+        },
         code: ({ className, children, ...props }) => {
           const isInline =
             !className &&

--- a/src/renderer/src/screens/Chat/MessageRow.tsx
+++ b/src/renderer/src/screens/Chat/MessageRow.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from "react";
+import { memo, useMemo, useState } from "react";
 import icon from "../../assets/icon.png";
 import { AgentMarkdown } from "../../components/AgentMarkdown";
 import { AttachmentChip } from "../../components/AttachmentChip";
@@ -69,6 +69,21 @@ export const MessageRow = memo(function MessageRow({
     APPROVAL_RE.test(msg.content);
   const hasAttachments = !!msg.attachments && msg.attachments.length > 0;
 
+  // MessageRow is wrapped in memo() but still re-renders on any prop change
+  // (e.g. isLoading toggling at the end of a stream), and `parseMediaTokens`
+  // runs a full regex pipeline. Cache the result against the message content
+  // so a long conversation doesn't reparse every row on every render.
+  // Only agent bubbles need media parsing — user bubbles render content
+  // verbatim — so this is gated on the role to skip the work entirely for
+  // user rows. (Follow-up item from PR #303 review.)
+  const segments = useMemo(
+    () =>
+      msg.role === "agent" && msg.content
+        ? parseMediaTokens(msg.content)
+        : null,
+    [msg.role, msg.content],
+  );
+
   return (
     <div className={`chat-message chat-message-${msg.role}`}>
       {msg.role === "user" ? (
@@ -89,24 +104,29 @@ export const MessageRow = memo(function MessageRow({
           </div>
         )}
         {msg.content &&
-          (msg.role === "agent" ? (
-            parseMediaTokens(msg.content).map((segment, i) =>
-              segment.type === "text" ? (
-                segment.value.trim() ? (
-                  <AgentMarkdown key={i}>{segment.value}</AgentMarkdown>
-                ) : null
-              ) : (
-                <MediaSegmentView
-                  key={i}
-                  token={segment.token}
-                  raw={segment.raw}
-                  source={segment.source}
-                />
-              ),
-            )
-          ) : (
-            msg.content
-          ))}
+          (msg.role === "agent" && segments
+            ? segments.map((segment) =>
+                segment.type === "text" ? (
+                  segment.value.trim() ? (
+                    // Keyed on the segment's character offset rather than its
+                    // array index — a MEDIA: token appearing mid-stream shifts
+                    // every subsequent index, which would otherwise re-mount
+                    // each downstream MediaSegmentView and re-fire its
+                    // `mediaFileExists` probe.
+                    <AgentMarkdown key={`t-${segment.start}`}>
+                      {segment.value}
+                    </AgentMarkdown>
+                  ) : null
+                ) : (
+                  <MediaSegmentView
+                    key={`m-${segment.start}`}
+                    token={segment.token}
+                    raw={segment.raw}
+                    source={segment.source}
+                  />
+                ),
+              )
+            : msg.content)}
       </div>
       {showApprovalBar && (
         <div className="chat-approval-bar">

--- a/src/renderer/src/screens/Chat/mediaUtils.test.ts
+++ b/src/renderer/src/screens/Chat/mediaUtils.test.ts
@@ -18,7 +18,7 @@ function media(segs: MediaSegment[]): Extract<MediaSegment, { type: "media" }> {
 describe("parseMediaTokens (issue #299)", () => {
   it("returns a single text segment when there is nothing to extract", () => {
     expect(parseMediaTokens("just a normal reply")).toEqual([
-      { type: "text", value: "just a normal reply" },
+      { type: "text", value: "just a normal reply", start: 0 },
     ]);
   });
 
@@ -27,7 +27,11 @@ describe("parseMediaTokens (issue #299)", () => {
     const segs = parseMediaTokens(
       "Here it is:\n\nMEDIA:C:\\Users\\pmos6\\cat.png",
     );
-    expect(segs[0]).toEqual({ type: "text", value: "Here it is:\n\n" });
+    expect(segs[0]).toEqual({
+      type: "text",
+      value: "Here it is:\n\n",
+      start: 0,
+    });
     expect(segs[1]).toMatchObject({
       type: "media",
       source: "media-token",
@@ -90,14 +94,23 @@ describe("parseMediaTokens (issue #299)", () => {
   // ── Inline bare paths (mid-sentence) ───────────────────
   it("detects an inline absolute path mentioned mid-sentence", () => {
     const segs = parseMediaTokens("I saved it to C:\\Users\\me\\x.pdf today.");
-    expect(segs[0]).toEqual({ type: "text", value: "I saved it to " });
+    expect(segs[0]).toEqual({
+      type: "text",
+      value: "I saved it to ",
+      start: 0,
+    });
     expect(media(segs)).toMatchObject({
       type: "media",
       source: "bare-path",
       raw: "C:\\Users\\me\\x.pdf",
       token: { src: "C:\\Users\\me\\x.pdf", isImage: false },
     });
-    expect(segs[segs.length - 1]).toEqual({ type: "text", value: " today." });
+    expect(segs[segs.length - 1]).toEqual({
+      type: "text",
+      value: " today.",
+      // 14 ("I saved it to ") + 17 ("C:\\Users\\me\\x.pdf") = 31.
+      start: 31,
+    });
   });
 
   it("detects an inline POSIX absolute path", () => {
@@ -187,6 +200,8 @@ describe("parseMediaTokens (issue #299)", () => {
     expect(segs[segs.length - 1]).toEqual({
       type: "text",
       value: "\n\nEnjoy!",
+      // "MEDIA:/tmp/a.png" is 16 chars — trailing text begins at offset 16.
+      start: 16,
     });
   });
 
@@ -196,11 +211,51 @@ describe("parseMediaTokens (issue #299)", () => {
     expect(hasMediaTokens("no media")).toBe(false);
   });
 
-  it("describeImageSrc classifies a plain src", () => {
+  it("describeImageSrc classifies a plain image src", () => {
     expect(describeImageSrc("https://x.test/p.png")).toMatchObject({
       isUrl: true,
       isImage: true,
       name: "p.png",
     });
+  });
+
+  it("describeImageSrc sets isImage:false for a non-image src so the caller can route to DownloadChip", () => {
+    // markdown allows ![alt](file.pdf) — that parses as an image tag but the
+    // actual file is a PDF. Hardcoding isImage:true here caused MediaImage
+    // to try to load it as an image and surface "could not load file.pdf"
+    // to the user. Honouring IMAGE_EXT lets the caller route non-images to
+    // the download chip instead. (Follow-up from PR #303 review.)
+    expect(describeImageSrc("./report.pdf")).toMatchObject({
+      isImage: false,
+      name: "report.pdf",
+    });
+    expect(describeImageSrc("https://x.test/data.csv")).toMatchObject({
+      isUrl: true,
+      isImage: false,
+      name: "data.csv",
+    });
+  });
+
+  it("emits stable `start` offsets on every segment for use as React keys", () => {
+    // The map() in MessageRow used the array index as key. When a MEDIA:
+    // token appears mid-stream, every subsequent segment shifts index,
+    // re-mounting downstream MediaSegmentView instances and re-firing
+    // their `mediaFileExists` probes. Keying on `start` instead is
+    // streaming-stable. (Follow-up from PR #303 review.)
+    const segs = parseMediaTokens(
+      "intro MEDIA:/tmp/a.png tail MEDIA:/tmp/b.png end",
+    );
+    // Every segment carries its origin offset.
+    for (const s of segs) {
+      expect(typeof s.start).toBe("number");
+      expect(s.start).toBeGreaterThanOrEqual(0);
+    }
+    // Offsets are strictly increasing across the segment stream.
+    for (let i = 1; i < segs.length; i++) {
+      expect(segs[i].start).toBeGreaterThan(segs[i - 1].start);
+    }
+    // Used as React keys, the values are unique.
+    const keys = segs.map((s) => `${s.type}-${s.start}`);
+    expect(new Set(keys).size).toBe(keys.length);
   });
 });

--- a/src/renderer/src/screens/Chat/mediaUtils.ts
+++ b/src/renderer/src/screens/Chat/mediaUtils.ts
@@ -59,7 +59,15 @@ export interface MediaToken {
 }
 
 export type MediaSegment =
-  | { type: "text"; value: string }
+  | {
+      type: "text";
+      value: string;
+      /** Character offset of this segment in the original content string.
+       *  Used as a stable React key during streaming — `start` doesn't shift
+       *  when a later MEDIA: token appears mid-stream, whereas an array
+       *  index would. (Follow-up item from PR #303 review.) */
+      start: number;
+    }
   | {
       type: "media";
       token: MediaToken;
@@ -69,6 +77,9 @@ export type MediaSegment =
       /** `media-token` — explicit MEDIA: tag, rendered eagerly.
        *  `bare-path` — inferred path, rendered only once verified to exist. */
       source: "media-token" | "bare-path";
+      /** Character offset of this segment in the original content string —
+       *  same stability rationale as the text segment's `start`. */
+      start: number;
     };
 
 interface Hit {
@@ -171,18 +182,23 @@ export function parseMediaTokens(content: string): MediaSegment[] {
   let last = 0;
   for (const h of hits) {
     if (h.start > last) {
-      segments.push({ type: "text", value: content.slice(last, h.start) });
+      segments.push({
+        type: "text",
+        value: content.slice(last, h.start),
+        start: last,
+      });
     }
     segments.push({
       type: "media",
       token: h.token,
       raw: h.raw,
       source: h.source,
+      start: h.start,
     });
     last = h.end;
   }
   if (last < content.length) {
-    segments.push({ type: "text", value: content.slice(last) });
+    segments.push({ type: "text", value: content.slice(last), start: last });
   }
   return segments;
 }
@@ -193,10 +209,19 @@ export function hasMediaTokens(content: string): boolean {
   return MEDIA_RE.test(content);
 }
 
-/** Classify a plain image src (used by the markdown `img` override). */
+/**
+ * Classify a plain `src` from a markdown `![alt](src)` image syntax. The
+ * markdown image syntax doesn't actually guarantee an image — the agent
+ * may emit `![alt](file.pdf)` or `![alt](report.csv)`. Without checking
+ * the extension here the caller would unconditionally try to render it
+ * via `MediaImage` → `readMediaAsDataUrl` returns `null` (no MIME map
+ * entry) → the user sees an "image failed to load" error. Honour the
+ * extension so non-image markdown images can fall through to the
+ * download-chip path (follow-up item from PR #303 review).
+ */
 export function describeImageSrc(src: string): MediaToken {
   const trimmed = src.trim();
   const isUrl = /^https?:\/\//i.test(trimmed);
   const name = trimmed.split(/[\\/]/).filter(Boolean).pop() || trimmed;
-  return { src: trimmed, isUrl, isImage: true, name };
+  return { src: trimmed, isUrl, isImage: IMAGE_EXT.test(trimmed), name };
 }


### PR DESCRIPTION
Addresses items 1–3 from @fathah's post-merge review note on #303 ([comment](https://github.com/fathah/hermes-desktop/pull/303#issuecomment-4528488847)). Item 4 (the #301/#303 context-menu integration gap) is tracked separately at #349.

All three changes are localized to chat media rendering — no public API moves, no behaviour change for the common case where the agent emits a `MEDIA:` token or a bare-path image.

## 1. Memoize `parseMediaTokens` in `MessageRow`

`parseMediaTokens(msg.content)` was called directly in the render body of a `memo()`'d component. `MessageRow` still re-renders on any prop change — `isLoading` toggling at the end of a stream is the usual culprit — so the full regex pipeline ran on every message on every render. In a long conversation that's quadratic in messages and noticeable.

```tsx
// MessageRow.tsx
const segments = useMemo(
  () =>
    msg.role === "agent" && msg.content
      ? parseMediaTokens(msg.content)
      : null,
  [msg.role, msg.content],
);
```

Gated on `msg.role === "agent"` so user bubbles skip the work entirely — user content isn't parsed for media tokens.

## 2. Stable React keys for segments

`map((segment, i) => … key={i})` was unstable during streaming: when a `MEDIA:` token first appears mid-content, every subsequent segment's index shifts, which re-mounts each downstream `MediaSegmentView` and re-fires its `mediaFileExists` IPC probe.

Exposed a `start: number` (character offset in the original content) on both branches of `MediaSegment`:

```ts
export type MediaSegment =
  | { type: "text"; value: string; start: number }
  | { type: "media"; token: MediaToken; raw: string; source: ...; start: number };
```

…and key on `${type}-${start}` in the render. Offsets are strictly increasing across a segment stream, so existing segments survive token insertions instead of unmounting.

## 3. `describeImageSrc` honours `IMAGE_EXT`

Markdown allows `![alt](anything)` — the `anything` may be a non-image (e.g. `![Report](report.pdf)`). The old `describeImageSrc` hard-coded `isImage: true` and the `img` override unconditionally rendered `MediaImage`. The image-load path failed (PDF MIME not in `MIME_BY_EXT`), and the user saw `⚠ Could not load report.pdf`.

Fixed by:

- `describeImageSrc` now uses the existing `IMAGE_EXT` regex to set `isImage` correctly.
- The `img` override in `AgentMarkdown` routes non-images to `DownloadChip` instead of `MediaImage`.

```tsx
img: ({ src }) => {
  if (typeof src !== "string" || src.length === 0) return null;
  const token = describeImageSrc(src);
  return token.isImage ? <MediaImage token={token} /> : <DownloadChip token={token} />;
}
```

## Tests

Added two new tests in `mediaUtils.test.ts`:

- `describeImageSrc` returns `isImage: false` for a non-image src (PDF, CSV), so the markdown `img` override can route to `DownloadChip`.
- `parseMediaTokens` emits strictly-increasing `start` offsets with unique `${type}-${start}` keys across an interleaved text/MEDIA stream.

Updated four existing `.toEqual` assertions on text segments to include the new `start` field. No behavioural assertions changed.

## Verification

- `npm run typecheck` — clean.
- `npm test` — **52 files / 623 passed / 3 skipped / 0 failures.**

Refs #303.