### PR TITLE
chore(privacy): surface analytics in Settings → Privacy with disclosure (refs #344)

### DIFF
--- a/src/renderer/src/screens/Settings/Settings.tsx
+++ b/src/renderer/src/screens/Settings/Settings.tsx
@@ -861,6 +861,12 @@ function Settings({ profile }: { profile?: string }): React.JSX.Element {
             {t("settings.language.hint")}
           </div>
         </div>
+      </div>
+
+      <div className="settings-section">
+        <div className="settings-section-title">
+          {t("settings.sections.privacy")}
+        </div>
         <div className="settings-field">
           <label className="settings-field-label">
             {t("settings.analytics.label")}
@@ -883,6 +889,16 @@ function Settings({ profile }: { profile?: string }): React.JSX.Element {
           <div className="settings-field-hint">
             {t("settings.analytics.hint")}
           </div>
+          <ul
+            className="settings-field-hint"
+            style={{ paddingLeft: "1.25em", marginTop: 4 }}
+          >
+            <li>{t("settings.analytics.disclosure.uuid")}</li>
+            <li>{t("settings.analytics.disclosure.platform")}</li>
+            <li>{t("settings.analytics.disclosure.navigation")}</li>
+            <li>{t("settings.analytics.disclosure.endpoint")}</li>
+            <li>{t("settings.analytics.disclosure.notCollected")}</li>
+          </ul>
         </div>
       </div>
 

--- a/src/renderer/src/utils/analytics.ts
+++ b/src/renderer/src/utils/analytics.ts
@@ -52,6 +52,17 @@ export function initAnalytics(): void {
     capture_pageleave: false,
     disable_session_recording: true, // Privacy-first: no session recording
     persistence: "localStorage",
+    // Privacy hardening:
+    //  - respect_dnt: honour the user's "Do Not Track" preference if set.
+    //  - mask_personal_data_properties: auto-mask common PII patterns
+    //    (emails, names) from any properties we ever pass to capture().
+    // Note: full IP-address suppression is NOT possible from the client —
+    // PostHog's deprecated `ip: false` option is a no-op. IP capture must
+    // be disabled server-side in the PostHog project settings
+    // ("Discard IP data"). See:
+    // https://posthog.com/tutorials/web-redact-properties#hiding-customer-ip-address
+    respect_dnt: true,
+    mask_personal_data_properties: true,
     loaded: () => {
       posthog.identify(getOrCreateAnonymousId(), {
         app_version: window.electron?.process?.versions?.electron || "unknown",

--- a/src/shared/i18n/locales/en/settings.ts
+++ b/src/shared/i18n/locales/en/settings.ts
@@ -3,6 +3,7 @@ export default {
   sections: {
     hermesAgent: "Hermes Agent",
     appearance: "Appearance",
+    privacy: "Privacy",
     credentialPool: "Credential Pool",
   },
   theme: {
@@ -22,8 +23,15 @@ export default {
     hint: "Choose the interface language",
   },
   analytics: {
-    label: "Analytics",
-    hint: "Help improve Hermes by sending anonymous usage data. No personal information or chat content is collected.",
+    label: "Send anonymous usage analytics",
+    hint: "Helps improve Hermes by sending anonymous, aggregated usage data to the project's PostHog instance (EU-hosted). You can turn this off at any time.",
+    disclosure: {
+      uuid: "A random per-install identifier stored only on this device (no name, email, or account info).",
+      platform: "Your operating system, Electron version, and Node.js version.",
+      navigation: "Which screens you visit inside the app (e.g. Chat, Sessions, Settings). No chat content, prompts, model responses, or file contents are collected.",
+      endpoint: "Data is sent to eu.i.posthog.com (PostHog EU cloud). Session recordings and pageview auto-capture are disabled.",
+      notCollected: "Never collected: chat messages, file paths, API keys, model configuration, account credentials.",
+    },
   },
   notDetected: "Not detected",
   updatedSuccessfully: "Updated successfully!",

--- a/src/shared/i18n/locales/es/settings.ts
+++ b/src/shared/i18n/locales/es/settings.ts
@@ -3,7 +3,19 @@ export default {
   sections: {
     hermesAgent: "Hermes Agent",
     appearance: "Apariencia",
+    privacy: "Privacidad",
     credentialPool: "Grupo de credenciales",
+  },
+  analytics: {
+    label: "Enviar analíticas de uso anónimas",
+    hint: "Ayuda a mejorar Hermes enviando datos de uso anónimos y agregados a la instancia PostHog del proyecto (alojada en la UE). Puedes desactivarlo en cualquier momento.",
+    disclosure: {
+      uuid: "Un identificador aleatorio por instalación almacenado únicamente en este dispositivo (sin nombre, correo electrónico ni datos de cuenta).",
+      platform: "Tu sistema operativo, versión de Electron y versión de Node.js.",
+      navigation: "Qué pantallas visitas dentro de la aplicación (p. ej. Chat, Sesiones, Configuración). No se recopila contenido de chats, prompts, respuestas del modelo ni contenido de archivos.",
+      endpoint: "Los datos se envían a eu.i.posthog.com (nube europea de PostHog). Las grabaciones de sesión y la captura automática de páginas vistas están desactivadas.",
+      notCollected: "Nunca se recopila: mensajes de chat, rutas de archivos, claves de API, configuración del modelo, credenciales de cuenta.",
+    },
   },
   theme: {
     label: "Tema",

--- a/src/shared/i18n/locales/id/settings.ts
+++ b/src/shared/i18n/locales/id/settings.ts
@@ -3,7 +3,19 @@ export default {
   sections: {
     hermesAgent: "Hermes Agent",
     appearance: "Tampilan",
+    privacy: "Privasi",
     credentialPool: "Kumpulan Kredensial",
+  },
+  analytics: {
+    label: "Kirim analitik penggunaan anonim",
+    hint: "Membantu meningkatkan Hermes dengan mengirim data penggunaan anonim dan teragregasi ke instans PostHog proyek (di-host di UE). Anda dapat menonaktifkannya kapan saja.",
+    disclosure: {
+      uuid: "Pengenal acak per-instalasi yang disimpan hanya di perangkat ini (tanpa nama, email, atau info akun).",
+      platform: "Sistem operasi, versi Electron, dan versi Node.js Anda.",
+      navigation: "Layar mana yang Anda kunjungi di dalam aplikasi (mis. Chat, Sesi, Pengaturan). Tidak ada konten chat, prompt, respons model, atau isi file yang dikumpulkan.",
+      endpoint: "Data dikirim ke eu.i.posthog.com (cloud PostHog UE). Rekaman sesi dan tangkapan pageview otomatis dinonaktifkan.",
+      notCollected: "Tidak pernah dikumpulkan: pesan chat, jalur file, kunci API, konfigurasi model, kredensial akun.",
+    },
   },
   theme: {
     label: "Tema",

--- a/src/shared/i18n/locales/ja/settings.ts
+++ b/src/shared/i18n/locales/ja/settings.ts
@@ -3,7 +3,19 @@ export default {
   sections: {
     hermesAgent: "Hermes Agent",
     appearance: "外観",
+    privacy: "プライバシー",
     credentialPool: "認証情報プール",
+  },
+  analytics: {
+    label: "匿名の利用状況分析を送信する",
+    hint: "プロジェクトの PostHog インスタンス（EU ホスト）に匿名・集計済みの利用状況データを送信することで Hermes の改善に役立てます。いつでもオフにできます。",
+    disclosure: {
+      uuid: "このデバイスにのみ保存されるインストールごとのランダムな識別子（氏名・メールアドレス・アカウント情報は含まれません）。",
+      platform: "ご利用の OS、Electron バージョン、Node.js バージョン。",
+      navigation: "アプリ内で開いた画面（例：チャット、セッション、設定）。チャット内容、プロンプト、モデル応答、ファイルの内容は収集しません。",
+      endpoint: "データは eu.i.posthog.com（PostHog EU クラウド）に送信されます。セッション録画とページビューの自動取得は無効です。",
+      notCollected: "収集しないもの：チャットメッセージ、ファイルパス、API キー、モデル設定、アカウント認証情報。",
+    },
   },
   theme: {
     label: "テーマ",

--- a/src/shared/i18n/locales/pt-BR/settings.ts
+++ b/src/shared/i18n/locales/pt-BR/settings.ts
@@ -3,7 +3,19 @@ export default {
   sections: {
     hermesAgent: "Hermes Agent",
     appearance: "Aparência",
+    privacy: "Privacidade",
     credentialPool: "Pool de Credenciais",
+  },
+  analytics: {
+    label: "Enviar análises de uso anônimas",
+    hint: "Ajuda a melhorar o Hermes enviando dados de uso anônimos e agregados para a instância PostHog do projeto (hospedada na UE). Você pode desativar a qualquer momento.",
+    disclosure: {
+      uuid: "Um identificador aleatório por instalação armazenado apenas neste dispositivo (sem nome, e-mail ou dados de conta).",
+      platform: "Seu sistema operacional, versão do Electron e versão do Node.js.",
+      navigation: "Quais telas você abre dentro do app (ex.: Chat, Sessões, Configurações). Conteúdo de chats, prompts, respostas do modelo e conteúdo de arquivos não são coletados.",
+      endpoint: "Os dados são enviados para eu.i.posthog.com (nuvem PostHog da UE). Gravações de sessão e captura automática de pageviews estão desativadas.",
+      notCollected: "Nunca coletado: mensagens de chat, caminhos de arquivos, chaves de API, configuração do modelo, credenciais de conta.",
+    },
   },
   theme: {
     label: "Tema",

--- a/src/shared/i18n/locales/pt-PT/settings.ts
+++ b/src/shared/i18n/locales/pt-PT/settings.ts
@@ -3,7 +3,19 @@ export default {
   sections: {
     hermesAgent: "Agente Hermes",
     appearance: "Aparência",
+    privacy: "Privacidade",
     credentialPool: "Pool de Credenciais",
+  },
+  analytics: {
+    label: "Enviar análises de utilização anónimas",
+    hint: "Ajuda a melhorar o Hermes ao enviar dados de utilização anónimos e agregados para a instância PostHog do projecto (alojada na UE). Pode desactivar a qualquer momento.",
+    disclosure: {
+      uuid: "Um identificador aleatório por instalação guardado apenas neste dispositivo (sem nome, e-mail ou dados de conta).",
+      platform: "O seu sistema operativo, versão do Electron e versão do Node.js.",
+      navigation: "Que ecrãs abre dentro da aplicação (ex.: Conversa, Sessões, Definições). Não é recolhido conteúdo de conversas, prompts, respostas do modelo nem conteúdo de ficheiros.",
+      endpoint: "Os dados são enviados para eu.i.posthog.com (nuvem PostHog da UE). As gravações de sessão e a captura automática de páginas visitadas estão desactivadas.",
+      notCollected: "Nunca é recolhido: mensagens de conversa, caminhos de ficheiros, chaves de API, configuração do modelo, credenciais de conta.",
+    },
   },
   theme: {
     label: "Tema",

--- a/src/shared/i18n/locales/zh-CN/settings.ts
+++ b/src/shared/i18n/locales/zh-CN/settings.ts
@@ -3,7 +3,19 @@ export default {
   sections: {
     hermesAgent: "Hermes Agent",
     appearance: "外观",
+    privacy: "隐私",
     credentialPool: "凭据池",
+  },
+  analytics: {
+    label: "发送匿名使用情况分析",
+    hint: "通过向项目的 PostHog 实例（托管于欧盟）发送匿名、聚合的使用数据来帮助改进 Hermes。您可以随时关闭。",
+    disclosure: {
+      uuid: "仅存储在本设备上的每次安装的随机标识符（不包含姓名、电子邮件或账户信息）。",
+      platform: "您的操作系统、Electron 版本和 Node.js 版本。",
+      navigation: "您在应用内打开了哪些界面（例如聊天、会话、设置）。不会收集任何聊天内容、提示词、模型响应或文件内容。",
+      endpoint: "数据将发送至 eu.i.posthog.com（PostHog 欧盟云）。已禁用会话录制和页面浏览自动捕获。",
+      notCollected: "永不收集：聊天消息、文件路径、API 密钥、模型配置、账户凭据。",
+    },
   },
   theme: {
     label: "主题",

--- a/src/shared/i18n/locales/zh-TW/settings.ts
+++ b/src/shared/i18n/locales/zh-TW/settings.ts
@@ -3,7 +3,19 @@ export default {
   sections: {
     hermesAgent: "Hermes Agent",
     appearance: "外觀",
+    privacy: "隱私",
     credentialPool: "憑證池",
+  },
+  analytics: {
+    label: "傳送匿名使用情況分析",
+    hint: "透過向專案的 PostHog 執行個體（位於歐盟）傳送匿名、彙總的使用資料，協助改進 Hermes。您隨時可以關閉此功能。",
+    disclosure: {
+      uuid: "僅儲存在本裝置上、每次安裝的隨機識別碼（不含姓名、電子郵件或帳戶資訊）。",
+      platform: "您的作業系統、Electron 版本和 Node.js 版本。",
+      navigation: "您在應用程式中開啟的畫面（例如聊天、工作階段、設定）。不會收集任何聊天內容、提示、模型回應或檔案內容。",
+      endpoint: "資料會傳送至 eu.i.posthog.com（PostHog 歐盟雲端）。工作階段錄製和頁面瀏覽自動擷取均已停用。",
+      notCollected: "絕不收集：聊天訊息、檔案路徑、API 金鑰、模型設定、帳戶憑證。",
+    },
   },
   theme: {
     label: "主題",


### PR DESCRIPTION
Implements the disclosure + privacy-hardening parts of #344.

## Summary

Moves the existing analytics toggle out of *Appearance* into its own **Settings → Privacy** section and adds a plain-language disclosure of exactly what gets sent. Also adds two `posthog-js` client-side privacy options that are real and effective.

Scope is intentionally limited to **how analytics is surfaced** and a couple of low-risk client-side flags. Nothing changes about *what* events get captured, and the existing default-on behavior for official builds is preserved — this PR is about discoverability, not policy.

## Changes

### `src/renderer/src/utils/analytics.ts`

Add two PostHog client-side privacy options to `posthog.init`:

- `respect_dnt: true` — honour the user's "Do Not Track" browser/system preference. If DNT is on, no events are sent.
- `mask_personal_data_properties: true` — auto-mask common PII patterns (emails, names) in any event properties.

Plus an explanatory comment noting that **full IP-address suppression is not possible from the client** — `posthog-js` exposes an `ip: false` option but it is documented as deprecated and a no-op. The PostHog ingestion server captures IP at the TCP layer; the only effective fix is to enable *Discard IP data* in the PostHog project settings (per [their own docs](https://posthog.com/tutorials/web-redact-properties#hiding-customer-ip-address)). Flagging here because that's the one remaining piece — it requires a one-checkbox change in the PostHog dashboard that only the project owner can make.

### `src/renderer/src/screens/Settings/Settings.tsx`

The analytics toggle now lives under a dedicated **Privacy** section instead of being hidden at the bottom of *Appearance*. Below the toggle, a short bulleted disclosure lists:

- The per-install random identifier (stored only on the device)
- OS / Electron / Node versions
- Which app screens are visited (and explicitly: no chat content, prompts, model responses, or file contents)
- The destination endpoint (`eu.i.posthog.com`) and that session recording / pageview auto-capture are disabled
- An explicit "never collected" line for chat messages, file paths, API keys, model config, account credentials

This makes the existence of analytics visible to anyone who opens Settings, and gives users the information they need to decide whether to keep it enabled.

### i18n

New keys in all 8 locales (`en`, `es`, `id`, `ja`, `pt-BR`, `pt-PT`, `zh-CN`, `zh-TW`):

- `settings.sections.privacy`
- `settings.analytics.label` (revised — more descriptive)
- `settings.analytics.hint` (revised — mentions PostHog + EU hosting + the ability to turn off)
- `settings.analytics.disclosure.{uuid,platform,navigation,endpoint,notCollected}` (new)

The previous EN `settings.analytics` block was the only locale that had any analytics strings — the other 7 fell back to the key string at runtime. This PR brings all 8 locales to parity. Happy to native-review pt-PT if useful; pt-BR drafted to mirror.

## Out of scope (separate, optional follow-ups)

- A first-run banner / dialog that surfaces the existence of analytics on initial launch. Useful but invasive; better as a separate PR once the direction here is approved.
- Flipping the default from opt-out to opt-in. Bigger policy conversation; intentionally left untouched.
- Disabling server-side IP collection on the PostHog project (one checkbox in the PostHog dashboard — needs project-owner access).

## Verification

- `npm run typecheck` — clean.
- `npm test` — 49 files / 577 passed / 3 skipped / **0 failures**.
- `npm run lint` — 0 errors (44k pre-existing CRLF warnings; none new from this PR).
- Manually verified the new Privacy section renders, the toggle reads/writes `hermes-analytics-enabled` localStorage as before, and the disclosure bullets fall back gracefully when a locale key is missing (none are; this is for paranoia).

Closes (part of) #344.
