### PR TITLE
feat: queue messages while agent is processing

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1691,6 +1691,15 @@ body {
   }
 }
 
+.chat-queue-indicator {
+  text-align: center;
+  padding: 6px 12px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  background: var(--bg-secondary);
+  border-top: 1px solid var(--border);
+}
+
 /* Input area */
 .chat-input-area {
   position: relative;

--- a/src/renderer/src/screens/Chat/Chat.tsx
+++ b/src/renderer/src/screens/Chat/Chat.tsx
@@ -12,7 +12,13 @@ import { useFastMode } from "./hooks/useFastMode";
 import { useLocalCommands } from "./hooks/useLocalCommands";
 import { useI18n } from "../../components/useI18n";
 import { buildChatTranscript } from "./transcriptUtils";
+import type { Attachment } from "../../../../shared/attachments";
 import type { ChatMessage, UsageState } from "./types";
+
+interface QueuedMessage {
+  text: string;
+  attachments: Attachment[];
+}
 
 export type { ChatMessage } from "./types";
 
@@ -45,6 +51,8 @@ function Chat({
   const [contextFolder, setContextFolder] = useState<string | null>(null);
   const dragCounter = useRef(0);
   const chatInputRef = useRef<ChatInputHandle>(null);
+  const queueRef = useRef<QueuedMessage[]>([]);
+  const [queuedCount, setQueuedCount] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -79,8 +87,9 @@ function Chat({
   useEffect(() => {
     if (messages.length === 0) {
       setHermesSessionId(null);
-
       setContextFolder(null);
+      queueRef.current = [];
+      setQueuedCount(0);
     }
   }, [messages]);
 
@@ -90,8 +99,9 @@ function Chat({
   // not remounted on session switch, so this must be done explicitly.
   useEffect(() => {
     setHermesSessionId(sessionId);
-
     setContextFolder(null);
+    queueRef.current = [];
+    setQueuedCount(0);
   }, [sessionId]);
 
   // Cmd/Ctrl+N → new chat
@@ -159,6 +169,8 @@ function Chat({
     setContextFolder(null);
     setUsage(null);
     setToolProgress(null);
+    queueRef.current = [];
+    setQueuedCount(0);
   }, [isLoading, hermesSessionId, sessionId, setMessages]);
 
   const localCommands = useLocalCommands({
@@ -182,6 +194,34 @@ function Chat({
     localCommands,
     contextFolder,
   });
+
+  // Stable ref to handleSend so the drain effect doesn't re-trigger on
+  // identity changes (regression #5 from PR #315).
+  const handleSendRef = useRef(actions.handleSend);
+  useEffect(() => {
+    handleSendRef.current = actions.handleSend;
+  });
+
+  // Drain queued messages one at a time when the agent finishes.
+  useEffect(() => {
+    if (isLoading) return;
+    const next = queueRef.current.shift();
+    if (!next) return;
+    setQueuedCount(queueRef.current.length);
+    handleSendRef.current(next.text, next.attachments);
+  }, [isLoading]);
+
+  const handleSubmitOrQueue = useCallback(
+    (text: string, attachments: Attachment[]) => {
+      if (isLoading) {
+        queueRef.current.push({ text, attachments });
+        setQueuedCount(queueRef.current.length);
+        return;
+      }
+      actions.handleSend(text, attachments);
+    },
+    [isLoading, actions.handleSend],
+  );
 
   const handleSuggestion = useCallback((text: string) => {
     chatInputRef.current?.setText(text);
@@ -282,6 +322,11 @@ function Chat({
         <div ref={bottomRef} />
       </div>
 
+      {queuedCount > 0 && (
+        <div className="chat-queue-indicator">
+          {t("chat.queued", { count: queuedCount })}
+        </div>
+      )}
       <div className="chat-input-area">
         <ChatInput
           ref={chatInputRef}
@@ -289,7 +334,7 @@ function Chat({
           hasSession={!!hermesSessionId}
           sessionId={hermesSessionId}
           remoteMode={remoteMode}
-          onSubmit={actions.handleSend}
+          onSubmit={handleSubmitOrQueue}
           onQuickAsk={actions.handleQuickAsk}
           onAbort={actions.handleAbort}
         />

--- a/src/renderer/src/screens/Chat/ChatInput.tsx
+++ b/src/renderer/src/screens/Chat/ChatInput.tsx
@@ -210,7 +210,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
     function handleSend(): void {
       const text = input.trim();
       const hasPayload = text.length > 0 || attachments.length > 0;
-      if (!hasPayload || isLoading) return;
+      if (!hasPayload) return;
       setSlashMenuOpen(false);
       const sendAttachments = attachments;
       clearAfterSend(text);
@@ -338,8 +338,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
       setAttachmentError(null);
     }
 
-    const canSend =
-      (input.trim().length > 0 || attachments.length > 0) && !isLoading;
+    const canSend = input.trim().length > 0 || attachments.length > 0;
 
     return (
       <>

--- a/src/shared/i18n/locales/en/chat.ts
+++ b/src/shared/i18n/locales/en/chat.ts
@@ -80,4 +80,5 @@ export default {
     persona: "Show current persona",
     version: "Show Hermes version",
   },
+  queued: "{{count}} message(s) queued — will send when the agent finishes",
 } as const;

--- a/src/shared/i18n/locales/zh-TW/chat.ts
+++ b/src/shared/i18n/locales/zh-TW/chat.ts
@@ -63,4 +63,5 @@ export default {
     persona: "檢視目前人格",
     version: "檢視 Hermes 版本",
   },
+  queued: "{{count}} 則訊息已排隊 — 代理完成後將自動傳送",
 } as const;


### PR DESCRIPTION
## What

When the agent is busy processing, user-typed messages are now queued instead of being silently dropped. Messages drain one-by-one as the agent finishes each turn. A small indicator shows how many messages are queued.

Supersedes #315 — clean reimplementation that avoids all 6 regressions identified in the review.

## Changes

**`src/renderer/src/screens/Chat/Chat.tsx`**
- `queueRef` (useRef) + `queuedCount` (useState) for queue state
- `handleSubmitOrQueue` wrapper: if `isLoading`, push to queue; otherwise send directly
- Drain `useEffect` depends only on `[isLoading]`, reads `handleSend` via stable ref (fixes regression #5)
- Queue cleared on: session switch, new chat (`messages.length === 0`), `/clear`
- Queue indicator rendered above input area

**`src/renderer/src/screens/Chat/ChatInput.tsx`**
- Removed `isLoading` guard from `handleSend()` — parent wrapper decides whether to queue or send
- `canSend` no longer blocked by `isLoading` — user can type and submit while agent runs

**`src/shared/i18n/locales/en/chat.ts`** + **`zh-TW/chat.ts`**
- Added `queued` key (no existing keys removed — fixes regression #3)

**`src/renderer/src/assets/main.css`**
- `.chat-queue-indicator` styling

## How PR #315's 6 regressions are avoided

| # | Regression | How avoided |
|---|-----------|-------------|
| 1 | `contextFolder` dropped | Not touched — all state, effects, and ChatHeader props preserved |
| 2 | Copy-chat + select-bubble removed | Not touched — both IPC listeners preserved |
| 3 | i18n keys deleted | Only `queued` added, nothing removed |
| 4 | Queue not cleared on session switch | Cleared in `sessionId` effect, `messages` effect, and `handleClear` |
| 5 | Drain depends on `handleSend` identity | Drain effect depends only on `[isLoading]`, reads via `handleSendRef` |
| 6 | Slash commands dropped mid-run | Slash commands go through `onSubmit` → `handleSubmitOrQueue` → queued |

## Verification

- `npm run typecheck` passes
- Renderer-only changes (no IPC or main-process changes)