### PR TITLE
fix(ui): make window usable on 1366×768 displays (#393)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -249,7 +249,12 @@ function createWindow(): void {
     width: 1100,
     height: 850,
     minWidth: 900,
-    minHeight: 820,
+    // Lowered from 820 to fit on 768p / 720p displays — Linux WMs
+    // enforce minHeight strictly, clipping content (chat input, bottom
+    // nav items) below the screen edge on 1366×768 laptops. Issue #393.
+    // Companion CSS change makes .sidebar-nav scrollable when content
+    // exceeds available vertical space.
+    minHeight: 600,
     show: false,
     autoHideMenuBar: true,
     titleBarStyle: process.platform === "darwin" ? "hiddenInset" : undefined,

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -948,6 +948,13 @@ body {
   display: flex;
   flex-direction: column;
   gap: 2px;
+  /* When vertical space is tight (small screens, narrow windows), let
+   * the nav scroll instead of clipping the bottom items (Gateway,
+   * Settings). `min-height: 0` is required so the flex child can
+   * shrink below its content size — without it, `overflow-y: auto`
+   * never activates because the flex item refuses to shrink. #393. */
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .sidebar-nav-item {


### PR DESCRIPTION
## Problem

Closes #393.

User on a Linux laptop (1366×768) reported the chat input was below the screen edge and couldn't be reached. The same issue clips the bottom of the left nav — "Settings" was visible in the reporter's screenshot but clearly cut off.

Root cause: `BrowserWindow.minHeight: 820` exceeds the available vertical space once the OS top bar and Electron title bar are subtracted (~744px usable on a 1366×768 display). The window can't shrink to fit; the chat composer and bottom nav items render below the viewport. Linux WMs enforce minHeight more strictly than Windows/macOS, which is why a Linux user hit this first.

## Fix

Two small changes:

1. **`src/main/index.ts`** — lower `BrowserWindow.minHeight` from 820 to 600 so the window can shrink to fit common laptop screens.

2. **`src/renderer/src/assets/main.css`** — add `min-height: 0; overflow-y: auto;` to `.sidebar-nav` so the nav scrolls when there isn't room for all 14 items. `min-height: 0` is required because flex children default to `min-height: auto`, which prevents shrinking below content size — that's actually why the bottom nav items were already clipping at 768p even before `minHeight` became binding.

## Testing

Live-tested in dev electron on Windows at window heights 600, 700, and 768:

- Chat input is reachable at every height
- All 14 nav items are reachable (scrollable below ~700px window height)
- Window can be shrunk down to 600px without UI breakage
- At default 850px window height (the typical case), behaviour is unchanged