### PR TITLE
fix(office): guard executeJavaScript against pre-dom-ready throw

### DIFF
--- a/src/renderer/src/screens/Office/Office.tsx
+++ b/src/renderer/src/screens/Office/Office.tsx
@@ -123,11 +123,17 @@ function Office({
     const ONBOARDING_JS = `try { localStorage.setItem("claw3d:onboarding:completed", "true") } catch(e) {}`;
 
     // Inject onboarding flag as early as possible (before Claw3D's scripts run).
-    // did-start-loading fires before any page resources load, so the injection
-    // is queued early enough that Claw3D's useOnboardingState hook sees it.
+    // did-start-loading fires before any page resources load, so the first
+    // attempt may run before the webview is attached + dom-ready has fired.
+    // Electron throws *synchronously* in that case ("WebView must be attached
+    // to the DOM and the dom-ready event emitted before this method can be
+    // called"). Catch that — the dom-ready handler below re-injects.
     const injectOnboardingFlag = (): void => {
-      if (wv.executeJavaScript) {
+      if (!wv.executeJavaScript) return;
+      try {
         wv.executeJavaScript(ONBOARDING_JS).catch(() => {});
+      } catch {
+        // Pre-dom-ready synchronous throw; safe to ignore — re-injected on dom-ready.
       }
     };
 


### PR DESCRIPTION
## Fix: Office tab — `executeJavaScript` synchronous throw before dom-ready

### Problem

When the Office tab is opened, the Claw3D `<webview>`'s
`did-start-loading` handler tries to inject an onboarding flag
via `executeJavaScript` so that Claw3D's `useOnboardingState`
hook sees the desktop-managed setting.

`did-start-loading` fires *before* the webview is fully attached
to the DOM and `dom-ready` has emitted. Electron's `WebContents`
throws **synchronously** in that case:

> The WebView must be attached to the DOM and the dom-ready
> event emitted before this method can be called.

The previous code attached a `.catch()` to the returned Promise,
which handles the async path — but the synchronous throw bypasses
that and surfaces as an unhandled `[RENDERER ERROR]` in the
console every time the Office tab opens.

### Fix

Wrap the call in `try/catch` so the synchronous pre-dom-ready
throw is swallowed silently. The existing `dom-ready` handler
below already re-injects the onboarding flag defensively once the
webview is ready, so dropping the early call has no functional
impact — it was always a best-effort early injection.

```ts
const injectOnboardingFlag = (): void => {
  if (!wv.executeJavaScript) return;
  try {
    wv.executeJavaScript(ONBOARDING_JS).catch(() => {});
  } catch {
    // Pre-dom-ready synchronous throw; safe to ignore —
    // re-injected on dom-ready.
  }
};
```

### Scope

One file, +9 / −3. No tests added because the throw is a timing
race condition inside Electron's webview lifecycle — synthetic
coverage would just mock the throw itself. The console-error
disappearance is the observable change.

### How to verify

1. `npm run dev`
2. Open the Office tab
3. Watch the dev-tools console — no `[RENDERER ERROR]` line
   mentioning `executeJavaScript` / `WebView must be attached`
4. Open another tab and come back — the onboarding flag is still
   set (the `dom-ready` handler injection still fires)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
