### PR TITLE
feat(kanban): tooltips on header + add-board buttons

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -5776,7 +5776,9 @@ body {
   color: var(--error);
 }
 
-.kanban-card-action[data-tooltip]::after {
+.kanban-card-action[data-tooltip]::after,
+.kanban-header .btn[data-tooltip]::after,
+.kanban-board-chip-add[data-tooltip]::after {
   content: attr(data-tooltip);
   position: absolute;
   bottom: calc(100% + 6px);
@@ -5796,8 +5798,27 @@ body {
   z-index: 10;
 }
 
-.kanban-card-action[data-tooltip]:hover::after {
+.kanban-card-action[data-tooltip]:hover::after,
+.kanban-header .btn[data-tooltip]:hover:not(:disabled)::after,
+.kanban-board-chip-add[data-tooltip]:hover::after {
   opacity: 1;
+}
+
+/* Header buttons + add-board chip need an anchor for the absolutely-
+   positioned tooltip pseudo-element. The card actions already have
+   position:relative from their main rule. */
+.kanban-header .btn[data-tooltip],
+.kanban-board-chip-add[data-tooltip] {
+  position: relative;
+}
+
+/* The rightmost header button (New task) sits hard against the pane
+   edge, so its centered tooltip clips the viewport. Anchor to the
+   button's right edge instead. */
+.kanban-header .schedules-header-actions .btn[data-tooltip]:last-child::after {
+  left: auto;
+  right: 0;
+  transform: none;
 }
 
 /* Detail modal */

--- a/src/renderer/src/screens/Kanban/Kanban.tsx
+++ b/src/renderer/src/screens/Kanban/Kanban.tsx
@@ -567,6 +567,7 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
             className="btn btn-secondary"
             onClick={() => loadAll()}
             disabled={actionBusy !== null}
+            data-tooltip={t("kanban.refreshTooltip")}
           >
             <Refresh size={14} />
             {t("kanban.refresh")}
@@ -585,6 +586,7 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
               <button
                 className="btn btn-primary"
                 onClick={() => setShowCreate(true)}
+                data-tooltip={t("kanban.newTaskTooltip")}
               >
                 <Plus size={14} />
                 {t("kanban.newTask")}
@@ -635,6 +637,7 @@ function Kanban({ profile, visible }: KanbanProps): React.JSX.Element {
             <button
               className="kanban-board-chip kanban-board-chip-add"
               onClick={() => setShowNewBoard(true)}
+              data-tooltip={t("kanban.newBoardTooltip")}
             >
               <Plus size={12} />
               {t("kanban.newBoard")}

--- a/src/shared/i18n/locales/en/kanban.ts
+++ b/src/shared/i18n/locales/en/kanban.ts
@@ -5,11 +5,14 @@ export default {
 
   // Header actions
   refresh: "Refresh",
+  refreshTooltip: "Reload boards and tasks from the agent",
   dispatch: "Dispatch",
   dispatchTooltip:
     "Run one dispatcher pass — promote ready tasks and spawn workers",
   newTask: "New task",
+  newTaskTooltip: "Create a new task on the current board",
   newBoard: "New board",
+  newBoardTooltip: "Create a new kanban board",
 
   // Remote-mode unsupported notice
   remoteUnsupportedTitle:

--- a/src/shared/i18n/locales/pt-PT/kanban.ts
+++ b/src/shared/i18n/locales/pt-PT/kanban.ts
@@ -5,11 +5,14 @@ export default {
 
   // Header actions
   refresh: "Actualizar",
+  refreshTooltip: "Recarregar quadros e tarefas a partir do agente",
   dispatch: "Despachar",
   dispatchTooltip:
     "Executar uma passagem do despachante — promover tarefas prontas e iniciar trabalhadores",
   newTask: "Nova tarefa",
+  newTaskTooltip: "Criar uma nova tarefa no quadro actual",
   newBoard: "Novo quadro",
+  newBoardTooltip: "Criar um novo quadro kanban",
 
   // Remote-mode unsupported notice
   remoteUnsupportedTitle:


### PR DESCRIPTION
## Summary

Adds hover tooltips to the four buttons in the Kanban pane that didn't have any: **Refresh**, **New task**, **+ New board**, and fixes a latent bug where **Dispatch** already had a tooltip string in code but the CSS never rendered it.

## Why

Picked up from user feedback on the Kanban pane. The action buttons in the header carry no hover hints — Dispatch in particular is non-obvious (it runs one dispatcher pass to promote ready tasks and spawn workers, but the button label alone doesn't convey that). New users had to either read docs or guess.

While wiring this up I noticed the Dispatch button already had a \`data-tooltip\` attribute in JSX, but no CSS rule matched \`.btn[data-tooltip]\` — only \`.schedules-action-btn[data-tooltip]\` and \`.kanban-card-action[data-tooltip]\` had the \`::after\` pseudo-element styled. So that tooltip was silently broken. Confirmed via DOM inspection: attribute present, pseudo-element \`content\` was \`none\`.

## What changed

| File | Change |
|------|--------|
| \`Kanban.tsx\` | Add \`data-tooltip\` to Refresh, New task, + New board. Dispatch already had one (now actually renders). |
| \`main.css\` | Extend the existing \`.kanban-card-action[data-tooltip]\` tooltip rule to also cover \`.kanban-header .btn[data-tooltip]\` and \`.kanban-board-chip-add[data-tooltip]\`, reusing the same positioning/styling so all kanban-pane tooltips look identical. Right-anchor the last header button's tooltip so New task's hint doesn't clip the right edge. |
| \`en/kanban.ts\`, \`pt-PT/kanban.ts\` | Three new keys: \`refreshTooltip\`, \`newTaskTooltip\`, \`newBoardTooltip\`. Other locales fall back to en via i18next. |

No new components, no new dependencies, no IPC surface — pure UI polish.

## Test plan

- [x] Typecheck (\`npx tsc --noEmit\`) passes
- [x] Lint clean on touched files (only pre-existing CRLF warnings on the rest of the repo)
- [x] Live-verified in dev electron: hovered each of the four buttons via Playwright CDP attach, confirmed \`::after\` opacity transitions 0 → 1 on hover, captured screenshots of all four tooltips fully visible with correct copy
- [x] Confirmed the right-most button's tooltip (New task) no longer clips the viewport edge