### PR TITLE
feat: improve local LLM discovery and Codex OAuth defaults

### DIFF
--- a/src/main/default-models.ts
+++ b/src/main/default-models.ts
@@ -5,7 +5,7 @@
  * on fresh install. Format:
  *   { name: "Display Name", provider: "provider-key", model: "model-id", baseUrl: "" }
  *
- * Provider keys: openrouter, anthropic, openai, custom
+ * Provider keys: openrouter, anthropic, openai, openai-codex, custom
  * For openrouter models, use the full path (e.g. "anthropic/claude-sonnet-4-20250514")
  * For direct provider models, use the provider's model ID (e.g. "claude-sonnet-4-20250514")
  */
@@ -40,6 +40,14 @@ const DEFAULT_MODELS: DefaultModel[] = [
     provider: "openai",
     model: "gpt-4.1",
     baseUrl: "",
+  },
+
+  // ── OpenAI Codex OAuth / ChatGPT subscription ────────────────────────
+  {
+    name: "GPT-5.5 Codex (OAuth)",
+    provider: "openai-codex",
+    model: "gpt-5.5",
+    baseUrl: "https://chatgpt.com/backend-api/codex",
   },
 ];
 

--- a/src/main/model-discovery.ts
+++ b/src/main/model-discovery.ts
@@ -26,7 +26,11 @@ import {
 // PROVIDER_BASE_URLS lives in its own module so `config.ts` can use the
 // same lookup without pulling in this whole file (and triggering a
 // circular import via `model-discovery → config → ...`).
-import { PROVIDER_BASE_URLS } from "./provider-registry";
+import {
+  PROVIDER_BASE_URLS,
+  isLocalOpenAICompatibleProvider,
+  isLoopbackBaseUrl,
+} from "./provider-registry";
 
 /** Providers whose `/models` we never call — either they don't expose it,
  *  use a different protocol, or rely on OAuth credentials we can't
@@ -327,9 +331,16 @@ export async function discoverProviderModels(
   const cached = fromCache(lowerProvider, baseUrl);
   if (cached) return { models: cached, status: "ok", cached: true };
 
-  const apiKey =
+  let apiKey =
     (apiKeyOverride || "").trim() ||
     envApiKeyFor(lowerProvider, baseUrl, profile);
+  if (
+    !apiKey &&
+    isLocalOpenAICompatibleProvider(lowerProvider) &&
+    isLoopbackBaseUrl(baseUrl)
+  ) {
+    apiKey = "no-key-required";
+  }
   if (!apiKey) return { models: [], status: "no-key", cached: false };
 
   const url = buildUrl(baseUrl);

--- a/src/main/provider-registry.ts
+++ b/src/main/provider-registry.ts
@@ -1,3 +1,5 @@
+import { isIP } from "net";
+
 /**
  * Canonical inference base URLs for built-in providers — mirrors
  * hermes-agent's `PROVIDER_REGISTRY` defaults.
@@ -35,4 +37,38 @@ export const PROVIDER_BASE_URLS: Record<string, string> = {
 export function canonicalProviderBaseUrl(provider: string): string | null {
   const direct = PROVIDER_BASE_URLS[provider.toLowerCase()];
   return direct ?? null;
+}
+/** Local OpenAI-compatible provider ids. These providers typically expose
+ *  `/v1/*` endpoints on a user-supplied base URL and often do not require
+ *  a bearer token when served locally. */
+export const LOCAL_OPENAI_COMPATIBLE_PROVIDERS = new Set<string>([
+  "custom",
+  "lmstudio",
+  "ollama",
+  "vllm",
+  "llamacpp",
+]);
+
+export function isLocalOpenAICompatibleProvider(provider: string): boolean {
+  return LOCAL_OPENAI_COMPATIBLE_PROVIDERS.has(provider.toLowerCase());
+}
+
+/** Return true when a base URL points at the local machine.
+ *
+ * This deliberately checks host identity rather than specific ports so it
+ * works for Ollama, LM Studio, llama.cpp, vLLM, and custom local proxies
+ * regardless of the port a user configured. */
+export function isLoopbackBaseUrl(baseUrl: string): boolean {
+  try {
+    const hostname = new URL(baseUrl).hostname.toLowerCase();
+    if (hostname === "localhost") return true;
+
+    const normalizedHost = hostname.replace(/^\[(.*)\]$/, "$1");
+    const ipVersion = isIP(normalizedHost);
+    if (ipVersion === 4) return normalizedHost.startsWith("127.");
+    if (ipVersion === 6) return normalizedHost === "::1";
+  } catch {
+    // Invalid/missing URLs are handled by callers as unknown-host.
+  }
+  return false;
 }

--- a/tests/model-discovery.test.ts
+++ b/tests/model-discovery.test.ts
@@ -81,18 +81,16 @@ describe("model-discovery", () => {
     expect(result.models).toEqual(["alpha", "beta", "gamma"]);
   });
 
-  it("returns status=no-key when no apiKey is provided or in .env", async () => {
-    server = http.createServer(() => {
-      throw new Error("must not be called when there's no key");
-    });
-    await listen();
-    // .env intentionally empty of DEEPSEEK_API_KEY
+  it("returns status=no-key for non-loopback custom URLs when no apiKey is provided or in .env", async () => {
+    // .env intentionally empty of matching API keys. Non-loopback custom
+    // endpoints still require an explicit key; loopback local LLMs are
+    // covered by the keyless discovery test below.
     writeFileSync(join(testHome, ".env"), "");
 
     const { discoverProviderModels } = await loadDiscovery();
     const result = await discoverProviderModels(
       "custom",
-      baseUrl,
+      "https://example.invalid/v1",
       undefined,
       undefined,
     );
@@ -282,5 +280,35 @@ describe("model-discovery", () => {
     // URL which isn't our loopback server.  Sanity check the .env load
     // path separately:
     expect(receivedAuth).toBe(""); // confirms the canonical URL was used, not our test server
+  });
+
+  it("discovers loopback custom models without an API key", async () => {
+    let receivedAuth = "";
+    server = http.createServer((req, res) => {
+      receivedAuth = String(req.headers["authorization"] || "");
+      if (req.url === "/v1/models" && req.method === "GET") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({ data: [{ id: "local-a" }, { id: "local-b" }] }),
+        );
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    await listen();
+    writeFileSync(join(testHome, ".env"), "");
+
+    const { discoverProviderModels } = await loadDiscovery();
+    const result = await discoverProviderModels(
+      "custom",
+      baseUrl,
+      undefined,
+      undefined,
+    );
+
+    expect(result.status).toBe("ok");
+    expect(result.models).toEqual(["local-a", "local-b"]);
+    expect(receivedAuth).toBe("Bearer no-key-required");
   });
 });

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   PROVIDER_BASE_URLS,
   canonicalProviderBaseUrl,
+  isLocalOpenAICompatibleProvider,
+  isLoopbackBaseUrl,
 } from "../src/main/provider-registry";
 
 describe("provider-registry", () => {
@@ -76,6 +78,25 @@ describe("provider-registry", () => {
       for (const provider of requiredBuiltins) {
         expect(PROVIDER_BASE_URLS[provider]).toBeTruthy();
       }
+    });
+  });
+
+  describe("local OpenAI-compatible providers", () => {
+    it("identifies local provider ids case-insensitively", () => {
+      expect(isLocalOpenAICompatibleProvider("custom")).toBe(true);
+      expect(isLocalOpenAICompatibleProvider("Ollama")).toBe(true);
+      expect(isLocalOpenAICompatibleProvider("lmstudio")).toBe(true);
+      expect(isLocalOpenAICompatibleProvider("openai")).toBe(false);
+      expect(isLocalOpenAICompatibleProvider("deepseek")).toBe(false);
+    });
+
+    it("detects loopback base URLs without depending on a fixed port", () => {
+      expect(isLoopbackBaseUrl("http://localhost:1234/v1")).toBe(true);
+      expect(isLoopbackBaseUrl("http://127.42.0.9:11434/v1")).toBe(true);
+      expect(isLoopbackBaseUrl("http://[::1]:8080/v1")).toBe(true);
+      expect(isLoopbackBaseUrl("http://192.168.1.10:8000/v1")).toBe(false);
+      expect(isLoopbackBaseUrl("https://api.openai.com/v1")).toBe(false);
+      expect(isLoopbackBaseUrl("not a url")).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

This improves Hermes Desktop support for local OpenAI-compatible runtimes and OAuth-backed model providers.

- Allow model discovery for local OpenAI-compatible providers without requiring a static API key when the configured base URL points at the local machine.
- Centralize local-provider and loopback URL detection in `provider-registry.ts` instead of inlining provider-specific or port-specific checks in model discovery.
- Add `GPT-5.5 Codex (OAuth)` as a seeded default model entry using the existing `openai-codex` provider path.
- Preserve existing behavior for remote/custom endpoints: non-loopback custom providers still require an explicit API key or matching env var.

## Why

Local LLM servers such as Ollama, LM Studio, llama.cpp, and vLLM commonly expose OpenAI-compatible `/v1/models` endpoints on user-configured local ports and do not require bearer tokens. Hermes Desktop previously returned `status="no-key"` before attempting discovery, so local model autocomplete/listing failed even though the endpoint was reachable.

OAuth providers are already represented in the app/provider list; seeding a Codex OAuth default model makes that path easier to select without confusing it with the static-key OpenAI provider.

## Implementation notes

- Loopback detection checks URL host identity, not a specific port, so it works with user-configured ports.
- IPv4 loopback is handled as the full `127.0.0.0/8` range; IPv6 loopback is handled as `::1`; `localhost` is also supported.
- The local no-key fallback only applies when both conditions are true:
  1. provider is a local OpenAI-compatible provider (`custom`, `ollama`, `lmstudio`, `vllm`, `llamacpp`)
  2. base URL resolves to the local machine
- Remote custom providers keep the existing `no-key` behavior.

## Test plan

- `npm run typecheck`
- `npx vitest run tests/model-discovery.test.ts tests/provider-registry.test.ts tests/oauth-model-discovery.test.ts`
- `npm run build`
