### PR TITLE
fix(providers): Nous Portal UI cards + credential-pool schema + OAuth + discovery (#367)

### DIFF
--- a/scripts/drive-nous-chat.js
+++ b/scripts/drive-nous-chat.js
@@ -1,0 +1,133 @@
+/**
+ * Drive a Nous Portal end-to-end chat round-trip via the dev electron.
+ *
+ *   1. Backup config.yaml + remember active model.
+ *   2. Switch model.provider → "nous", model.default → "Hermes-4-405B"
+ *      (or the smallest available Nous model name; the engine resolves
+ *      it). Clear base_url so the engine uses portal's inference URL
+ *      from auth.json.
+ *   3. Send a one-liner chat.
+ *   4. Wait for chat-done; capture the agent's reply.
+ *   5. Restore the original model selection.
+ */
+const { attach } = require("./e2e-attach");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const CONFIG = path.join(
+  os.homedir(),
+  "AppData",
+  "Local",
+  "hermes",
+  "config.yaml",
+);
+const CONFIG_BAK = CONFIG + ".nous-chat-bk";
+
+const NOUS_MODEL = process.env.NOUS_MODEL || "Hermes-4-405B";
+const PROMPT =
+  process.env.PROMPT ||
+  "Reply with exactly two words: 'NOUS WORKS'. Nothing else.";
+
+(async () => {
+  fs.copyFileSync(CONFIG, CONFIG_BAK);
+
+  try {
+    // Mutate config: provider = nous, default = NOUS_MODEL, blank base_url
+    const cfg = fs.readFileSync(CONFIG, "utf-8");
+    const cfgNew = cfg
+      .replace(/^(model:\s*\n(?:.*\n)*?\s*provider:\s+).*$/m, `$1"nous"`)
+      .replace(
+        /^(model:\s*\n(?:.*\n)*?\s*default:\s+).*$/m,
+        `$1"${NOUS_MODEL}"`,
+      )
+      .replace(/^(model:\s*\n(?:.*\n)*?\s*base_url:\s+).*$/m, `$1""`);
+    fs.writeFileSync(CONFIG, cfgNew);
+    console.log("[setup] active model switched to nous /", NOUS_MODEL);
+
+    const { browser, page } = await attach();
+
+    // Make sure we're on the Chat tab (drive-nous-oauth left us on
+    // Providers).
+    await page.click('text=/^Chat$/').catch(() => {});
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Kill any in-flight chat + clear chat — new conversation
+    await page.click("button.chat-clear-btn").catch(() => {});
+    await new Promise((r) => setTimeout(r, 400));
+
+    // Bust the main-process model-config cache by writing it through IPC
+    await page.evaluate(async (model) => {
+      await window.hermesAPI.setModelConfig("nous", model, "");
+    }, NOUS_MODEL);
+    await new Promise((r) => setTimeout(r, 400));
+
+    // Snapshot agent bubble count before send
+    const beforeCount = await page.evaluate(
+      () => document.querySelectorAll(".chat-bubble-agent").length,
+    );
+    console.log("[setup] agent bubbles before send:", beforeCount);
+
+    // Type + send
+    await page.fill("textarea.chat-input", PROMPT);
+    await page.keyboard.press("Enter");
+    console.log("[step 1] sent:", PROMPT);
+
+    // Wait for streaming to finish — stop button disappears AND at
+    // least one agent bubble exists. Time-bound to 90s.
+    await page.waitForFunction(
+      (prev) => {
+        const stop = document.querySelector(".chat-stop-btn");
+        const agents = document.querySelectorAll(".chat-bubble-agent").length;
+        return !stop && agents > prev;
+      },
+      beforeCount,
+      { timeout: 90_000, polling: 250 },
+    );
+    await new Promise((r) => setTimeout(r, 800));
+
+    // Capture the latest agent bubble text
+    const result = await page.evaluate(() => {
+      const bubbles = document.querySelectorAll(".chat-bubble-agent");
+      const last = bubbles[bubbles.length - 1];
+      return {
+        bubbleCount: bubbles.length,
+        text: last ? (last.textContent || "").trim() : null,
+        anyError: Array.from(bubbles).some((b) =>
+          /^Error:|Internal server error|Hermes is not logged into/i.test(
+            (b.textContent || "").trim(),
+          ),
+        ),
+      };
+    });
+    console.log("[step 2] agent bubbles after:", result.bubbleCount);
+    console.log("[step 2] last bubble text:");
+    console.log("  " + (result.text || "<empty>").replace(/\n/g, "\n  "));
+
+    await browser.close();
+
+    console.log();
+    if (result.anyError) {
+      console.log("[VERDICT] 🔴 Chat returned an error.");
+      process.exit(2);
+    } else if (result.bubbleCount > beforeCount && result.text) {
+      console.log("[VERDICT] ✅ Nous Portal chat round-trip succeeded.");
+    } else {
+      console.log("[VERDICT] ⚠️ No agent reply observed.");
+      process.exit(3);
+    }
+  } finally {
+    fs.copyFileSync(CONFIG_BAK, CONFIG);
+    fs.unlinkSync(CONFIG_BAK);
+    console.log("[teardown] config.yaml restored");
+  }
+})().catch((e) => {
+  try {
+    if (fs.existsSync(CONFIG_BAK)) {
+      fs.copyFileSync(CONFIG_BAK, CONFIG);
+      fs.unlinkSync(CONFIG_BAK);
+    }
+  } catch {}
+  console.error("FAILED:", e.stack || e.message || e);
+  process.exit(1);
+});

--- a/scripts/drive-nous-oauth.js
+++ b/scripts/drive-nous-oauth.js
@@ -1,0 +1,145 @@
+/**
+ * Drive the Nous Portal OAuth sign-in via the new card.
+ *
+ *   1. Navigate to Providers tab.
+ *   2. Click the Nous Portal (OAuth) Sign-in button.
+ *   3. Stream the modal's <pre> log live (1.5s polling).
+ *   4. Print the verification URL + user code so the human can complete
+ *      the Google auth in their own browser.
+ *   5. Watch for status to flip to "success" or "error".
+ *   6. Snapshot auth.json before exiting.
+ */
+const { attach } = require("./e2e-attach");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const AUTH = path.join(os.homedir(), "AppData", "Local", "hermes", "auth.json");
+
+(async () => {
+  const { browser, page } = await attach();
+
+  // Navigate to Providers
+  await page.click('text=/^Providers$/').catch(() => {});
+  await new Promise((r) => setTimeout(r, 500));
+
+  // Scroll the page to bring the OAuth section into view (the card list
+  // is below the LLM Providers section)
+  await page.evaluate(() => {
+    const cards = Array.from(document.querySelectorAll(".provider-key-card"));
+    const nousOauth = cards.find((c) =>
+      /Nous Portal \(OAuth\)/i.test(c.textContent || ""),
+    );
+    if (nousOauth) nousOauth.scrollIntoView({ behavior: "instant", block: "center" });
+  });
+
+  // Click the Sign-in button on the Nous OAuth card
+  const clickResult = await page.evaluate(() => {
+    const cards = Array.from(document.querySelectorAll(".provider-key-card"));
+    const nousOauth = cards.find((c) =>
+      /Nous Portal \(OAuth\)/i.test(c.textContent || ""),
+    );
+    if (!nousOauth) return { clicked: false, reason: "no card" };
+    const btn = nousOauth.querySelector(".oauth-signin-btn");
+    if (!btn) return { clicked: false, reason: "no button" };
+    btn.click();
+    return { clicked: true };
+  });
+  console.log("[step 1] Sign-in click:", JSON.stringify(clickResult));
+
+  // Wait for the modal to appear
+  await page.waitForSelector(".models-modal", { timeout: 5000 });
+  console.log("[step 2] OAuth modal open. Streaming log...");
+  console.log("─".repeat(70));
+
+  // Poll the log + status. Stream new content as it arrives.
+  let lastLog = "";
+  let status = "running";
+  const startTs = Date.now();
+  const MAX_WAIT_MS = 300_000; // 5 min — device code flows expire fast
+
+  while (status === "running" && Date.now() - startTs < MAX_WAIT_MS) {
+    await new Promise((r) => setTimeout(r, 1500));
+    const snap = await page.evaluate(() => {
+      const pre = document.querySelector(".settings-hermes-doctor");
+      const log = pre ? pre.textContent || "" : "";
+      const ok = document.querySelector(".oauth-login-result-success");
+      const err = document.querySelector(".oauth-login-result-error");
+      let status = "running";
+      if (ok) status = "success";
+      else if (err) status = "error";
+      const errText = err ? (err.textContent || "").trim() : "";
+      const modalOpen = document.querySelector(".models-modal") !== null;
+      return { log, status, errText, modalOpen };
+    });
+    if (!snap.modalOpen) {
+      console.log("[modal closed unexpectedly]");
+      break;
+    }
+    if (snap.log !== lastLog) {
+      const delta = snap.log.slice(lastLog.length);
+      process.stdout.write(delta);
+      lastLog = snap.log;
+    }
+    if (snap.status !== status) {
+      status = snap.status;
+      console.log();
+      console.log("─".repeat(70));
+      console.log(`[status] ${status}${snap.errText ? ": " + snap.errText : ""}`);
+    }
+  }
+
+  if (status === "running") {
+    console.log();
+    console.log("[timeout] no status change after 5 min — leaving modal open");
+  }
+
+  // Snapshot auth.json regardless — useful for partial diagnosis
+  let nousProvider = null;
+  let nousPool = null;
+  try {
+    const auth = JSON.parse(fs.readFileSync(AUTH, "utf-8"));
+    nousProvider = auth.providers?.nous || null;
+    nousPool = auth.credential_pool?.nous || null;
+  } catch {}
+  console.log();
+  console.log("─".repeat(70));
+  console.log("auth.json state:");
+  console.log("  providers.nous:", nousProvider ? Object.keys(nousProvider).join(", ") : "absent");
+  console.log("  credential_pool.nous:", nousPool ? `${nousPool.length} entries` : "absent");
+  if (nousProvider) {
+    // Show non-secret fields
+    const safe = {};
+    for (const [k, v] of Object.entries(nousProvider)) {
+      if (typeof v === "string" && v.length > 20) safe[k] = `<string, ${v.length} chars>`;
+      else safe[k] = v;
+    }
+    console.log("  providers.nous (sanitized):", JSON.stringify(safe));
+  }
+  if (nousPool && nousPool[0]) {
+    const safe = {};
+    for (const [k, v] of Object.entries(nousPool[0])) {
+      if (typeof v === "string" && v.length > 20) safe[k] = `<string, ${v.length} chars>`;
+      else safe[k] = v;
+    }
+    console.log("  credential_pool.nous[0] (sanitized):", JSON.stringify(safe));
+  }
+
+  await browser.close();
+
+  if (status === "success") {
+    console.log();
+    console.log("[VERDICT] ✅ OAuth login completed successfully.");
+  } else if (status === "error") {
+    console.log();
+    console.log("[VERDICT] 🔴 OAuth login failed.");
+    process.exit(2);
+  } else {
+    console.log();
+    console.log("[VERDICT] ⚠️ OAuth login still running at timeout.");
+    process.exit(3);
+  }
+})().catch((e) => {
+  console.error("FAILED:", e.stack || e.message || e);
+  process.exit(1);
+});

--- a/scripts/e2e-attach.js
+++ b/scripts/e2e-attach.js
@@ -1,0 +1,98 @@
+/**
+ * Attach to a running dev Electron instance via the Chrome DevTools Protocol.
+ *
+ * Requires the app to have been launched with ENABLE_CDP=1 (see main/index.ts —
+ * the switch opens remote-debugging-port=9222 only when that env var is set).
+ *
+ * Usage from a test/repro script:
+ *
+ *   const { attach } = require("./scripts/e2e-attach");
+ *   const { browser, context, page } = await attach();
+ *   await page.click('text=New Chat');
+ *   await page.fill('textarea', 'hello');
+ *   await page.keyboard.press('Enter');
+ *   await page.waitForSelector('text=Hey', { timeout: 30000 });
+ *   await browser.close();   // detaches; does NOT close the Electron app
+ */
+
+const { chromium } = require("playwright");
+
+/**
+ * @param {object} [opts]
+ * @param {string} [opts.cdpUrl] — CDP HTTP endpoint. Default http://127.0.0.1:9222.
+ * @param {string} [opts.titleHint] — substring of window title to pick a page when
+ *                                    multiple windows are open. Default: the
+ *                                    first page whose URL ends with index.html.
+ * @returns {Promise<{browser: import('playwright').Browser, context: import('playwright').BrowserContext, page: import('playwright').Page}>}
+ */
+async function attach(opts = {}) {
+  const cdpUrl =
+    opts.cdpUrl ||
+    `http://127.0.0.1:${process.env.CDP_PORT || "9222"}`;
+  const titleHint = opts.titleHint || null;
+
+  const browser = await chromium.connectOverCDP(cdpUrl);
+  const contexts = browser.contexts();
+  if (contexts.length === 0) {
+    throw new Error(
+      `No browser contexts found at ${cdpUrl}. ` +
+        `Is the dev electron running with ENABLE_CDP=1?`,
+    );
+  }
+  const context = contexts[0];
+  const pages = context.pages();
+
+  let page;
+  if (titleHint) {
+    page = pages.find(async (p) => (await p.title()).includes(titleHint));
+  }
+  if (!page) {
+    // electron-vite dev serves the renderer at http://localhost:5173/ (no
+    // index.html in the URL). Accept either form, and fall back to the
+    // first page if there's only one.
+    page =
+      pages.find((p) => /index\.html(\?|$)/.test(p.url())) ||
+      pages.find((p) => /^http:\/\/localhost:\d+\/?$/.test(p.url())) ||
+      pages[0];
+  }
+  if (!page) {
+    throw new Error(
+      `No pages in the first context at ${cdpUrl}. URLs: ${pages
+        .map((p) => p.url())
+        .join(", ")}`,
+    );
+  }
+
+  return { browser, context, page };
+}
+
+module.exports = { attach };
+
+// CLI sanity check — `node scripts/e2e-attach.js` prints a one-line summary
+// of the attached page so you can verify the harness works.
+if (require.main === module) {
+  attach()
+    .then(async ({ browser, page }) => {
+      const title = await page.title();
+      const url = page.url();
+      const sessionsCount = await page.evaluate(async () => {
+        if (!window.hermesAPI || !window.hermesAPI.listSessions) return null;
+        try {
+          const s = await window.hermesAPI.listSessions(5, 0);
+          return Array.isArray(s) ? s.length : "unknown";
+        } catch (e) {
+          return `error: ${e?.message || e}`;
+        }
+      });
+      console.log(`[attach OK]`);
+      console.log(`  url:            ${url}`);
+      console.log(`  title:          ${title}`);
+      console.log(`  hermesAPI:      ${sessionsCount === null ? "absent" : "present"}`);
+      console.log(`  listSessions(5): ${sessionsCount}`);
+      await browser.close();
+    })
+    .catch((err) => {
+      console.error("[attach FAILED]", err.message);
+      process.exit(1);
+    });
+}

--- a/scripts/probe-nous-models.js
+++ b/scripts/probe-nous-models.js
@@ -1,0 +1,31 @@
+/**
+ * Query Nous Portal's /v1/models via the gateway to find free models.
+ */
+const { attach } = require("./e2e-attach");
+
+(async () => {
+  const { browser, page } = await attach();
+  const models = await page.evaluate(async () => {
+    try {
+      return await window.hermesAPI.discoverProviderModels(
+        "nous",
+        "",
+        "",
+      );
+    } catch (e) {
+      return { error: String(e) };
+    }
+  });
+  if (models?.error) {
+    console.log("discoverModels error:", models.error);
+  } else if (Array.isArray(models)) {
+    console.log("Available models:", models.length);
+    for (const m of models) console.log(" -", typeof m === "string" ? m : JSON.stringify(m));
+  } else {
+    console.log("unexpected result:", JSON.stringify(models)?.slice(0, 500));
+  }
+  await browser.close();
+})().catch((e) => {
+  console.error("FAILED:", e.message);
+  process.exit(1);
+});

--- a/scripts/repro-nous-cards-schema-367.js
+++ b/scripts/repro-nous-cards-schema-367.js
@@ -1,0 +1,124 @@
+/**
+ * Live verification of issue #367's PR (Bugs 1, 2, 3).
+ *
+ *   A. Bug 1 — Nous Portal API Key card renders in the LLM Providers
+ *              section.
+ *   B. Bug 2 — Nous Portal OAuth Sign-in card renders in the OAuth
+ *              section.
+ *   C. Bug 3 — Adding a credential-pool entry writes the upstream
+ *              engine schema (`access_token`, `auth_type`, `id`,
+ *              `base_url`, `priority`, `source`, `request_count`),
+ *              not the malformed `{key, label}`.
+ */
+const { attach } = require("./e2e-attach");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const AUTH = path.join(os.homedir(), "AppData", "Local", "hermes", "auth.json");
+const AUTH_BAK = AUTH + ".nous-cards-bk";
+
+(async () => {
+  if (fs.existsSync(AUTH)) fs.copyFileSync(AUTH, AUTH_BAK);
+
+  try {
+    const { browser, page } = await attach();
+
+    // Navigate to Providers tab
+    await page.click('text=/^Providers$/').catch(() => {});
+    await new Promise((r) => setTimeout(r, 600));
+
+    // --- A. Nous API Key card present in LLM Providers section ---
+    const apiKeyCardPresent = await page.evaluate(() => {
+      // The card renders the input with placeholder = card's title.
+      // We can find it by attribute or by walking the section.
+      const inputs = Array.from(
+        document.querySelectorAll(".provider-key-card input"),
+      );
+      // Match by surrounding text "Nous Portal API Key"
+      const cards = Array.from(document.querySelectorAll(".provider-key-card"));
+      return cards.some((c) =>
+        /Nous Portal API Key/i.test(c.textContent || ""),
+      ) && inputs.length > 0;
+    });
+    console.log(`[A] Nous Portal API Key card: present=${apiKeyCardPresent}`);
+
+    // --- B. Nous OAuth card present ---
+    const oauthCardPresent = await page.evaluate(() => {
+      const cards = Array.from(document.querySelectorAll(".provider-key-card"));
+      // OAuth cards have a "Sign in" button; the Nous card's title
+      // is "Nous Portal (OAuth)".
+      return cards.some(
+        (c) =>
+          /Nous Portal \(OAuth\)/i.test(c.textContent || "") &&
+          c.querySelector(".oauth-signin-btn") !== null,
+      );
+    });
+    console.log(`[B] Nous Portal OAuth card: present=${oauthCardPresent}`);
+
+    // --- C. Schema fix: add a pool entry via IPC, verify shape ---
+    const TEST_LABEL = `__nous-test-${Date.now()}__`;
+    const TEST_KEY = `sk-nous-test-${Date.now()}`;
+    const entries = await page.evaluate(
+      async ({ label, key }) => {
+        return await window.hermesAPI.addCredentialPoolEntry(
+          "nous",
+          key,
+          label,
+        );
+      },
+      { label: TEST_LABEL, key: TEST_KEY },
+    );
+    const ours = (entries || []).find((e) => e.label === TEST_LABEL);
+    console.log(`[C] new pool entry shape:`, JSON.stringify(ours));
+
+    // Also confirm it landed on disk
+    const auth = JSON.parse(fs.readFileSync(AUTH, "utf-8"));
+    const onDisk = (auth.credential_pool?.nous || []).find(
+      (e) => e.label === TEST_LABEL,
+    );
+    console.log(`[C] on-disk entry:`, JSON.stringify(onDisk));
+
+    await browser.close();
+
+    // Verdicts
+    const aPass = apiKeyCardPresent;
+    const bPass = oauthCardPresent;
+    const cPass =
+      ours &&
+      ours.access_token === TEST_KEY &&
+      ours.auth_type === "api_key" &&
+      typeof ours.id === "string" &&
+      ours.id.length > 0 &&
+      typeof ours.priority === "number" &&
+      ours.source === "manual" &&
+      ours.key === undefined;
+    const cDisk =
+      onDisk &&
+      onDisk.access_token === TEST_KEY &&
+      onDisk.auth_type === "api_key" &&
+      onDisk.key === undefined;
+    console.log();
+    console.log(`[VERDICT A] ${aPass ? "✅" : "🔴"} Nous Portal API Key card renders in LLM Providers section`);
+    console.log(`[VERDICT B] ${bPass ? "✅" : "🔴"} Nous Portal OAuth Sign-in card renders in OAuth section`);
+    console.log(`[VERDICT C] ${cPass ? "✅" : "🔴"} addCredentialPoolEntry returns canonical engine schema (no legacy {key, label})`);
+    console.log(`[VERDICT D] ${cDisk ? "✅" : "🔴"} canonical schema persisted to auth.json`);
+  } finally {
+    if (fs.existsSync(AUTH_BAK)) {
+      fs.copyFileSync(AUTH_BAK, AUTH);
+      fs.unlinkSync(AUTH_BAK);
+    } else if (fs.existsSync(AUTH)) {
+      fs.unlinkSync(AUTH);
+    }
+    console.log("[teardown] auth.json restored");
+  }
+})().catch((e) => {
+  try {
+    if (fs.existsSync(AUTH_BAK)) {
+      fs.copyFileSync(AUTH_BAK, AUTH);
+      fs.unlinkSync(AUTH_BAK);
+    }
+  } catch {}
+  console.error("FAILED:", e.stack || e.message || e);
+  process.exit(1);
+});

--- a/scripts/verify-nous-discovery.js
+++ b/scripts/verify-nous-discovery.js
@@ -1,0 +1,48 @@
+/**
+ * Live verify Nous model discovery (#367 follow-up):
+ *   1. Calls discoverProviderModels("nous") through the renderer.
+ *   2. Checks status === "ok" and models.length > 0.
+ *   3. Checks freeModels contains the known free entries (Nous Portal
+ *      free tier currently exposes deepseek/deepseek-v4-flash:free and
+ *      openrouter/owl-alpha).
+ */
+const { attach } = require("./e2e-attach");
+
+(async () => {
+  const { browser, page } = await attach();
+  const result = await page.evaluate(async () => {
+    return await window.hermesAPI.discoverProviderModels(
+      "nous",
+      undefined,
+      undefined,
+      undefined,
+    );
+  });
+  await browser.close();
+
+  console.log("status:", result.status);
+  console.log("cached:", result.cached);
+  console.log("models.length:", (result.models || []).length);
+  console.log("freeModels:", JSON.stringify(result.freeModels));
+  console.log("sample (first 6):");
+  for (const m of (result.models || []).slice(0, 6)) console.log(" -", m);
+
+  const okStatus = result.status === "ok";
+  const hasModels = (result.models || []).length > 50; // expect many
+  const hasFree = (result.freeModels || []).length > 0;
+  const knownFreeIds = ["deepseek/deepseek-v4-flash:free", "openrouter/owl-alpha"];
+  const matchesKnown = knownFreeIds.every((id) =>
+    (result.freeModels || []).includes(id),
+  );
+
+  console.log();
+  console.log(`[VERDICT A] ${okStatus ? "✅" : "🔴"} discovery status === "ok"`);
+  console.log(`[VERDICT B] ${hasModels ? "✅" : "🔴"} returned >50 models (got ${(result.models || []).length})`);
+  console.log(`[VERDICT C] ${hasFree ? "✅" : "🔴"} freeModels populated (${(result.freeModels || []).length} entries)`);
+  console.log(`[VERDICT D] ${matchesKnown ? "✅" : "🔴"} freeModels contains known Nous free tier (deepseek/deepseek-v4-flash:free + openrouter/owl-alpha)`);
+
+  if (!okStatus || !hasModels || !hasFree || !matchesKnown) process.exit(2);
+})().catch((e) => {
+  console.error("FAILED:", e.stack || e.message || e);
+  process.exit(1);
+});

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -1157,12 +1157,36 @@ function authFilePath(profile?: string): string {
   return join(profileHome(profile || getActiveProfileNameSync()), "auth.json");
 }
 
+/**
+ * Shape of a credential-pool entry as the upstream gateway expects it.
+ *
+ * The engine's resolver (`hermes_cli/auth.py` and the credential-pool
+ * entry parser) reads `access_token` (not `key`), needs an
+ * `auth_type` to distinguish OAuth from API-key entries inside the
+ * same pool, and uses `id` / `priority` / `source` for rotation and
+ * telemetry. Issue #367 — pool entries written by the desktop with
+ * just `{key, label}` were rejected at runtime ("Hermes is not
+ * logged into Nous Portal") because none of the canonical fields
+ * were present.
+ *
+ * `key` is retained for read-only compatibility — old auth.json files
+ * that already contain `{key, label}` entries are still parsed
+ * (otherwise a user's existing manual entries would vanish on first
+ * read). New writes always use the full canonical shape.
+ */
 interface CredentialEntry {
-  key?: string;
-  api_key?: string;
+  id?: string;
+  label?: string;
+  auth_type?: "api_key" | "oauth_device_code" | string;
+  priority?: number;
+  source?: string;
   access_token?: string;
   refresh_token?: string;
-  label?: string;
+  api_key?: string;
+  base_url?: string;
+  request_count?: number;
+  /** Legacy field — historical pool entries written with `{key, label}`. */
+  key?: string;
 }
 
 function readAuthStore(profile?: string): Record<string, unknown> {
@@ -1203,6 +1227,72 @@ export function setCredentialPool(
   (store.credential_pool as Record<string, CredentialEntry[]>)[provider] =
     entries;
   writeAuthStore(store, profile);
+}
+
+/**
+ * Build a credential-pool entry in the canonical engine shape from a
+ * user-typed (key, label). Used by the Providers screen so the
+ * renderer doesn't need to know the upstream schema — issue #367.
+ *
+ * The base URL for known providers comes from `canonicalProviderBaseUrl`;
+ * unknown providers (`custom`, user-defined) get an empty `base_url`
+ * and the engine falls back to its own registry.
+ */
+export function buildCredentialPoolEntry(
+  provider: string,
+  apiKey: string,
+  label: string,
+  existingEntries: CredentialEntry[] = [],
+): CredentialEntry {
+  const baseUrl = canonicalProviderBaseUrl(provider) || "";
+  // Next priority — pool entries are sorted ascending, so a new entry
+  // appended at the end gets the highest priority value.
+  const nextPriority =
+    existingEntries.reduce(
+      (max, e) => (typeof e.priority === "number" ? Math.max(max, e.priority + 1) : max),
+      0,
+    );
+  return {
+    id: cryptoRandomId(),
+    label: label.trim() || `Key ${existingEntries.length + 1}`,
+    auth_type: "api_key",
+    priority: nextPriority,
+    source: "manual",
+    access_token: apiKey.trim(),
+    base_url: baseUrl,
+    request_count: 0,
+  };
+}
+
+function cryptoRandomId(): string {
+  // 8-hex-char id — matches the existing pool entries' id length and
+  // doesn't import the heavier `crypto.randomUUID` machinery if a
+  // collision is astronomically unlikely at the per-pool level.
+  let out = "";
+  for (let i = 0; i < 8; i++) {
+    out += Math.floor(Math.random() * 16).toString(16);
+  }
+  return out;
+}
+
+/**
+ * Append a manually-typed credential pool entry, constructing the
+ * full canonical shape. Used by the renderer's "Add" button so the
+ * shape stays consistent with what the engine's resolver expects.
+ *
+ * Returns the updated entries list for that provider.
+ */
+export function addCredentialPoolEntry(
+  provider: string,
+  apiKey: string,
+  label: string,
+  profile?: string,
+): CredentialEntry[] {
+  const existing = getCredentialPool(profile)[provider] || [];
+  const entry = buildCredentialPoolEntry(provider, apiKey, label, existing);
+  const next = [...existing, entry];
+  setCredentialPool(provider, next, profile);
+  return next;
 }
 
 /**

--- a/src/main/hermes-auth.ts
+++ b/src/main/hermes-auth.ts
@@ -13,9 +13,13 @@ import { stripAnsi } from "./utils";
 /**
  * Provider identifiers that authenticate via an interactive OAuth flow
  * (`hermes auth add <provider> --type oauth`) rather than a static API
- * key. Mirrors hermes-agent's `_OAUTH_CAPABLE_PROVIDERS` set, minus the
- * API-key-capable `anthropic`/`nous` which the desktop sets up through
- * the normal key flow.
+ * key. Mirrors hermes-agent's `_OAUTH_CAPABLE_PROVIDERS` set.
+ *
+ * `nous` is included even though it also has an API-key variant — the
+ * Providers UI now offers both surfaces (an API Key card and an
+ * OAuth Sign-in card, issue #367), and the OAuth path goes through
+ * this gate. The desktop previously excluded `nous` here on the
+ * (incorrect) assumption that it used the normal key flow only.
  */
 export const OAUTH_LOGIN_PROVIDERS = [
   "openai-codex",
@@ -23,6 +27,7 @@ export const OAUTH_LOGIN_PROVIDERS = [
   "qwen-oauth",
   "google-gemini-cli",
   "minimax-oauth",
+  "nous",
 ] as const;
 
 export type OAuthLoginProvider = (typeof OAUTH_LOGIN_PROVIDERS)[number];

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1695,6 +1695,17 @@ function setupUpdater(): void {
   }, 5000);
 }
 
+// Opt-in Chrome DevTools Protocol port for E2E testing. Set
+// ENABLE_CDP=1 (with optional CDP_PORT, default 9222) before
+// launching `npm run dev` to expose the renderer for Playwright
+// attach. Off by default — no effect on normal dev or prod builds.
+if (process.env.ENABLE_CDP === "1") {
+  app.commandLine.appendSwitch(
+    "remote-debugging-port",
+    process.env.CDP_PORT || "9222",
+  );
+}
+
 app.whenReady().then(() => {
   app.name = "Hermes";
   electronApp.setAppUserModelId("com.nousresearch.hermes");

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -90,6 +90,7 @@ import {
   setModelConfig,
   getCredentialPool,
   setCredentialPool,
+  addCredentialPoolEntry,
   getConnectionConfig,
   getPublicConnectionConfig,
   resolveConnectionApiKeyUpdate,
@@ -1203,11 +1204,28 @@ function setupIPC(): void {
     (
       _event,
       provider: string,
-      entries: Array<{ key: string; label: string }>,
+      entries: Array<Record<string, unknown>>,
       profile?: string,
     ) => {
       setCredentialPool(provider, entries, profile);
       return true;
+    },
+  );
+
+  // Append a user-typed key as a properly-shaped credential pool
+  // entry. Constructs the full upstream schema (id, label, auth_type,
+  // priority, source, access_token, base_url, request_count) so the
+  // engine's resolver can read it — issue #367 Bug 3.
+  ipcMain.handle(
+    "add-credential-pool-entry",
+    (
+      _event,
+      provider: string,
+      apiKey: string,
+      label: string,
+      profile?: string,
+    ) => {
+      return addCredentialPoolEntry(provider, apiKey, label, profile);
     },
   );
 

--- a/src/main/model-discovery.ts
+++ b/src/main/model-discovery.ts
@@ -15,7 +15,10 @@ import http from "http";
 import https from "https";
 import { URL } from "url";
 import { execFile } from "child_process";
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
 import { readEnv } from "./config";
+import { profileHome } from "./utils";
 import {
   expectedEnvKeyForModel,
   HERMES_PYTHON,
@@ -35,7 +38,6 @@ import { PROVIDER_BASE_URLS } from "./provider-registry";
 const NON_DISCOVERABLE_PROVIDERS = new Set<string>([
   "auto",
   "custom",
-  "nous",
   "google",
   "xai",
   "qwen",
@@ -45,13 +47,16 @@ const NON_DISCOVERABLE_PROVIDERS = new Set<string>([
 
 /** OAuth/subscription providers — no static-key `/v1/models` endpoint.
  *  Their model lists come from hermes-agent's `provider_model_ids`
- *  (live + account-aware for Codex), reached via a short Python call. */
+ *  (live + account-aware for Codex), reached via a short Python call.
+ *  `nous` is included here since the desktop now exposes its OAuth
+ *  sign-in surface (issue #367). */
 const OAUTH_DISCOVERY_PROVIDERS = new Set<string>([
   "openai-codex",
   "xai-oauth",
   "qwen-oauth",
   "google-gemini-cli",
   "minimax-oauth",
+  "nous",
 ]);
 
 /** Curated fallback model lists, mirrored from hermes-agent's
@@ -134,6 +139,102 @@ async function discoverOAuthModels(provider: string): Promise<string[]> {
   return OAUTH_PROVIDER_CURATED[provider] ?? [];
 }
 
+/**
+ * Fetch the Nous Portal `/v1/models` catalogue with the OAuth token
+ * stored in `auth.json`, and return the IDs of models whose prompt +
+ * completion pricing are both zero — i.e. the free tier. Issue #367
+ * found that a free-subscription user picking the default Nous model
+ * (Hermes-4-405B) gets a billing error. Surfacing free models in the
+ * autocomplete makes the right choice discoverable.
+ *
+ * Returns [] on any failure (no token, no inference_base_url, HTTP
+ * error, parse error). Best-effort enrichment — never blocks the
+ * main discovery call.
+ */
+async function fetchNousFreeModelIds(
+  profile: string | undefined,
+): Promise<string[]> {
+  try {
+    const authPath = join(profileHome(profile), "auth.json");
+    if (!existsSync(authPath)) return [];
+    const auth = JSON.parse(readFileSync(authPath, "utf-8")) as {
+      providers?: { nous?: { access_token?: string; inference_base_url?: string } };
+    };
+    const token = (auth.providers?.nous?.access_token || "").trim();
+    const base = (auth.providers?.nous?.inference_base_url || "").trim();
+    if (!token || !base) return [];
+
+    const url = `${base.replace(/\/+$/, "")}/models`;
+    return await new Promise<string[]>((resolve) => {
+      const u = new URL(url);
+      const mod = u.protocol === "https:" ? https : http;
+      const req = mod.request(
+        {
+          method: "GET",
+          protocol: u.protocol,
+          hostname: u.hostname,
+          port: u.port || undefined,
+          path: `${u.pathname}${u.search}`,
+          headers: {
+            Accept: "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          timeout: 10_000,
+        },
+        (res) => {
+          if (!res.statusCode || res.statusCode >= 400) {
+            res.resume();
+            resolve([]);
+            return;
+          }
+          let body = "";
+          res.setEncoding("utf-8");
+          res.on("data", (chunk) => {
+            body += chunk;
+          });
+          res.on("end", () => {
+            try {
+              const j = JSON.parse(body) as {
+                data?: Array<{
+                  id?: string;
+                  pricing?: { prompt?: string; completion?: string };
+                }>;
+              };
+              const free = (j.data || [])
+                .filter((m) => {
+                  // Free iff both prompt and completion cost zero. The
+                  // Portal returns them as strings like "0.0000000000".
+                  const pr = String(m.pricing?.prompt ?? "").trim();
+                  const co = String(m.pricing?.completion ?? "").trim();
+                  return (
+                    pr !== "" &&
+                    co !== "" &&
+                    parseFloat(pr) === 0 &&
+                    parseFloat(co) === 0
+                  );
+                })
+                .map((m) => String(m.id || "").trim())
+                .filter(Boolean);
+              resolve(uniqueSorted(free));
+            } catch {
+              resolve([]);
+            }
+          });
+          res.on("error", () => resolve([]));
+        },
+      );
+      req.on("error", () => resolve([]));
+      req.on("timeout", () => {
+        req.destroy();
+        resolve([]);
+      });
+      req.end();
+    });
+  } catch {
+    return [];
+  }
+}
+
 // In-memory result cache to avoid hammering the provider on every keystroke.
 interface CacheEntry {
   models: string[];
@@ -141,6 +242,9 @@ interface CacheEntry {
 }
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 const _cache = new Map<string, CacheEntry>();
+// Parallel cache of free-model ids, keyed by provider. Cleared together
+// with the main cache via `_clearCache` for test isolation.
+const _freeCache = new Map<string, string[]>();
 
 function cacheKey(provider: string, baseUrl: string): string {
   return `${provider.toLowerCase()}|${baseUrl.replace(/\/+$/, "").toLowerCase()}`;
@@ -290,6 +394,11 @@ export interface DiscoverModelsResult {
   status: "ok" | "no-key" | "unsupported" | "unknown-host";
   /** ``true`` when the result came from the in-memory cache. */
   cached: boolean;
+  /** Subset of `models` flagged as free (no cost per token). Populated
+   *  for providers whose catalog exposes pricing — Nous Portal today,
+   *  others as we add them. Empty when no pricing info is available
+   *  (everything is treated as paid by default in the UI). */
+  freeModels?: string[];
 }
 
 /** Discover available models for a provider.  Returns an object so the
@@ -306,10 +415,34 @@ export async function discoverProviderModels(
   // endpoint — route them through hermes-agent's provider_model_ids.
   if (OAUTH_DISCOVERY_PROVIDERS.has(lowerProvider)) {
     const hit = fromCache(lowerProvider, "");
-    if (hit) return { models: hit, status: "ok", cached: true };
+    if (hit) {
+      // Re-attach free flags from cache. Pricing is fetched fresh on
+      // the next non-cache hit; meanwhile the renderer keeps the
+      // previous free list.
+      return {
+        models: hit,
+        status: "ok",
+        cached: true,
+        freeModels: _freeCache.get(lowerProvider) || [],
+      };
+    }
     const models = await discoverOAuthModels(lowerProvider);
     setCache(lowerProvider, "", models);
-    return { models, status: "ok", cached: false };
+    // Nous Portal exposes pricing in its catalog — enrich with the
+    // subset of models that are free, so the renderer can badge them.
+    // Other OAuth providers have no equivalent yet.
+    let freeModels: string[] = [];
+    if (lowerProvider === "nous") {
+      const allFree = await fetchNousFreeModelIds(profile);
+      // Keep only the free IDs that are actually in the curated list
+      // we're surfacing — avoids confusing the user with names that
+      // wouldn't autocomplete anyway. If hermes-agent's list misses
+      // some free ones, fall back to the full live list.
+      const inCurated = allFree.filter((id) => models.includes(id));
+      freeModels = inCurated.length > 0 ? inCurated : allFree;
+      _freeCache.set(lowerProvider, freeModels);
+    }
+    return { models, status: "ok", cached: false, freeModels };
   }
 
   if (!lowerProvider || NON_DISCOVERABLE_PROVIDERS.has(lowerProvider)) {
@@ -343,4 +476,5 @@ export async function discoverProviderModels(
  *  should always go through ``discoverProviderModels``. */
 export function _clearCache(): void {
   _cache.clear();
+  _freeCache.clear();
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -28,6 +28,27 @@ interface InstallProgress {
   log: string;
 }
 
+/**
+ * Shape of a credential-pool entry as the upstream engine expects
+ * (issue #367). Old entries written by the renderer with just
+ * `{key, label}` are still readable via the optional `key` field.
+ * New entries written from the UI use the canonical shape.
+ */
+interface CredentialPoolEntry {
+  id?: string;
+  label?: string;
+  auth_type?: "api_key" | "oauth_device_code" | string;
+  priority?: number;
+  source?: string;
+  access_token?: string;
+  refresh_token?: string;
+  api_key?: string;
+  base_url?: string;
+  request_count?: number;
+  /** Legacy field for backward compat with old auth.json shapes. */
+  key?: string;
+}
+
 interface KanbanTask {
   id: string;
   title: string;
@@ -470,15 +491,22 @@ interface HermesAPI {
     }>
   >;
 
-  // Credential Pool (profile-aware)
+  // Credential Pool (profile-aware) — entries follow the upstream
+  // engine schema (issue #367). See `CredentialPoolEntry` below.
   getCredentialPool: (
     profile?: string,
-  ) => Promise<Record<string, Array<{ key: string; label: string }>>>;
+  ) => Promise<Record<string, Array<CredentialPoolEntry>>>;
   setCredentialPool: (
     provider: string,
-    entries: Array<{ key: string; label: string }>,
+    entries: Array<CredentialPoolEntry>,
     profile?: string,
   ) => Promise<boolean>;
+  addCredentialPoolEntry: (
+    provider: string,
+    apiKey: string,
+    label: string,
+    profile?: string,
+  ) => Promise<Array<CredentialPoolEntry>>;
 
   // Models
   listModels: () => Promise<

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -270,6 +270,8 @@ interface HermesAPI {
     models: string[];
     status: "ok" | "no-key" | "unsupported" | "unknown-host";
     cached: boolean;
+    /** Subset of `models` flagged as free (Nous Portal today). #367. */
+    freeModels?: string[];
   }>;
   onChatChunk: (callback: (chunk: string) => void) => () => void;
   onChatReasoningChunk: (callback: (chunk: string) => void) => () => void;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2,6 +2,25 @@ import { contextBridge, ipcRenderer, webUtils } from "electron";
 import type { AppLocale } from "../shared/i18n/types";
 import type { Attachment } from "../shared/attachments";
 
+/**
+ * Mirror of the renderer-side `CredentialPoolEntry` ambient type
+ * (src/preload/index.d.ts) — preload is type-checked under
+ * tsconfig.node.json which doesn't include the .d.ts. See #367.
+ */
+interface CredentialPoolEntry {
+  id?: string;
+  label?: string;
+  auth_type?: "api_key" | "oauth_device_code" | string;
+  priority?: number;
+  source?: string;
+  access_token?: string;
+  refresh_token?: string;
+  api_key?: string;
+  base_url?: string;
+  request_count?: number;
+  key?: string;
+}
+
 const electronAPI = {
   process: {
     platform: process.platform,
@@ -567,16 +586,35 @@ const hermesAPI = {
 
   // Credential Pool (profile-aware: reads/writes the named profile's
   // auth.json; defaults to the currently active profile when omitted)
+  //
+  // Pool entries follow the upstream engine schema (issue #367) —
+  // `access_token` for the secret, `auth_type` to distinguish OAuth
+  // from API key, plus `id`/`priority`/`source` for rotation.
   getCredentialPool: (
     profile?: string,
-  ): Promise<Record<string, Array<{ key: string; label: string }>>> =>
+  ): Promise<Record<string, Array<CredentialPoolEntry>>> =>
     ipcRenderer.invoke("get-credential-pool", profile),
   setCredentialPool: (
     provider: string,
-    entries: Array<{ key: string; label: string }>,
+    entries: Array<CredentialPoolEntry>,
     profile?: string,
   ): Promise<boolean> =>
     ipcRenderer.invoke("set-credential-pool", provider, entries, profile),
+  // Add a manually-typed key as a properly-shaped pool entry. Returns
+  // the updated entries list for the provider.
+  addCredentialPoolEntry: (
+    provider: string,
+    apiKey: string,
+    label: string,
+    profile?: string,
+  ): Promise<Array<CredentialPoolEntry>> =>
+    ipcRenderer.invoke(
+      "add-credential-pool-entry",
+      provider,
+      apiKey,
+      label,
+      profile,
+    ),
 
   // Models
   listModels: (): Promise<

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -289,6 +289,10 @@ const hermesAPI = {
     models: string[];
     status: "ok" | "no-key" | "unsupported" | "unknown-host";
     cached: boolean;
+    /** Subset of `models` flagged as free per the provider catalog
+     *  (Nous Portal today). Optional — providers without pricing
+     *  metadata return undefined. Issue #367. */
+    freeModels?: string[];
   }> =>
     ipcRenderer.invoke(
       "discover-provider-models",

--- a/src/renderer/src/constants.ts
+++ b/src/renderer/src/constants.ts
@@ -220,6 +220,15 @@ export const OAUTH_PROVIDERS: OAuthProviderDef[] = [
     name: "MiniMax (OAuth)",
     desc: "providers.oauth.minimaxDesc",
   },
+  // Nous Portal OAuth — issue #367 Bug 2. The engine's
+  // PROVIDER_REGISTRY registers `nous` with auth_type="oauth_device_code";
+  // without this card the only way to trigger the sign-in flow was
+  // `hermes auth add nous --type oauth` from PowerShell.
+  {
+    id: "nous",
+    name: "Nous Portal (OAuth)",
+    desc: "providers.oauth.nousDesc",
+  },
 ];
 
 export interface LocalPreset {
@@ -356,6 +365,15 @@ export const SETTINGS_SECTIONS: SectionDef[] = [
         label: "constants.minimaxApiKey",
         type: "password",
         hint: "constants.minimaxHint",
+      },
+      // Nous Portal API-key variant — the OAuth variant has its own
+      // card in the OAuth section below. Missing-API-key-card was
+      // issue #367 Bug 1.
+      {
+        key: "NOUS_API_KEY",
+        label: "constants.nousApiKey",
+        type: "password",
+        hint: "constants.nousHint",
       },
       {
         key: "MINIMAX_CN_API_KEY",

--- a/src/renderer/src/hooks/useDiscoveredModels.ts
+++ b/src/renderer/src/hooks/useDiscoveredModels.ts
@@ -29,6 +29,10 @@ export interface UseDiscoveredModelsResult {
   models: string[];
   status: DiscoveryStatus;
   cached: boolean;
+  /** Subset of `models` that the provider's catalog flags as free.
+   *  Renderer surfaces this as an "(free)" suffix in autocomplete.
+   *  Empty/undefined for providers without pricing info. Issue #367. */
+  freeModels: string[];
 }
 
 /**
@@ -50,6 +54,7 @@ export function useDiscoveredModels(
   const [models, setModels] = useState<string[]>([]);
   const [status, setStatus] = useState<DiscoveryStatus>("idle");
   const [cached, setCached] = useState(false);
+  const [freeModels, setFreeModels] = useState<string[]>([]);
   const cancelRef = useRef(0);
 
   useEffect(() => {
@@ -57,6 +62,7 @@ export function useDiscoveredModels(
       setStatus("idle");
       setModels([]);
       setCached(false);
+      setFreeModels([]);
       return;
     }
     const seq = ++cancelRef.current;
@@ -73,11 +79,13 @@ export function useDiscoveredModels(
         setModels(result.models);
         setCached(result.cached);
         setStatus(result.status);
+        setFreeModels(result.freeModels ?? []);
       } catch {
         if (seq !== cancelRef.current) return;
         setStatus("error");
         setModels([]);
         setCached(false);
+        setFreeModels([]);
       }
     }, 400);
     return (): void => {
@@ -85,5 +93,5 @@ export function useDiscoveredModels(
     };
   }, [enabled, provider, baseUrl, apiKey, profile, refreshToken]);
 
-  return { models, status, cached };
+  return { models, status, cached, freeModels };
 }

--- a/src/renderer/src/screens/Models/Models.tsx
+++ b/src/renderer/src/screens/Models/Models.tsx
@@ -443,9 +443,20 @@ function Models({ visible }: ModelsProps = {}): React.JSX.Element {
                 </div>
                 {discovery.models.length > 0 && (
                   <datalist id={modelDiscoveryListId}>
-                    {discovery.models.map((m) => (
-                      <option key={m} value={m} />
-                    ))}
+                    {discovery.models.map((m) => {
+                      // Surface free vs paid in the autocomplete —
+                      // Nous Portal flags this in its catalog (#367).
+                      // The browser's datalist renders the `label`
+                      // attribute as a grey suffix next to the value.
+                      const isFree = discovery.freeModels?.includes(m);
+                      return (
+                        <option
+                          key={m}
+                          value={m}
+                          label={isFree ? t("models.freeBadge") : undefined}
+                        />
+                      );
+                    })}
                   </datalist>
                 )}
                 {discovery.status !== "idle" &&

--- a/src/renderer/src/screens/Providers/Providers.tsx
+++ b/src/renderer/src/screens/Providers/Providers.tsx
@@ -6,6 +6,23 @@ import { useDiscoveredModels } from "../../hooks/useDiscoveredModels";
 import OAuthLoginModal from "../../components/OAuthLoginModal";
 import { KeyRound } from "../../assets/icons";
 
+// Local mirror of the ambient `CredentialPoolEntry` from
+// src/preload/index.d.ts — the renderer's tsconfig sometimes doesn't
+// pick up the d.ts depending on where the file lives.
+interface CredentialPoolEntry {
+  id?: string;
+  label?: string;
+  auth_type?: "api_key" | "oauth_device_code" | string;
+  priority?: number;
+  source?: string;
+  access_token?: string;
+  refresh_token?: string;
+  api_key?: string;
+  base_url?: string;
+  request_count?: number;
+  key?: string;
+}
+
 function Providers({
   profile,
   visible,
@@ -28,9 +45,11 @@ function Providers({
   const modelLoaded = useRef(false);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Credential pool
+  // Credential pool — entries follow the upstream engine schema
+  // (issue #367). Old `{key, label}` entries are read tolerantly via
+  // the optional `key` field on CredentialPoolEntry.
   const [credPool, setCredPool] = useState<
-    Record<string, Array<{ key: string; label: string }>>
+    Record<string, Array<CredentialPoolEntry>>
   >({});
   const [poolProvider, setPoolProvider] = useState("");
   const [poolNewKey, setPoolNewKey] = useState("");
@@ -198,16 +217,18 @@ function Providers({
 
   async function handleAddPoolKey(): Promise<void> {
     if (!poolProvider || !poolNewKey.trim()) return;
-    const existing = credPool[poolProvider] || [];
-    const entries = [
-      ...existing,
-      {
-        key: poolNewKey.trim(),
-        label: poolNewLabel.trim() || `Key ${existing.length + 1}`,
-      },
-    ];
-    await window.hermesAPI.setCredentialPool(poolProvider, entries);
-    setCredPool((prev) => ({ ...prev, [poolProvider]: entries }));
+    // Use the main-process helper which constructs the canonical
+    // engine schema — `{id, label, auth_type, priority, source,
+    // access_token, base_url, request_count}` — so the entry is
+    // actually readable by the gateway's credential resolver. The
+    // previous code wrote `{key, label}` which the engine couldn't
+    // parse (issue #367).
+    const updated = await window.hermesAPI.addCredentialPoolEntry(
+      poolProvider,
+      poolNewKey.trim(),
+      poolNewLabel.trim(),
+    );
+    setCredPool((prev) => ({ ...prev, [poolProvider]: updated }));
     setPoolNewKey("");
     setPoolNewLabel("");
   }
@@ -431,25 +452,37 @@ function Providers({
                         )
                       : provider}
                   </div>
-                  {entries.map((entry, idx) => (
-                    <div key={idx} className="settings-pool-entry">
-                      <span className="settings-pool-label">
-                        {entry.label || `${t("settings.keyLabel")} ${idx + 1}`}
-                      </span>
-                      <span className="settings-pool-key">
-                        {entry.key
-                          ? `${entry.key.slice(0, 8)}...${entry.key.slice(-4)}`
-                          : t("settings.empty")}
-                      </span>
-                      <button
-                        className="btn-ghost"
-                        style={{ color: "var(--error)", fontSize: 11 }}
-                        onClick={() => handleRemovePoolKey(provider, idx)}
-                      >
-                        {t("settings.remove")}
-                      </button>
-                    </div>
-                  ))}
+                  {entries.map((entry, idx) => {
+                    // Display the secret from whichever field this
+                    // entry has — new entries use `access_token` per
+                    // the engine schema (#367); old entries may still
+                    // be in `key` (backward compat).
+                    const secret =
+                      entry.access_token ||
+                      entry.api_key ||
+                      entry.key ||
+                      "";
+                    return (
+                      <div key={entry.id || idx} className="settings-pool-entry">
+                        <span className="settings-pool-label">
+                          {entry.label ||
+                            `${t("settings.keyLabel")} ${idx + 1}`}
+                        </span>
+                        <span className="settings-pool-key">
+                          {secret
+                            ? `${secret.slice(0, 8)}...${secret.slice(-4)}`
+                            : t("settings.empty")}
+                        </span>
+                        <button
+                          className="btn-ghost"
+                          style={{ color: "var(--error)", fontSize: 11 }}
+                          onClick={() => handleRemovePoolKey(provider, idx)}
+                        >
+                          {t("settings.remove")}
+                        </button>
+                      </div>
+                    );
+                  })}
                 </div>
               ),
           )}

--- a/src/renderer/src/screens/Providers/Providers.tsx
+++ b/src/renderer/src/screens/Providers/Providers.tsx
@@ -350,9 +350,16 @@ function Providers({
           </div>
           {discovery.models.length > 0 && (
             <datalist id={discoveryListId}>
-              {discovery.models.map((m) => (
-                <option key={m} value={m} />
-              ))}
+              {discovery.models.map((m) => {
+                const isFree = discovery.freeModels?.includes(m);
+                return (
+                  <option
+                    key={m}
+                    value={m}
+                    label={isFree ? t("models.freeBadge") : undefined}
+                  />
+                );
+              })}
             </datalist>
           )}
           <div className="settings-field-hint">

--- a/src/shared/i18n/locales/en/constants.ts
+++ b/src/shared/i18n/locales/en/constants.ts
@@ -59,6 +59,8 @@ export default {
   kimiHint: "Moonshot AI coding models",
   minimaxApiKey: "MiniMax API Key",
   minimaxHint: "MiniMax models (global)",
+  nousApiKey: "Nous Portal API Key",
+  nousHint: "Nous Portal API key — use the OAuth card below if you have a Nous subscription instead",
   minimaxCnApiKey: "MiniMax China API Key",
   minimaxCnHint: "MiniMax models (China endpoint)",
   opencodeZenApiKey: "OpenCode Zen API Key",

--- a/src/shared/i18n/locales/en/models.ts
+++ b/src/shared/i18n/locales/en/models.ts
@@ -1,5 +1,6 @@
 export default {
   title: "Models",
+  freeBadge: "(free)",
   searchPlaceholder: "Search models...",
   empty: "No models yet",
   noMatch: "No models match your search",

--- a/src/shared/i18n/locales/en/providers.ts
+++ b/src/shared/i18n/locales/en/providers.ts
@@ -14,5 +14,6 @@ export default {
     qwenDesc: "Use your Qwen subscription",
     geminiDesc: "Use your Google AI Pro / Gemini plan",
     minimaxDesc: "Use your MiniMax subscription",
+    nousDesc: "Sign in with your Nous Portal subscription",
   },
 } as const;

--- a/src/shared/i18n/locales/pt-PT/constants.ts
+++ b/src/shared/i18n/locales/pt-PT/constants.ts
@@ -55,6 +55,8 @@ export default {
   kimiHint: "Modelos IA de programação Moonshot",
   minimaxApiKey: "Chave de API da MiniMax",
   minimaxHint: "Modelos MiniMax (global)",
+  nousApiKey: "Chave de API do Nous Portal",
+  nousHint: "Chave de API do Nous Portal — use o cartão OAuth abaixo se tiver uma subscrição do Nous",
   minimaxCnApiKey: "Chave de API da MiniMax China",
   minimaxCnHint: "Modelos MiniMax (endpoint China)",
   opencodeZenApiKey: "Chave de API da OpenCode Zen",

--- a/src/shared/i18n/locales/pt-PT/models.ts
+++ b/src/shared/i18n/locales/pt-PT/models.ts
@@ -1,5 +1,6 @@
 export default {
   title: "Modelos",
+  freeBadge: "(grátis)",
   searchPlaceholder: "Pesquisar modelos...",
   empty: "Ainda sem modelos",
   noMatch: "Nenhum modelo corresponde à sua pesquisa",

--- a/src/shared/i18n/locales/pt-PT/providers.ts
+++ b/src/shared/i18n/locales/pt-PT/providers.ts
@@ -16,5 +16,6 @@ export default {
     qwenDesc: "Use a sua subscrição do Qwen",
     geminiDesc: "Use o seu plano Google AI Pro / Gemini",
     minimaxDesc: "Use a sua subscrição do MiniMax",
+    nousDesc: "Inicie sessão com a sua subscrição do Nous Portal",
   },
 } as const;

--- a/tests/credential-pool-schema.test.ts
+++ b/tests/credential-pool-schema.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { join } from "path";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+
+/**
+ * Credential pool schema — issue #367 Bug 3.
+ *
+ * Before this fix, the renderer wrote entries as `{key, label}` only.
+ * The upstream engine resolver reads `access_token` (not `key`) and
+ * needs `auth_type` to distinguish OAuth vs API-key entries inside
+ * the same pool. The malformed entry meant the gateway couldn't find
+ * the credential — "Hermes is not logged into Nous Portal".
+ *
+ * The fix: a main-process helper `addCredentialPoolEntry()` that
+ * constructs the full canonical shape.
+ */
+
+const TEST_DIR = join(
+  tmpdir(),
+  `hermes-test-cred-pool-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+);
+
+async function freshConfig(
+  home: string,
+): Promise<typeof import("../src/main/config")> {
+  vi.resetModules();
+  process.env.HERMES_HOME = home;
+  return await import("../src/main/config");
+}
+
+beforeEach(() => {
+  mkdirSync(TEST_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  delete process.env.HERMES_HOME;
+  vi.resetModules();
+  rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe("addCredentialPoolEntry", () => {
+  it("writes the full upstream-engine shape (not the legacy {key,label})", async () => {
+    const { addCredentialPoolEntry } = await freshConfig(TEST_DIR);
+
+    const entries = addCredentialPoolEntry(
+      "nous",
+      "sk-nous-test-12345",
+      "My Nous Key",
+    );
+
+    expect(entries).toHaveLength(1);
+    const entry = entries[0];
+    // Canonical fields
+    expect(entry.access_token).toBe("sk-nous-test-12345");
+    expect(entry.label).toBe("My Nous Key");
+    expect(entry.auth_type).toBe("api_key");
+    expect(entry.priority).toBe(0);
+    expect(entry.source).toBe("manual");
+    expect(typeof entry.id).toBe("string");
+    expect(entry.id?.length).toBeGreaterThan(0);
+    expect(entry.request_count).toBe(0);
+    // Legacy field NOT written
+    expect(entry.key).toBeUndefined();
+  });
+
+  it("persists to auth.json with the canonical fields", async () => {
+    const { addCredentialPoolEntry } = await freshConfig(TEST_DIR);
+    addCredentialPoolEntry("openrouter", "sk-or-test", "Test");
+
+    const auth = JSON.parse(
+      readFileSync(join(TEST_DIR, "auth.json"), "utf-8"),
+    );
+    const pool = auth.credential_pool.openrouter;
+    expect(Array.isArray(pool)).toBe(true);
+    expect(pool[0].access_token).toBe("sk-or-test");
+    expect(pool[0].auth_type).toBe("api_key");
+    // Not the malformed shape
+    expect(pool[0].key).toBeUndefined();
+  });
+
+  it("populates base_url for known providers", async () => {
+    const { addCredentialPoolEntry } = await freshConfig(TEST_DIR);
+    const entries = addCredentialPoolEntry("openai", "sk-test", "OpenAI");
+    expect(entries[0].base_url).toBe("https://api.openai.com/v1");
+  });
+
+  it("leaves base_url empty for unknown providers", async () => {
+    const { addCredentialPoolEntry } = await freshConfig(TEST_DIR);
+    const entries = addCredentialPoolEntry(
+      "some-custom-provider",
+      "k",
+      "Test",
+    );
+    expect(entries[0].base_url).toBe("");
+  });
+
+  it("defaults the label when omitted", async () => {
+    const { addCredentialPoolEntry } = await freshConfig(TEST_DIR);
+    const entries = addCredentialPoolEntry("nous", "sk-1", "");
+    expect(entries[0].label).toBe("Key 1");
+  });
+
+  it("appends with monotonically-increasing priority", async () => {
+    const { addCredentialPoolEntry } = await freshConfig(TEST_DIR);
+    addCredentialPoolEntry("nous", "sk-1", "First");
+    addCredentialPoolEntry("nous", "sk-2", "Second");
+    const final = addCredentialPoolEntry("nous", "sk-3", "Third");
+    expect(final.map((e) => e.priority)).toEqual([0, 1, 2]);
+  });
+
+  it("generates unique ids per entry", async () => {
+    const { addCredentialPoolEntry } = await freshConfig(TEST_DIR);
+    addCredentialPoolEntry("nous", "k1", "");
+    addCredentialPoolEntry("nous", "k2", "");
+    const entries = addCredentialPoolEntry("nous", "k3", "");
+    const ids = entries.map((e) => e.id);
+    expect(new Set(ids).size).toBe(3);
+  });
+});
+
+describe("readback compatibility", () => {
+  it("still reads old `{key, label}` entries from auth.json", async () => {
+    // Pre-fix shape that some users have in their auth.json
+    mkdirSync(TEST_DIR, { recursive: true });
+    writeFileSync(
+      join(TEST_DIR, "auth.json"),
+      JSON.stringify(
+        {
+          version: 1,
+          credential_pool: {
+            nous: [{ key: "sk-legacy-shape", label: "Old Entry" }],
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    const { getCredentialPool, hasOAuthCredentials } =
+      await freshConfig(TEST_DIR);
+    const pool = getCredentialPool();
+    expect(pool.nous[0].key).toBe("sk-legacy-shape");
+    // The legacy {key, label} shape does NOT satisfy hasOAuthCredentials
+    // (it checks access_token/refresh_token/api_key) — which is why
+    // the engine rejected it. Pin that as a behaviour assertion.
+    expect(hasOAuthCredentials("nous")).toBe(false);
+  });
+
+  it("hasOAuthCredentials recognises new-shape entries", async () => {
+    const { addCredentialPoolEntry, hasOAuthCredentials } =
+      await freshConfig(TEST_DIR);
+    addCredentialPoolEntry("nous", "sk-new-shape", "Test");
+    expect(hasOAuthCredentials("nous")).toBe(true);
+  });
+});
+
+describe("buildCredentialPoolEntry (pure)", () => {
+  it("doesn't write to disk", async () => {
+    const { buildCredentialPoolEntry } = await freshConfig(TEST_DIR);
+    const entry = buildCredentialPoolEntry("nous", "sk-no-write", "Test");
+    expect(entry.access_token).toBe("sk-no-write");
+    // No auth.json created
+    expect(existsSync(join(TEST_DIR, "auth.json"))).toBe(false);
+  });
+});

--- a/tests/model-discovery.test.ts
+++ b/tests/model-discovery.test.ts
@@ -102,9 +102,10 @@ describe("model-discovery", () => {
 
   it("returns status=unsupported for known no-discovery providers", async () => {
     const { discoverProviderModels } = await loadDiscovery();
-    // openai-codex / qwen-oauth are no longer here — OAuth providers are
-    // discovered via hermes-agent's provider_model_ids instead.
-    for (const provider of ["nous", "google", "xai"]) {
+    // openai-codex / qwen-oauth / nous are no longer here — OAuth
+    // providers (including `nous` as of #367) are discovered via
+    // hermes-agent's provider_model_ids instead.
+    for (const provider of ["google", "xai"]) {
       const result = await discoverProviderModels(
         provider,
         undefined,
@@ -282,5 +283,90 @@ describe("model-discovery", () => {
     // URL which isn't our loopback server.  Sanity check the .env load
     // path separately:
     expect(receivedAuth).toBe(""); // confirms the canonical URL was used, not our test server
+  });
+
+  // Issue #367 — Nous Portal model discovery routes through the
+  // OAuth path (provider_model_ids via Python) AND enriches the
+  // result with a `freeModels` subset parsed from the live catalog
+  // at `inference_base_url`. The Python call can be unreachable in
+  // tests, but the live /v1/models fetch using the auth.json token
+  // is testable end-to-end against the loopback server.
+
+  it("nous discovery flags free models from the live /v1/models pricing data (#367)", async () => {
+    let receivedAuth = "";
+    server = http.createServer((req, res) => {
+      receivedAuth = String(req.headers["authorization"] || "");
+      if (req.url === "/v1/models" && req.method === "GET") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            data: [
+              {
+                id: "deepseek/deepseek-v4-flash:free",
+                pricing: { prompt: "0", completion: "0" },
+              },
+              { id: "openrouter/owl-alpha", pricing: { prompt: "0.0", completion: "0.0" } },
+              {
+                id: "anthropic/claude-opus-4.7",
+                pricing: { prompt: "0.000003", completion: "0.000015" },
+              },
+              { id: "missing-pricing" },
+            ],
+          }),
+        );
+      } else {
+        res.writeHead(404);
+        res.end();
+      }
+    });
+    await listen();
+
+    // Plant auth.json with the loopback server's URL as the inference
+    // base. Token can be anything — the test server checks it came.
+    writeFileSync(
+      join(testHome, "auth.json"),
+      JSON.stringify({
+        providers: {
+          nous: {
+            access_token: "tok-nous-test",
+            inference_base_url: baseUrl,
+          },
+        },
+      }),
+    );
+
+    const { discoverProviderModels } = await loadDiscovery();
+    const result = await discoverProviderModels(
+      "nous",
+      undefined,
+      undefined,
+      undefined,
+    );
+
+    // Bearer header reached the live /v1/models endpoint
+    expect(receivedAuth).toBe("Bearer tok-nous-test");
+    // Free flag carries through, two free models found
+    expect(result.freeModels).toBeDefined();
+    expect(result.freeModels?.sort()).toEqual([
+      "deepseek/deepseek-v4-flash:free",
+      "openrouter/owl-alpha",
+    ]);
+    // Status stays "ok" regardless of the Python provider_model_ids
+    // call (which may fail under tests — that path returns the
+    // curated fallback or an empty list, but `status:ok` either way).
+    expect(result.status).toBe("ok");
+  });
+
+  it("nous discovery returns empty freeModels when auth.json is missing", async () => {
+    server = http.createServer((_req, res) => {
+      res.writeHead(404);
+      res.end();
+    });
+    await listen();
+    // No auth.json planted in testHome — fetchNousFreeModelIds returns []
+    const { discoverProviderModels } = await loadDiscovery();
+    const result = await discoverProviderModels("nous", undefined, undefined, undefined);
+    expect(result.freeModels).toEqual([]);
+    expect(result.status).toBe("ok");
   });
 });


### PR DESCRIPTION
Closes the renderer + IPC + discovery + OAuth surfaces for #367. All four bugs from the report, plus two follow-ups uncovered while live-testing against a real Nous Portal account.

| Commit | Bug / scope |
|---|---|
| `fix(credential-pool): write entries in the upstream engine schema` | **Bug 3** — `addCredentialPoolEntry` builds `{id, label, auth_type, priority, source, access_token, base_url, request_count}`. Legacy `{key, label}` entries are still read tolerantly. |
| `feat(providers): add Nous Portal API key + OAuth cards` | **Bugs 1 & 2** — the two missing surfaces. EN + pt-PT i18n. |
| `chore(test): CDP harness + live-verify script for #367 fixes` | DOM-level verifier (`scripts/repro-nous-cards-schema-367.js`). |
| `fix(auth): unblock Nous Portal in the OAuth IPC allowlist` | **Found in live testing** — the main-process `OAUTH_LOGIN_PROVIDERS` was a second allowlist that didn't include `nous`. Without this, clicking Sign-in errored with "Unsupported OAuth provider: nous". |
| `feat(models): Nous Portal model discovery + (free) flag in autocomplete` | **Follow-up from live testing** — `discoverProviderModels(\"nous\")` returned `unsupported`. Moved to OAUTH_DISCOVERY_PROVIDERS (244-model curated list now flows through). Plus: query the portal's live /v1/models with the OAuth token to flag free models — surfaced as `<option label=\"(free)\">` in the autocomplete so free-tier users don't pick a paid model by accident. |

## Bug 4 — handled by sibling PR

The fourth bug (silent misconfiguration when `model.provider: \"nous\"` is set without any creds) is the **detection** half — addressed in #369. The two PRs are independently mergeable in either order.

## Verification

- `npm run typecheck` clean
- `npm test` — **670 passed | 3 skipped** (was 658 baseline; +12 new tests in `tests/credential-pool-schema.test.ts` and `tests/model-discovery.test.ts`)
- **Live verified end-to-end with @pmos69's free Nous Portal subscription** (signed in via Google OAuth, real Nous inference endpoint):
  - ✅ `Nous Portal API Key` card renders in LLM Providers section
  - ✅ `Nous Portal (OAuth)` Sign-in card renders + button is clickable
  - ✅ OAuth device-code flow opens browser → user signs in with Google → tokens land in `auth.json` (`providers.nous` + `credential_pool.nous[0]` in canonical shape with `access_token`, `refresh_token`, `agent_key`, `auth_type: \"oauth\"`, `source: \"device_code\"`, `inference_base_url`, etc.)
  - ✅ `discoverProviderModels(\"nous\")` returns 244 models with `freeModels: [\"deepseek/deepseek-v4-flash:free\", \"openrouter/owl-alpha\"]`
  - ✅ Chat round-trip: switch `model.provider: \"nous\"` + `default: \"deepseek/deepseek-v4-flash:free\"` → send a prompt → real reply from `inference-api.nousresearch.com`: **\"NOUS WORKS\"**

Live-verify scripts persisted in `scripts/`:
  - `drive-nous-oauth.js` — drives the Sign-in card, captures verification URL + code, watches for completion
  - `drive-nous-chat.js` — switches the active model and sends a one-line probe
  - `verify-nous-discovery.js` — pins the discovery + free-flag contract against a real account
  - `repro-nous-cards-schema-367.js` — DOM-only check for card rendering + schema (no account needed)

## Migration safety

- Existing `{key, label}` entries in users' `auth.json` are **read** tolerantly but not rewritten. They stay as-is until the user re-adds them.
- Adding a Nous key through the UI now produces a working credential the engine can resolve — that's the new behaviour. Pre-fix, the same user action produced a non-functional entry.

Closes part of #367 (Bugs 1, 2, 3, plus the OAuth IPC + discovery infrastructure to make them work end-to-end). Sibling PR #369 handles Bug 4 (detection).