### PR TITLE
fix(linux): set SUID on chrome-sandbox in .deb/.rpm postinst (#395)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# Shell scripts must always be LF — CRLF breaks the shebang line on
+# Linux ("bad interpreter: /bin/bash\r: No such file or directory"),
+# which silently fails the .deb / .rpm postinst hook (#395).
+*.sh text eol=lf

--- a/build/linux-after-install.sh
+++ b/build/linux-after-install.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# After-install hook for the .deb and .rpm packages.
+#
+# Sets the SUID root bit on chrome-sandbox so Electron's sandbox helper
+# can elevate as required. Without this, Electron crashes on close (and
+# on first sandboxed renderer launch on some configs) — issue #395.
+#
+# Why it's needed: Electron's setuid sandbox is the supported sandboxing
+# path on Linux when unprivileged user namespaces aren't available. Newer
+# Ubuntu (24.04+, definitely 26.04 LTS) ships AppArmor + kernel hardening
+# that disable unprivileged user namespaces by default, so the SUID path
+# becomes mandatory.
+#
+# This matches the postinst behaviour of other Electron apps (VS Code,
+# Slack, Discord, Signal, etc.). electron-builder doesn't ship this by
+# default — it has to be wired up via {deb,rpm}.afterInstall.
+
+set -e
+
+SANDBOX="/opt/Hermes Agent/chrome-sandbox"
+
+if [ -f "$SANDBOX" ]; then
+  # 4755 = SUID + rwxr-xr-x. Root-owned by package install; SUID is what
+  # lets the sandbox briefly elevate for the chroot/setresuid step before
+  # dropping back to the calling user.
+  chmod 4755 "$SANDBOX"
+fi
+
+exit 0

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -56,8 +56,15 @@ linux:
     messaging, and a closed learning loop.
 appImage:
   artifactName: ${name}-${version}.${ext}
+deb:
+  # Run chmod 4755 on chrome-sandbox so Electron's setuid sandbox helper
+  # works on modern Linux distros that disable unprivileged user
+  # namespaces (Ubuntu 24.04+, etc.). Closes #395.
+  afterInstall: build/linux-after-install.sh
 rpm:
   artifactName: ${name}-${version}.${ext}
+  # Same SUID fix for .rpm consumers (Fedora 40+ also restricts userns).
+  afterInstall: build/linux-after-install.sh
 npmRebuild: false
 publish:
   provider: github


### PR DESCRIPTION
## Problem

Closes #395.

Reporter on Ubuntu 26.04 LTS installs the `.deb` v0.5.1 and observes Electron crashing on close. Inspection of the installed file shows:

```
$ ls -la "/opt/Hermes Agent/chrome-sandbox"
-rwxr-xr-x 1 root root 15328 May 24 22:46 chrome-sandbox
```

No SUID bit. The reporter's workaround (`chmod 4755`) confirmed the diagnosis.

## Why this happens

Electron's setuid sandbox helper needs **either**:
1. The SUID root bit on `chrome-sandbox`, or
2. `kernel.unprivileged_userns_clone=1` (unprivileged user namespaces enabled)

Modern Ubuntu (24.04+) ships AppArmor + kernel hardening that disable unprivileged user namespaces by default, so the SUID path becomes mandatory. Same story on Fedora 40+.

electron-builder doesn't ship this postinst step by default — it has to be wired up via `{deb,rpm}.afterInstall`. Other Electron apps (VS Code, Slack, Discord, Signal, …) all do the same thing.

## Fix

Three small changes:

1. **`build/linux-after-install.sh`** (new) — `chmod 4755` on `/opt/Hermes Agent/chrome-sandbox`. Guarded by `[ -f ]` so it's a no-op if the file isn't there. Set executable in the git index (`git update-index --chmod=+x`) so the .deb and .rpm builders preserve the bit.

2. **`electron-builder.yml`** — wire the script into both `deb:` and `rpm:` target sections via `afterInstall`. AppImage doesn't need this (self-mounting, different sandbox path); snap doesn't either (its own confinement).

3. **`.gitattributes`** — pin `*.sh` to `eol=lf`. CRLF on a shell script breaks the shebang on Linux (`bad interpreter: /bin/bash\r: No such file or directory`), which would silently fail the postinst hook. Defensive against future Windows-side edits.

## Verification

This change only takes effect on `.deb` / `.rpm` built from this commit, and end-to-end verification requires Ubuntu 26.04 (or similar hardened distro) + the resulting package. I'm on Windows so I can't run that myself.

Once this lands and a release goes out, the reporter on #395 can confirm with:

```bash
ls -la "/opt/Hermes Agent/chrome-sandbox"
# → -rwsr-xr-x   (the 's' in place of 'x' for the owner is the SUID bit)
```

And the close-crash should disappear.

## Static checks done locally

- `electron-builder.yml` syntax valid — `deb.afterInstall` and `rpm.afterInstall` are standard `LinuxTargetSpecificOptions` per electron-builder docs
- Script is mode 0755 in the git index (`git ls-files --stage build/linux-after-install.sh` → `100755`)
- Script body is LF-terminated (verified via hex dump — no `0d` before `0a` on the shebang line)
- Typecheck clean, lint clean (no errors in changed files)



---

## Maintainer Merge Note

Suggested full-stack order from the pre-release rebuild:

#383 -> #369 -> #400 -> #402 -> #404 -> #415 -> #419 -> #421 -> #422 -> #417 -> #430 -> #434 -> #437 -> #439 -> #440 -> #441

Suggested position: after #402, or any time after current main.

No known code conflict from the pre-release rebuild. This PR is packaging-focused and independent from the chat/provider/session stack.

