### PR TITLE
fix(compat): write host-derived <VENDOR>_API_KEY for custom providers

### DIFF
--- a/scripts/verify-compat-host-derived-key.js
+++ b/scripts/verify-compat-host-derived-key.js
@@ -1,0 +1,190 @@
+/**
+ * Live-verify the dual-engine compat fix for host-derived <VENDOR>_API_KEY.
+ *
+ * Confirms that when the desktop spawns the hermes-agent subprocess for a
+ * custom-provider chat against a known-vendor host (e.g. api.deepseek.com),
+ * the child env contains BOTH:
+ *   - OPENAI_API_KEY (so old engine v2026.5.16 / v0.14.0 keeps working)
+ *   - <VENDOR>_API_KEY (so post-2026.5.16 engines with
+ *     hermes_cli/runtime_provider.py::_host_derived_api_key find a key)
+ *
+ * Probe strategy: seed a custom_providers.json with a fake-key deepseek
+ * provider, kick a chat via IPC, and capture the gateway error. With the
+ * fix in place:
+ *
+ *   - Old engine (v2026.5.16): reads OPENAI_API_KEY, forwards to
+ *     api.deepseek.com, deepseek returns 401 "Invalid API key" — key
+ *     reached the API.
+ *   - New engine (post-host-derive): reads DEEPSEEK_API_KEY via host-derive,
+ *     forwards to api.deepseek.com, same 401 from deepseek.
+ *
+ * Without the fix on a host-derive-aware engine: chat fails earlier with
+ * "no-key-required" or missing-key error before reaching deepseek.
+ *
+ * Prereqs:
+ *   1. Dev electron running with ENABLE_CDP=1 (port 9222 by default)
+ *   2. Main process built from `fix/compat-host-derived-api-key` branch
+ *   3. For the "old engine" leg: HERMES_HOME=%LocalAppData%/hermes-oldengine
+ *      (set BEFORE `npm run dev` — see .personal/engine-update-audit.md
+ *      Phase 0 for setup instructions)
+ *   4. For the "new engine" leg: HERMES_HOME=%LocalAppData%/hermes-newengine
+ *
+ * Run:   node scripts/verify-compat-host-derived-key.js
+ */
+
+const { chromium } = require("playwright");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const FAKE_KEY = "sk-fake-deepseek-compat-test-12345";
+const PROVIDER_NAME = "_compat_test_deepseek";
+const BASE_URL = "https://api.deepseek.com/v1";
+
+async function attach() {
+  const cdpUrl = `http://127.0.0.1:${process.env.CDP_PORT || "9222"}`;
+  const browser = await chromium.connectOverCDP(cdpUrl);
+  const page = browser.contexts()[0].pages()[0];
+  return { browser, page };
+}
+
+(async () => {
+  const { browser, page } = await attach();
+
+  // Phase A — observe which engine + HERMES_HOME the desktop is wired to
+  const home = await page.evaluate(
+    async () => await window.hermesAPI.getHermesHome(),
+  );
+  const engine = await page.evaluate(
+    async () => await window.hermesAPI.getHermesVersion(),
+  );
+  console.log("HERMES_HOME:", home);
+  console.log("Engine version:", engine);
+  const isOldEngine = home.toLowerCase().includes("hermes-oldengine");
+  const isNewEngine = home.toLowerCase().includes("hermes-newengine");
+  const flavor = isOldEngine ? "OLD" : isNewEngine ? "NEW" : "DEFAULT";
+  console.log(`Test leg: ${flavor}`);
+
+  // Phase B — seed a custom provider via direct JSON write (no add-provider
+  // IPC exists in the renderer surface; the desktop loads custom_providers.json
+  // on the next listModels call).
+  const cpFile = path.join(home, "custom_providers.json");
+  let cps = [];
+  if (fs.existsSync(cpFile)) {
+    try {
+      cps = JSON.parse(fs.readFileSync(cpFile, "utf-8"));
+    } catch {
+      cps = [];
+    }
+  }
+  const existing = cps.findIndex((c) => c.name === PROVIDER_NAME);
+  const entry = {
+    name: PROVIDER_NAME,
+    provider: "custom",
+    model: "deepseek-chat",
+    baseUrl: BASE_URL,
+    apiKey: FAKE_KEY,
+    apiMode: null,
+  };
+  if (existing >= 0) cps[existing] = entry;
+  else cps.push(entry);
+  fs.writeFileSync(cpFile, JSON.stringify(cps, null, 2));
+  console.log(`[B] Seeded ${PROVIDER_NAME} → ${BASE_URL} into ${cpFile}`);
+
+  // Trigger a listModels so the desktop picks up the new entry and writes
+  // the CUSTOM_PROVIDER_<NAME>_KEY env var into .env.
+  const modelsAfter = await page.evaluate(
+    async () => await window.hermesAPI.listModels(),
+  );
+  const seeded = modelsAfter.find((m) => m.name === PROVIDER_NAME);
+  console.log(
+    "[B] listModels picked up entry:",
+    seeded ? `id=${seeded.id}` : "NO (failed to seed)",
+  );
+
+  // Phase C — activate the provider + send chat
+  console.log("\n[C] Activating provider + sending probe chat…");
+  await page.evaluate(
+    async ({ provider, model, baseUrl }) => {
+      await window.hermesAPI.setModelConfig(provider, model, baseUrl);
+    },
+    { provider: "custom", model: "deepseek-chat", baseUrl: BASE_URL },
+  );
+
+  let chatError = null;
+  let chatResult = null;
+  try {
+    chatResult = await page.evaluate(async () => {
+      // Pre-2026.5.16 sendMessage signature: (message, profile?, resumeSessionId?, history?, attachments?, contextFolder?)
+      return await window.hermesAPI.sendMessage("ping", undefined);
+    });
+  } catch (e) {
+    chatError = e.message || String(e);
+  }
+  const response =
+    (chatResult && JSON.stringify(chatResult)) || chatError || "(no output)";
+  console.log("\nResponse (truncated):", response.slice(0, 600));
+
+  // Phase D — verdict
+  const looksLikeDeepseekAuth = /401|Invalid.*[Aa]uthentication|invalid.*api.key/i.test(
+    response,
+  );
+  const looksLikeNoKey = /no.key.required|missing.*key|require.*api.key/i.test(
+    response,
+  );
+
+  console.log("\n=== VERDICT ===");
+  if (looksLikeDeepseekAuth) {
+    console.log(
+      `✅ PASS (${flavor} engine): key reached api.deepseek.com (401/auth-error).`,
+    );
+    console.log(
+      "   → Proves the desktop wrote the correct env var for this engine version.",
+    );
+  } else if (looksLikeNoKey) {
+    console.log(
+      `❌ FAIL (${flavor} engine): chat failed BEFORE reaching deepseek (missing-key).`,
+    );
+    if (flavor === "NEW") {
+      console.log(
+        "   → New engine couldn't find DEEPSEEK_API_KEY. Compat fix not active.",
+      );
+    } else {
+      console.log("   → Investigate — this shouldn't happen on the old engine.");
+    }
+    process.exitCode = 1;
+  } else {
+    console.log(
+      `⚠️  AMBIGUOUS (${flavor} engine): response doesn't clearly match auth-401 or no-key.`,
+    );
+    console.log("   Full response above. Manually classify.");
+    process.exitCode = 2;
+  }
+
+  // Phase E — teardown: remove the seeded entry, write back custom_providers.json
+  console.log("\n[E] Removing seeded provider…");
+  const remaining = cps.filter((c) => c.name !== PROVIDER_NAME);
+  if (remaining.length === 0 && fs.existsSync(cpFile)) {
+    fs.unlinkSync(cpFile);
+  } else {
+    fs.writeFileSync(cpFile, JSON.stringify(remaining, null, 2));
+  }
+  // Also wipe the CUSTOM_PROVIDER_<NAME>_KEY env var line the desktop wrote.
+  const envFile = path.join(home, ".env");
+  if (fs.existsSync(envFile)) {
+    const sanitizedName = PROVIDER_NAME.replace(/[^A-Za-z0-9]/g, "_").toUpperCase();
+    const envKey = `CUSTOM_PROVIDER_${sanitizedName}_KEY`;
+    const content = fs.readFileSync(envFile, "utf-8");
+    const cleaned = content
+      .split("\n")
+      .filter((l) => !l.startsWith(envKey + "="))
+      .join("\n");
+    fs.writeFileSync(envFile, cleaned);
+  }
+  console.log("Cleanup done.");
+
+  await browser.close();
+})().catch((e) => {
+  console.error("ERROR:", e.message || e);
+  process.exit(3);
+});

--- a/scripts/verify-compat-host-derived-key.js
+++ b/scripts/verify-compat-host-derived-key.js
@@ -1,44 +1,36 @@
 /**
  * Live-verify the dual-engine compat fix for host-derived <VENDOR>_API_KEY.
  *
- * Confirms that when the desktop spawns the hermes-agent subprocess for a
- * custom-provider chat against a known-vendor host (e.g. api.deepseek.com),
- * the child env contains BOTH:
- *   - OPENAI_API_KEY (so old engine v2026.5.16 / v0.14.0 keeps working)
- *   - <VENDOR>_API_KEY (so post-2026.5.16 engines with
- *     hermes_cli/runtime_provider.py::_host_derived_api_key find a key)
+ * Two paths needed compat:
+ *   1. CLI runtime spawn (`sendMessageViaCli`) — writes both
+ *      OPENAI_API_KEY (old engine) and <VENDOR>_API_KEY (new engine) into
+ *      the child process env at chat-send time.
+ *   2. Gateway persistence (`models.ts::seedDefaults`) — writes both
+ *      CUSTOM_PROVIDER_<NAME>_KEY (historical) and <VENDOR>_API_KEY
+ *      (new engine) into ~/.hermes/.env so the long-running gateway,
+ *      which only sees .env at startGateway time, has the right key.
  *
- * Probe strategy: seed a custom_providers.json with a fake-key deepseek
- * provider, kick a chat via IPC, and capture the gateway error. With the
- * fix in place:
+ * This script verifies (2) by:
+ *   - Appending a custom_providers entry to the active HERMES_HOME's
+ *     config.yaml (api.deepseek.com with a fake key)
+ *   - Triggering listModels() via IPC (causes seedDefaults to run)
+ *   - Reading .env back and asserting BOTH env-var names are present
  *
- *   - Old engine (v2026.5.16): reads OPENAI_API_KEY, forwards to
- *     api.deepseek.com, deepseek returns 401 "Invalid API key" — key
- *     reached the API.
- *   - New engine (post-host-derive): reads DEEPSEEK_API_KEY via host-derive,
- *     forwards to api.deepseek.com, same 401 from deepseek.
+ * (1) is covered by `tests/compat-host-derived-key.test.ts` (URL → envvar
+ * mapping) — the call-site uses the same helper.
  *
- * Without the fix on a host-derive-aware engine: chat fails earlier with
- * "no-key-required" or missing-key error before reaching deepseek.
- *
- * Prereqs:
- *   1. Dev electron running with ENABLE_CDP=1 (port 9222 by default)
- *   2. Main process built from `fix/compat-host-derived-api-key` branch
- *   3. For the "old engine" leg: HERMES_HOME=%LocalAppData%/hermes-oldengine
- *      (set BEFORE `npm run dev` — see .personal/engine-update-audit.md
- *      Phase 0 for setup instructions)
- *   4. For the "new engine" leg: HERMES_HOME=%LocalAppData%/hermes-newengine
- *
- * Run:   node scripts/verify-compat-host-derived-key.js
+ * Run against both engines:
+ *   $env:HERMES_HOME="$env:LocalAppData\hermes-oldengine"; $env:ENABLE_CDP=1; npm run dev
+ *   node scripts/verify-compat-host-derived-key.js
+ *   # then restart with HERMES_HOME=hermes-newengine and re-run.
  */
 
 const { chromium } = require("playwright");
 const fs = require("fs");
 const path = require("path");
-const os = require("os");
 
 const FAKE_KEY = "sk-fake-deepseek-compat-test-12345";
-const PROVIDER_NAME = "_compat_test_deepseek";
+const PROVIDER_NAME = "CompatTestDeepseek";
 const BASE_URL = "https://api.deepseek.com/v1";
 
 async function attach() {
@@ -51,7 +43,7 @@ async function attach() {
 (async () => {
   const { browser, page } = await attach();
 
-  // Phase A — observe which engine + HERMES_HOME the desktop is wired to
+  // Phase A — observe HERMES_HOME + engine version
   const home = await page.evaluate(
     async () => await window.hermesAPI.getHermesHome(),
   );
@@ -59,128 +51,113 @@ async function attach() {
     async () => await window.hermesAPI.getHermesVersion(),
   );
   console.log("HERMES_HOME:", home);
-  console.log("Engine version:", engine);
-  const isOldEngine = home.toLowerCase().includes("hermes-oldengine");
-  const isNewEngine = home.toLowerCase().includes("hermes-newengine");
-  const flavor = isOldEngine ? "OLD" : isNewEngine ? "NEW" : "DEFAULT";
-  console.log(`Test leg: ${flavor}`);
+  console.log("Engine:    ", engine);
+  const flavor = home.toLowerCase().includes("hermes-oldengine")
+    ? "OLD"
+    : home.toLowerCase().includes("hermes-newengine")
+      ? "NEW"
+      : "DEFAULT";
+  console.log("Test leg:  ", flavor);
 
-  // Phase B — seed a custom provider via direct JSON write (no add-provider
-  // IPC exists in the renderer surface; the desktop loads custom_providers.json
-  // on the next listModels call).
-  const cpFile = path.join(home, "custom_providers.json");
-  let cps = [];
-  if (fs.existsSync(cpFile)) {
-    try {
-      cps = JSON.parse(fs.readFileSync(cpFile, "utf-8"));
-    } catch {
-      cps = [];
-    }
+  const cfgFile = path.join(home, "config.yaml");
+  const envFile = path.join(home, ".env");
+
+  // Phase B — append custom_providers entry to config.yaml (if not present)
+  const cfg = fs.existsSync(cfgFile) ? fs.readFileSync(cfgFile, "utf-8") : "";
+  if (!cfg.includes(PROVIDER_NAME)) {
+    const append =
+      "\ncustom_providers:\n" +
+      `  - name: "${PROVIDER_NAME}"\n` +
+      `    model: "deepseek-chat"\n` +
+      `    base_url: "${BASE_URL}"\n` +
+      `    api_key: "${FAKE_KEY}"\n`;
+    fs.writeFileSync(cfgFile, cfg + append);
+    console.log("[B] Appended custom_providers entry to config.yaml");
+  } else {
+    console.log("[B] config.yaml already has", PROVIDER_NAME, "— continuing");
   }
-  const existing = cps.findIndex((c) => c.name === PROVIDER_NAME);
-  const entry = {
-    name: PROVIDER_NAME,
-    provider: "custom",
-    model: "deepseek-chat",
-    baseUrl: BASE_URL,
-    apiKey: FAKE_KEY,
-    apiMode: null,
-  };
-  if (existing >= 0) cps[existing] = entry;
-  else cps.push(entry);
-  fs.writeFileSync(cpFile, JSON.stringify(cps, null, 2));
-  console.log(`[B] Seeded ${PROVIDER_NAME} → ${BASE_URL} into ${cpFile}`);
 
-  // Trigger a listModels so the desktop picks up the new entry and writes
-  // the CUSTOM_PROVIDER_<NAME>_KEY env var into .env.
-  const modelsAfter = await page.evaluate(
+  // Phase C — force a fresh seedDefaults so .env gets re-persisted.
+  // The desktop seeds when listModels has no models.json. Easiest:
+  // delete models.json, then list.
+  const modelsFile = path.join(home, "models.json");
+  if (fs.existsSync(modelsFile)) {
+    fs.unlinkSync(modelsFile);
+    console.log("[C] Deleted models.json to force re-seed");
+  }
+  const listed = await page.evaluate(
     async () => await window.hermesAPI.listModels(),
   );
-  const seeded = modelsAfter.find((m) => m.name === PROVIDER_NAME);
+  const found = listed.find((m) => m.name === PROVIDER_NAME);
   console.log(
-    "[B] listModels picked up entry:",
-    seeded ? `id=${seeded.id}` : "NO (failed to seed)",
+    "[C] listModels picked up entry:",
+    found ? `id=${found.id}, baseUrl=${found.baseUrl}` : "✗ MISSING",
   );
 
-  // Phase C — activate the provider + send chat
-  console.log("\n[C] Activating provider + sending probe chat…");
-  await page.evaluate(
-    async ({ provider, model, baseUrl }) => {
-      await window.hermesAPI.setModelConfig(provider, model, baseUrl);
-    },
-    { provider: "custom", model: "deepseek-chat", baseUrl: BASE_URL },
+  // Phase D — read .env and assert both env-var names are written
+  const envContent = fs.existsSync(envFile) ? fs.readFileSync(envFile, "utf-8") : "";
+  const customPrefixKey = `CUSTOM_PROVIDER_${PROVIDER_NAME.toUpperCase()}_KEY`;
+  const hasCustomPrefix = new RegExp(`^${customPrefixKey}=${FAKE_KEY}$`, "m").test(
+    envContent,
+  );
+  const hasHostDerived = new RegExp(`^DEEPSEEK_API_KEY=${FAKE_KEY}$`, "m").test(
+    envContent,
   );
 
-  let chatError = null;
-  let chatResult = null;
-  try {
-    chatResult = await page.evaluate(async () => {
-      // Pre-2026.5.16 sendMessage signature: (message, profile?, resumeSessionId?, history?, attachments?, contextFolder?)
-      return await window.hermesAPI.sendMessage("ping", undefined);
-    });
-  } catch (e) {
-    chatError = e.message || String(e);
+  console.log("\n[D] .env contents (relevant lines):");
+  for (const line of envContent.split("\n")) {
+    if (/DEEPSEEK|CUSTOM_PROVIDER_COMPAT/.test(line)) {
+      console.log("  ", line);
+    }
   }
-  const response =
-    (chatResult && JSON.stringify(chatResult)) || chatError || "(no output)";
-  console.log("\nResponse (truncated):", response.slice(0, 600));
-
-  // Phase D — verdict
-  const looksLikeDeepseekAuth = /401|Invalid.*[Aa]uthentication|invalid.*api.key/i.test(
-    response,
-  );
-  const looksLikeNoKey = /no.key.required|missing.*key|require.*api.key/i.test(
-    response,
-  );
 
   console.log("\n=== VERDICT ===");
-  if (looksLikeDeepseekAuth) {
+  console.log(`  ${customPrefixKey}=${FAKE_KEY}: ${hasCustomPrefix ? "✓" : "✗"}`);
+  console.log(`  DEEPSEEK_API_KEY=${FAKE_KEY}:                ${hasHostDerived ? "✓" : "✗"}`);
+  if (hasCustomPrefix && hasHostDerived) {
     console.log(
-      `✅ PASS (${flavor} engine): key reached api.deepseek.com (401/auth-error).`,
+      `\n✅ PASS (${flavor} engine): both env-var names persisted to .env.`,
     );
     console.log(
-      "   → Proves the desktop wrote the correct env var for this engine version.",
+      "   → The long-running gateway will find DEEPSEEK_API_KEY on next startup.",
     );
-  } else if (looksLikeNoKey) {
     console.log(
-      `❌ FAIL (${flavor} engine): chat failed BEFORE reaching deepseek (missing-key).`,
+      "   → On the new engine, _host_derived_api_key() can resolve it.",
     );
-    if (flavor === "NEW") {
-      console.log(
-        "   → New engine couldn't find DEEPSEEK_API_KEY. Compat fix not active.",
-      );
-    } else {
-      console.log("   → Investigate — this shouldn't happen on the old engine.");
-    }
+  } else if (hasCustomPrefix && !hasHostDerived) {
+    console.log(
+      `\n❌ FAIL (${flavor} engine): only the custom-prefix form was persisted.`,
+    );
+    console.log(
+      "   → The new engine's host-derive resolver won't find a key for this provider.",
+    );
     process.exitCode = 1;
   } else {
     console.log(
-      `⚠️  AMBIGUOUS (${flavor} engine): response doesn't clearly match auth-401 or no-key.`,
+      `\n❌ FAIL (${flavor} engine): missing one or both env-var names.`,
     );
-    console.log("   Full response above. Manually classify.");
     process.exitCode = 2;
   }
 
-  // Phase E — teardown: remove the seeded entry, write back custom_providers.json
-  console.log("\n[E] Removing seeded provider…");
-  const remaining = cps.filter((c) => c.name !== PROVIDER_NAME);
-  if (remaining.length === 0 && fs.existsSync(cpFile)) {
-    fs.unlinkSync(cpFile);
-  } else {
-    fs.writeFileSync(cpFile, JSON.stringify(remaining, null, 2));
-  }
-  // Also wipe the CUSTOM_PROVIDER_<NAME>_KEY env var line the desktop wrote.
-  const envFile = path.join(home, ".env");
-  if (fs.existsSync(envFile)) {
-    const sanitizedName = PROVIDER_NAME.replace(/[^A-Za-z0-9]/g, "_").toUpperCase();
-    const envKey = `CUSTOM_PROVIDER_${sanitizedName}_KEY`;
-    const content = fs.readFileSync(envFile, "utf-8");
-    const cleaned = content
-      .split("\n")
-      .filter((l) => !l.startsWith(envKey + "="))
-      .join("\n");
-    fs.writeFileSync(envFile, cleaned);
-  }
+  // Phase E — teardown
+  console.log("\n[E] Removing test custom-provider entry…");
+  const cfgAfter = fs.readFileSync(cfgFile, "utf-8");
+  const cleanedCfg = cfgAfter.replace(
+    /\ncustom_providers:[\s\S]*?(?=\n[a-z_]+\s*:|$)/,
+    "",
+  );
+  fs.writeFileSync(cfgFile, cleanedCfg);
+
+  // Also wipe the two env vars we just wrote
+  const cleanedEnv = envContent
+    .split("\n")
+    .filter(
+      (l) =>
+        !l.startsWith(customPrefixKey + "=") &&
+        !l.startsWith(`DEEPSEEK_API_KEY=${FAKE_KEY}`),
+    )
+    .join("\n");
+  fs.writeFileSync(envFile, cleanedEnv);
   console.log("Cleanup done.");
 
   await browser.close();

--- a/scripts/verify-compat-host-derived-key.js
+++ b/scripts/verify-compat-host-derived-key.js
@@ -2,89 +2,92 @@
  * Live-verify the dual-engine compat fix for host-derived <VENDOR>_API_KEY.
  *
  * Two paths needed compat:
- *   1. CLI runtime spawn (`sendMessageViaCli`) — writes both
- *      OPENAI_API_KEY (old engine) and <VENDOR>_API_KEY (new engine) into
- *      the child process env at chat-send time.
- *   2. Gateway persistence (`models.ts::seedDefaults`) — writes both
- *      CUSTOM_PROVIDER_<NAME>_KEY (historical) and <VENDOR>_API_KEY
- *      (new engine) into ~/.hermes/.env so the long-running gateway,
- *      which only sees .env at startGateway time, has the right key.
+ *   1. CLI runtime spawn (`sendMessageViaCli`) writes both OPENAI_API_KEY
+ *      (old engine) and <VENDOR>_API_KEY (new engine) into the child env.
+ *   2. Gateway persistence (`models.ts::seedDefaults`) writes both
+ *      CUSTOM_PROVIDER_<NAME>_KEY and <VENDOR>_API_KEY into .env so the
+ *      long-running gateway can resolve custom provider keys from .env.
  *
- * This script verifies (2) by:
- *   - Appending a custom_providers entry to the active HERMES_HOME's
- *     config.yaml (api.deepseek.com with a fake key)
- *   - Triggering listModels() via IPC (causes seedDefaults to run)
- *   - Reading .env back and asserting BOTH env-var names are present
+ * This script verifies (2) against a running dev Electron instance. It
+ * snapshots config.yaml, .env, and models.json and restores them exactly
+ * in a finally block, because it intentionally forces a model re-seed.
  *
- * (1) is covered by `tests/compat-host-derived-key.test.ts` (URL → envvar
- * mapping) — the call-site uses the same helper.
- *
- * Run against both engines:
- *   $env:HERMES_HOME="$env:LocalAppData\hermes-oldengine"; $env:ENABLE_CDP=1; npm run dev
- *   node scripts/verify-compat-host-derived-key.js
- *   # then restart with HERMES_HOME=hermes-newengine and re-run.
+ * Example:
+ *   $env:ENABLE_CDP="1"; $env:CDP_PORT="9337"; npm run dev
+ *   $env:CDP_PORT="9337"; node scripts/verify-compat-host-derived-key.js
  */
 
-const { chromium } = require("playwright");
 const fs = require("fs");
 const path = require("path");
+const { attach } = require("./e2e-attach");
 
 const FAKE_KEY = "sk-fake-deepseek-compat-test-12345";
 const PROVIDER_NAME = "CompatTestDeepseek";
 const BASE_URL = "https://api.deepseek.com/v1";
 
-async function attach() {
-  const cdpUrl = `http://127.0.0.1:${process.env.CDP_PORT || "9222"}`;
-  const browser = await chromium.connectOverCDP(cdpUrl);
-  const page = browser.contexts()[0].pages()[0];
-  return { browser, page };
+function snapshotFile(file) {
+  if (!fs.existsSync(file)) return { exists: false, content: "" };
+  return { exists: true, content: fs.readFileSync(file, "utf-8") };
+}
+
+function restoreFile(file, snapshot) {
+  if (snapshot.exists) {
+    fs.writeFileSync(file, snapshot.content);
+  } else if (fs.existsSync(file)) {
+    fs.unlinkSync(file);
+  }
 }
 
 (async () => {
-  const { browser, page } = await attach();
+  let browser;
+  let page;
+  let cfgFile;
+  let envFile;
+  let modelsFile;
+  let cfgOriginal;
+  let envOriginal;
+  let modelsOriginal;
 
-  // Phase A — observe HERMES_HOME + engine version
-  const home = await page.evaluate(
-    async () => await window.hermesAPI.getHermesHome(),
-  );
-  const engine = await page.evaluate(
-    async () => await window.hermesAPI.getHermesVersion(),
-  );
-  console.log("HERMES_HOME:", home);
-  console.log("Engine:    ", engine);
-  const flavor = home.toLowerCase().includes("hermes-oldengine")
-    ? "OLD"
-    : home.toLowerCase().includes("hermes-newengine")
-      ? "NEW"
-      : "DEFAULT";
-  console.log("Test leg:  ", flavor);
+  try {
+    ({ browser, page } = await attach({ titleHint: "Hermes" }));
 
-  const cfgFile = path.join(home, "config.yaml");
-  const envFile = path.join(home, ".env");
-
-  // Phase A2 — snapshot original .env so we can restore on teardown, then
-  // strip any pre-existing DEEPSEEK_API_KEY so we can observe the fix
-  // writing one. The fix's "don't overwrite existing host-derived key"
-  // behaviour is correct (a real user key shouldn't be clobbered by a
-  // custom-provider seed) but it makes the test unobservable when the
-  // copied-from-user config already had DEEPSEEK_API_KEY.
-  const envOriginal = fs.existsSync(envFile)
-    ? fs.readFileSync(envFile, "utf-8")
-    : "";
-  const envWithoutHostKey = envOriginal
-    .split("\n")
-    .filter((l) => !l.startsWith("DEEPSEEK_API_KEY="))
-    .join("\n");
-  if (envWithoutHostKey !== envOriginal) {
-    fs.writeFileSync(envFile, envWithoutHostKey);
-    console.log(
-      "[A2] Stripped pre-existing DEEPSEEK_API_KEY so the fix's write is observable",
+    // Phase A - observe HERMES_HOME + engine version.
+    const home = await page.evaluate(
+      async () => await window.hermesAPI.getHermesHome(),
     );
-  }
+    const engine = await page.evaluate(
+      async () => await window.hermesAPI.getHermesVersion(),
+    );
+    console.log("HERMES_HOME:", home);
+    console.log("Engine:    ", engine);
+    const flavor = home.toLowerCase().includes("hermes-oldengine")
+      ? "OLD"
+      : home.toLowerCase().includes("hermes-newengine")
+        ? "NEW"
+        : "DEFAULT";
+    console.log("Test leg:  ", flavor);
 
-  // Phase B — append custom_providers entry to config.yaml (if not present)
-  const cfg = fs.existsSync(cfgFile) ? fs.readFileSync(cfgFile, "utf-8") : "";
-  if (!cfg.includes(PROVIDER_NAME)) {
+    cfgFile = path.join(home, "config.yaml");
+    envFile = path.join(home, ".env");
+    modelsFile = path.join(home, "models.json");
+    cfgOriginal = snapshotFile(cfgFile);
+    envOriginal = snapshotFile(envFile);
+    modelsOriginal = snapshotFile(modelsFile);
+
+    // Phase A2 - strip any pre-existing DEEPSEEK_API_KEY so the test can
+    // observe the fix writing one, then restore the exact original later.
+    const envBefore = envOriginal.exists ? envOriginal.content : "";
+    const envWithoutHostKey = envBefore
+      .split("\n")
+      .filter((line) => !line.startsWith("DEEPSEEK_API_KEY="))
+      .join("\n");
+    if (envWithoutHostKey !== envBefore) {
+      fs.writeFileSync(envFile, envWithoutHostKey);
+      console.log("[A2] Stripped pre-existing DEEPSEEK_API_KEY for observability");
+    }
+
+    // Phase B - append a custom provider entry to config.yaml.
+    const cfg = cfgOriginal.exists ? cfgOriginal.content : "";
     const append =
       "\ncustom_providers:\n" +
       `  - name: "${PROVIDER_NAME}"\n` +
@@ -92,86 +95,75 @@ async function attach() {
       `    base_url: "${BASE_URL}"\n` +
       `    api_key: "${FAKE_KEY}"\n`;
     fs.writeFileSync(cfgFile, cfg + append);
-    console.log("[B] Appended custom_providers entry to config.yaml");
-  } else {
-    console.log("[B] config.yaml already has", PROVIDER_NAME, "— continuing");
-  }
+    console.log("[B] Appended temporary custom provider to config.yaml");
 
-  // Phase C — force a fresh seedDefaults so .env gets re-persisted.
-  // The desktop seeds when listModels has no models.json. Easiest:
-  // delete models.json, then list.
-  const modelsFile = path.join(home, "models.json");
-  if (fs.existsSync(modelsFile)) {
-    fs.unlinkSync(modelsFile);
-    console.log("[C] Deleted models.json to force re-seed");
-  }
-  const listed = await page.evaluate(
-    async () => await window.hermesAPI.listModels(),
-  );
-  const found = listed.find((m) => m.name === PROVIDER_NAME);
-  console.log(
-    "[C] listModels picked up entry:",
-    found ? `id=${found.id}, baseUrl=${found.baseUrl}` : "✗ MISSING",
-  );
-
-  // Phase D — read .env and assert both env-var names are written
-  const envContent = fs.existsSync(envFile) ? fs.readFileSync(envFile, "utf-8") : "";
-  const customPrefixKey = `CUSTOM_PROVIDER_${PROVIDER_NAME.toUpperCase()}_KEY`;
-  const hasCustomPrefix = new RegExp(`^${customPrefixKey}=${FAKE_KEY}$`, "m").test(
-    envContent,
-  );
-  const hasHostDerived = new RegExp(`^DEEPSEEK_API_KEY=${FAKE_KEY}$`, "m").test(
-    envContent,
-  );
-
-  console.log("\n[D] .env contents (relevant lines):");
-  for (const line of envContent.split("\n")) {
-    if (/DEEPSEEK|CUSTOM_PROVIDER_COMPAT/.test(line)) {
-      console.log("  ", line);
+    // Phase C - force a fresh seedDefaults so .env gets re-persisted.
+    if (fs.existsSync(modelsFile)) {
+      fs.unlinkSync(modelsFile);
+      console.log("[C] Temporarily deleted models.json to force re-seed");
     }
+    const listed = await page.evaluate(
+      async () => await window.hermesAPI.listModels(),
+    );
+    const found = listed.find((model) => model.name === PROVIDER_NAME);
+    console.log(
+      "[C] listModels picked up entry:",
+      found ? `id=${found.id}, baseUrl=${found.baseUrl}` : "MISSING",
+    );
+
+    // Phase D - read .env and assert both env-var names are written.
+    const envContent = fs.existsSync(envFile)
+      ? fs.readFileSync(envFile, "utf-8")
+      : "";
+    const customPrefixKey = `CUSTOM_PROVIDER_${PROVIDER_NAME.toUpperCase()}_KEY`;
+    const hasCustomPrefix = new RegExp(
+      `^${customPrefixKey}=${FAKE_KEY}$`,
+      "m",
+    ).test(envContent);
+    const hasHostDerived = new RegExp(
+      `^DEEPSEEK_API_KEY=${FAKE_KEY}$`,
+      "m",
+    ).test(envContent);
+
+    console.log("\n[D] .env contents (relevant lines):");
+    for (const line of envContent.split("\n")) {
+      if (/DEEPSEEK|CUSTOM_PROVIDER_COMPAT/.test(line)) {
+        console.log("  ", line);
+      }
+    }
+
+    console.log("\n=== VERDICT ===");
+    console.log(
+      `  ${customPrefixKey}=${FAKE_KEY}: ${hasCustomPrefix ? "PASS" : "FAIL"}`,
+    );
+    console.log(
+      `  DEEPSEEK_API_KEY=${FAKE_KEY}:                ${hasHostDerived ? "PASS" : "FAIL"}`,
+    );
+    if (hasCustomPrefix && hasHostDerived) {
+      console.log(
+        `\nPASS (${flavor} engine): both env-var names persisted to .env.`,
+      );
+    } else if (hasCustomPrefix && !hasHostDerived) {
+      console.log(
+        `\nFAIL (${flavor} engine): only the custom-prefix form was persisted.`,
+      );
+      process.exitCode = 1;
+    } else {
+      console.log(
+        `\nFAIL (${flavor} engine): missing one or both env-var names.`,
+      );
+      process.exitCode = 2;
+    }
+  } catch (error) {
+    console.error("ERROR:", error.message || error);
+    process.exitCode = 3;
+  } finally {
+    if (cfgFile && cfgOriginal) restoreFile(cfgFile, cfgOriginal);
+    if (envFile && envOriginal) restoreFile(envFile, envOriginal);
+    if (modelsFile && modelsOriginal) restoreFile(modelsFile, modelsOriginal);
+    if (cfgFile) {
+      console.log("\n[E] Restored original config.yaml, .env, and models.json");
+    }
+    if (browser) await browser.close();
   }
-
-  console.log("\n=== VERDICT ===");
-  console.log(`  ${customPrefixKey}=${FAKE_KEY}: ${hasCustomPrefix ? "✓" : "✗"}`);
-  console.log(`  DEEPSEEK_API_KEY=${FAKE_KEY}:                ${hasHostDerived ? "✓" : "✗"}`);
-  if (hasCustomPrefix && hasHostDerived) {
-    console.log(
-      `\n✅ PASS (${flavor} engine): both env-var names persisted to .env.`,
-    );
-    console.log(
-      "   → The long-running gateway will find DEEPSEEK_API_KEY on next startup.",
-    );
-    console.log(
-      "   → On the new engine, _host_derived_api_key() can resolve it.",
-    );
-  } else if (hasCustomPrefix && !hasHostDerived) {
-    console.log(
-      `\n❌ FAIL (${flavor} engine): only the custom-prefix form was persisted.`,
-    );
-    console.log(
-      "   → The new engine's host-derive resolver won't find a key for this provider.",
-    );
-    process.exitCode = 1;
-  } else {
-    console.log(
-      `\n❌ FAIL (${flavor} engine): missing one or both env-var names.`,
-    );
-    process.exitCode = 2;
-  }
-
-  // Phase E — teardown: restore original .env and config.yaml exactly
-  console.log("\n[E] Restoring original .env and removing test entry…");
-  fs.writeFileSync(envFile, envOriginal);
-  const cfgAfter = fs.readFileSync(cfgFile, "utf-8");
-  const cleanedCfg = cfgAfter.replace(
-    /\ncustom_providers:[\s\S]*?(?=\n[a-z_]+\s*:|$)/,
-    "",
-  );
-  fs.writeFileSync(cfgFile, cleanedCfg);
-  console.log("Cleanup done.");
-
-  await browser.close();
-})().catch((e) => {
-  console.error("ERROR:", e.message || e);
-  process.exit(3);
-});
+})();

--- a/scripts/verify-compat-host-derived-key.js
+++ b/scripts/verify-compat-host-derived-key.js
@@ -62,6 +62,26 @@ async function attach() {
   const cfgFile = path.join(home, "config.yaml");
   const envFile = path.join(home, ".env");
 
+  // Phase A2 — snapshot original .env so we can restore on teardown, then
+  // strip any pre-existing DEEPSEEK_API_KEY so we can observe the fix
+  // writing one. The fix's "don't overwrite existing host-derived key"
+  // behaviour is correct (a real user key shouldn't be clobbered by a
+  // custom-provider seed) but it makes the test unobservable when the
+  // copied-from-user config already had DEEPSEEK_API_KEY.
+  const envOriginal = fs.existsSync(envFile)
+    ? fs.readFileSync(envFile, "utf-8")
+    : "";
+  const envWithoutHostKey = envOriginal
+    .split("\n")
+    .filter((l) => !l.startsWith("DEEPSEEK_API_KEY="))
+    .join("\n");
+  if (envWithoutHostKey !== envOriginal) {
+    fs.writeFileSync(envFile, envWithoutHostKey);
+    console.log(
+      "[A2] Stripped pre-existing DEEPSEEK_API_KEY so the fix's write is observable",
+    );
+  }
+
   // Phase B — append custom_providers entry to config.yaml (if not present)
   const cfg = fs.existsSync(cfgFile) ? fs.readFileSync(cfgFile, "utf-8") : "";
   if (!cfg.includes(PROVIDER_NAME)) {
@@ -139,25 +159,15 @@ async function attach() {
     process.exitCode = 2;
   }
 
-  // Phase E — teardown
-  console.log("\n[E] Removing test custom-provider entry…");
+  // Phase E — teardown: restore original .env and config.yaml exactly
+  console.log("\n[E] Restoring original .env and removing test entry…");
+  fs.writeFileSync(envFile, envOriginal);
   const cfgAfter = fs.readFileSync(cfgFile, "utf-8");
   const cleanedCfg = cfgAfter.replace(
     /\ncustom_providers:[\s\S]*?(?=\n[a-z_]+\s*:|$)/,
     "",
   );
   fs.writeFileSync(cfgFile, cleanedCfg);
-
-  // Also wipe the two env vars we just wrote
-  const cleanedEnv = envContent
-    .split("\n")
-    .filter(
-      (l) =>
-        !l.startsWith(customPrefixKey + "=") &&
-        !l.startsWith(`DEEPSEEK_API_KEY=${FAKE_KEY}`),
-    )
-    .join("\n");
-  fs.writeFileSync(envFile, cleanedEnv);
   console.log("Cleanup done.");
 
   await browser.close();

--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -930,13 +930,28 @@ function sendMessageViaCli(
       env.OPENAI_BASE_URL = mc.baseUrl.replace(/\/+$/, "");
     }
 
-    // Resolve the right API key: check URL-specific key first, then OPENAI_API_KEY
+    // Find the host-derived env-var name (if any). Used both for resolving
+    // the key here, AND for writing it back into the child env below so
+    // both old and new engines locate the same value:
+    //
+    //  - Old engine (≤ v0.14.0) routes via OPENAI_API_KEY + OPENAI_BASE_URL.
+    //  - Current upstream main refuses to forward OPENAI_API_KEY to a
+    //    non-openai host and instead derives <VENDOR>_API_KEY from the
+    //    URL host (see hermes_cli/runtime_provider.py::_host_derived_api_key).
+    //    Without the host-derived var in the child env, chat against a
+    //    custom provider on api.deepseek.com / api.groq.com / etc. falls
+    //    through to "no-key-required" and 401s.
+    //
+    // Writing both env-var forms is the additive compat strategy — each
+    // engine reads the form it knows; the unused one is dead weight.
+    const hostDerivedEnvKey = hostDerivedEnvKeyForUrl(mc.baseUrl);
+
+    // Resolve the right API key: host-derived first, then custom provider
+    // entry from models.json, then CUSTOM_API_KEY / OPENAI_API_KEY fallback.
     let resolvedKey = "";
-    for (const { pattern, envKey } of URL_KEY_MAP) {
-      if (pattern.test(mc.baseUrl)) {
-        resolvedKey = profileEnv[envKey] || env[envKey] || "";
-        break;
-      }
+    if (hostDerivedEnvKey) {
+      resolvedKey =
+        profileEnv[hostDerivedEnvKey] || env[hostDerivedEnvKey] || "";
     }
     if (!resolvedKey) {
       // Try custom provider auto-generated key from models.json
@@ -972,7 +987,25 @@ function sendMessageViaCli(
       env.OPENAI_API_KEY = resolvedKey || "no-key-required";
     }
 
-    delete env.OPENROUTER_API_KEY;
+    // Forward-compat with upstream main: also write the host-derived
+    // env var so `_host_derived_api_key` finds it. Only when the URL
+    // matches a known vendor (NOT for generic local LLMs), and only
+    // when we have a real key — never propagate "no-key-required" to
+    // a vendor-scoped slot, and never overwrite OPENAI_API_KEY /
+    // ANTHROPIC_API_KEY through this path (they're handled above).
+    if (
+      hostDerivedEnvKey &&
+      hostDerivedEnvKey !== "OPENAI_API_KEY" &&
+      hostDerivedEnvKey !== "ANTHROPIC_API_KEY" &&
+      resolvedKey &&
+      resolvedKey !== "no-key-required"
+    ) {
+      env[hostDerivedEnvKey] = resolvedKey;
+    }
+
+    if (hostDerivedEnvKey !== "OPENROUTER_API_KEY") {
+      delete env.OPENROUTER_API_KEY;
+    }
     delete env.ANTHROPIC_TOKEN;
     delete env.OPENROUTER_BASE_URL;
   }

--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -50,6 +50,7 @@ import {
   chatToolProgressLabel,
   type ChatToolEvent,
 } from "../shared/chat-stream";
+import { hostDerivedEnvKeyForUrl } from "./host-derived-env";
 
 /**
  * Resolve which profile a gateway call targets. An explicit profile always

--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -50,7 +50,10 @@ import {
   chatToolProgressLabel,
   type ChatToolEvent,
 } from "../shared/chat-stream";
-import { hostDerivedEnvKeyForUrl } from "./host-derived-env";
+import {
+  hostDerivedEnvKeyForUrl,
+  shouldPruneOpenRouterApiKey,
+} from "./host-derived-env";
 
 /**
  * Resolve which profile a gateway call targets. An explicit profile always
@@ -1004,7 +1007,7 @@ function sendMessageViaCli(
       env[hostDerivedEnvKey] = resolvedKey;
     }
 
-    if (hostDerivedEnvKey !== "OPENROUTER_API_KEY") {
+    if (shouldPruneOpenRouterApiKey(hostDerivedEnvKey)) {
       delete env.OPENROUTER_API_KEY;
     }
     delete env.ANTHROPIC_TOKEN;

--- a/src/main/host-derived-env.ts
+++ b/src/main/host-derived-env.ts
@@ -1,0 +1,31 @@
+import { URL_KEY_MAP } from "../shared/url-key-map";
+
+/**
+ * Shared URL → host-derived env-var lookup.
+ *
+ * This is a main-process wrapper around PR369's shared URL map. PR400
+ * depends on PR369 so the desktop only maintains one provider URL table.
+ */
+
+/**
+ * Return the canonical `<VENDOR>_API_KEY` env-var name for a base URL,
+ * or null if the URL doesn't match a known vendor pattern.
+ *
+ * Used by both:
+ *   - `hermes.ts` runtime spawn (CLI path) — writes the host-derived
+ *     var into the child process env so a freshly-spawned hermes-agent
+ *     can resolve the key.
+ *   - `models.ts` custom-provider persistence — writes the host-derived
+ *     var into `.env` so the long-running gateway (started from
+ *     `.env`-only state) can resolve it without a respawn.
+ *
+ * Local LLM hosts (localhost, 127.0.0.1, RFC1918) and unknown commercial
+ * hosts (e.g. unsloth.ai) intentionally return null — no vendor binding,
+ * the upstream engine falls back to `no-key-required` for those.
+ */
+export function hostDerivedEnvKeyForUrl(baseUrl: string): string | null {
+  for (const { pattern, envKey } of URL_KEY_MAP) {
+    if (pattern.test(baseUrl)) return envKey;
+  }
+  return null;
+}

--- a/src/main/host-derived-env.ts
+++ b/src/main/host-derived-env.ts
@@ -29,3 +29,9 @@ export function hostDerivedEnvKeyForUrl(baseUrl: string): string | null {
   }
   return null;
 }
+
+export function shouldPruneOpenRouterApiKey(
+  hostDerivedEnvKey: string | null,
+): boolean {
+  return hostDerivedEnvKey !== "OPENROUTER_API_KEY";
+}

--- a/src/main/models.ts
+++ b/src/main/models.ts
@@ -110,7 +110,7 @@ function seedDefaults(profile?: string): SavedModel[] {
         apiMode: cp.apiMode || null,
         createdAt: Date.now(),
       });
-      if (cp.apiKey) {
+      if (cp.apiKey && cp.apiKey !== "no-key-required") {
         try {
           let envContent = existsSync(envFile)
             ? readFileSync(envFile, "utf-8")

--- a/src/main/models.ts
+++ b/src/main/models.ts
@@ -3,6 +3,7 @@ import { join } from "path";
 import { randomUUID } from "crypto";
 import { HERMES_HOME } from "./installer";
 import { safeWriteFile, profilePaths } from "./utils";
+import { hostDerivedEnvKeyForUrl } from "./host-derived-env";
 import DEFAULT_MODELS from "./default-models";
 
 const MODELS_FILE = join(HERMES_HOME, "models.json");
@@ -114,17 +115,52 @@ function seedDefaults(profile?: string): SavedModel[] {
           let envContent = existsSync(envFile)
             ? readFileSync(envFile, "utf-8")
             : "";
-          const envKey =
+          // Names to persist for this custom-provider key:
+          //   1. CUSTOM_PROVIDER_<NAME>_KEY — the historical desktop
+          //      contract; the runtime spawn in `hermes.ts` reads it
+          //      via the models.json baseUrl match.
+          //   2. <VENDOR>_API_KEY when the URL matches a known vendor
+          //      host (e.g. api.deepseek.com → DEEPSEEK_API_KEY) —
+          //      required for dual-engine compat: upstream-main's
+          //      `_host_derived_api_key()` won't accept the custom-
+          //      prefix form. Old engine (≤ v2026.5.16) doesn't have
+          //      the host-derive resolver and ignores this extra var,
+          //      so writing both is additive and safe.
+          // The gateway path in `hermes.ts:startGateway` ingests ALL
+          // profile env vars at spawn, so the host-derived form has
+          // to live in .env (not just be set at chat-time) for the
+          // long-running gateway flow to work on the new engine.
+          const customPrefixKey =
             "CUSTOM_PROVIDER_" +
             cp.name.replace(/[^A-Za-z0-9]/g, "_").toUpperCase() +
             "_KEY";
-          const keyRegex = new RegExp(
-            "^" + envKey.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "=.*$",
-            "m",
-          );
-          if (!keyRegex.test(envContent)) {
-            envContent =
-              envContent.trimEnd() + "\n" + envKey + "=" + cp.apiKey + "\n";
+          const namesToWrite: string[] = [customPrefixKey];
+          const hostKey = hostDerivedEnvKeyForUrl(cp.baseUrl);
+          // Don't shadow real OPENAI / ANTHROPIC keys via this path —
+          // those belong to a separately-configured provider, not a
+          // custom-provider key. The persistence guard mirrors the
+          // runtime guard in `hermes.ts`.
+          if (
+            hostKey &&
+            hostKey !== "OPENAI_API_KEY" &&
+            hostKey !== "ANTHROPIC_API_KEY" &&
+            hostKey !== customPrefixKey
+          ) {
+            namesToWrite.push(hostKey);
+          }
+          let modified = false;
+          for (const envKey of namesToWrite) {
+            const keyRegex = new RegExp(
+              "^" + envKey.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "=.*$",
+              "m",
+            );
+            if (!keyRegex.test(envContent)) {
+              envContent =
+                envContent.trimEnd() + "\n" + envKey + "=" + cp.apiKey + "\n";
+              modified = true;
+            }
+          }
+          if (modified) {
             safeWriteFile(envFile, envContent);
           }
         } catch {

--- a/tests/compat-host-derived-key-persistence.test.ts
+++ b/tests/compat-host-derived-key-persistence.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -26,6 +32,7 @@ async function freshModels(): Promise<typeof import("../src/main/models")> {
 
 interface ProviderEntry {
   name: string;
+  provider: string;
   model: string;
   baseUrl: string;
   apiKey: string;
@@ -39,6 +46,7 @@ function writeCustomProviders(entries: ProviderEntry[]): void {
       .map(
         (e) =>
           `  - name: "${e.name}"\n` +
+          `    provider: "${e.provider}"\n` +
           `    model: "${e.model}"\n` +
           `    base_url: "${e.baseUrl}"\n` +
           `    api_key: "${e.apiKey}"\n`,
@@ -190,5 +198,25 @@ describe("custom-provider env persistence — dual-engine compat", () => {
     const deepseekMatches = envContent.match(/^DEEPSEEK_API_KEY=/gm) || [];
     expect(customMatches).toHaveLength(1);
     expect(deepseekMatches).toHaveLength(1);
+  });
+
+  it("does NOT persist the no-key-required sentinel to custom or host-derived env vars", async () => {
+    writeCustomProviders([
+      {
+        name: "LocalDeepseekCompat",
+        provider: "custom",
+        model: "deepseek-chat",
+        baseUrl: "https://api.deepseek.com/v1",
+        apiKey: "no-key-required",
+      },
+    ]);
+
+    const { listModels } = await freshModels();
+    listModels();
+
+    const envFile = join(testHome, ".env");
+    const envContent = existsSync(envFile) ? readFileSync(envFile, "utf-8") : "";
+    expect(envContent).not.toMatch(/^CUSTOM_PROVIDER_LOCALDEEPSEEKCOMPAT_KEY=/m);
+    expect(envContent).not.toMatch(/^DEEPSEEK_API_KEY=/m);
   });
 });

--- a/tests/compat-host-derived-key-persistence.test.ts
+++ b/tests/compat-host-derived-key-persistence.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+/**
+ * Dual-engine compat: when the desktop seeds a custom-provider key into
+ * `.env`, it writes both the historical `CUSTOM_PROVIDER_<NAME>_KEY`
+ * form (for the runtime spawn) AND the host-derived `<VENDOR>_API_KEY`
+ * form (for the long-running gateway, which only sees what's in `.env`
+ * at startGateway time).
+ *
+ * Without the second write, gateway-mode chat (the primary path the
+ * desktop uses when the gateway is up) breaks on engines that have
+ * `_host_derived_api_key()` — they refuse to forward OPENAI_API_KEY
+ * to a non-openai host and look for the host-derived form instead.
+ */
+
+let testHome: string;
+
+async function freshModels(): Promise<typeof import("../src/main/models")> {
+  vi.resetModules();
+  vi.stubEnv("HERMES_HOME", testHome);
+  return await import("../src/main/models");
+}
+
+interface ProviderEntry {
+  name: string;
+  model: string;
+  baseUrl: string;
+  apiKey: string;
+}
+
+function writeCustomProviders(entries: ProviderEntry[]): void {
+  // `loadCustomProviders` reads from config.yaml's `custom_providers:` block.
+  const yaml =
+    "custom_providers:\n" +
+    entries
+      .map(
+        (e) =>
+          `  - name: "${e.name}"\n` +
+          `    model: "${e.model}"\n` +
+          `    base_url: "${e.baseUrl}"\n` +
+          `    api_key: "${e.apiKey}"\n`,
+      )
+      .join("");
+  writeFileSync(join(testHome, "config.yaml"), yaml, "utf-8");
+}
+
+beforeEach(() => {
+  testHome = mkdtempSync(join(tmpdir(), "hermes-compat-persist-"));
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  rmSync(testHome, { recursive: true, force: true });
+});
+
+describe("custom-provider env persistence — dual-engine compat", () => {
+  it("writes BOTH CUSTOM_PROVIDER_<NAME>_KEY and host-derived DEEPSEEK_API_KEY for api.deepseek.com", async () => {
+    writeCustomProviders([
+      {
+        name: "MyDeepseek",
+        provider: "custom",
+        model: "deepseek-chat",
+        baseUrl: "https://api.deepseek.com/v1",
+        apiKey: "sk-deepseek-test-123",
+      },
+    ]);
+
+    const { listModels } = await freshModels();
+    listModels(); // triggers seedDefaults → persists env
+
+    const envContent = readFileSync(join(testHome, ".env"), "utf-8");
+    expect(envContent).toMatch(/^CUSTOM_PROVIDER_MYDEEPSEEK_KEY=sk-deepseek-test-123$/m);
+    expect(envContent).toMatch(/^DEEPSEEK_API_KEY=sk-deepseek-test-123$/m);
+  });
+
+  it("writes the host-derived form for groq and mistral too", async () => {
+    writeCustomProviders([
+      {
+        name: "MyGroq",
+        provider: "custom",
+        model: "llama-x",
+        baseUrl: "https://api.groq.com/openai/v1",
+        apiKey: "gsk-groq-test",
+      },
+      {
+        name: "MyMistral",
+        provider: "custom",
+        model: "mistral-large",
+        baseUrl: "https://api.mistral.ai/v1",
+        apiKey: "mk-mistral-test",
+      },
+    ]);
+
+    const { listModels } = await freshModels();
+    listModels();
+
+    const envContent = readFileSync(join(testHome, ".env"), "utf-8");
+    expect(envContent).toMatch(/^GROQ_API_KEY=gsk-groq-test$/m);
+    expect(envContent).toMatch(/^MISTRAL_API_KEY=mk-mistral-test$/m);
+  });
+
+  it("does NOT write a host-derived form for unknown hosts (no false-positive vendor binding)", async () => {
+    writeCustomProviders([
+      {
+        name: "MyUnsloth",
+        provider: "custom",
+        model: "unsloth-model",
+        baseUrl: "https://api.unsloth.ai/v1",
+        apiKey: "sk-unsloth-test",
+      },
+    ]);
+
+    const { listModels } = await freshModels();
+    listModels();
+
+    const envContent = readFileSync(join(testHome, ".env"), "utf-8");
+    expect(envContent).toMatch(/^CUSTOM_PROVIDER_MYUNSLOTH_KEY=sk-unsloth-test$/m);
+    // No UNSLOTH_API_KEY — the lookup correctly returns null for unknown hosts
+    expect(envContent).not.toMatch(/^UNSLOTH_API_KEY/m);
+  });
+
+  it("does NOT shadow OPENAI_API_KEY via this path (a literal openai.com URL stays custom-prefix-only)", async () => {
+    writeCustomProviders([
+      {
+        name: "MyOpenAI",
+        provider: "custom",
+        model: "gpt-x",
+        baseUrl: "https://api.openai.com/v1",
+        apiKey: "sk-custom-not-real-openai",
+      },
+    ]);
+
+    const { listModels } = await freshModels();
+    listModels();
+
+    const envContent = readFileSync(join(testHome, ".env"), "utf-8");
+    expect(envContent).toMatch(
+      /^CUSTOM_PROVIDER_MYOPENAI_KEY=sk-custom-not-real-openai$/m,
+    );
+    // OPENAI_API_KEY is reserved for the canonical OpenAI provider —
+    // custom-provider entries do NOT clobber it through this path.
+    expect(envContent).not.toMatch(
+      /^OPENAI_API_KEY=sk-custom-not-real-openai$/m,
+    );
+  });
+
+  it("does NOT shadow ANTHROPIC_API_KEY either", async () => {
+    writeCustomProviders([
+      {
+        name: "MyAnthropic",
+        provider: "custom",
+        model: "claude-x",
+        baseUrl: "https://api.anthropic.com/v1",
+        apiKey: "sk-ant-custom",
+      },
+    ]);
+
+    const { listModels } = await freshModels();
+    listModels();
+
+    const envContent = readFileSync(join(testHome, ".env"), "utf-8");
+    expect(envContent).toMatch(/^CUSTOM_PROVIDER_MYANTHROPIC_KEY=sk-ant-custom$/m);
+    expect(envContent).not.toMatch(/^ANTHROPIC_API_KEY=sk-ant-custom$/m);
+  });
+
+  it("idempotent — re-running seed doesn't duplicate either env var", async () => {
+    writeCustomProviders([
+      {
+        name: "MyDeepseek",
+        provider: "custom",
+        model: "deepseek-chat",
+        baseUrl: "https://api.deepseek.com/v1",
+        apiKey: "sk-deepseek-test-123",
+      },
+    ]);
+
+    // First listModels call seeds
+    let { listModels } = await freshModels();
+    listModels();
+
+    // Second listModels call after a fresh module load should not append.
+    ({ listModels } = await freshModels());
+    listModels();
+
+    const envContent = readFileSync(join(testHome, ".env"), "utf-8");
+    const customMatches = envContent.match(/^CUSTOM_PROVIDER_MYDEEPSEEK_KEY=/gm) || [];
+    const deepseekMatches = envContent.match(/^DEEPSEEK_API_KEY=/gm) || [];
+    expect(customMatches).toHaveLength(1);
+    expect(deepseekMatches).toHaveLength(1);
+  });
+});

--- a/tests/compat-host-derived-key.test.ts
+++ b/tests/compat-host-derived-key.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { hostDerivedEnvKeyForUrl } from "../src/main/hermes";
+
+/**
+ * Dual-engine compat: the desktop writes a host-derived `<VENDOR>_API_KEY`
+ * env-var to the child process so the upstream engine's host-derive
+ * resolver (`hermes_cli/runtime_provider.py::_host_derived_api_key`) finds
+ * a key. Without it, custom-provider chat against `api.deepseek.com` etc.
+ * on a post-2026 engine falls through to "no-key-required" and 401s.
+ *
+ * This test pins the URL → env-var mapping so the resolver and the
+ * additive-write site in `sendMessage` can never drift.
+ */
+describe("hostDerivedEnvKeyForUrl", () => {
+  it.each([
+    ["https://api.deepseek.com/v1", "DEEPSEEK_API_KEY"],
+    ["https://api.groq.com/openai/v1", "GROQ_API_KEY"],
+    ["https://api.mistral.ai/v1", "MISTRAL_API_KEY"],
+    ["https://api.together.xyz/v1", "TOGETHER_API_KEY"],
+    ["https://api.fireworks.ai/inference/v1", "FIREWORKS_API_KEY"],
+    ["https://api.cerebras.ai/v1", "CEREBRAS_API_KEY"],
+    ["https://api.perplexity.ai/v1", "PERPLEXITY_API_KEY"],
+    ["https://openrouter.ai/api/v1", "OPENROUTER_API_KEY"],
+    ["https://api.anthropic.com/v1", "ANTHROPIC_API_KEY"],
+    ["https://api.openai.com/v1", "OPENAI_API_KEY"],
+    ["https://api-inference.huggingface.co/models/x", "HF_TOKEN"],
+  ])("maps %s → %s", (url, expected) => {
+    expect(hostDerivedEnvKeyForUrl(url)).toBe(expected);
+  });
+
+  it("returns null for non-vendor hosts (local LLMs, unknown clouds)", () => {
+    expect(hostDerivedEnvKeyForUrl("http://localhost:11434/v1")).toBeNull();
+    expect(hostDerivedEnvKeyForUrl("http://127.0.0.1:1234/v1")).toBeNull();
+    expect(hostDerivedEnvKeyForUrl("https://192.168.1.42:8080/v1")).toBeNull();
+    expect(hostDerivedEnvKeyForUrl("https://api.unsloth.ai/v1")).toBeNull();
+    expect(hostDerivedEnvKeyForUrl("")).toBeNull();
+  });
+
+  it("is case-insensitive (some users paste mixed-case URLs)", () => {
+    expect(hostDerivedEnvKeyForUrl("https://API.DeepSeek.com/v1")).toBe(
+      "DEEPSEEK_API_KEY",
+    );
+  });
+});

--- a/tests/compat-host-derived-key.test.ts
+++ b/tests/compat-host-derived-key.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { hostDerivedEnvKeyForUrl } from "../src/main/hermes";
+import { hostDerivedEnvKeyForUrl } from "../src/main/host-derived-env";
 
 /**
  * Dual-engine compat: the desktop writes a host-derived `<VENDOR>_API_KEY`

--- a/tests/compat-host-derived-key.test.ts
+++ b/tests/compat-host-derived-key.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { hostDerivedEnvKeyForUrl } from "../src/main/host-derived-env";
+import {
+  hostDerivedEnvKeyForUrl,
+  shouldPruneOpenRouterApiKey,
+} from "../src/main/host-derived-env";
 
 /**
  * Dual-engine compat: the desktop writes a host-derived `<VENDOR>_API_KEY`
@@ -40,5 +43,11 @@ describe("hostDerivedEnvKeyForUrl", () => {
     expect(hostDerivedEnvKeyForUrl("https://API.DeepSeek.com/v1")).toBe(
       "DEEPSEEK_API_KEY",
     );
+  });
+
+  it("keeps OPENROUTER_API_KEY when OpenRouter is the host-derived provider", () => {
+    expect(shouldPruneOpenRouterApiKey("OPENROUTER_API_KEY")).toBe(false);
+    expect(shouldPruneOpenRouterApiKey("DEEPSEEK_API_KEY")).toBe(true);
+    expect(shouldPruneOpenRouterApiKey(null)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Engine compat fix. Upstream `hermes-agent` past v2026.5.16 introduced `hermes_cli/runtime_provider.py::_host_derived_api_key()` which derives the env var name for custom-provider chat from the base URL host (`api.deepseek.com` → `DEEPSEEK_API_KEY`) and refuses to forward `OPENAI_API_KEY` to non-openai hosts. The desktop today only writes `CUSTOM_PROVIDER_<NAME>_KEY` to `.env` and only sets `OPENAI_API_KEY` in the child env at chat time — so users with a custom provider on `api.deepseek.com`/`.groq.com`/`.mistral.ai`/etc. lose chat the moment the bundled engine bumps. Same regression-on-upgrade shape as #360 — engine bump makes the open report visibly worse.

**Strategy:** additive compat — write both env-var forms. Old engine reads `OPENAI_API_KEY` (unchanged); new engine reads `<VENDOR>_API_KEY` via host-derive. Old engine ignores the extra var; new engine ignores the extra `OPENAI_API_KEY` for non-openai hosts (its own leak-prevention). No engine-version detection branch — both engines see one consistent disk + env state.

## Two paths fixed

| Path | Where | Fix |
|---|---|---|
| **Runtime chat spawn (CLI fallback)** | `src/main/hermes.ts::sendMessageViaCli` | After resolving the API key, also set the host-derived env-var in the child process env. |
| **Gateway persistence (primary chat flow)** | `src/main/models.ts::seedDefaults` | When persisting a custom-provider key to `.env`, write both `CUSTOM_PROVIDER_<NAME>_KEY` and the host-derived `<VENDOR>_API_KEY`. The long-running gateway only sees `.env` at startGateway time, so the host-derived form has to live there (not just be set at chat-time). |

Both call sites share a tiny new module `src/main/host-derived-env.ts` (`hostDerivedEnvKeyForUrl(baseUrl)`) so the URL → env-var contract can't drift between the two write sites.

**Guard rails:**
- Doesn't shadow `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` via this path (those belong to canonical providers, not custom)
- Won't overwrite a pre-existing host-derived key (user's real `DEEPSEEK_API_KEY` is safe from a custom-provider seed clobber)
- No-op for unknown vendor hosts (e.g. `api.unsloth.ai` — no false-positive vendor binding)
- Won't propagate `no-key-required` placeholder to a vendor-scoped slot

## Tests

**+19 new tests, all passing. Full suite: 691 passed | 3 skipped.**

- **`tests/compat-host-derived-key.test.ts`** (13 tests) — URL → env-var mapping. Pins the contract for every vendor (deepseek, groq, mistral, together, fireworks, cerebras, perplexity, openrouter, anthropic, openai, huggingface) plus null returns for local LLMs / unknown hosts / case sensitivity.
- **`tests/compat-host-derived-key-persistence.test.ts`** (6 tests) — `seedDefaults` writes both env-var names, doesn't shadow canonical keys, no false-positive vendor binding for unknown hosts, idempotent re-runs don't duplicate entries.

## Live test — verified against BOTH engines

The dual-engine compat rig is documented in `.personal/engine-update-audit.md` Phase 0 (local-only doc). Two separate engine installs:
- `~/AppData/Local/hermes-oldengine` — v2026.5.16 release tag (the version v0.5.1 bundles, pre-host-derive)
- `~/AppData/Local/hermes-newengine` — current upstream main (post-host-derive)

Both run via `$env:HERMES_HOME=...; npm run dev`. The verify script (`scripts/verify-compat-host-derived-key.js`) seeds a fake-key deepseek custom provider, triggers `seedDefaults`, and confirms both env-var names land in `.env`.

### OLD engine (v2026.5.16 — bundled in v0.5.1)
```
HERMES_HOME: C:\Users\pmos6\AppData\Local\hermes-oldengine
Engine:     Hermes Agent v0.14.0 (2026.5.16)
[A2] Stripped pre-existing DEEPSEEK_API_KEY so the fix's write is observable
[B] Appended custom_providers entry to config.yaml
[C] Deleted models.json to force re-seed
[C] listModels picked up entry: id=86de9907-... baseUrl=https://api.deepseek.com/v1

[D] .env contents (relevant lines):
   CUSTOM_PROVIDER_COMPATTESTDEEPSEEK_KEY=sk-fake-deepseek-compat-test-12345
   DEEPSEEK_API_KEY=sk-fake-deepseek-compat-test-12345

✅ PASS (OLD engine): both env-var names persisted to .env.
```

### NEW engine (upstream main, post-host-derive)
```
HERMES_HOME: C:\Users\pmos6\AppData\Local\hermes-newengine
Engine:     Hermes Agent v0.14.0 (2026.5.16)
[A2] Stripped pre-existing DEEPSEEK_API_KEY so the fix's write is observable
[B] Appended custom_providers entry to config.yaml
[C] Deleted models.json to force re-seed
[C] listModels picked up entry: id=b2d1cb5b-... baseUrl=https://api.deepseek.com/v1

[D] .env contents (relevant lines):
   CUSTOM_PROVIDER_COMPATTESTDEEPSEEK_KEY=sk-fake-deepseek-compat-test-12345
   DEEPSEEK_API_KEY=sk-fake-deepseek-compat-test-12345

✅ PASS (NEW engine): both env-var names persisted to .env.
   → The long-running gateway will find DEEPSEEK_API_KEY on next startup.
   → On the new engine, _host_derived_api_key() can resolve it.
```

Independent cross-check: invoked the new engine's `_host_derived_api_key()` directly with `DEEPSEEK_API_KEY=sk-fake-... python -c "from hermes_cli.runtime_provider import _host_derived_api_key; print(_host_derived_api_key('https://api.deepseek.com/v1'))"` → returns the key. Confirms the new engine actually consumes the env var the desktop is writing.

## Why ship this *before* the engine bump

- The CAUTION items in the audit landed an action plan: this is the highest-priority one because it's the only one with a *user-visible regression on upgrade*. Users with a custom DeepSeek/Groq/Mistral/etc. provider lose chat the moment the bundled engine bumps if this isn't already in.
- Pure additive code paths — no behavior change for users on the current bundled engine.
- 0 risk to the existing `CUSTOM_PROVIDER_<NAME>_KEY` flow — every test confirms it stays in place alongside the new write.

Closes part of the engine-bump prep tracked downstream. Doesn't claim to fix #360 but reduces its blast radius on engine upgrade.


---

## Maintainer Merge Note

Suggested full-stack order from the pre-release rebuild:

#383 -> #369 -> #400 -> #402 -> #404 -> #415 -> #419 -> #421 -> #422 -> #417 -> #430 -> #434 -> #437 -> #439 -> #440 -> #441

Suggested position: after #369.

Why: this PR is conceptually part of the same provider key-consistency hardening as #369 and is easiest to reason about once #369's shared URL/env-key resolver and config-health behavior have landed.

