### PR TITLE
fix: sync title and model for existing sessions in cache

### DIFF
--- a/src/main/session-cache.ts
+++ b/src/main/session-cache.ts
@@ -130,12 +130,12 @@ export function syncSessionCache(): CachedSession[] {
       refreshedIds.add(row.id);
       const existing = existingById.get(row.id);
       if (existing) {
-        // Update existing entry (message count may have changed)
         existing.messageCount = row.message_count;
+        if (row.model) existing.model = row.model;
+        if (row.title) existing.title = row.title;
         continue;
       }
 
-      // Generate title from first user message
       let title = row.title || "";
       if (!title) {
         try {
@@ -199,9 +199,12 @@ export function syncSessionCache(): CachedSession[] {
       }
     }
 
-    // Merge: new sessions first (most recent), then existing
-    const allSessions = [...newSessions, ...cache.sessions];
-    // Sort by startedAt descending
+    // Merge via Map to prevent duplicates: existing sessions (already
+    // mutated in-place above) plus newly discovered sessions.
+    const merged = new Map<string, CachedSession>();
+    for (const s of cache.sessions) merged.set(s.id, s);
+    for (const s of newSessions) merged.set(s.id, s);
+    const allSessions = Array.from(merged.values());
     allSessions.sort((a, b) => b.startedAt - a.startedAt);
 
     const updated: CacheData = {

--- a/tests/session-cache-sync.test.ts
+++ b/tests/session-cache-sync.test.ts
@@ -457,6 +457,40 @@ describe("syncSessionCache", () => {
     expect(byId.get("new-c")?.messageCount).toBe(7);
   });
 
+  it("updates title and model on existing sessions when DB values change", () => {
+    const future = Math.floor(Date.now() / 1000) + 600;
+    seedDb([
+      {
+        id: "s1",
+        started_at: future,
+        message_count: 2,
+        model: "gpt-4o",
+        title: "Old title",
+        firstUserMessage: "hi",
+      },
+    ]);
+    const first = syncSessionCache();
+    expect(first[0].title).toBe("Old title");
+    expect(first[0].model).toBe("gpt-4o");
+
+    seedDb([
+      {
+        id: "s1",
+        started_at: future,
+        message_count: 5,
+        model: "claude-sonnet-4-20250514",
+        title: "Updated title",
+        firstUserMessage: "hi",
+      },
+    ]);
+    const second = syncSessionCache();
+
+    expect(second).toHaveLength(1);
+    expect(second[0].title).toBe("Updated title");
+    expect(second[0].model).toBe("claude-sonnet-4-20250514");
+    expect(second[0].messageCount).toBe(5);
+  });
+
   it("handles a large existing cache without quadratic blowup (issue #16)", () => {
     // 1500 existing sessions in cache, then sync sees same 1500 but with
     // bumped message counts. The pre-fix O(N²) implementation took >2s here


### PR DESCRIPTION
## What

Fixes incomplete session cache sync — when an existing session's `title` or `model` changes in the DB, the cache now picks up those changes instead of only updating `messageCount`.

Relates to the discussion in PR #197.

## Root cause

In `syncSessionCache()` Phase 1, when a row matches an existing cached session (line 131-135), only `messageCount` was updated:

```ts
if (existing) {
  existing.messageCount = row.message_count;
  continue; // ← title and model changes silently dropped
}
```

## Changes

**`src/main/session-cache.ts`**
- Phase 1 update path now also syncs `title` (when DB has non-null value) and `model`
- Replaced `[...newSessions, ...cache.sessions]` concat with Map-based merge to prevent theoretical duplicates

**`tests/session-cache-sync.test.ts`**
- New test: verifies title and model are updated on subsequent syncs for existing sessions

## What this does NOT change

- Keeps `started_at` for the Phase 1 query (the `updated_at` column does not exist in the hermes state.db schema — PR #197's approach would crash at runtime)
- Keeps the `lastSync - 300` overlap window (already correct — `lastSync` is in seconds, not milliseconds)
- Keeps Phase 2 intact (still needed for sessions outside the 5-minute `started_at` window)

## Verification

- `npm run typecheck` passes
- `npm run test` — all 8 session-cache tests pass (including new test)