### PR TITLE
chat: surface reasoning + tool rows live in the chat (closes #352)

### DIFF
--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -1,4 +1,5 @@
 import { ChildProcess, spawn } from "child_process";
+import { randomUUID } from "crypto";
 import { existsSync, readFileSync, appendFileSync, unlinkSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
@@ -372,14 +373,6 @@ function sendMessageViaApi(
     "Content-Type": "application/json",
     ...getRemoteAuthHeader(),
   };
-  // Session continuity: the gateway resumes an existing session via the
-  // `X-Hermes-Session-Id` *request header* — the `session_id` body field
-  // above is not honoured. Without this header every request forks a new
-  // server-side session, fragmenting stored history and messageCount
-  // (issue #226). The gateway echoes the id back in the response header.
-  if (_resumeSessionId) {
-    headers["X-Hermes-Session-Id"] = _resumeSessionId;
-  }
   // Local API server key (API_SERVER_KEY in the profile's .env /
   // config.yaml) only applies in local mode — in remote/SSH mode the
   // remote endpoint's own auth header (set above) is authoritative and
@@ -391,7 +384,36 @@ function sendMessageViaApi(
     }
   }
 
-  let sessionId = _resumeSessionId || "";
+  // Session id: always send via `X-Hermes-Session-Id` so the gateway
+  // doesn't fall back to its `_derive_chat_session_id` fingerprint —
+  // sha256(system_prompt + first_user_message)[:16] — which collides
+  // across every chat whose first user message is the same (e.g. "Hi").
+  // The collision silently fragments state.db rows across unrelated
+  // conversations and, post-#352, surfaces as old-session content
+  // bleeding into new chats when our end-of-stream merge reads
+  // getSessionMessages(). Filed upstream as
+  // NousResearch/hermes-agent#7484 (security framing — same root cause).
+  //
+  // Format: `desk-<ms>-<uuidv4>`. UUIDv4 alone is collision-safe
+  // probabilistically (~10⁻³⁶ for any pair); the timestamp prefix makes
+  // it defensively unique even under a hypothetical PRNG bug, and the
+  // `desk-` tag makes desktop-originated sessions visually distinct
+  // from the gateway's fingerprint-derived `api-<hash>` ids in
+  // state.db / logs.
+  //
+  // Gate on auth: the gateway rejects `X-Hermes-Session-Id` with 403
+  // when API_SERVER_KEY isn't configured (its history-load is gated
+  // behind auth). The desktop auto-generates API_SERVER_KEY at install
+  // and remote mode supplies its own bearer, so in practice this
+  // branch is always taken; the guard exists only so a misconfigured
+  // local install degrades to the pre-fix (fingerprint) behaviour
+  // rather than 403-looping.
+  const hasAuth = "Authorization" in headers;
+  let sessionId =
+    _resumeSessionId || (hasAuth ? `desk-${Date.now()}-${randomUUID()}` : "");
+  if (sessionId) {
+    headers["X-Hermes-Session-Id"] = sessionId;
+  }
   let hasContent = false;
   let finished = false; // guard against double callbacks
   let lastError = ""; // capture embedded error messages

--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -196,8 +196,39 @@ platforms:
 //  HTTP API streaming (fast path — no process spawn)
 // ────────────────────────────────────────────────────
 
+/**
+ * Pull the streaming reasoning / thinking text from one SSE `delta`
+ * object, if present. Two shapes seen in the wild:
+ *
+ *   - DeepSeek (reasoning models): `delta.reasoning_content`
+ *   - OpenAI o1/o3-style streams + some OpenRouter routes:
+ *     `delta.reasoning` (older OpenAI thinking-mode docs also use this
+ *     field name).
+ *
+ * Returns `""` (falsy) for any other shape, so the caller can skip
+ * forwarding without a null check.
+ *
+ * Exported so we can unit-test the field-extraction without booting
+ * the whole HTTP path. (#352)
+ */
+export function extractReasoningDelta(delta: unknown): string {
+  if (!delta || typeof delta !== "object") return "";
+  const d = delta as Record<string, unknown>;
+  if (typeof d.reasoning_content === "string" && d.reasoning_content)
+    return d.reasoning_content;
+  if (typeof d.reasoning === "string" && d.reasoning) return d.reasoning;
+  return "";
+}
+
 export interface ChatCallbacks {
   onChunk: (text: string) => void;
+  /** Streaming reasoning / thinking tokens, when the provider emits them
+   *  alongside `content`. DeepSeek surfaces these as `delta.reasoning_content`;
+   *  OpenAI o1/o3-style streams use `delta.reasoning`. Forwarded on a
+   *  dedicated channel so the renderer can render the thinking bubble
+   *  live instead of waiting for a state-DB refresh on focus change
+   *  (issue #352). */
+  onReasoningChunk?: (text: string) => void;
   onDone: (sessionId?: string) => void;
   onError: (error: string) => void;
   onToolProgress?: (tool: string) => void;
@@ -469,6 +500,16 @@ function sendMessageViaApi(
           rateLimitRemaining: parsed.usage.rate_limit_remaining,
           rateLimitReset: parsed.usage.rate_limit_reset,
         });
+      }
+
+      // Reasoning / thinking tokens, when the provider emits them.
+      // Forwarded on a dedicated callback so the renderer can render the
+      // thinking bubble live (#352). We do NOT set `hasContent = true`
+      // here — reasoning alone shouldn't suppress the "empty stream"
+      // diagnostic probe.
+      const reasoningDelta = extractReasoningDelta(delta);
+      if (reasoningDelta && cb.onReasoningChunk) {
+        cb.onReasoningChunk(reasoningDelta);
       }
 
       if (delta?.content) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -789,6 +789,15 @@ function setupIPC(): void {
               currentChatAbort();
             }
           },
+          onReasoningChunk: (chunk) => {
+            // Forward reasoning/thinking tokens on a dedicated channel so
+            // the renderer can render the thinking bubble live during the
+            // stream rather than waiting for a focus-change refresh (#352).
+            // Same renderer-gone abort guard as the content channel.
+            if (!safeSend("chat-reasoning-chunk", chunk) && currentChatAbort) {
+              currentChatAbort();
+            }
+          },
           onDone: (sessionId) => {
             currentChatAbort = null;
             safeSend("chat-done", sessionId || "");

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -251,6 +251,7 @@ interface HermesAPI {
     cached: boolean;
   }>;
   onChatChunk: (callback: (chunk: string) => void) => () => void;
+  onChatReasoningChunk: (callback: (chunk: string) => void) => () => void;
   onChatDone: (callback: (sessionId?: string) => void) => () => void;
   onChatToolProgress: (callback: (tool: string) => void) => () => void;
   onChatUsage: (

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -288,6 +288,18 @@ const hermesAPI = {
     return () => ipcRenderer.removeListener("chat-chunk", handler);
   },
 
+  /** Streaming reasoning / thinking tokens — separate from `onChatChunk`
+   *  so the renderer can render a "thinking" bubble that grows
+   *  independently of the assistant's content (#352). */
+  onChatReasoningChunk: (
+    callback: (chunk: string) => void,
+  ): (() => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, chunk: string): void =>
+      callback(chunk);
+    ipcRenderer.on("chat-reasoning-chunk", handler);
+    return () => ipcRenderer.removeListener("chat-reasoning-chunk", handler);
+  },
+
   onChatDone: (callback: (sessionId?: string) => void): (() => void) => {
     const handler = (
       _event: Electron.IpcRendererEvent,

--- a/src/renderer/src/screens/Chat/hooks/useChatIPC.ts
+++ b/src/renderer/src/screens/Chat/hooks/useChatIPC.ts
@@ -46,6 +46,46 @@ export function useChatIPC({
       });
     });
 
+    // Streaming reasoning / thinking bubbles for the current turn (#352).
+    // Reasoning typically arrives BEFORE content (DeepSeek, o1/o3), but
+    // we don't rely on that order — we find the reasoning row for the
+    // active turn (last agent reasoning row since the most recent user
+    // message) and append to it. If no such row exists yet, create one
+    // and place it BEFORE any assistant content bubbles in the same
+    // turn so the visual order is reasoning → answer.
+    const cleanupReasoning = window.hermesAPI.onChatReasoningChunk((chunk) => {
+      if (!chunk) return;
+      setMessages((prev) => {
+        let insertAt = prev.length;
+        for (let i = prev.length - 1; i >= 0; i--) {
+          const m = prev[i];
+          if (m.role === "user") break;
+          // Append to the active turn's reasoning row if one exists.
+          if ("kind" in m && m.kind === "reasoning") {
+            return [
+              ...prev.slice(0, i),
+              { ...m, text: m.text + chunk },
+              ...prev.slice(i + 1),
+            ];
+          }
+          // Otherwise track the earliest in-turn agent row so the new
+          // reasoning bubble lands ahead of it (typical case: content
+          // bubble started first because reasoning arrived a tick late).
+          insertAt = i;
+        }
+        return [
+          ...prev.slice(0, insertAt),
+          {
+            id: `reasoning-${Date.now()}`,
+            kind: "reasoning",
+            role: "agent",
+            text: chunk,
+          },
+          ...prev.slice(insertAt),
+        ];
+      });
+    });
+
     const cleanupDone = window.hermesAPI.onChatDone((sessionId) => {
       if (sessionId) setHermesSessionId(sessionId);
       setToolProgress(null);
@@ -80,6 +120,7 @@ export function useChatIPC({
 
     return () => {
       cleanupChunk();
+      cleanupReasoning();
       cleanupDone();
       cleanupError();
       cleanupToolProgress();

--- a/src/renderer/src/screens/Chat/hooks/useChatIPC.ts
+++ b/src/renderer/src/screens/Chat/hooks/useChatIPC.ts
@@ -1,5 +1,10 @@
 import { useEffect } from "react";
 import type { ChatMessage, UsageState } from "../types";
+import {
+  dbItemsToChatMessages,
+  reconcileStreamedWithDb,
+  type DbHistoryItem,
+} from "../sessionHistory";
 
 interface UseChatIPCArgs {
   setMessages: React.Dispatch<React.SetStateAction<ChatMessage[]>>;
@@ -86,10 +91,33 @@ export function useChatIPC({
       });
     });
 
-    const cleanupDone = window.hermesAPI.onChatDone((sessionId) => {
+    const cleanupDone = window.hermesAPI.onChatDone(async (sessionId) => {
       if (sessionId) setHermesSessionId(sessionId);
       setToolProgress(null);
       setIsLoading(false);
+      // End-of-stream merge from state.db. The gateway doesn't forward
+      // streaming reasoning_content / tool deltas over the OpenAI-compatible
+      // SSE (NousResearch/hermes-agent#30449) — the agent writes them to
+      // state.db at finalisation instead. Without this merge, the
+      // reasoning / tool bubbles only materialise when something else
+      // triggers a re-sync (window focus change, tab switch). Doing it
+      // here makes them appear immediately on stream completion (#352).
+      //
+      // We *merge* (not replace) so that once #30449 lands and reasoning
+      // does stream, the already-rendered streamed bubble keeps its
+      // React identity instead of being re-mounted by a DB-id swap.
+      // `reconcileStreamedWithDb` does the matching — see its doc block.
+      if (!sessionId) return;
+      try {
+        const items = (await window.hermesAPI.getSessionMessages(
+          sessionId,
+        )) as DbHistoryItem[];
+        const dbMessages = dbItemsToChatMessages(items);
+        if (dbMessages.length === 0) return;
+        setMessages((prev) => reconcileStreamedWithDb(prev, dbMessages));
+      } catch {
+        // Merge is a UX nicety — don't break the chat flow if it fails.
+      }
     });
 
     const cleanupError = window.hermesAPI.onChatError((error) => {

--- a/src/renderer/src/screens/Chat/sessionHistory.ts
+++ b/src/renderer/src/screens/Chat/sessionHistory.ts
@@ -1,0 +1,197 @@
+import type { Attachment } from "../../../../shared/attachments";
+import type { ChatMessage, ChatBubbleMessage } from "./types";
+
+/**
+ * Shape of one row from the main process's `getSessionMessages` IPC.
+ * Mirrors `src/main/sessions.ts:HistoryItem` (kept loose here so the
+ * renderer doesn't have to import main-process types).
+ */
+export interface DbHistoryItem {
+  kind: "user" | "assistant" | "reasoning" | "tool_call" | "tool_result";
+  id: number;
+  content?: string;
+  text?: string;
+  callId?: string;
+  name?: string;
+  args?: string;
+  timestamp?: number;
+  attachments?: Attachment[];
+}
+
+/**
+ * Convert a stream of `getSessionMessages` rows into renderer-ready
+ * `ChatMessage`s. Extracted from `Layout.handleResumeSession` so both
+ * "resume a saved session from the Sessions tab" and "refresh the
+ * active chat's transcript from state.db at end of stream" can share
+ * the same mapping.
+ *
+ * The end-of-stream refresh is the desktop's user-side mitigation for
+ * NousResearch/hermes-agent#30449 ("API server: reasoning_content and
+ * reasoning_effort never reach OpenAI-compatible SSE stream"). Until
+ * the gateway forwards reasoning chunks during the stream, the agent
+ * still writes them to state.db at finalisation — refreshing here
+ * makes them appear without the user having to focus-change to
+ * trigger a re-sync (issue #352).
+ */
+export function dbItemsToChatMessages(
+  items: ReadonlyArray<DbHistoryItem>,
+): ChatMessage[] {
+  return items
+    .map((it): ChatMessage | null => {
+      switch (it.kind) {
+        case "user":
+          return {
+            id: `db-${it.id}`,
+            role: "user",
+            content: it.content || "",
+            ...(it.attachments && it.attachments.length > 0
+              ? { attachments: it.attachments }
+              : {}),
+          };
+        case "assistant":
+          return {
+            id: `db-${it.id}`,
+            role: "agent",
+            content: it.content || "",
+            ...(it.attachments && it.attachments.length > 0
+              ? { attachments: it.attachments }
+              : {}),
+          };
+        case "reasoning":
+          return {
+            id: `db-r-${it.id}`,
+            kind: "reasoning",
+            role: "agent",
+            text: it.text || "",
+          };
+        case "tool_call":
+          return {
+            id: `db-tc-${it.id}-${it.callId || "x"}`,
+            kind: "tool_call",
+            role: "agent",
+            callId: it.callId || "",
+            name: it.name || "",
+            args: it.args || "",
+          };
+        case "tool_result":
+          return {
+            id: `db-tr-${it.id}`,
+            kind: "tool_result",
+            role: "agent",
+            callId: it.callId || "",
+            name: it.name || "",
+            content: it.content || "",
+            ...(it.attachments && it.attachments.length > 0
+              ? { attachments: it.attachments }
+              : {}),
+          };
+        default:
+          return null;
+      }
+    })
+    .filter((m): m is ChatMessage => m !== null);
+}
+
+/**
+ * Match key for cross-source reconciliation between streamed in-memory
+ * messages and DB-loaded equivalents. Returned key matches when two
+ * messages represent the same logical row regardless of which side
+ * produced them.
+ *
+ * The strategy:
+ *
+ *   - For the chat-bubble kinds (user / agent content) we key on
+ *     `role:contentSnippet`. Trimming guards against trailing
+ *     whitespace drift between the stream-accumulated string and the
+ *     DB-finalised one. The snippet length is intentionally short
+ *     (first 200 chars) so a very long assistant reply doesn't blow
+ *     out the map for no incremental matching benefit — collisions
+ *     across two distinct turns at the same prefix are vanishingly
+ *     unlikely.
+ *   - For `tool_call` / `tool_result` we key on the OpenAI callId,
+ *     which the agent generates and is stable across the streamed
+ *     callback (when one exists) and the DB row.
+ *   - For `reasoning`, key on the trimmed text. Reasoning has no
+ *     callId. When streaming concatenates many tiny tokens into one
+ *     reasoning message, the result text equals the DB row text
+ *     because both sides see the same agent output.
+ *
+ * `null` opts a message out of matching — there's no equivalent on
+ * the other side and the reconciliation should treat it as unique.
+ */
+function reconciliationKey(m: ChatMessage): string | null {
+  if ("kind" in m) {
+    switch (m.kind) {
+      case "reasoning":
+        return `reasoning:${(m.text || "").trim().slice(0, 200)}`;
+      case "tool_call":
+        return `tool_call:${m.callId || m.id}`;
+      case "tool_result":
+        return `tool_result:${m.callId || m.id}`;
+      default:
+        return null;
+    }
+  }
+  const bubble = m as ChatBubbleMessage;
+  return `${bubble.role}:${(bubble.content || "").trim().slice(0, 200)}`;
+}
+
+/**
+ * Merge an in-memory streamed transcript with the canonical state.db
+ * transcript at end-of-stream.
+ *
+ * The desktop streams `user` + `agent content` in real time (and, once
+ * `NousResearch/hermes-agent#30449` lands, `reasoning` too). `tool_call`
+ * and `tool_result` rows never stream — they only exist in `state.db`
+ * after the agent finalises the message. So at end-of-stream we need
+ * to surface the DB rows the streaming pass didn't deliver.
+ *
+ * The naive approach — replace the whole transcript with the DB version
+ * — works today but will cause a one-frame re-mount flicker once
+ * reasoning streaming starts working: the streamed reasoning bubble
+ * (id `reasoning-${ts}`) would be replaced by a DB-loaded one (id
+ * `db-r-${row}`) with identical text but a new React key. Solving it
+ * properly: walk the DB rows in their canonical order, but when a
+ * streamed equivalent already exists in memory, keep the streamed
+ * row's React identity. New DB rows that have no streamed counterpart
+ * (tool_call / tool_result today, plus any agent-finalised text the
+ * stream dropped) appear in the merged result in the DB's order.
+ *
+ * Issue #352. Pure function, no state — testable in isolation.
+ */
+export function reconcileStreamedWithDb(
+  streamed: ReadonlyArray<ChatMessage>,
+  db: ReadonlyArray<ChatMessage>,
+): ChatMessage[] {
+  // Index streamed messages by their reconciliation key. Duplicate
+  // keys (same text in two turns) are tracked as a FIFO queue so the
+  // walk below consumes them in the original order rather than
+  // collapsing both DB occurrences onto the first streamed one.
+  const streamedByKey = new Map<string, ChatMessage[]>();
+  for (const m of streamed) {
+    const key = reconciliationKey(m);
+    if (!key) continue;
+    const bucket = streamedByKey.get(key);
+    if (bucket) bucket.push(m);
+    else streamedByKey.set(key, [m]);
+  }
+
+  const result: ChatMessage[] = [];
+  for (const dbMsg of db) {
+    const key = reconciliationKey(dbMsg);
+    const bucket = key ? streamedByKey.get(key) : undefined;
+    const streamedMatch = bucket?.shift();
+    result.push(streamedMatch ?? dbMsg);
+  }
+
+  // Pathological case: the in-memory transcript carried something the
+  // DB doesn't have yet (e.g. a renderer-side error bubble inserted by
+  // `onChatError`). Preserve those tail-of-stream additions so the
+  // reconciliation never silently drops UI-only state.
+  const consumedIds = new Set(result.map((m) => m.id));
+  for (const m of streamed) {
+    if (!consumedIds.has(m.id)) result.push(m);
+  }
+
+  return result;
+}

--- a/src/renderer/src/screens/Layout/Layout.tsx
+++ b/src/renderer/src/screens/Layout/Layout.tsx
@@ -1,5 +1,9 @@
 import { useState, useCallback, useEffect } from "react";
 import Chat, { ChatMessage } from "../Chat/Chat";
+import {
+  dbItemsToChatMessages,
+  type DbHistoryItem,
+} from "../Chat/sessionHistory";
 import Sessions from "../Sessions/Sessions";
 import Agents from "../Agents/Agents";
 import Settings from "../Settings/Settings";
@@ -194,62 +198,10 @@ function Layout({
 
   const handleResumeSession = useCallback(
     async (sessionId: string) => {
-      const items = await window.hermesAPI.getSessionMessages(sessionId);
-      const chatMessages: ChatMessage[] = items
-        .map((it): ChatMessage | null => {
-          switch (it.kind) {
-            case "user":
-              return {
-                id: `db-${it.id}`,
-                role: "user",
-                content: it.content,
-                ...(it.attachments && it.attachments.length > 0
-                  ? { attachments: it.attachments }
-                  : {}),
-              };
-            case "assistant":
-              return {
-                id: `db-${it.id}`,
-                role: "agent",
-                content: it.content,
-                ...(it.attachments && it.attachments.length > 0
-                  ? { attachments: it.attachments }
-                  : {}),
-              };
-            case "reasoning":
-              return {
-                id: `db-r-${it.id}`,
-                kind: "reasoning",
-                role: "agent",
-                text: it.text,
-              };
-            case "tool_call":
-              return {
-                id: `db-tc-${it.id}-${it.callId || "x"}`,
-                kind: "tool_call",
-                role: "agent",
-                callId: it.callId,
-                name: it.name,
-                args: it.args,
-              };
-            case "tool_result":
-              return {
-                id: `db-tr-${it.id}`,
-                kind: "tool_result",
-                role: "agent",
-                callId: it.callId,
-                name: it.name,
-                content: it.content,
-                ...(it.attachments && it.attachments.length > 0
-                  ? { attachments: it.attachments }
-                  : {}),
-              };
-            default:
-              return null;
-          }
-        })
-        .filter((m): m is ChatMessage => m !== null);
-      setMessages(chatMessages);
+      const items = (await window.hermesAPI.getSessionMessages(
+        sessionId,
+      )) as DbHistoryItem[];
+      setMessages(dbItemsToChatMessages(items));
       setCurrentSessionId(sessionId);
       goTo("chat");
     },

--- a/tests/extract-reasoning-delta.test.ts
+++ b/tests/extract-reasoning-delta.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { extractReasoningDelta } from "../src/main/hermes";
+
+/**
+ * `extractReasoningDelta` pulls the streaming reasoning / thinking text
+ * out of one SSE `delta` object so the chat-send path can forward it to
+ * the renderer on a dedicated channel — fixing the "reasoning only
+ * appears after window focus change" UX bug from issue #352.
+ *
+ * Two field names matter in practice:
+ *   - `reasoning_content` (DeepSeek reasoning models)
+ *   - `reasoning` (OpenAI o1/o3-style streams, some OpenRouter routes)
+ *
+ * Everything else returns `""` so the caller can skip forwarding without
+ * a null check.
+ */
+
+describe("extractReasoningDelta", () => {
+  it("pulls DeepSeek-shaped `reasoning_content`", () => {
+    expect(
+      extractReasoningDelta({ reasoning_content: "Let me think step by step…" }),
+    ).toBe("Let me think step by step…");
+  });
+
+  it("pulls OpenAI-style `reasoning`", () => {
+    expect(extractReasoningDelta({ reasoning: "Analysing the request." })).toBe(
+      "Analysing the request.",
+    );
+  });
+
+  it("prefers `reasoning_content` over `reasoning` when both are present", () => {
+    // Real responses occasionally include both (a gateway adding a
+    // second alias). Pick the canonical DeepSeek field so we don't
+    // double up if the caller is also tee'ing the other field.
+    expect(
+      extractReasoningDelta({
+        reasoning_content: "deepseek-shaped",
+        reasoning: "openai-shaped",
+      }),
+    ).toBe("deepseek-shaped");
+  });
+
+  it("returns empty for a delta that only carries content (no reasoning)", () => {
+    expect(extractReasoningDelta({ content: "Hello there" })).toBe("");
+  });
+
+  it("returns empty for an empty reasoning field", () => {
+    expect(extractReasoningDelta({ reasoning_content: "" })).toBe("");
+    expect(extractReasoningDelta({ reasoning: "" })).toBe("");
+  });
+
+  it("ignores non-string reasoning fields defensively", () => {
+    expect(extractReasoningDelta({ reasoning_content: null })).toBe("");
+    expect(extractReasoningDelta({ reasoning: 42 })).toBe("");
+    expect(extractReasoningDelta({ reasoning: { nested: "value" } })).toBe("");
+  });
+
+  it("returns empty for non-object inputs (malformed chunks)", () => {
+    expect(extractReasoningDelta(null)).toBe("");
+    expect(extractReasoningDelta(undefined)).toBe("");
+    expect(extractReasoningDelta("a string")).toBe("");
+    expect(extractReasoningDelta(123)).toBe("");
+  });
+
+  it("handles multi-line reasoning content as a single chunk", () => {
+    // Streamed reasoning often arrives as small fragments (a few
+    // characters at a time), but a whole-step delta is also possible
+    // — both should pass through unchanged.
+    const multiLine = "Step 1: parse the question\nStep 2: pick a tool";
+    expect(extractReasoningDelta({ reasoning_content: multiLine })).toBe(
+      multiLine,
+    );
+  });
+});

--- a/tests/hermes-api.test.ts
+++ b/tests/hermes-api.test.ts
@@ -216,7 +216,13 @@ describe("sendMessageViaApi forwards resumeSessionId", () => {
     expect(headers["X-Hermes-Session-Id"]).toBe(testSessionId);
   });
 
-  it("omits the X-Hermes-Session-Id header for a fresh session", async () => {
+  it("generates a fresh `desk-`-prefixed X-Hermes-Session-Id when no resumeSessionId is passed", async () => {
+    // Pin the new-chat session-id behaviour: instead of letting the
+    // gateway fall back to its `_derive_chat_session_id` fingerprint
+    // (sha256(system_prompt + first_user_message)[:16]), the desktop
+    // generates `desk-<ms>-<uuid>` per fresh chat and ships it via the
+    // header. The fingerprint collides across all chats whose first
+    // message is the same — see NousResearch/hermes-agent#7484.
     await sendMessage(
       "hello",
       {
@@ -234,6 +240,38 @@ describe("sendMessageViaApi forwards resumeSessionId", () => {
     expect(chatRequest).toBeDefined();
     const headers = chatRequest!.options.headers as Record<string, string>;
 
-    expect(headers).not.toHaveProperty("X-Hermes-Session-Id");
+    expect(headers).toHaveProperty("X-Hermes-Session-Id");
+    expect(headers["X-Hermes-Session-Id"]).toMatch(
+      /^desk-\d{13,}-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("generates a different X-Hermes-Session-Id on each fresh send (no fingerprint collision)", async () => {
+    // The same first message twice MUST NOT produce the same session
+    // id — the whole point of the fix.
+    await sendMessage(
+      "Hello there",
+      { onChunk: () => {}, onDone: () => {}, onError: () => {} },
+      "default",
+      undefined,
+    );
+    await sendMessage(
+      "Hello there",
+      { onChunk: () => {}, onDone: () => {}, onError: () => {} },
+      "default",
+      undefined,
+    );
+
+    const chatRequests = capturedRequests.filter((r) =>
+      r.url.includes("/v1/chat/completions"),
+    );
+    expect(chatRequests.length).toBeGreaterThanOrEqual(2);
+    const ids = chatRequests.map(
+      (r) =>
+        (r.options.headers as Record<string, string>)["X-Hermes-Session-Id"],
+    );
+    expect(ids[0]).toBeTruthy();
+    expect(ids[1]).toBeTruthy();
+    expect(ids[0]).not.toBe(ids[1]);
   });
 });

--- a/tests/preload-api-surface.test.ts
+++ b/tests/preload-api-surface.test.ts
@@ -119,6 +119,7 @@ describe("Legacy APIs preserved (backward compat)", () => {
     "sendMessage",
     "abortChat",
     "onChatChunk",
+    "onChatReasoningChunk",
     "onChatDone",
     "onChatToolProgress",
     "onChatUsage",

--- a/tests/reconcile-streamed-with-db.test.ts
+++ b/tests/reconcile-streamed-with-db.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect } from "vitest";
+import { reconcileStreamedWithDb } from "../src/renderer/src/screens/Chat/sessionHistory";
+import type { ChatMessage } from "../src/renderer/src/screens/Chat/types";
+
+/**
+ * `reconcileStreamedWithDb` is the end-of-stream merge between the
+ * in-memory streamed transcript and the canonical `state.db` rows
+ * returned by `getSessionMessages`.
+ *
+ * Two cases drive the design:
+ *
+ *   1. Today — DeepSeek (and o1/o3) emit `reasoning_content` over SSE
+ *      but the gateway (NousResearch/hermes-agent#30449) doesn't
+ *      forward it. So reasoning + tool rows only exist in state.db.
+ *      The merge must ADD those rows so the user sees them without
+ *      a window-focus dance.
+ *
+ *   2. After upstream #30449 lands — reasoning streams in real time
+ *      with a renderer-side id like `reasoning-${ts}`. The merge
+ *      must KEEP that streamed id so React doesn't re-mount the
+ *      already-rendered bubble when the DB version (id `db-r-…`)
+ *      arrives at end-of-stream.
+ *
+ * Both behaviours are pinned below.
+ */
+
+const STREAMED_USER = (content: string, id = "u-1"): ChatMessage => ({
+  id,
+  role: "user",
+  content,
+});
+
+const STREAMED_AGENT = (content: string, id = "a-1"): ChatMessage => ({
+  id,
+  role: "agent",
+  content,
+});
+
+const STREAMED_REASONING = (text: string, id = "r-1"): ChatMessage => ({
+  id,
+  kind: "reasoning",
+  role: "agent",
+  text,
+});
+
+const DB_USER = (content: string, dbId = 10): ChatMessage => ({
+  id: `db-${dbId}`,
+  role: "user",
+  content,
+});
+
+const DB_AGENT = (content: string, dbId = 11): ChatMessage => ({
+  id: `db-${dbId}`,
+  role: "agent",
+  content,
+});
+
+const DB_REASONING = (text: string, dbId = 12): ChatMessage => ({
+  id: `db-r-${dbId}`,
+  kind: "reasoning",
+  role: "agent",
+  text,
+});
+
+const DB_TOOL_CALL = (
+  callId: string,
+  name: string,
+  args: string,
+  dbId = 13,
+): ChatMessage => ({
+  id: `db-tc-${dbId}-${callId}`,
+  kind: "tool_call",
+  role: "agent",
+  callId,
+  name,
+  args,
+});
+
+const DB_TOOL_RESULT = (
+  callId: string,
+  name: string,
+  content: string,
+  dbId = 14,
+): ChatMessage => ({
+  id: `db-tr-${dbId}`,
+  kind: "tool_result",
+  role: "agent",
+  callId,
+  name,
+  content,
+});
+
+describe("reconcileStreamedWithDb", () => {
+  it("today: gateway doesn't stream reasoning — merge inserts reasoning from DB", () => {
+    // Streamed transcript: user msg + assistant content (no reasoning).
+    const streamed: ChatMessage[] = [
+      STREAMED_USER("hi", "u-1"),
+      STREAMED_AGENT("hello", "a-1"),
+    ];
+    // DB has the same user/assistant rows + a reasoning row in between.
+    const db: ChatMessage[] = [
+      DB_USER("hi", 1),
+      DB_REASONING("user said hi, respond politely", 2),
+      DB_AGENT("hello", 3),
+    ];
+
+    const merged = reconcileStreamedWithDb(streamed, db);
+
+    expect(merged).toHaveLength(3);
+    // User & assistant keep their streamed ids (no re-mount).
+    expect(merged[0].id).toBe("u-1");
+    expect(merged[2].id).toBe("a-1");
+    // Reasoning came in from DB — has the db-r- prefix.
+    expect(merged[1].id).toBe("db-r-2");
+    expect((merged[1] as Extract<ChatMessage, { kind: "reasoning" }>).text).toBe(
+      "user said hi, respond politely",
+    );
+  });
+
+  it("future: reasoning DOES stream — merge keeps the streamed id, no re-mount", () => {
+    const streamed: ChatMessage[] = [
+      STREAMED_USER("hi", "u-1"),
+      STREAMED_REASONING("user said hi, respond politely", "r-stream-99"),
+      STREAMED_AGENT("hello", "a-1"),
+    ];
+    const db: ChatMessage[] = [
+      DB_USER("hi", 1),
+      DB_REASONING("user said hi, respond politely", 2),
+      DB_AGENT("hello", 3),
+    ];
+
+    const merged = reconcileStreamedWithDb(streamed, db);
+
+    expect(merged).toHaveLength(3);
+    // All three retain their streamed ids — React doesn't re-mount.
+    expect(merged.map((m) => m.id)).toEqual(["u-1", "r-stream-99", "a-1"]);
+  });
+
+  it("tool_call and tool_result rows come straight from DB (they never stream)", () => {
+    const streamed: ChatMessage[] = [
+      STREAMED_USER("read foo.txt", "u-1"),
+      STREAMED_AGENT("Done.", "a-1"),
+    ];
+    const db: ChatMessage[] = [
+      DB_USER("read foo.txt", 1),
+      DB_TOOL_CALL("call-42", "fs.read", '{"path":"foo.txt"}', 2),
+      DB_TOOL_RESULT("call-42", "fs.read", "(file contents)", 3),
+      DB_AGENT("Done.", 4),
+    ];
+
+    const merged = reconcileStreamedWithDb(streamed, db);
+
+    expect(merged).toHaveLength(4);
+    // User and assistant keep their streamed identities.
+    expect(merged[0].id).toBe("u-1");
+    expect(merged[3].id).toBe("a-1");
+    // Tool rows are sourced from DB with their db- ids.
+    expect(merged[1].id).toBe("db-tc-2-call-42");
+    expect(merged[2].id).toBe("db-tr-3");
+  });
+
+  it("handles a turn that fully streamed including reasoning AND has new tool rows in DB", () => {
+    // The most common "future" case: reasoning streamed live, then the
+    // model used a tool, then produced a final answer. Only the tool
+    // rows are new at merge time.
+    const streamed: ChatMessage[] = [
+      STREAMED_USER("what time is it in Tokyo?", "u-1"),
+      STREAMED_REASONING("I need to call get_time for Tokyo.", "r-stream-1"),
+      STREAMED_AGENT("It's 3pm in Tokyo.", "a-1"),
+    ];
+    const db: ChatMessage[] = [
+      DB_USER("what time is it in Tokyo?", 1),
+      DB_REASONING("I need to call get_time for Tokyo.", 2),
+      DB_TOOL_CALL("call-99", "get_time", '{"zone":"Asia/Tokyo"}', 3),
+      DB_TOOL_RESULT("call-99", "get_time", "15:00 JST", 4),
+      DB_AGENT("It's 3pm in Tokyo.", 5),
+    ];
+
+    const merged = reconcileStreamedWithDb(streamed, db);
+
+    expect(merged).toHaveLength(5);
+    // Streamed rows preserved.
+    expect(merged[0].id).toBe("u-1");
+    expect(merged[1].id).toBe("r-stream-1");
+    expect(merged[4].id).toBe("a-1");
+    // Tool rows added from DB at their canonical positions.
+    expect(merged[2].id).toBe("db-tc-3-call-99");
+    expect(merged[3].id).toBe("db-tr-4");
+  });
+
+  it("duplicate content across turns is matched in order (FIFO, not collapse)", () => {
+    // User asked "ping" twice in two separate turns. The merge must not
+    // collapse both DB "ping" rows onto the first streamed "ping".
+    const streamed: ChatMessage[] = [
+      STREAMED_USER("ping", "u-first"),
+      STREAMED_AGENT("pong", "a-first"),
+      STREAMED_USER("ping", "u-second"),
+      STREAMED_AGENT("pong", "a-second"),
+    ];
+    const db: ChatMessage[] = [
+      DB_USER("ping", 1),
+      DB_AGENT("pong", 2),
+      DB_USER("ping", 3),
+      DB_AGENT("pong", 4),
+    ];
+
+    const merged = reconcileStreamedWithDb(streamed, db);
+
+    expect(merged.map((m) => m.id)).toEqual([
+      "u-first",
+      "a-first",
+      "u-second",
+      "a-second",
+    ]);
+  });
+
+  it("preserves a renderer-only bubble that has no DB equivalent (error rows)", () => {
+    // `onChatError` writes a synthetic "Error: …" row into the in-memory
+    // transcript. It has no state.db row. Reconciliation must keep it
+    // so the user doesn't lose visibility of what went wrong.
+    const errorBubble: ChatMessage = {
+      id: "error-1",
+      role: "agent",
+      content: "Error: provider returned 401",
+    };
+    const streamed: ChatMessage[] = [STREAMED_USER("hi", "u-1"), errorBubble];
+    const db: ChatMessage[] = [DB_USER("hi", 1)];
+
+    const merged = reconcileStreamedWithDb(streamed, db);
+
+    // The user row reconciled by content; the error row appended at end.
+    expect(merged).toHaveLength(2);
+    expect(merged[0].id).toBe("u-1");
+    expect(merged[1].id).toBe("error-1");
+  });
+
+  it("handles an empty streamed array (cold session load)", () => {
+    const db: ChatMessage[] = [
+      DB_USER("hi", 1),
+      DB_REASONING("respond politely", 2),
+      DB_AGENT("hello", 3),
+    ];
+
+    const merged = reconcileStreamedWithDb([], db);
+
+    // Pure pass-through of DB rows.
+    expect(merged).toEqual(db);
+  });
+
+  it("handles a duplicate streamed message that exceeds DB row count", () => {
+    // Edge case: the renderer somehow held two streamed bubbles with
+    // identical content, but the DB only has one. The merge should
+    // consume DB's single row, substitute one streamed equivalent,
+    // and append the unmatched second streamed row at the end as a
+    // UI-only message (covered by the "preserve renderer-only" path).
+    const streamed: ChatMessage[] = [
+      STREAMED_AGENT("hello", "a-1"),
+      STREAMED_AGENT("hello", "a-2"),
+    ];
+    const db: ChatMessage[] = [DB_AGENT("hello", 7)];
+
+    const merged = reconcileStreamedWithDb(streamed, db);
+
+    expect(merged).toHaveLength(2);
+    // First slot took the streamed equivalent for the DB row.
+    expect(merged[0].id).toBe("a-1");
+    // Unmatched streamed row preserved at the tail.
+    expect(merged[1].id).toBe("a-2");
+  });
+});

--- a/tests/session-history-mapping.test.ts
+++ b/tests/session-history-mapping.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import {
+  dbItemsToChatMessages,
+  type DbHistoryItem,
+} from "../src/renderer/src/screens/Chat/sessionHistory";
+
+/**
+ * Two call sites share this mapping:
+ *
+ *   1. `Layout.handleResumeSession` — when the user opens a saved
+ *      session from the Sessions tab, we re-hydrate the chat from
+ *      state.db.
+ *   2. `useChatIPC.onChatDone` — at end of stream, we re-fetch the
+ *      session and replace the in-memory transcript so reasoning /
+ *      tool messages the gateway didn't stream (DeepSeek's
+ *      `reasoning_content`, see NousResearch/hermes-agent#30449)
+ *      become visible without a window-focus dance (#352).
+ *
+ * Both rely on this conversion producing the right `ChatMessage`
+ * shape for every `DbHistoryItem.kind`. Tests below pin each branch
+ * + the filter-null cases that protect against future kinds being
+ * added upstream without a renderer update.
+ */
+
+describe("dbItemsToChatMessages", () => {
+  it("returns user / assistant / reasoning rows in original order", () => {
+    const items: DbHistoryItem[] = [
+      { kind: "user", id: 1, content: "what's 2+2?" },
+      { kind: "reasoning", id: 2, text: "Adding 2 and 2 gives 4." },
+      { kind: "assistant", id: 3, content: "4" },
+    ];
+
+    const out = dbItemsToChatMessages(items);
+
+    expect(out).toHaveLength(3);
+    expect(out[0]).toMatchObject({ role: "user", content: "what's 2+2?" });
+    expect(out[1]).toMatchObject({
+      kind: "reasoning",
+      role: "agent",
+      text: "Adding 2 and 2 gives 4.",
+    });
+    expect(out[2]).toMatchObject({ role: "agent", content: "4" });
+  });
+
+  it("preserves attachments on user, assistant, and tool_result", () => {
+    const att = [{ id: "a1", kind: "image" as const, name: "x.png", size: 1 }];
+    const items: DbHistoryItem[] = [
+      { kind: "user", id: 1, content: "see this", attachments: att },
+      { kind: "assistant", id: 2, content: "Got it.", attachments: att },
+      {
+        kind: "tool_result",
+        id: 3,
+        callId: "c1",
+        name: "fs.read",
+        content: "ok",
+        attachments: att,
+      },
+    ];
+
+    const out = dbItemsToChatMessages(items);
+
+    expect(out).toHaveLength(3);
+    expect("attachments" in out[0] && out[0].attachments).toEqual(att);
+    expect("attachments" in out[1] && out[1].attachments).toEqual(att);
+    expect("attachments" in out[2] && out[2].attachments).toEqual(att);
+  });
+
+  it("omits attachments when empty or missing (no spurious `attachments: []`)", () => {
+    const items: DbHistoryItem[] = [
+      { kind: "user", id: 1, content: "hi" },
+      { kind: "user", id: 2, content: "hi", attachments: [] },
+    ];
+
+    const out = dbItemsToChatMessages(items);
+
+    for (const m of out) {
+      expect(m).not.toHaveProperty("attachments");
+    }
+  });
+
+  it("emits stable ids per kind so React keys don't collide across kinds", () => {
+    // All four agent-side kinds can have the same raw db row id;
+    // distinct prefixes (`db-N`, `db-r-N`, `db-tc-N-…`, `db-tr-N`)
+    // keep the React keys unique. A regression here would cause
+    // collisions and disappearing rows when streaming refreshes
+    // bring in new reasoning/tool rows after content.
+    const items: DbHistoryItem[] = [
+      { kind: "assistant", id: 7, content: "hello" },
+      { kind: "reasoning", id: 7, text: "thinking…" },
+      {
+        kind: "tool_call",
+        id: 7,
+        callId: "abc",
+        name: "fs.read",
+        args: '{"path":"."}',
+      },
+      {
+        kind: "tool_result",
+        id: 7,
+        callId: "abc",
+        name: "fs.read",
+        content: "ok",
+      },
+    ];
+
+    const ids = dbItemsToChatMessages(items).map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("filters out unknown kinds rather than crashing", () => {
+    const items = [
+      { kind: "user", id: 1, content: "ok" },
+      // Future kind the renderer doesn't know about yet.
+      { kind: "future_thing", id: 2 } as unknown as DbHistoryItem,
+      { kind: "assistant", id: 3, content: "yes" },
+    ];
+
+    const out = dbItemsToChatMessages(items as DbHistoryItem[]);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toMatchObject({ role: "user" });
+    expect(out[1]).toMatchObject({ role: "agent" });
+  });
+
+  it("survives missing optional fields with defensive defaults", () => {
+    // Old sessions in state.db may have NULL values for fields the
+    // current schema treats as optional. Mapping must produce a
+    // usable `ChatMessage` even when those land as undefined.
+    const items: DbHistoryItem[] = [
+      { kind: "assistant", id: 1 },
+      { kind: "reasoning", id: 2 },
+      { kind: "tool_call", id: 3 },
+      { kind: "tool_result", id: 4 },
+    ];
+
+    const out = dbItemsToChatMessages(items);
+    expect(out).toHaveLength(4);
+    expect(out[0]).toMatchObject({ role: "agent", content: "" });
+    expect(out[1]).toMatchObject({ kind: "reasoning", text: "" });
+    expect(out[2]).toMatchObject({ kind: "tool_call", name: "", args: "" });
+    expect(out[3]).toMatchObject({ kind: "tool_result", content: "" });
+  });
+});


### PR DESCRIPTION
## Bug

Reported by @sasachu332 on #352 — confirmed locally on DeepSeek-V4-Pro:

> Send a message → answer streams. The **reasoning/thinking chain doesn't appear** during streaming. Then switch to another window and switch back — the thinking chain materialises above the answer.

`src/renderer/src/screens/Chat/types.ts:23-24` already flags the gap explicitly:

> *"Created by the main-process session loader from the agent's state DB — none of these have a live-streaming counterpart in the desktop yet."*

Same applies to `tool_call` and `tool_result` rows.

## Three layers — addressed independently in three commits

### 1. `feat(chat): stream reasoning/thinking tokens live` (commit 1)

The desktop's SSE parser in `hermes.ts:processSseData` only forwarded `delta.content`. The DeepSeek + o1/o3 reasoning fields (`delta.reasoning_content` / `delta.reasoning`) were silently dropped.

This commit:
- Adds an optional `onReasoningChunk(text)` to `ChatCallbacks`.
- Adds a pure helper `extractReasoningDelta(delta)` that extracts either field name with the right precedence (DeepSeek-style first, OpenAI-style fallback).
- Forwards via a new IPC channel `chat-reasoning-chunk`.
- Subscribes from the renderer; appends to the active turn's reasoning row, or inserts a new `kind: "reasoning"` row before any assistant content bubbles in the same turn (so visual order is reasoning → answer regardless of which chunk type arrives first).

⚠️ **The upstream gateway currently doesn't forward `reasoning_content` over the OpenAI-compatible SSE** — see [NousResearch/hermes-agent#30449](https://github.com/NousResearch/hermes-agent/issues/30449). So this code is forward-compatible plumbing: it doesn't fire until that upstream issue lands. Tests pin the parser logic on synthetic SSE deltas so it's verifiable today.

### 2. `chat: surface reasoning + tool rows at end-of-stream via state.db merge` (commit 2)

This is the **user-side fix that closes #352 today** without waiting on upstream. When `onChatDone` fires, the renderer re-fetches the active session via `getSessionMessages` and merges the DB rows back into the in-memory transcript.

Critically the merge is **additive**, not a replace:

| Row | Today (#30449 unresolved) | Future (#30449 lands) |
|---|---|---|
| `user` / `assistant` content | Streamed → kept (matched by content) | Same |
| `reasoning` | Comes from DB only → inserted at canonical position | Streamed → kept (matched by content), DB row substituted away — **no React re-mount, no flicker** |
| `tool_call` / `tool_result` | Comes from DB only → inserted | Same — these never stream |

Matching is keyed by `role:content[:200]` for bubbles, `kind:callId` for tool rows, `kind:text[:200]` for reasoning rows, with FIFO bucket queues so duplicate content across turns reconciles in order. Renderer-only rows like `onChatError` synthetic bubbles survive the merge as trailing appends.

The merge logic is extracted to a pure function `reconcileStreamedWithDb` in `Chat/sessionHistory.ts` and unit-tested.

Refactored along the way: the DB-row → ChatMessage mapping that lived inline in `Layout.handleResumeSession` is now the shared `dbItemsToChatMessages` helper, so the resume path and the new end-of-stream merge agree on the conversion. Plus defensive `|| ""` defaults on optional fields so old state.db rows with NULL columns don't crash.

### 3. `chat: generate per-chat session ids` (commit 3 — fold-in)

Caught during live testing of commit 2: with the end-of-stream merge in place, **opening a new chat and sending an opener identical to a previous chat's first message would pull the previous chat's content into the new one.**

Root cause is upstream. When no `X-Hermes-Session-Id` header is sent, the gateway derives a session id from `sha256(system_prompt + first_user_message)[:16]` ([`api_server.py:_derive_chat_session_id`](https://github.com/NousResearch/hermes-agent/blob/main/gateway/platforms/api_server.py#L589)). Same opener → same session id → shared `state.db` row. The desktop never noticed until #357's merge surfaced the conflated rows. Stateless clients like Open WebUI / LibreChat don't notice either because they never read back from `state.db` — for them the fingerprint is a (intended) feature for sandbox continuity, not a bug.

Filed upstream as [NousResearch/hermes-agent#7484](https://github.com/NousResearch/hermes-agent/issues/7484) — same root cause, originally framed as session-fixation security.

Desktop fix: always send our own `X-Hermes-Session-Id`. Format `desk-<ms>-<uuidv4>` per fresh chat:
- UUIDv4 carries the entropy (~10⁻³⁶ collision odds for any pair).
- The millisecond prefix is defence-in-depth against a hypothetical PRNG fault.
- The `desk-` tag visually distinguishes desktop-originated sessions from the gateway's `api-<hash>` ones in `state.db` and logs.

Gated on auth: the gateway 403s `X-Hermes-Session-Id` without `API_SERVER_KEY` (its history-load is auth-gated). The desktop auto-generates `API_SERVER_KEY` at install and remote mode supplies its own bearer, so in practice the new path is always taken; the guard keeps a misconfigured local install on the pre-fix fingerprint path instead of 403-looping.

Backward-compatible: existing `api-<hash>` sessions in users' `state.db` continue to resume correctly — only *new* chats get the new format.

## Verification

- `npm run typecheck` — clean.
- `npm test` — **55 files / 648 passed / 3 skipped / 0 failures.** 23 new tests across four files; no existing tests touched:
  - `tests/extract-reasoning-delta.test.ts` (8 cases on the SSE-delta parser)
  - `tests/session-history-mapping.test.ts` (6 cases on the DB→ChatMessage mapping)
  - `tests/reconcile-streamed-with-db.test.ts` (8 cases on the merge)
  - `tests/hermes-api.test.ts` (1 rewritten + 1 new case: fresh-session id format and uniqueness across two sends with identical openers)
- `tests/preload-api-surface.test.ts` updated to enumerate `onChatReasoningChunk`.
- **Live test on DeepSeek-V4-Pro**:
  1. Original #352 symptom — "reasoning only appears after window focus change" — no longer reproduces; the thinking bubble pops in immediately on stream completion.
  2. Two consecutive fresh chats with identical opener "Hello there" produce **two distinct `desk-…` rows in `state.db`** (msgs=2 each), instead of the previous behaviour of one shared `api-<hash>` row that accumulated turns from every same-opener chat.

## What happens once upstream #30449 ships

No further desktop work needed. The streaming wiring (commit 1) starts firing automatically when the gateway begins forwarding `delta.reasoning_content`. The additive merge (commit 2) keeps the streamed reasoning bubble's React identity at end-of-stream because it matches on content rather than id — proven in `tests/reconcile-streamed-with-db.test.ts` ("future: reasoning DOES stream — merge keeps the streamed id, no re-mount").

## What happens once upstream #7484 ships

Independent of this PR. Once the gateway stops fingerprint-deriving session ids (or gates the derivation behind an opt-in flag), the `desk-` UUIDs continue to work unchanged — they go through the same `provided_session_id` branch as today. No code path changes required either way.

Closes #352. Cross-references NousResearch/hermes-agent#30449 and NousResearch/hermes-agent#7484 (upstream).
