### PR TITLE
fix(providers): route built-in OpenAI-compat providers correctly end-to-end

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -9,6 +9,7 @@ import {
   safeWriteFile,
 } from "./utils";
 import { getYamlPath } from "./yaml-path";
+import { canonicalProviderBaseUrl } from "./provider-registry";
 
 // ── Connection Config (local / remote / ssh) ─────────────
 
@@ -727,8 +728,26 @@ export function setModelConfig(
 
   content = upsertBlockChild(content, "model", "provider", provider);
   content = upsertBlockChild(content, "model", "default", model);
-  if (baseUrl) {
-    content = upsertBlockChild(content, "model", "base_url", baseUrl);
+
+  // Pick the effective base_url to write.  Precedence:
+  //   1. User-supplied `baseUrl` (the renderer passes this when the user
+  //      typed an explicit value into the "Base URL (optional)" field).
+  //   2. Otherwise, the canonical default for built-in providers
+  //      (DeepSeek → api.deepseek.com, Groq → api.groq.com, etc. — see
+  //      `provider-registry.ts`).
+  //   3. Otherwise (custom / auto / unknown provider with no baseUrl),
+  //      leave `base_url:` out of the model block entirely.
+  //
+  // Without (2), switching from a model with an explicit baseUrl (e.g.
+  // a previous OAuth Codex selection at `chatgpt.com/backend-api/codex`)
+  // to a built-in provider with no baseUrl in its library entry used to
+  // leave the stale URL in `config.yaml`. Chat then routed to the wrong
+  // host while still sending the new provider's key, producing a 401
+  // from OpenAI carrying e.g. a DeepSeek key. See issue analysis in
+  // PR description.
+  const effectiveBaseUrl = baseUrl || canonicalProviderBaseUrl(provider) || "";
+  if (effectiveBaseUrl) {
+    content = upsertBlockChild(content, "model", "base_url", effectiveBaseUrl);
   }
 
   // Workaround for upstream gateway bug — see pickAutoApiKeyForCustomProvider.

--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -114,12 +114,44 @@ export async function ensureSshTunnelIfNeeded(): Promise<void> {
   }
 }
 
-const LOCAL_PROVIDERS = new Set([
+/**
+ * Providers whose chat path the desktop wires up explicitly with
+ * `OPENAI_BASE_URL` + a resolved `OPENAI_API_KEY` — rather than relying
+ * on the agent's native provider routing.
+ *
+ * The original set was just *local* LLM endpoints (lmstudio / ollama /
+ * vllm / llamacpp) plus the generic `custom` entry. That meant the
+ * built-in remote OpenAI-compatible providers (Groq, DeepSeek,
+ * Together, Fireworks, Cerebras, Mistral) — which are defined in
+ * `src/renderer/src/constants.ts:LOCAL_PRESETS` with their own
+ * `baseUrl` + `envKey` — slipped past this branch and tripped an
+ * upstream hermes-agent fallback that misroutes the request to
+ * OpenAI's API while still sending the user's provider key, producing
+ * a 401 like *"Incorrect API key provided: sk-… You can find your
+ * API key at https://platform.openai.com/account/api-keys."*
+ *
+ * Including them here lets the same `URL_KEY_MAP` lookup that already
+ * handles `provider="custom"` with a known commercial host also fire
+ * when the user picks the built-in entry — same routing, same key,
+ * no upstream-fallback leak.
+ */
+const OPENAI_COMPAT_PROVIDERS = new Set([
+  // Generic
   "custom",
+  // Local LLMs
   "lmstudio",
   "ollama",
   "vllm",
   "llamacpp",
+  // Built-in remote OpenAI-compatible providers (must stay in sync
+  // with the `id` field of remote-group entries in renderer
+  // `LOCAL_PRESETS`).
+  "groq",
+  "deepseek",
+  "together",
+  "fireworks",
+  "cerebras",
+  "mistral",
 ]);
 
 // Map base-URL patterns to the API key env var they need
@@ -646,12 +678,24 @@ function sendMessageViaCli(
     PYTHONUNBUFFERED: "1",
   };
 
-  // Inject all API keys from the profile .env so the CLI can access them
+  // Inject all API keys from the profile .env so the CLI can access them.
+  // The built-in remote OpenAI-compatible providers (DeepSeek, Together,
+  // Fireworks, Cerebras, Mistral) are listed here too — without them the
+  // agent has no way to see the user-configured key when the user picked
+  // the built-in provider entry rather than a `custom` entry, and the
+  // upstream fallback chain then misroutes the request (see #260 / the
+  // `pickAutoApiKeyForCustomProvider` workaround in config.ts).
   const KNOWN_API_KEYS = [
     "OPENROUTER_API_KEY",
     "OPENAI_API_KEY",
     "ANTHROPIC_API_KEY",
     "GROQ_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "TOGETHER_API_KEY",
+    "FIREWORKS_API_KEY",
+    "CEREBRAS_API_KEY",
+    "MISTRAL_API_KEY",
+    "PERPLEXITY_API_KEY",
     "GLM_API_KEY",
     "KIMI_API_KEY",
     "MINIMAX_API_KEY",
@@ -675,7 +719,7 @@ function sendMessageViaCli(
     }
   }
 
-  const isCustomEndpoint = LOCAL_PROVIDERS.has(mc.provider);
+  const isCustomEndpoint = OPENAI_COMPAT_PROVIDERS.has(mc.provider);
   if (isCustomEndpoint && mc.baseUrl) {
     // Check if this model has an explicit apiMode from custom_providers
     let modelApiMode: string | null = null;

--- a/src/main/model-discovery.ts
+++ b/src/main/model-discovery.ts
@@ -23,25 +23,10 @@ import {
   HERMES_HOME,
   getEnhancedPath,
 } from "./installer";
-
-/** Canonical inference base URL for each named provider, mirroring
- *  hermes-agent's PROVIDER_REGISTRY defaults.  Only the providers whose
- *  `/models` endpoint we know responds usefully are listed; everything
- *  else falls through to caller-supplied baseUrl or no discovery. */
-const PROVIDER_BASE_URLS: Record<string, string> = {
-  openai: "https://api.openai.com/v1",
-  openrouter: "https://openrouter.ai/api/v1",
-  deepseek: "https://api.deepseek.com/v1",
-  groq: "https://api.groq.com/openai/v1",
-  mistral: "https://api.mistral.ai/v1",
-  together: "https://api.together.xyz/v1",
-  fireworks: "https://api.fireworks.ai/inference/v1",
-  cerebras: "https://api.cerebras.ai/v1",
-  perplexity: "https://api.perplexity.ai",
-  huggingface: "https://router.huggingface.co/v1",
-  zai: "https://api.z.ai/api/paas/v4",
-  anthropic: "https://api.anthropic.com/v1",
-};
+// PROVIDER_BASE_URLS lives in its own module so `config.ts` can use the
+// same lookup without pulling in this whole file (and triggering a
+// circular import via `model-discovery → config → ...`).
+import { PROVIDER_BASE_URLS } from "./provider-registry";
 
 /** Providers whose `/models` we never call — either they don't expose it,
  *  use a different protocol, or rely on OAuth credentials we can't

--- a/src/main/provider-registry.ts
+++ b/src/main/provider-registry.ts
@@ -1,0 +1,38 @@
+/**
+ * Canonical inference base URLs for built-in providers — mirrors
+ * hermes-agent's `PROVIDER_REGISTRY` defaults.
+ *
+ * Lives in its own module (not in `model-discovery.ts` or `config.ts`)
+ * to avoid a circular import: `model-discovery` already depends on
+ * `config` for `readEnv`, and `config` needs this lookup for
+ * `setModelConfig` to write the right `base_url:` when the user picks a
+ * built-in provider entry that doesn't carry a baseUrl of its own.
+ *
+ * Only providers whose `/v1/chat/completions` endpoint we trust are
+ * listed; anything else (`custom`, `auto`, OAuth-only providers,
+ * user-defined entries) falls back to caller-supplied baseUrl.
+ */
+export const PROVIDER_BASE_URLS: Record<string, string> = {
+  openai: "https://api.openai.com/v1",
+  openrouter: "https://openrouter.ai/api/v1",
+  deepseek: "https://api.deepseek.com/v1",
+  groq: "https://api.groq.com/openai/v1",
+  mistral: "https://api.mistral.ai/v1",
+  together: "https://api.together.xyz/v1",
+  fireworks: "https://api.fireworks.ai/inference/v1",
+  cerebras: "https://api.cerebras.ai/v1",
+  perplexity: "https://api.perplexity.ai",
+  huggingface: "https://router.huggingface.co/v1",
+  zai: "https://api.z.ai/api/paas/v4",
+  anthropic: "https://api.anthropic.com/v1",
+};
+
+/**
+ * Look up the canonical inference base URL for a built-in provider id.
+ * Returns null when the provider isn't in the registry (e.g. `custom`,
+ * `auto`, or anything user-defined).
+ */
+export function canonicalProviderBaseUrl(provider: string): string | null {
+  const direct = PROVIDER_BASE_URLS[provider.toLowerCase()];
+  return direct ?? null;
+}

--- a/src/renderer/src/screens/Models/Models.tsx
+++ b/src/renderer/src/screens/Models/Models.tsx
@@ -165,12 +165,41 @@ function Models({ visible }: ModelsProps = {}): React.JSX.Element {
     setFormError("");
 
     if (editingModel) {
+      // Detect whether this edit is hitting the *currently active* model
+      // before the library write — if it is, the user's intent is to
+      // update that active configuration too. Without this sync, edits
+      // to the active model only land in `models.json` and the next chat
+      // still uses the stale `model:` block in `config.yaml` (e.g. with
+      // a stale `base_url` from a previous selection). The user has to
+      // open Chat, switch model away, switch back — and only that round
+      // trip refreshes `config.yaml`. Library edits should "take" on
+      // the active configuration when the entry being edited IS the
+      // active one.
+      const activeBefore = await window.hermesAPI.getModelConfig();
+      const editedWasActive =
+        activeBefore.provider === editingModel.provider &&
+        activeBefore.model === editingModel.model;
+
       await window.hermesAPI.updateModel(editingModel.id, {
         name,
         provider: formProvider,
         model,
         baseUrl: formBaseUrl.trim(),
       });
+
+      // Mirror the new values into config.yaml when this edit affects
+      // the active model. The empty-baseUrl case is handled by
+      // setModelConfig itself (substitutes the canonical URL for
+      // built-in providers — see `provider-registry.ts`).
+      if (editedWasActive) {
+        const effectiveBaseUrl =
+          formProvider === "custom" ? formBaseUrl.trim() : "";
+        await window.hermesAPI.setModelConfig(
+          formProvider,
+          model,
+          effectiveBaseUrl,
+        );
+      }
     } else {
       await window.hermesAPI.addModel(
         name,

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import {
+  PROVIDER_BASE_URLS,
+  canonicalProviderBaseUrl,
+} from "../src/main/provider-registry";
+
+describe("provider-registry", () => {
+  describe("canonicalProviderBaseUrl", () => {
+    it("returns the canonical URL for built-in OpenAI-compatible providers", () => {
+      expect(canonicalProviderBaseUrl("deepseek")).toBe(
+        "https://api.deepseek.com/v1",
+      );
+      expect(canonicalProviderBaseUrl("groq")).toBe(
+        "https://api.groq.com/openai/v1",
+      );
+      expect(canonicalProviderBaseUrl("mistral")).toBe(
+        "https://api.mistral.ai/v1",
+      );
+      expect(canonicalProviderBaseUrl("together")).toBe(
+        "https://api.together.xyz/v1",
+      );
+      expect(canonicalProviderBaseUrl("fireworks")).toBe(
+        "https://api.fireworks.ai/inference/v1",
+      );
+      expect(canonicalProviderBaseUrl("cerebras")).toBe(
+        "https://api.cerebras.ai/v1",
+      );
+    });
+
+    it("returns the canonical URL for the Big3 (openai / anthropic / openrouter)", () => {
+      expect(canonicalProviderBaseUrl("openai")).toBe(
+        "https://api.openai.com/v1",
+      );
+      expect(canonicalProviderBaseUrl("anthropic")).toBe(
+        "https://api.anthropic.com/v1",
+      );
+      expect(canonicalProviderBaseUrl("openrouter")).toBe(
+        "https://openrouter.ai/api/v1",
+      );
+    });
+
+    it("is case-insensitive on the provider id", () => {
+      expect(canonicalProviderBaseUrl("DeepSeek")).toBe(
+        "https://api.deepseek.com/v1",
+      );
+      expect(canonicalProviderBaseUrl("MISTRAL")).toBe(
+        "https://api.mistral.ai/v1",
+      );
+    });
+
+    it("returns null for providers that don't have a canonical URL", () => {
+      // `custom` and `auto` are intentionally not in the registry — the
+      // user must supply their own baseUrl.
+      expect(canonicalProviderBaseUrl("custom")).toBeNull();
+      expect(canonicalProviderBaseUrl("auto")).toBeNull();
+      // Unknown/user-defined provider ids.
+      expect(canonicalProviderBaseUrl("my-private-llm")).toBeNull();
+      expect(canonicalProviderBaseUrl("")).toBeNull();
+    });
+
+    it("the registry covers every built-in remote OpenAI-compat provider", () => {
+      // These are the provider ids that hermes-desktop's renderer
+      // exposes as built-in "remote" presets (constants.ts:LOCAL_PRESETS,
+      // group: "remote"). They MUST have canonical URLs here — otherwise
+      // setModelConfig would silently leave `base_url:` empty when the
+      // user picks them, which is the regression this module exists to
+      // prevent.
+      const requiredBuiltins = [
+        "groq",
+        "deepseek",
+        "together",
+        "fireworks",
+        "cerebras",
+        "mistral",
+      ];
+      for (const provider of requiredBuiltins) {
+        expect(PROVIDER_BASE_URLS[provider]).toBeTruthy();
+      }
+    });
+  });
+});

--- a/tests/set-model-config-base-url.test.ts
+++ b/tests/set-model-config-base-url.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { join } from "path";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+
+/**
+ * `setModelConfig` must write the right `base_url:` into `config.yaml` —
+ * specifically, when the renderer passes an empty `baseUrl` (because the
+ * user picked a built-in provider entry whose model library row doesn't
+ * carry an explicit URL), it should substitute the provider's canonical
+ * URL from `provider-registry.ts` rather than leaving the previous
+ * `base_url:` untouched.
+ *
+ * Concrete failure mode this prevents (the bug that motivated this fix):
+ *
+ *   1. User selects OAuth Codex → `model.base_url` becomes
+ *      `https://chatgpt.com/backend-api/codex`.
+ *   2. User then picks DeepSeek's `deepseek-v4-pro` (a built-in provider
+ *      entry; the library row has no baseUrl).
+ *   3. `setModelConfig("deepseek", "deepseek-v4-pro", "")` would
+ *      historically leave the Codex URL in place — the next chat hits
+ *      OpenAI's Codex endpoint carrying the DeepSeek key, and the user
+ *      sees a 401 from `platform.openai.com`.
+ *
+ * The fix: substitute the canonical URL for built-in providers; clear
+ * the field when the provider has no canonical and the caller supplied
+ * nothing.
+ */
+
+const TEST_DIR = join(tmpdir(), `hermes-test-set-model-base-url-${Date.now()}`);
+
+async function importConfigWithHome(
+  home: string,
+): Promise<typeof import("../src/main/config")> {
+  vi.resetModules();
+  process.env.HERMES_HOME = home;
+  return await import("../src/main/config");
+}
+
+beforeEach(() => {
+  mkdirSync(TEST_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  delete process.env.HERMES_HOME;
+  vi.resetModules();
+  rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe("setModelConfig — base_url substitution", () => {
+  it("writes the canonical URL when the user picks a built-in provider with no explicit baseUrl", async () => {
+    const configFile = join(TEST_DIR, "config.yaml");
+    const { setModelConfig, getModelConfig } =
+      await importConfigWithHome(TEST_DIR);
+
+    setModelConfig("deepseek", "deepseek-v4-pro", "");
+
+    const mc = getModelConfig();
+    expect(mc.provider).toBe("deepseek");
+    expect(mc.model).toBe("deepseek-v4-pro");
+    // Canonical URL got written even though the caller passed "".
+    expect(mc.baseUrl).toBe("https://api.deepseek.com/v1");
+    // And it landed in the actual `model:` block on disk.
+    const content = readFileSync(configFile, "utf-8");
+    expect(content).toMatch(/^model:/m);
+    expect(content).toContain('  base_url: "https://api.deepseek.com/v1"');
+  });
+
+  it("respects an explicit baseUrl when the caller supplies one", async () => {
+    const { setModelConfig, getModelConfig } =
+      await importConfigWithHome(TEST_DIR);
+
+    // User configured a self-hosted DeepSeek-compatible proxy on their LAN.
+    setModelConfig(
+      "deepseek",
+      "deepseek-v4-pro",
+      "https://my-llm-proxy.lan/v1",
+    );
+
+    const mc = getModelConfig();
+    expect(mc.baseUrl).toBe("https://my-llm-proxy.lan/v1");
+  });
+
+  it("overwrites a stale base_url when switching to a different built-in provider — the actual bug repro", async () => {
+    const configFile = join(TEST_DIR, "config.yaml");
+
+    // Step 1 — user was previously on OAuth Codex.
+    writeFileSync(
+      configFile,
+      [
+        "model:",
+        '  provider: "openai-codex"',
+        '  default: "gpt-5-codex"',
+        '  base_url: "https://chatgpt.com/backend-api/codex"',
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const { setModelConfig, getModelConfig } =
+      await importConfigWithHome(TEST_DIR);
+
+    // Step 2 — user picks DeepSeek's deepseek-v4-pro from the model picker.
+    //          The library row has no baseUrl, so the renderer passes "".
+    setModelConfig("deepseek", "deepseek-v4-pro", "");
+
+    const mc = getModelConfig();
+    expect(mc.provider).toBe("deepseek");
+    expect(mc.model).toBe("deepseek-v4-pro");
+    // Critical: the stale Codex URL is gone, replaced by DeepSeek's
+    // canonical URL. Before this fix, mc.baseUrl would still be
+    // "https://chatgpt.com/backend-api/codex" and chat would 401.
+    expect(mc.baseUrl).toBe("https://api.deepseek.com/v1");
+  });
+
+  it("leaves base_url unset for `custom` providers with no explicit baseUrl", async () => {
+    const configFile = join(TEST_DIR, "config.yaml");
+    const { setModelConfig, getModelConfig } =
+      await importConfigWithHome(TEST_DIR);
+
+    // `custom` has no canonical — there's nothing sensible to fill in,
+    // and writing a fake URL would be worse than leaving it empty (the
+    // user already saw the validation that prompts them for a URL).
+    setModelConfig("custom", "my-local-model", "");
+
+    const mc = getModelConfig();
+    expect(mc.provider).toBe("custom");
+    expect(mc.baseUrl).toBe("");
+
+    const content = readFileSync(configFile, "utf-8");
+    expect(content).not.toMatch(/^\s+base_url:/m);
+  });
+
+  it("covers every built-in remote provider — the full coverage check", async () => {
+    // If this test starts failing because a built-in remote provider
+    // got added to constants.ts:LOCAL_PRESETS without a corresponding
+    // entry in provider-registry.ts, the right fix is to add the URL —
+    // not to weaken the assertion here.
+    const provider_to_canonical: Record<string, string> = {
+      deepseek: "https://api.deepseek.com/v1",
+      groq: "https://api.groq.com/openai/v1",
+      mistral: "https://api.mistral.ai/v1",
+      together: "https://api.together.xyz/v1",
+      fireworks: "https://api.fireworks.ai/inference/v1",
+      cerebras: "https://api.cerebras.ai/v1",
+    };
+
+    for (const [provider, expected] of Object.entries(provider_to_canonical)) {
+      // Fresh import each iteration to reset the file.
+      rmSync(TEST_DIR, { recursive: true, force: true });
+      mkdirSync(TEST_DIR, { recursive: true });
+
+      const { setModelConfig, getModelConfig } =
+        await importConfigWithHome(TEST_DIR);
+      setModelConfig(provider, "some-model", "");
+
+      const mc = getModelConfig();
+      expect(mc.baseUrl).toBe(expected);
+    }
+  });
+});


### PR DESCRIPTION
## Repro

Configure a DeepSeek API key in **Providers** → pick `deepseek-v4-pro` as the active model in **Chat** → send a message:

```
Error: 401 - { 'error': { 'message': "Incorrect API key provided: sk-3ab7c***318f. You can find your API key at https://platform.openai.com/account/api-keys.", ... }}
```

The request hits **OpenAI's API** carrying the DeepSeek key. The DeepSeek key is rejected by OpenAI (correctly — it's not an OpenAI key).

## What's actually broken — three independent gaps that combine

I expected one root cause and ended up finding three. They each touch a different layer, so fixing one isn't enough to close the user-visible bug from every entry point.

### 1. `setModelConfig` leaves a stale `base_url`

In `src/main/config.ts:730-732`:

```ts
if (baseUrl) {
  content = upsertBlockChild(content, "model", "base_url", baseUrl);
}
```

When the user picks a built-in provider (DeepSeek, Groq, Mistral, …) the renderer passes `baseUrl = ""` because the model-library row carries no URL of its own — the canonical URL is supposed to come from elsewhere. The old code wrote `provider` and `default` but **silently left the existing `base_url:` line untouched**. So in the repro:

1. User was previously on Codex OAuth → `model.base_url = https://chatgpt.com/backend-api/codex`.
2. User then picks `deepseek-v4-pro` → only `provider` + `default` get rewritten.
3. `model.base_url` is *still* the Codex URL. Chat hits Codex's endpoint carrying the DeepSeek key.

**Fix:** when `baseUrl` is empty, substitute the canonical URL for built-in providers. The lookup table already existed in `model-discovery.ts:PROVIDER_BASE_URLS` (mirroring hermes-agent's `PROVIDER_REGISTRY`); promoting it to its own tiny module (`provider-registry.ts`) lets both `model-discovery` and `config` share it without a circular import.

### 2. Models pane edits never resync the active config

`src/renderer/src/screens/Models/Models.tsx:handleSave` only called `updateModel` (writes `models.json`), never `setModelConfig`. Editing the *active* model in the library was a no-op against `config.yaml` — the user had to open Chat, switch model away, and switch back just to refresh `config.yaml`.

**Fix:** detect when the edit hits the currently-active entry (`provider + model` match) and re-call `setModelConfig` with the new values. Non-active edits stay library-only, as before — verified by a live test that edited Claude Sonnet 4 (non-active) and confirmed the deepseek active config was untouched.

### 3. `hermes.ts` treats built-in remote providers as if they had native agent routing

In `src/main/hermes.ts`:

```ts
const LOCAL_PROVIDERS = new Set(["custom", "lmstudio", "ollama", "vllm", "llamacpp"]);
// …
const isCustomEndpoint = LOCAL_PROVIDERS.has(mc.provider);
if (isCustomEndpoint && mc.baseUrl) { /* set OPENAI_BASE_URL + key */ }
```

So for `provider="deepseek"` (or groq, together, fireworks, cerebras, mistral) the desktop **never set `OPENAI_BASE_URL` + a resolved key**, leaving the upstream gateway to route from the bare provider name. That's the path that trips the fallback chain already documented in the `pickAutoApiKeyForCustomProvider` comment block in `config.ts` (the workaround only fires for `provider="custom"` and so doesn't help here).

**Fix:** rename `LOCAL_PROVIDERS` → `OPENAI_COMPAT_PROVIDERS` and include the built-in remote OpenAI-compatible providers. They now take the same explicit-routing branch as `custom`. Also add their env vars (`DEEPSEEK_API_KEY`, `TOGETHER_API_KEY`, `FIREWORKS_API_KEY`, `CEREBRAS_API_KEY`, `MISTRAL_API_KEY`, `PERPLEXITY_API_KEY`) to `KNOWN_API_KEYS` so the agent sees them in env when they're set in `.env`.

## Changes

| File | Why |
|---|---|
| `src/main/provider-registry.ts` *(new)* | `PROVIDER_BASE_URLS` + `canonicalProviderBaseUrl()` — extracted from `model-discovery.ts` so `config.ts` can use the same lookup without a circular import |
| `src/main/model-discovery.ts` | Now imports `PROVIDER_BASE_URLS` from `provider-registry` (was defined inline) |
| `src/main/config.ts` | `setModelConfig` substitutes canonical URL when caller passes empty `baseUrl` |
| `src/main/hermes.ts` | `LOCAL_PROVIDERS` → `OPENAI_COMPAT_PROVIDERS` (+ built-in remote providers); `KNOWN_API_KEYS` gains the matching env vars |
| `src/renderer/src/screens/Models/Models.tsx` | `handleSave` resyncs active config when editing the currently-active library entry |
| `tests/provider-registry.test.ts` *(new)* | 5 cases covering canonical lookup |
| `tests/set-model-config-base-url.test.ts` *(new)* | 5 cases covering `setModelConfig`'s new substitution behaviour, including the exact stale-Codex-URL → DeepSeek repro |

## Verification

- `npm run typecheck` — clean.
- `npm test` — **54 files / 633 passed / 3 skipped / 0 failures** (10 new tests added; no existing tests touched).
- **Live test 1 — the repro:** reproduced the 401 on `main` with the exact corrupted config (`provider="deepseek"` + `base_url="https://chatgpt.com/backend-api/codex"`). On this branch, opening **Models → deepseek-v4-pro → Update** overwrites the stale URL with `https://api.deepseek.com/v1` in `config.yaml`. Next chat reaches DeepSeek cleanly ("Hi! What can I help you with?" responses round-trip).
- **Live test 2 — guard against active-model hijack:** edited Claude Sonnet 4 (Anthropic) in the library — `config.yaml`'s active model stays as `deepseek-v4-pro / api.deepseek.com`. The provider+model match guard works.

## Out of scope

- The user's library also has stale `base_url: "https://chatgpt.com/backend-api/codex"` on a couple of historical entries (e.g. an entry literally named "deepseek" pointing at Codex). Those are pre-existing library corruption that this PR doesn't try to clean up — they'd need to be edited/deleted by the user. Fix scope is the *active-model* write path that produces new corruption.
- Cleaning the upstream hermes-agent fallback chain (`_resolve_openrouter_runtime`) is upstream work; the `config.ts:651-664` comment block has the link.