### PR TITLE
fix: ensure SSH API key is cached before sending messages (#212)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -55,6 +55,7 @@ import {
   restartGateway,
   ensureSshTunnelIfNeeded,
   setSshRemoteApiKey,
+  getRemoteAuthHeader,
 } from "./hermes";
 import {
   startSshTunnel,
@@ -740,6 +741,10 @@ function setupIPC(): void {
         if (!gatewayRunning || !tunnelHealthy) {
           await sshStartGateway(conn.ssh);
           await startSshTunnel(conn.ssh);
+        }
+        // Always ensure the API key is cached — the key may not have been
+        // read yet if the app-launch auto-start failed silently (#212).
+        if (!getRemoteAuthHeader().Authorization) {
           const key = await sshReadRemoteApiKey(conn.ssh);
           setSshRemoteApiKey(key);
         }


### PR DESCRIPTION
## What

Fixes #212 — in SSH tunnel mode, chat messages are sent but never reach the server. The gateway only receives health checks.

## Root cause

The `send-message` IPC handler (index.ts line 737-745) only reads and caches the remote API key (`setSshRemoteApiKey`) when the gateway or tunnel is **unhealthy**:

```ts
if (!gatewayRunning || !tunnelHealthy) {
  await sshStartGateway(conn.ssh);
  await startSshTunnel(conn.ssh);
  const key = await sshReadRemoteApiKey(conn.ssh);  // only here
  setSshRemoteApiKey(key);
}
```

If the tunnel is healthy but the key was never cached (e.g. app-launch auto-start at line 1706-1708 failed silently via `.catch()`), `_sshRemoteApiKey` stays `""`. Then `getRemoteAuthHeader()` returns `{}` (no Authorization header), and the gateway rejects the POST with 401/403. The health endpoint (`GET /health`) doesn't require auth, so the UI shows "Connected" while messages silently fail.

## Fix

Check `getRemoteAuthHeader().Authorization` on every SSH-mode send. If missing, re-read the key from the remote `.env` before proceeding:

```ts
if (!getRemoteAuthHeader().Authorization) {
  const key = await sshReadRemoteApiKey(conn.ssh);
  setSshRemoteApiKey(key);
}
```

## Verification

- `npm run typecheck` passes
- 1 file changed, 5 lines added
- No behavioral change when the key is already cached (the `if` guard skips the read)