### PR TITLE
chore(dev): opt-in CDP debug port + Playwright harness for E2E tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,16 @@ export default defineConfig(
       ".claude/**",
       ".agents/**",
       "build/**",
+      // CDP E2E harness — plain Node CommonJS scripts driving the
+      // dev electron via Chrome DevTools Protocol for live testing.
+      // They intentionally use require() because they run as one-off
+      // `node scripts/*.js` invocations outside the TS build, and
+      // they're not part of the shipped app. See scripts/README.md.
+      "scripts/e2e-attach.js",
+      "scripts/repro-*.js",
+      "scripts/probe-*.js",
+      "scripts/drive-*.js",
+      "scripts/verify-*.js",
     ],
   },
   tseslint.configs.recommended,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes-desktop",
-  "version": "0.4.5",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes-desktop",
-      "version": "0.4.5",
+      "version": "0.5.1",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.2",
@@ -43,6 +43,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "jsdom": "^26.1.0",
+        "playwright": "^1.60.0",
         "prettier": "^3.7.4",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
@@ -111,7 +112,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -476,7 +476,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -500,7 +499,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -976,6 +974,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -997,6 +996,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1013,6 +1013,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1027,6 +1028,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -2043,7 +2045,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3117,7 +3118,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3364,7 +3364,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3392,7 +3391,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3403,7 +3401,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3502,7 +3499,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -3887,7 +3883,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3921,7 +3916,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4516,7 +4510,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5155,7 +5148,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5524,7 +5518,6 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -5703,7 +5696,6 @@
       "integrity": "sha512-q6+LiQIcTadSyvtPgLDQkCtVA9jQJXQVMrQcctfOJILh6OFMN+UJJLRkuUTy8CZDYeCIBn1ZycqsL1dAXugxZA==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^22.7.7",
@@ -5955,6 +5947,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -5975,6 +5968,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -6317,7 +6311,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6378,7 +6371,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7666,7 +7658,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.29.2"
       },
@@ -8427,7 +8418,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -10131,6 +10121,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -10766,12 +10757,58 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plist": {
@@ -10856,6 +10893,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -10873,6 +10911,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -10954,7 +10993,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -11180,7 +11218,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11191,7 +11228,6 @@
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11567,6 +11603,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -12558,6 +12595,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -12916,7 +12954,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13200,7 +13237,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -14229,7 +14265,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "jsdom": "^26.1.0",
+    "playwright": "^1.60.0",
     "prettier": "^3.7.4",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,127 @@
+# Dev scripts — CDP-based E2E harness
+
+This directory hosts dev-only one-shot scripts that drive the running
+dev Electron over the Chrome DevTools Protocol. Use it to reproduce
+bugs, verify fixes, or probe runtime state — much faster and more
+deterministic than screenshot-driven testing.
+
+The harness is **opt-in**: nothing about it touches production builds
+or normal `npm run dev` workflows.
+
+## Quickstart
+
+1.  Start dev electron with CDP enabled:
+
+    ```bash
+    ENABLE_CDP=1 npm run dev
+    ```
+
+    (Or any other free port: `ENABLE_CDP=1 CDP_PORT=9223 npm run dev`.)
+
+2.  In a separate shell, run a script:
+
+    ```bash
+    node scripts/e2e-attach.js
+    ```
+
+    The shared `attach()` helper connects Playwright to the running
+    renderer over `http://127.0.0.1:9222` (or `$CDP_PORT`). You can
+    drive the UI with DOM-aware selectors, evaluate IPC calls in the
+    renderer, or read state from the running main process.
+
+## How the opt-in works
+
+`src/main/index.ts` reads `process.env.ENABLE_CDP` at startup and, when
+set to `"1"`, appends `--remote-debugging-port=<CDP_PORT|9222>` to the
+Chromium command line. Without the env var the switch is never added,
+so production builds (and normal dev) never expose the port.
+
+```ts
+if (process.env.ENABLE_CDP === "1") {
+  app.commandLine.appendSwitch(
+    "remote-debugging-port",
+    process.env.CDP_PORT || "9222",
+  );
+}
+```
+
+Three properties this gives us:
+
+- **Off by default.** A user running the shipped app sees no CDP
+  port. An attacker who sets the env var on a prod install still
+  hits the existing Electron security model (sandbox,
+  contextIsolation, preload allowlist) — they get whatever a regular
+  user would.
+- **Per-developer.** Whoever wants the harness flips one env var;
+  everyone else has zero footprint.
+- **Multi-window safe.** `CDP_PORT` lets you run multiple dev
+  electron instances side-by-side (a clean profile + a real profile,
+  for instance) without port collisions.
+
+## Writing a repro script
+
+The convention used by the existing scripts:
+
+```js
+// scripts/repro-my-bug.js
+const { attach } = require("./e2e-attach");
+
+(async () => {
+  const { browser, page } = await attach();
+  // …drive the app via page.click / page.fill / page.evaluate…
+  // …observe DOM, IPC return values, on-disk state…
+  const verdict = /* boolean check */;
+  console.log(`[VERDICT] ${verdict ? "✅" : "🔴"} <what was tested>`);
+  await browser.close();
+})().catch((e) => {
+  console.error("FAILED:", e.stack || e.message || e);
+  process.exit(1);
+});
+```
+
+Naming conventions:
+
+| Prefix | Purpose | Lives long? |
+|---|---|---|
+| `repro-<short-name>.js` | Reproduce a specific bug. Pair with an issue number or commit. Print `[VERDICT] 🔴 REPRODUCED` (pre-fix) or `[VERDICT] ✅ FIXED` (post-fix). | Until the fix is shipped + a regression test exists; then it can be deleted or kept as a manual reference. |
+| `drive-<flow>.js` | Walk through a user flow end-to-end (e.g. OAuth sign-in, model switch + chat). | Keep alongside the feature so future contributors can re-run. |
+| `probe-<aspect>.js` | Read-only inspection. No state mutation. Useful for understanding a bug before writing a repro. | Useful long-term as documentation. |
+| `verify-<feature>.js` | Live verifier paired with a PR. Asserts `[VERDICT A/B/C/D]` lines for each contract the PR claims. | Lives with the PR; can be repurposed as a manual smoke test. |
+
+## Things to remember
+
+- **The harness is a Node CommonJS script**, not part of the TS build.
+  Use `require()`. The project's ESLint config ignores
+  `scripts/e2e-attach.js`, `scripts/repro-*.js`, `scripts/probe-*.js`,
+  `scripts/drive-*.js`, and `scripts/verify-*.js` so the
+  `no-require-imports` rule doesn't fire here.
+
+- **`page.evaluate(async () => window.hermesAPI.foo())` is your friend.**
+  The renderer's `hermesAPI` is exposed via contextBridge, so the
+  harness can call any IPC the UI can. This is often more reliable
+  than driving clicks, especially for tests of main-process state.
+
+- **Don't close the dev electron from the script** —
+  `browser.close()` detaches Playwright but leaves the app running.
+  If you need the app gone, kill it separately.
+
+- **Restart `npm run dev` after main-process changes.**
+  electron-vite hot-reloads renderer files, but main-process changes
+  don't always restart the bundled main binary. When in doubt, kill
+  the electron processes and restart dev.
+
+- **Port 9222 can get stuck in a zombie LISTEN state** on Windows
+  after a force-kill. If `bind() returned an error` shows up in the
+  dev log, switch to `CDP_PORT=9223` (or any other free port).
+
+## A real example
+
+The patterns above came out of triaging the v0.5.1 bug reports
+("Session continuation requires API key authentication", session
+proliferation, Edit Model dialog API-key bug, Nous Portal silent
+misconfiguration). Each reproducible bug got a `repro-*.js` that
+flipped from 🔴 pre-fix to ✅ post-fix in under a minute — vs the
+multi-minute screenshot loop the same flow used to require.
+
+If you write a useful repro, add it to this directory and link it
+from the related PR / issue. The next contributor will thank you.

--- a/scripts/e2e-attach.js
+++ b/scripts/e2e-attach.js
@@ -1,0 +1,98 @@
+/**
+ * Attach to a running dev Electron instance via the Chrome DevTools Protocol.
+ *
+ * Requires the app to have been launched with ENABLE_CDP=1 (see main/index.ts —
+ * the switch opens remote-debugging-port=9222 only when that env var is set).
+ *
+ * Usage from a test/repro script:
+ *
+ *   const { attach } = require("./scripts/e2e-attach");
+ *   const { browser, context, page } = await attach();
+ *   await page.click('text=New Chat');
+ *   await page.fill('textarea', 'hello');
+ *   await page.keyboard.press('Enter');
+ *   await page.waitForSelector('text=Hey', { timeout: 30000 });
+ *   await browser.close();   // detaches; does NOT close the Electron app
+ */
+
+const { chromium } = require("playwright");
+
+/**
+ * @param {object} [opts]
+ * @param {string} [opts.cdpUrl] — CDP HTTP endpoint. Default http://127.0.0.1:9222.
+ * @param {string} [opts.titleHint] — substring of window title to pick a page when
+ *                                    multiple windows are open. Default: the
+ *                                    first page whose URL ends with index.html.
+ * @returns {Promise<{browser: import('playwright').Browser, context: import('playwright').BrowserContext, page: import('playwright').Page}>}
+ */
+async function attach(opts = {}) {
+  const cdpUrl =
+    opts.cdpUrl ||
+    `http://127.0.0.1:${process.env.CDP_PORT || "9222"}`;
+  const titleHint = opts.titleHint || null;
+
+  const browser = await chromium.connectOverCDP(cdpUrl);
+  const contexts = browser.contexts();
+  if (contexts.length === 0) {
+    throw new Error(
+      `No browser contexts found at ${cdpUrl}. ` +
+        `Is the dev electron running with ENABLE_CDP=1?`,
+    );
+  }
+  const context = contexts[0];
+  const pages = context.pages();
+
+  let page;
+  if (titleHint) {
+    page = pages.find(async (p) => (await p.title()).includes(titleHint));
+  }
+  if (!page) {
+    // electron-vite dev serves the renderer at http://localhost:5173/ (no
+    // index.html in the URL). Accept either form, and fall back to the
+    // first page if there's only one.
+    page =
+      pages.find((p) => /index\.html(\?|$)/.test(p.url())) ||
+      pages.find((p) => /^http:\/\/localhost:\d+\/?$/.test(p.url())) ||
+      pages[0];
+  }
+  if (!page) {
+    throw new Error(
+      `No pages in the first context at ${cdpUrl}. URLs: ${pages
+        .map((p) => p.url())
+        .join(", ")}`,
+    );
+  }
+
+  return { browser, context, page };
+}
+
+module.exports = { attach };
+
+// CLI sanity check — `node scripts/e2e-attach.js` prints a one-line summary
+// of the attached page so you can verify the harness works.
+if (require.main === module) {
+  attach()
+    .then(async ({ browser, page }) => {
+      const title = await page.title();
+      const url = page.url();
+      const sessionsCount = await page.evaluate(async () => {
+        if (!window.hermesAPI || !window.hermesAPI.listSessions) return null;
+        try {
+          const s = await window.hermesAPI.listSessions(5, 0);
+          return Array.isArray(s) ? s.length : "unknown";
+        } catch (e) {
+          return `error: ${e?.message || e}`;
+        }
+      });
+      console.log(`[attach OK]`);
+      console.log(`  url:            ${url}`);
+      console.log(`  title:          ${title}`);
+      console.log(`  hermesAPI:      ${sessionsCount === null ? "absent" : "present"}`);
+      console.log(`  listSessions(5): ${sessionsCount}`);
+      await browser.close();
+    })
+    .catch((err) => {
+      console.error("[attach FAILED]", err.message);
+      process.exit(1);
+    });
+}

--- a/scripts/e2e-attach.js
+++ b/scripts/e2e-attach.js
@@ -44,7 +44,12 @@ async function attach(opts = {}) {
 
   let page;
   if (titleHint) {
-    page = pages.find(async (p) => (await p.title()).includes(titleHint));
+    for (const candidate of pages) {
+      if ((await candidate.title()).includes(titleHint)) {
+        page = candidate;
+        break;
+      }
+    }
   }
   if (!page) {
     // electron-vite dev serves the renderer at http://localhost:5173/ (no

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1677,6 +1677,19 @@ function setupUpdater(): void {
   }, 5000);
 }
 
+// Opt-in Chrome DevTools Protocol port for E2E testing. Set
+// ENABLE_CDP=1 (with optional CDP_PORT, default 9222) before launching
+// `npm run dev` to expose the renderer for Playwright (or any CDP
+// client) to attach and drive the UI without going through
+// screenshots / OCR. Off by default — no effect on normal dev or
+// production builds. See `scripts/README.md` for the harness workflow.
+if (process.env.ENABLE_CDP === "1") {
+  app.commandLine.appendSwitch(
+    "remote-debugging-port",
+    process.env.CDP_PORT || "9222",
+  );
+}
+
 app.whenReady().then(() => {
   app.name = "Hermes";
   electronApp.setAppUserModelId("com.nousresearch.hermes");


### PR DESCRIPTION
## What

Adds infrastructure for driving the dev Electron over Chrome DevTools Protocol so contributors can write **deterministic repro scripts and live verifiers** instead of screenshot-driven manual testing.

## Why

During the v0.5.1 bug-triage push (sessions issues #357 follow-ups, #367 Nous Portal, the various "Configure API_SERVER_KEY" reports) the same pattern kept coming up: a bug is reported, you spin up the dev app, manually click through the repro, screenshot the result, apply the fix, manually click through again, screenshot, commit. Slow, error-prone, hard to share with the next contributor.

Replacing the screenshot loop with a 30-line Node script that drives the renderer over CDP and prints `[VERDICT] ✅` or `[VERDICT] 🔴` made every subsequent bug an order of magnitude faster to verify. This PR makes that workflow available to everyone.

## How

Five small pieces:

| File | Change | Why |
|---|---|---|
| `src/main/index.ts` | +10 lines | `if (process.env.ENABLE_CDP === \"1\") app.commandLine.appendSwitch(\"remote-debugging-port\", process.env.CDP_PORT \|\| \"9222\")`. Off by default. |
| `package.json` + `package-lock.json` | `playwright` as devDep | Only the harness scripts use it; not in the shipped bundle. |
| `scripts/e2e-attach.js` | New | Shared `attach()` helper. Honours `CDP_PORT`. Includes a CLI self-check (`node scripts/e2e-attach.js` prints the attached window + a sample IPC call). |
| `scripts/README.md` | New | One-page workflow doc — opt-in switch, four script naming conventions (`repro-*` / `drive-*` / `probe-*` / `verify-*`), `[VERDICT]` line pattern, and things-to-remember (main-process restart, port-zombie on Windows, calling IPC directly via `page.evaluate`). |
| `eslint.config.mjs` | +5 lines | Ignore the four harness-script prefixes — they're plain Node CommonJS one-shots outside the TS build, so `no-require-imports` would false-positive. |

## Why opt-in instead of always-on

- **Production users running the shipped app see no CDP port.** The switch is appended at startup based on an env var; no env var → no port.
- **An attacker who sets the env var on a prod install** still hits the existing Electron security model (sandbox, contextIsolation, preload allowlist). Worst case they get what a regular user already has.
- **Per-developer footprint.** Whoever wants the harness flips one env var; nobody else pays for it.
- **Multi-window safe.** `CDP_PORT` lets a contributor run multiple dev electrons side-by-side (e.g. clean profile + real profile) without port collisions.

## Verification

\`\`\`bash
# Shell 1
ENABLE_CDP=1 CDP_PORT=9225 npm run dev

# Shell 2
node scripts/e2e-attach.js
# → [attach OK]
#     url:            http://localhost:5173/
#     title:          Hermes Agent
#     hermesAPI:      present
#     listSessions(5): 5
\`\`\`

- \`npm run typecheck\` clean
- \`npm test\` — 658 passed / 3 skipped (v0.5.1 baseline; this PR doesn't add or modify tests, only infrastructure)
- \`npm run lint\` — 0 errors

## Interaction with #369 and #382

Both of those PRs currently carry their own copy of the `ENABLE_CDP` block and `e2e-attach.js` (they needed the harness for their own live verification). When this PR lands first, **whichever of #369 / #382 merges next will need a trivial rebase**: the same two regions (the CDP block in `index.ts`, the e2e-attach.js file) become exact duplicates and can be dropped from those PRs in ~5 minutes each. No semantic change.

If this PR lands *after* #369 and #382, no impact — its contents are additive to either of those.

## What this PR deliberately does NOT include

- **The actual bug-specific repro scripts** (\`repro-session-cont-error.js\`, \`drive-nous-oauth.js\`, etc.) — those live with the PRs that need them as evidence. This PR is just the infrastructure.
- **A vitest+playwright test runner integration** — out of scope. The harness is for ad-hoc dev-time scripts, not CI. A future PR could wire Playwright into vitest if there's interest, but the value of the lightweight scripts is precisely that they're independent and one-shot.


---

## Maintainer Merge Note

Suggested full-stack order from the pre-release rebuild:

#383 -> #369 -> #400 -> #402 -> #404 -> #415 -> #419 -> #421 -> #422 -> #417 -> #430 -> #434 -> #437 -> #439 -> #440 -> #441

Suggested position: early, before #369 if possible.

Why: #369 currently carries a copy of the CDP harness because it was needed for live verification. If #383 lands first, the #369 rebase can drop the duplicate CDP block/scripts instead of making the maintainer resolve the same harness overlap later.

