### PR TITLE
Expose local model providers in model setup

### DIFF
--- a/src/main/model-discovery.ts
+++ b/src/main/model-discovery.ts
@@ -246,6 +246,13 @@ const _cache = new Map<string, CacheEntry>();
 // with the main cache via `_clearCache` for test isolation.
 const _freeCache = new Map<string, string[]>();
 
+const LOCAL_NO_KEY_PROVIDERS = new Set([
+  "lmstudio",
+  "ollama",
+  "vllm",
+  "llamacpp",
+]);
+
 function cacheKey(provider: string, baseUrl: string): string {
   return `${provider.toLowerCase()}|${baseUrl.replace(/\/+$/, "").toLowerCase()}`;
 }
@@ -330,7 +337,13 @@ function buildUrl(base: string): string {
   return `${trimmed}/models`;
 }
 
+interface FetchModelsResult {
+  models: string[];
+  reachable: boolean;
+}
+
 function authHeaders(provider: string, apiKey: string): Record<string, string> {
+  if (!apiKey) return {};
   const lower = provider.toLowerCase();
   if (lower === "anthropic") {
     // Anthropic uses x-api-key + an API version header on /v1/models.
@@ -342,13 +355,28 @@ function authHeaders(provider: string, apiKey: string): Record<string, string> {
   return { Authorization: `Bearer ${apiKey}` };
 }
 
+function isLoopbackBaseUrl(baseUrl: string): boolean {
+  try {
+    const host = new URL(baseUrl).hostname.toLowerCase();
+    return host === "localhost" || host === "127.0.0.1" || host === "::1";
+  } catch {
+    return false;
+  }
+}
+
 function fetchModelsHttp(
   url: string,
   headers: Record<string, string>,
   timeoutMs: number,
-): Promise<string[]> {
+): Promise<FetchModelsResult> {
   return new Promise((resolve) => {
-    const u = new URL(url);
+    let u: URL;
+    try {
+      u = new URL(url);
+    } catch {
+      resolve({ models: [], reachable: false });
+      return;
+    }
     const mod = u.protocol === "https:" ? https : http;
     const req = mod.request(
       {
@@ -363,7 +391,7 @@ function fetchModelsHttp(
       (res) => {
         if (!res.statusCode || res.statusCode >= 400) {
           res.resume();
-          resolve([]);
+          resolve({ models: [], reachable: true });
           return;
         }
         let body = "";
@@ -371,14 +399,16 @@ function fetchModelsHttp(
         res.on("data", (chunk) => {
           body += chunk;
         });
-        res.on("end", () => resolve(parseModelIds(body)));
-        res.on("error", () => resolve([]));
+        res.on("end", () =>
+          resolve({ models: parseModelIds(body), reachable: true }),
+        );
+        res.on("error", () => resolve({ models: [], reachable: false }));
       },
     );
-    req.on("error", () => resolve([]));
+    req.on("error", () => resolve({ models: [], reachable: false }));
     req.on("timeout", () => {
       req.destroy();
-      resolve([]);
+      resolve({ models: [], reachable: false });
     });
     req.end();
   });
@@ -388,10 +418,11 @@ export interface DiscoverModelsResult {
   models: string[];
   /** ``"ok"`` when the call succeeded (even if zero models came back).
    *  ``"no-key"`` when the caller didn't pass one and we couldn't find a
-   *  matching ``<NAME>_API_KEY``.  ``"unsupported"`` for providers we know
-   *  don't expose this endpoint.  ``"unknown-host"`` when neither caller
-   *  nor mapping table can resolve a base URL. */
-  status: "ok" | "no-key" | "unsupported" | "unknown-host";
+   *  matching ``<NAME>_API_KEY``.  ``"error"`` when the provider could not
+   *  be reached.  ``"unsupported"`` for providers we know don't expose this
+   *  endpoint.  ``"unknown-host"`` when neither caller nor mapping table can
+   *  resolve a base URL. */
+  status: "ok" | "no-key" | "error" | "unsupported" | "unknown-host";
   /** ``true`` when the result came from the in-memory cache. */
   cached: boolean;
   /** Subset of `models` flagged as free (no cost per token). Populated
@@ -463,13 +494,21 @@ export async function discoverProviderModels(
   const apiKey =
     (apiKeyOverride || "").trim() ||
     envApiKeyFor(lowerProvider, baseUrl, profile);
-  if (!apiKey) return { models: [], status: "no-key", cached: false };
+  const canDiscoverWithoutKey =
+    LOCAL_NO_KEY_PROVIDERS.has(lowerProvider) ||
+    (lowerProvider === "custom" && isLoopbackBaseUrl(baseUrl));
+  if (!apiKey && !canDiscoverWithoutKey) {
+    return { models: [], status: "no-key", cached: false };
+  }
 
   const url = buildUrl(baseUrl);
   const headers = authHeaders(lowerProvider, apiKey);
-  const models = await fetchModelsHttp(url, headers, 10_000);
-  setCache(lowerProvider, baseUrl, models);
-  return { models, status: "ok", cached: false };
+  const result = await fetchModelsHttp(url, headers, 10_000);
+  if (!result.reachable) {
+    return { models: [], status: "error", cached: false };
+  }
+  setCache(lowerProvider, baseUrl, result.models);
+  return { models: result.models, status: "ok", cached: false };
 }
 
 /** Internal: exposed for tests / debugging only.  Production callers

--- a/src/main/model-discovery.ts
+++ b/src/main/model-discovery.ts
@@ -248,6 +248,7 @@ const _freeCache = new Map<string, string[]>();
 
 const LOCAL_NO_KEY_PROVIDERS = new Set([
   "lmstudio",
+  "atomicchat",
   "ollama",
   "vllm",
   "llamacpp",

--- a/src/main/provider-registry.ts
+++ b/src/main/provider-registry.ts
@@ -25,6 +25,10 @@ export const PROVIDER_BASE_URLS: Record<string, string> = {
   huggingface: "https://router.huggingface.co/v1",
   zai: "https://api.z.ai/api/paas/v4",
   anthropic: "https://api.anthropic.com/v1",
+  lmstudio: "http://localhost:1234/v1",
+  ollama: "http://localhost:11434/v1",
+  vllm: "http://localhost:8000/v1",
+  llamacpp: "http://localhost:8080/v1",
 };
 
 /**

--- a/src/main/provider-registry.ts
+++ b/src/main/provider-registry.ts
@@ -26,6 +26,7 @@ export const PROVIDER_BASE_URLS: Record<string, string> = {
   zai: "https://api.z.ai/api/paas/v4",
   anthropic: "https://api.anthropic.com/v1",
   lmstudio: "http://localhost:1234/v1",
+  atomicchat: "http://localhost:1337/v1",
   ollama: "http://localhost:11434/v1",
   vllm: "http://localhost:8000/v1",
   llamacpp: "http://localhost:8080/v1",

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -347,7 +347,7 @@ interface HermesAPI {
     profile?: string,
   ) => Promise<{
     models: string[];
-    status: "ok" | "no-key" | "unsupported" | "unknown-host";
+    status: "ok" | "no-key" | "error" | "unsupported" | "unknown-host";
     cached: boolean;
     /** Subset of `models` flagged as free (Nous Portal today). #367. */
     freeModels?: string[];

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -342,7 +342,7 @@ const hermesAPI = {
     profile?: string,
   ): Promise<{
     models: string[];
-    status: "ok" | "no-key" | "unsupported" | "unknown-host";
+    status: "ok" | "no-key" | "error" | "unsupported" | "unknown-host";
     cached: boolean;
     /** Subset of `models` flagged as free per the provider catalog
      *  (Nous Portal today). Optional — providers without pricing

--- a/src/renderer/src/constants.ts
+++ b/src/renderer/src/constants.ts
@@ -47,6 +47,7 @@ export const PROVIDERS = {
     // looking for "Ollama" or "LM Studio" do not have to discover the
     // generic custom-provider path first.
     { value: "lmstudio", label: "constants.lmstudio" },
+    { value: "atomicchat", label: "constants.atomicchat" },
     { value: "ollama", label: "constants.ollama" },
     { value: "vllm", label: "constants.vllm" },
     { value: "llamacpp", label: "constants.llamacpp" },
@@ -83,6 +84,7 @@ export const PROVIDERS = {
     minimax: "MiniMax",
     nous: "constants.nousName",
     lmstudio: "constants.lmstudio",
+    atomicchat: "constants.atomicchat",
     ollama: "constants.ollama",
     vllm: "constants.vllm",
     llamacpp: "constants.llamacpp",

--- a/src/renderer/src/constants.ts
+++ b/src/renderer/src/constants.ts
@@ -43,6 +43,13 @@ export const PROVIDERS = {
     { value: "qwen", label: "Qwen" },
     { value: "minimax", label: "MiniMax" },
     { value: "nous", label: "constants.nousName" },
+    // Local OpenAI-compatible servers. Keep these explicit so users
+    // looking for "Ollama" or "LM Studio" do not have to discover the
+    // generic custom-provider path first.
+    { value: "lmstudio", label: "constants.lmstudio" },
+    { value: "ollama", label: "constants.ollama" },
+    { value: "vllm", label: "constants.vllm" },
+    { value: "llamacpp", label: "constants.llamacpp" },
     // Subscription / OAuth plans
     // openai-codex is listed once above (first-party group) via #102 —
     // not repeated here to avoid a duplicate <option> value.
@@ -75,6 +82,10 @@ export const PROVIDERS = {
     qwen: "Qwen",
     minimax: "MiniMax",
     nous: "constants.nousName",
+    lmstudio: "constants.lmstudio",
+    ollama: "constants.ollama",
+    vllm: "constants.vllm",
+    llamacpp: "constants.llamacpp",
     "xai-oauth": "xAI Grok (OAuth)",
     "qwen-oauth": "Qwen (OAuth)",
     "google-gemini-cli": "Gemini (CLI OAuth)",

--- a/src/renderer/src/screens/Models/Models.test.tsx
+++ b/src/renderer/src/screens/Models/Models.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../components/useI18n", () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+    locale: "en",
+    setLocale: () => {},
+  }),
+}));
+
+import { modelConfigBaseUrlForProvider } from "./Models";
+
+describe("modelConfigBaseUrlForProvider", () => {
+  it("preserves explicit custom local-provider URLs when syncing the active model", () => {
+    expect(
+      modelConfigBaseUrlForProvider("ollama", " http://localhost:11435/v1 "),
+    ).toBe("http://localhost:11435/v1");
+    expect(
+      modelConfigBaseUrlForProvider("lmstudio", "http://127.0.0.1:2234/v1"),
+    ).toBe("http://127.0.0.1:2234/v1");
+    expect(
+      modelConfigBaseUrlForProvider("atomicchat", "http://localhost:1338/v1"),
+    ).toBe("http://localhost:1338/v1");
+  });
+
+  it("keeps remote built-in providers on backend canonical URL substitution", () => {
+    expect(
+      modelConfigBaseUrlForProvider("deepseek", "https://proxy.local/v1"),
+    ).toBe("");
+  });
+
+  it("preserves custom provider URLs", () => {
+    expect(
+      modelConfigBaseUrlForProvider("custom", " https://custom.local/v1 "),
+    ).toBe("https://custom.local/v1");
+  });
+});

--- a/src/renderer/src/screens/Models/Models.tsx
+++ b/src/renderer/src/screens/Models/Models.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { Plus, Trash, Search, X } from "../../assets/icons";
-import { PROVIDERS } from "../../constants";
+import { LOCAL_PRESETS, PROVIDERS } from "../../constants";
 import { useI18n } from "../../components/useI18n";
 import BrandLogo from "../../components/common/BrandLogo";
 import { detectProviderFromUrl } from "./detect-provider";
@@ -18,6 +18,15 @@ interface SavedModel {
 
 function providerLabelKey(value: string): string {
   return PROVIDERS.options.find((p) => p.value === value)?.label || value;
+}
+
+function localPresetForProvider(value: string): {
+  id: string;
+  baseUrl: string;
+} | null {
+  return (
+    LOCAL_PRESETS.find((p) => p.group === "local" && p.id === value) || null
+  );
 }
 
 interface ModelsProps {
@@ -68,11 +77,14 @@ function Models({ visible }: ModelsProps = {}): React.JSX.Element {
   // Live model discovery for the Add/Edit modal — feeds an HTML
   // <datalist> off the Model ID input.  Pauses when the modal is closed
   // so we don't fire background requests on every keystroke elsewhere.
-  const isCustomForm = formProvider === "custom";
+  const discoveryBaseUrl =
+    formProvider === "custom" || localPresetForProvider(formProvider)
+      ? formBaseUrl
+      : undefined;
   const [discoveryRefresh, setDiscoveryRefresh] = useState(0);
   const discovery = useDiscoveredModels({
     provider: formProvider,
-    baseUrl: isCustomForm ? formBaseUrl : undefined,
+    baseUrl: discoveryBaseUrl,
     apiKey: formApiKey || undefined,
     enabled: showModal && formProvider !== "auto",
     refreshToken: discoveryRefresh,
@@ -398,7 +410,14 @@ function Models({ visible }: ModelsProps = {}): React.JSX.Element {
                   className="input"
                   value={formProvider}
                   onChange={(e) => {
-                    setFormProvider(e.target.value);
+                    const nextProvider = e.target.value;
+                    setFormProvider(nextProvider);
+                    const localPreset = localPresetForProvider(nextProvider);
+                    if (localPreset) {
+                      setFormBaseUrl(localPreset.baseUrl);
+                    } else if (nextProvider !== "custom") {
+                      setFormBaseUrl("");
+                    }
                     setProviderTouched(true);
                     setProviderAutoFilled(false);
                   }}

--- a/src/renderer/src/screens/Models/Models.tsx
+++ b/src/renderer/src/screens/Models/Models.tsx
@@ -29,6 +29,15 @@ function localPresetForProvider(value: string): {
   );
 }
 
+export function modelConfigBaseUrlForProvider(
+  provider: string,
+  baseUrl: string,
+): string {
+  return provider === "custom" || localPresetForProvider(provider)
+    ? baseUrl.trim()
+    : "";
+}
+
 interface ModelsProps {
   visible?: boolean;
 }
@@ -206,8 +215,10 @@ function Models({ visible }: ModelsProps = {}): React.JSX.Element {
       // setModelConfig itself (substitutes the canonical URL for
       // built-in providers — see `provider-registry.ts`).
       if (editedWasActive) {
-        const effectiveBaseUrl =
-          formProvider === "custom" ? formBaseUrl.trim() : "";
+        const effectiveBaseUrl = modelConfigBaseUrlForProvider(
+          formProvider,
+          formBaseUrl,
+        );
         await window.hermesAPI.setModelConfig(
           formProvider,
           model,

--- a/src/renderer/src/screens/Models/detect-provider.ts
+++ b/src/renderer/src/screens/Models/detect-provider.ts
@@ -26,7 +26,7 @@ export function detectProviderFromUrl(rawUrl: string): string | null {
   // require a private-IP match for the port-only heuristic.
   if (/:11434(\/|$)/.test(url)) return "ollama";
   if (/:1234(\/|$)/.test(url)) return "lmstudio";
-  if (/:1337(\/|$)/.test(url)) return "custom";
+  if (/:1337(\/|$)/.test(url)) return "atomicchat";
   if (/:8000(\/|$)/.test(url)) return "vllm";
   if (/:8080(\/|$)/.test(url)) return "llamacpp";
 

--- a/src/renderer/src/screens/Models/detect-provider.ts
+++ b/src/renderer/src/screens/Models/detect-provider.ts
@@ -21,17 +21,20 @@ export function detectProviderFromUrl(rawUrl: string): string | null {
   if (/dashscope(-intl)?\.aliyuncs\.com/.test(url)) return "qwen";
   if (/api\.minimax(i)?\.(chat|com)/.test(url)) return "minimax";
 
-  // Anything pointing at a private or loopback address is almost always a
-  // self-hosted OpenAI-compatible endpoint (Ollama, LM Studio, vLLM,
-  // llama.cpp) — surface that as "Local / Custom" so the model card label
-  // matches user expectation.
-  const host = extractHost(url);
-  if (host && isPrivateOrLoopback(host)) return "custom";
-
   // Well-known local-LLM ports on any host — Ollama 11434, LM Studio 1234,
   // Atomic Chat 1337, vLLM 8000, llama.cpp 8080. These run on LAN VMs too, so we don't
   // require a private-IP match for the port-only heuristic.
-  if (/:(11434|1234|1337|8000|8080)(\/|$)/.test(url)) return "custom";
+  if (/:11434(\/|$)/.test(url)) return "ollama";
+  if (/:1234(\/|$)/.test(url)) return "lmstudio";
+  if (/:1337(\/|$)/.test(url)) return "custom";
+  if (/:8000(\/|$)/.test(url)) return "vllm";
+  if (/:8080(\/|$)/.test(url)) return "llamacpp";
+
+  // Anything else pointing at a private or loopback address is almost
+  // always a self-hosted OpenAI-compatible endpoint. Surface that as the
+  // generic custom path when the port does not identify a known local app.
+  const host = extractHost(url);
+  if (host && isPrivateOrLoopback(host)) return "custom";
 
   return null;
 }

--- a/tests/constants.test.ts
+++ b/tests/constants.test.ts
@@ -29,6 +29,10 @@ describe("PROVIDERS", () => {
     expect(values).toContain("nous");
     expect(values).toContain("qwen");
     expect(values).toContain("minimax");
+    expect(values).toContain("lmstudio");
+    expect(values).toContain("ollama");
+    expect(values).toContain("vllm");
+    expect(values).toContain("llamacpp");
     expect(values).toContain("custom");
   });
 
@@ -206,6 +210,16 @@ describe("LOCAL_PRESETS", () => {
     const ids = LOCAL_PRESETS.map((p) => p.id);
     expect(ids).toContain("lmstudio");
     expect(ids).toContain("ollama");
+    expect(ids).toContain("vllm");
+    expect(ids).toContain("llamacpp");
+  });
+
+  it("exposes every local preset as a provider dropdown option", () => {
+    const options = new Set(PROVIDERS.options.map((o) => o.value));
+    for (const preset of LOCAL_PRESETS.filter((p) => p.group === "local")) {
+      expect(options.has(preset.id)).toBe(true);
+      expect(PROVIDERS.labels[preset.id]).toBeTruthy();
+    }
   });
 });
 

--- a/tests/detect-provider.test.ts
+++ b/tests/detect-provider.test.ts
@@ -61,7 +61,7 @@ describe("detectProviderFromUrl", () => {
     // Atomic Chat
     expect(
       detectProviderFromUrl("http://atomic-box.example.com:1337/v1"),
-    ).toBe("custom");
+    ).toBe("atomicchat");
     // vLLM
     expect(detectProviderFromUrl("http://gpu-rig.example.com:8000")).toBe(
       "vllm",

--- a/tests/detect-provider.test.ts
+++ b/tests/detect-provider.test.ts
@@ -32,40 +32,48 @@ describe("detectProviderFromUrl", () => {
     );
   });
 
-  it("identifies private-network and loopback addresses as custom", () => {
-    expect(detectProviderFromUrl("http://localhost:11434")).toBe("custom");
-    expect(detectProviderFromUrl("http://127.0.0.1:11434/v1")).toBe("custom");
-    expect(detectProviderFromUrl("http://192.168.1.50:11434")).toBe("custom");
-    expect(detectProviderFromUrl("http://10.0.0.5:8000")).toBe("custom");
-    expect(detectProviderFromUrl("http://172.20.0.3:1234")).toBe("custom");
-    expect(detectProviderFromUrl("http://hermes.local:11434")).toBe("custom");
+  it("identifies well-known local provider ports by provider", () => {
+    expect(detectProviderFromUrl("http://localhost:11434")).toBe("ollama");
+    expect(detectProviderFromUrl("http://127.0.0.1:11434/v1")).toBe("ollama");
+    expect(detectProviderFromUrl("http://192.168.1.50:11434")).toBe("ollama");
+    expect(detectProviderFromUrl("http://10.0.0.5:8000")).toBe("vllm");
+    expect(detectProviderFromUrl("http://172.20.0.3:1234")).toBe("lmstudio");
+    expect(detectProviderFromUrl("http://hermes.local:8080")).toBe(
+      "llamacpp",
+    );
   });
 
-  it("identifies well-known local-LLM ports on any host as custom", () => {
+  it("identifies private-network and loopback addresses with unknown ports as custom", () => {
+    expect(detectProviderFromUrl("http://localhost:9999")).toBe("custom");
+    expect(detectProviderFromUrl("http://192.168.1.50:9999")).toBe("custom");
+    expect(detectProviderFromUrl("http://hermes.local:9999")).toBe("custom");
+  });
+
+  it("identifies well-known local-LLM ports on any host", () => {
     // Ollama on a LAN VM with a public-looking hostname
     expect(
       detectProviderFromUrl("http://ollama.andrea-house.com:11434/v1"),
-    ).toBe("custom");
+    ).toBe("ollama");
     // LM Studio
     expect(
       detectProviderFromUrl("http://my-workstation.example.com:1234/v1"),
-    ).toBe("custom");
+    ).toBe("lmstudio");
     // Atomic Chat
     expect(
       detectProviderFromUrl("http://atomic-box.example.com:1337/v1"),
     ).toBe("custom");
     // vLLM
     expect(detectProviderFromUrl("http://gpu-rig.example.com:8000")).toBe(
-      "custom",
+      "vllm",
     );
     // llama.cpp server
     expect(detectProviderFromUrl("http://llama.example.com:8080")).toBe(
-      "custom",
+      "llamacpp",
     );
   });
 
   it("excludes 172.x outside the RFC1918 range", () => {
-    expect(detectProviderFromUrl("http://172.15.0.1:11434")).toBe("custom"); // port hits
+    expect(detectProviderFromUrl("http://172.15.0.1:11434")).toBe("ollama"); // port hits
     expect(detectProviderFromUrl("http://172.32.0.1:9999")).toBeNull();
   });
 
@@ -76,11 +84,11 @@ describe("detectProviderFromUrl", () => {
 
   it("is case-insensitive", () => {
     expect(detectProviderFromUrl("HTTPS://API.OPENAI.COM")).toBe("openai");
-    expect(detectProviderFromUrl("HTTP://LOCALHOST:11434")).toBe("custom");
+    expect(detectProviderFromUrl("HTTP://LOCALHOST:11434")).toBe("ollama");
   });
 
   it("tolerates bare host:port without a scheme", () => {
-    expect(detectProviderFromUrl("localhost:1234")).toBe("custom");
-    expect(detectProviderFromUrl("192.168.1.10:8080")).toBe("custom");
+    expect(detectProviderFromUrl("localhost:1234")).toBe("lmstudio");
+    expect(detectProviderFromUrl("192.168.1.10:8080")).toBe("llamacpp");
   });
 });

--- a/tests/model-discovery.test.ts
+++ b/tests/model-discovery.test.ts
@@ -81,7 +81,7 @@ describe("model-discovery", () => {
     expect(result.models).toEqual(["alpha", "beta", "gamma"]);
   });
 
-  it("returns status=no-key when no apiKey is provided or in .env", async () => {
+  it("returns status=no-key for public custom endpoints when no apiKey is provided or in .env", async () => {
     server = http.createServer(() => {
       throw new Error("must not be called when there's no key");
     });
@@ -92,12 +92,58 @@ describe("model-discovery", () => {
     const { discoverProviderModels } = await loadDiscovery();
     const result = await discoverProviderModels(
       "custom",
-      baseUrl,
+      "https://example.com/v1",
       undefined,
       undefined,
     );
     expect(result.status).toBe("no-key");
     expect(result.models).toEqual([]);
+  });
+
+  it("discovers loopback custom models without an API key", async () => {
+    let receivedAuth = "not-called";
+    server = http.createServer((req, res) => {
+      receivedAuth = String(req.headers["authorization"] || "");
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ data: [{ id: "llama3.2:latest" }] }));
+    });
+    await listen();
+    writeFileSync(join(testHome, ".env"), "");
+
+    const { discoverProviderModels } = await loadDiscovery();
+    const result = await discoverProviderModels(
+      "custom",
+      baseUrl,
+      undefined,
+      undefined,
+    );
+
+    expect(result.status).toBe("ok");
+    expect(result.models).toEqual(["llama3.2:latest"]);
+    expect(receivedAuth).toBe("");
+  });
+
+  it("discovers named local-provider models without an API key", async () => {
+    let receivedAuth = "not-called";
+    server = http.createServer((req, res) => {
+      receivedAuth = String(req.headers["authorization"] || "");
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ data: [{ id: "qwen2.5-coder:7b" }] }));
+    });
+    await listen();
+    writeFileSync(join(testHome, ".env"), "");
+
+    const { discoverProviderModels } = await loadDiscovery();
+    const result = await discoverProviderModels(
+      "ollama",
+      baseUrl,
+      undefined,
+      undefined,
+    );
+
+    expect(result.status).toBe("ok");
+    expect(result.models).toEqual(["qwen2.5-coder:7b"]);
+    expect(receivedAuth).toBe("");
   });
 
   it("returns status=unsupported for known no-discovery providers", async () => {
@@ -187,6 +233,26 @@ describe("model-discovery", () => {
       undefined,
     );
     expect(result.status).toBe("ok");
+    expect(result.models).toEqual([]);
+  });
+
+  it("returns status=error when the local provider cannot be reached", async () => {
+    server = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ data: [{ id: "lmstudio-model" }] }));
+    });
+    await listen();
+    const offlineBaseUrl = baseUrl;
+    await close();
+
+    const { discoverProviderModels } = await loadDiscovery();
+    const result = await discoverProviderModels(
+      "lmstudio",
+      offlineBaseUrl,
+      undefined,
+      undefined,
+    );
+    expect(result.status).toBe("error");
     expect(result.models).toEqual([]);
   });
 

--- a/tests/model-discovery.test.ts
+++ b/tests/model-discovery.test.ts
@@ -135,7 +135,7 @@ describe("model-discovery", () => {
 
     const { discoverProviderModels } = await loadDiscovery();
     const result = await discoverProviderModels(
-      "ollama",
+      "atomicchat",
       baseUrl,
       undefined,
       undefined,

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -39,6 +39,21 @@ describe("provider-registry", () => {
       );
     });
 
+    it("returns default URLs for local OpenAI-compatible providers", () => {
+      expect(canonicalProviderBaseUrl("lmstudio")).toBe(
+        "http://localhost:1234/v1",
+      );
+      expect(canonicalProviderBaseUrl("ollama")).toBe(
+        "http://localhost:11434/v1",
+      );
+      expect(canonicalProviderBaseUrl("vllm")).toBe(
+        "http://localhost:8000/v1",
+      );
+      expect(canonicalProviderBaseUrl("llamacpp")).toBe(
+        "http://localhost:8080/v1",
+      );
+    });
+
     it("is case-insensitive on the provider id", () => {
       expect(canonicalProviderBaseUrl("DeepSeek")).toBe(
         "https://api.deepseek.com/v1",

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -43,6 +43,9 @@ describe("provider-registry", () => {
       expect(canonicalProviderBaseUrl("lmstudio")).toBe(
         "http://localhost:1234/v1",
       );
+      expect(canonicalProviderBaseUrl("atomicchat")).toBe(
+        "http://localhost:1337/v1",
+      );
       expect(canonicalProviderBaseUrl("ollama")).toBe(
         "http://localhost:11434/v1",
       );

--- a/tests/set-model-config-base-url.test.ts
+++ b/tests/set-model-config-base-url.test.ts
@@ -158,4 +158,26 @@ describe("setModelConfig — base_url substitution", () => {
       expect(mc.baseUrl).toBe(expected);
     }
   });
+
+  it("writes default base URLs for explicit local providers", async () => {
+    const provider_to_canonical: Record<string, string> = {
+      lmstudio: "http://localhost:1234/v1",
+      ollama: "http://localhost:11434/v1",
+      vllm: "http://localhost:8000/v1",
+      llamacpp: "http://localhost:8080/v1",
+    };
+
+    for (const [provider, expected] of Object.entries(provider_to_canonical)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+      mkdirSync(TEST_DIR, { recursive: true });
+
+      const { setModelConfig, getModelConfig } =
+        await importConfigWithHome(TEST_DIR);
+      setModelConfig(provider, "some-local-model", "");
+
+      const mc = getModelConfig();
+      expect(mc.provider).toBe(provider);
+      expect(mc.baseUrl).toBe(expected);
+    }
+  });
 });

--- a/tests/set-model-config-base-url.test.ts
+++ b/tests/set-model-config-base-url.test.ts
@@ -162,6 +162,7 @@ describe("setModelConfig — base_url substitution", () => {
   it("writes default base URLs for explicit local providers", async () => {
     const provider_to_canonical: Record<string, string> = {
       lmstudio: "http://localhost:1234/v1",
+      atomicchat: "http://localhost:1337/v1",
       ollama: "http://localhost:11434/v1",
       vllm: "http://localhost:8000/v1",
       llamacpp: "http://localhost:8080/v1",


### PR DESCRIPTION
## Summary
- add explicit local provider choices for LM Studio, Ollama, vLLM, and llama.cpp in model setup
- prefill canonical local base URLs and auto-detect known local provider ports
- allow local provider model discovery without API keys and report unreachable local servers as discovery errors instead of empty model lists

## Testing
- npm test -- tests/constants.test.ts tests/detect-provider.test.ts tests/provider-registry.test.ts tests/set-model-config-base-url.test.ts tests/model-discovery.test.ts
- npm run typecheck
- npm run build
- npm test
- live tested with LM Studio local server on localhost:1234 and verified model discovery/population in the desktop UI

Closes #362
Closes #500



Refs #423 — this improves the local Ollama/local-provider setup path called out in that report. The specific session-continuation `API_SERVER_KEY` failure is handled by #369.



---

## Maintainer Merge Note

Suggested full-stack order from the pre-release rebuild:

#383 -> #369 -> #400 -> #402 -> #404 -> #415 -> #419 -> #421 -> #422 -> #417 -> #430 -> #434 -> #437 -> #439 -> #440 -> #441

Suggested position: after #400.

No known stacked conflict from the pre-release rebuild. This is mostly independent, but it is cleaner after the provider/key consistency work because it exposes local-provider setup paths that rely on the same model/provider configuration surface.


