### PR TITLE
fix(chat): compress oversize images + set Content-Length on chat POSTs (#405)

### DIFF
--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -401,8 +401,22 @@ function sendMessageViaApi(
     ...(_resumeSessionId ? { session_id: _resumeSessionId } : {}),
   });
 
+  // Encode the body up-front into a Buffer so we can:
+  //  1. Set `Content-Length` accurately based on byte length (NOT char
+  //     count — JSON.stringify of an image data URL is ASCII so they
+  //     match, but multi-byte chars in user text would diverge).
+  //  2. Disable Node's default `Transfer-Encoding: chunked` framing for
+  //     bodies written via `req.write(body); req.end();`. Chunked
+  //     framing skips the gateway's `body_limit_middleware` (which
+  //     inspects Content-Length only), so an oversized payload that
+  //     should produce a clean 413 "body_too_large" gets the
+  //     misleading 400 "Invalid JSON in request body" via aiohttp's
+  //     client_max_size overflow path. See #405.
+  const bodyBuf = Buffer.from(body, "utf-8");
+
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
+    "Content-Length": String(bodyBuf.length),
     ...getRemoteAuthHeader(),
   };
   // Local API server key (API_SERVER_KEY in the profile's .env /
@@ -479,11 +493,20 @@ function sendMessageViaApi(
       messages: [{ role: "user", content: userContent }],
       stream: false,
     });
+    const probeBodyBuf = Buffer.from(probeBody, "utf-8");
+    // Per-request Content-Length (the outer `headers` object's value
+    // belongs to the streaming request — reusing it here would lie about
+    // this body's size and break the framing the same way the missing
+    // Content-Length did before #405). Spread + override.
+    const probeHeaders = {
+      ...headers,
+      "Content-Length": String(probeBodyBuf.length),
+    };
     const probeUrl = `${getApiUrl()}/v1/chat/completions`;
     const probeMod = probeUrl.startsWith("https") ? https : http;
     const probeReq = probeMod.request(
       probeUrl,
-      { method: "POST", headers },
+      { method: "POST", headers: probeHeaders },
       (res) => {
         let raw = "";
         res.on("data", (d) => {
@@ -512,7 +535,7 @@ function sendMessageViaApi(
         "No response received from the model. Check your model configuration and API key.",
       );
     });
-    probeReq.write(probeBody);
+    probeReq.write(probeBodyBuf);
     probeReq.end();
   }
 
@@ -689,7 +712,7 @@ function sendMessageViaApi(
     );
   });
 
-  req.write(body);
+  req.write(bodyBuf);
   req.end();
 
   return {

--- a/src/renderer/src/components/AttachmentChip.tsx
+++ b/src/renderer/src/components/AttachmentChip.tsx
@@ -16,10 +16,19 @@ export function AttachmentChip({
 }: AttachmentChipProps): React.JSX.Element {
   const isImage = attachment.kind === "image";
 
+  // When the renderer compressed the image down to fit the gateway's
+  // request-body cap (#405), surface the size delta in the tooltip so the
+  // user knows quality changed and isn't surprised by a "compressed"
+  // version appearing in the chat transcript.
+  const tooltip =
+    attachment.originalSize && attachment.originalSize > attachment.size
+      ? `${attachment.name} (${formatSize(attachment.originalSize)} → ${formatSize(attachment.size)}, compressed)`
+      : `${attachment.name} (${formatSize(attachment.size)})`;
+
   return (
     <div
       className={`attachment-chip attachment-chip-${attachment.kind}`}
-      title={`${attachment.name} (${formatSize(attachment.size)})`}
+      title={tooltip}
     >
       {isImage && attachment.dataUrl ? (
         <button

--- a/src/renderer/src/screens/Chat/ChatInput.tsx
+++ b/src/renderer/src/screens/Chat/ChatInput.tsx
@@ -92,6 +92,8 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
             return t("chat.attachTooMany");
           case "image-too-large":
             return t("chat.attachImageTooLarge", { name: err.filename });
+          case "image-uncompressible":
+            return t("chat.attachImageUncompressible", { name: err.filename });
           case "text-too-large":
             return t("chat.attachTextTooLarge", { name: err.filename });
           case "unsupported-type":

--- a/src/renderer/src/screens/Chat/attachmentUtils.test.ts
+++ b/src/renderer/src/screens/Chat/attachmentUtils.test.ts
@@ -62,12 +62,16 @@ describe("processFiles", () => {
     expect(a.dataUrl?.startsWith("data:image/png;base64,")).toBe(true);
   });
 
-  it("rejects an image over the size limit", async () => {
+  it("rejects an image over the input cap (50 MB) without attempting compression", async () => {
+    // Post-#405: anything ≤ MAX_IMAGE_INPUT_BYTES (50 MB) goes through
+    // the compression path which downsamples to fit the gateway. Only
+    // pathologically large inputs (>50 MB) are rejected outright. Use
+    // 51 MB to exercise that boundary.
     const file = makeFile(
       "huge.png",
       "image/png",
       "x",
-      21 * 1024 * 1024, // 21 MB > 20 MB cap
+      51 * 1024 * 1024,
     );
     const out = await processFiles([file], 0);
     expect(out.attachments).toEqual([]);
@@ -76,6 +80,29 @@ describe("processFiles", () => {
       code: "image-too-large",
       filename: "huge.png",
     });
+  });
+
+  it("passes images under the compression target through untouched", async () => {
+    // 1 MB image — under MAX_IMAGE_TARGET_BYTES (5 MB) so compression
+    // short-circuits and the file isn't decoded.  Verifies the fast path
+    // doesn't accidentally transcode small images (no quality loss, no
+    // originalSize set).
+    const file = makeFile(
+      "small.png",
+      "image/png",
+      "data:image/png;base64,iVBORw0KGgo=",
+      1 * 1024 * 1024,
+    );
+    const out = await processFiles([file], 0);
+    expect(out.errors).toEqual([]);
+    expect(out.attachments).toHaveLength(1);
+    expect(out.attachments[0]).toMatchObject({
+      kind: "image",
+      name: "small.png",
+      size: 1 * 1024 * 1024,
+    });
+    // originalSize is only set when compression actually ran
+    expect(out.attachments[0].originalSize).toBeUndefined();
   });
 
   it("accepts a text file by MIME type", async () => {

--- a/src/renderer/src/screens/Chat/attachmentUtils.ts
+++ b/src/renderer/src/screens/Chat/attachmentUtils.ts
@@ -1,7 +1,8 @@
 import {
   type Attachment,
   MAX_ATTACHMENTS_PER_MESSAGE,
-  MAX_IMAGE_BYTES,
+  MAX_IMAGE_INPUT_BYTES,
+  MAX_IMAGE_TARGET_BYTES,
   MAX_TEXT_BYTES,
   isImageMime,
   isTextFile,
@@ -11,6 +12,7 @@ export interface AttachmentError {
   code:
     | "too-many"
     | "image-too-large"
+    | "image-uncompressible"
     | "text-too-large"
     | "unsupported-type"
     | "read-failed"
@@ -58,6 +60,178 @@ function readAsBase64(file: File): Promise<string> {
   });
 }
 
+// ─────────────────────────────────────────────────────────────────────
+//  Image compression (issue #405)
+// ─────────────────────────────────────────────────────────────────────
+//
+// The gateway accepts request bodies up to 10 MB (`MAX_REQUEST_BYTES` in
+// `gateway/platforms/api_server.py`). A user image is base64-encoded into
+// the JSON body — 4/3× inflation — so anything larger than ~7 MB binary
+// produces a body that fails to parse, and the gateway returns the
+// (misleading) error "Invalid JSON in request body".
+//
+// Rather than reject oversized images, the desktop downscales them client-
+// side to fit under `MAX_IMAGE_TARGET_BYTES`. The loop drops JPEG quality
+// first (cheap, perceptually fine to ~0.5) then scales down by 20% steps
+// (lossier but bounded). Images already under the target pass through
+// untouched — no quality loss, no recompression.
+//
+// Format strategy: transparent PNGs (alpha channel detected via canvas
+// pixel sampling) stay as PNG so transparency survives; everything else
+// becomes JPEG which compresses photos ~10× better at imperceptible
+// quality loss. Animated GIFs only have their first frame captured by
+// canvas, so we explicitly bail with `image-uncompressible` and let the
+// user decide whether to send the static thumbnail.
+
+function loadHtmlImage(file: File): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = (): void => {
+      URL.revokeObjectURL(url);
+      resolve(img);
+    };
+    img.onerror = (): void => {
+      URL.revokeObjectURL(url);
+      reject(new Error("image-decode-failed"));
+    };
+    img.src = url;
+  });
+}
+
+function canvasToBlob(
+  canvas: HTMLCanvasElement,
+  type: string,
+  quality?: number,
+): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => (blob ? resolve(blob) : reject(new Error("toBlob-failed"))),
+      type,
+      quality,
+    );
+  });
+}
+
+/**
+ * Detect a non-opaque pixel by sampling the canvas. Sampling instead of
+ * scanning every pixel because a 4000×3000 image has 12M pixels and
+ * `getImageData` for the whole thing is slow + allocates 48 MB. Strided
+ * sampling at ~10k points is sufficient to find any transparent region
+ * the user might have intentionally placed (logos, UI screenshots, etc.).
+ */
+function canvasHasTransparency(canvas: HTMLCanvasElement): boolean {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return false;
+  const { width, height } = canvas;
+  if (width === 0 || height === 0) return false;
+  const samples = 100; // 100 × 100 = 10_000 sample points
+  const stepX = Math.max(1, Math.floor(width / samples));
+  const stepY = Math.max(1, Math.floor(height / samples));
+  for (let y = 0; y < height; y += stepY) {
+    const row = ctx.getImageData(0, y, width, 1).data;
+    for (let x = 0; x < width; x += stepX) {
+      if (row[x * 4 + 3] < 255) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Compress an oversized image down to ≤ `targetBytes`.  No-ops when the
+ * file is already under the target (cheap fast path — no decode, no
+ * recompression).  Returns the original `File` in that case so callers
+ * can compare by reference and know whether compression actually ran.
+ *
+ * Throws `Error("image-uncompressible")` if compression can't get the
+ * file under the cap even at minimum scale and quality (rare — only
+ * triggers on degenerate inputs like multi-gigapixel images or formats
+ * the canvas can't re-encode).
+ */
+export async function compressImageToFit(
+  file: File,
+  targetBytes: number,
+): Promise<File> {
+  if (file.size <= targetBytes) return file;
+
+  // Animated GIFs lose animation through canvas. Pass through unchanged
+  // and let the caller reject if over-cap — re-encoding to a JPEG frame
+  // loses information silently which is worse than a clear "too big" UX.
+  if (file.type === "image/gif" && file.size > targetBytes) {
+    throw new Error("image-uncompressible");
+  }
+
+  let img: HTMLImageElement;
+  try {
+    img = await loadHtmlImage(file);
+  } catch {
+    throw new Error("image-decode-failed");
+  }
+
+  // Render once at full resolution to probe for alpha — decides whether
+  // we can switch to JPEG (huge size win) or must stay on PNG.
+  const probeCanvas = document.createElement("canvas");
+  probeCanvas.width = img.naturalWidth;
+  probeCanvas.height = img.naturalHeight;
+  const probeCtx = probeCanvas.getContext("2d");
+  if (!probeCtx) throw new Error("canvas-unavailable");
+  probeCtx.drawImage(img, 0, 0);
+  const hasAlpha = canvasHasTransparency(probeCanvas);
+  const outputType = hasAlpha ? "image/png" : "image/jpeg";
+
+  // Compression loop:
+  //   Phase 1 — JPEG only: step quality down from 0.85 to 0.5.
+  //   Phase 2 — PNG path or JPEG still too big: scale dimensions down
+  //     by 20% per step, resetting quality to 0.85 for JPEG each round.
+  let scale = 1.0;
+  let quality = 0.85;
+  // Reuse the probe canvas at scale=1 to skip a re-decode for the first
+  // iteration. Allocate a fresh canvas only when we actually downsample.
+  let workingCanvas: HTMLCanvasElement = probeCanvas;
+
+  // Safety bound: 20 iterations max so a pathological input can't hang
+  // the renderer thread. With the step sizes above this loop converges
+  // for any input we can decode (worst case: ~3 quality drops × ~6 scale
+  // drops = 18 iters).
+  for (let i = 0; i < 20; i++) {
+    const blob = await canvasToBlob(
+      workingCanvas,
+      outputType,
+      hasAlpha ? undefined : quality,
+    );
+    if (blob.size <= targetBytes) {
+      const ext = hasAlpha ? "png" : "jpg";
+      const newName = file.name.replace(/\.[^.]+$/, "") + "." + ext;
+      return new File([blob], newName, { type: outputType });
+    }
+
+    // For JPEG: drop quality before scaling — visually preferable.
+    if (!hasAlpha && quality > 0.5) {
+      quality -= 0.15;
+      continue;
+    }
+
+    // Need to scale down. PNG path always lands here (no quality knob).
+    scale *= 0.8;
+    if (workingCanvas.width * scale < 64 || workingCanvas.height * scale < 64) {
+      // Below 64 px we'd be unrecognisable even to vision models —
+      // refuse rather than silently emit a useless thumbnail.
+      throw new Error("image-uncompressible");
+    }
+
+    const scaled = document.createElement("canvas");
+    scaled.width = Math.max(64, Math.floor(img.naturalWidth * scale));
+    scaled.height = Math.max(64, Math.floor(img.naturalHeight * scale));
+    const sctx = scaled.getContext("2d");
+    if (!sctx) throw new Error("canvas-unavailable");
+    sctx.drawImage(img, 0, 0, scaled.width, scaled.height);
+    workingCanvas = scaled;
+    quality = 0.85; // reset for next JPEG attempt
+  }
+
+  throw new Error("image-uncompressible");
+}
+
 export interface ProcessFilesResult {
   attachments: Attachment[];
   errors: AttachmentError[];
@@ -101,19 +275,53 @@ export async function processFiles(
     const name = file.name || "untitled";
 
     if (isImageMime(mime)) {
-      if (file.size > MAX_IMAGE_BYTES) {
+      // Sanity cap: only reject pathologically large inputs that would
+      // OOM the canvas or fail to decode. Anything reasonable proceeds
+      // to the compression step below.
+      if (file.size > MAX_IMAGE_INPUT_BYTES) {
         errors.push({ code: "image-too-large", filename: name });
         continue;
       }
+
+      let compressedFile: File = file;
+      const originalSize = file.size;
+      // Skip compression for files already under the gateway-safe target.
+      // `compressImageToFit` itself short-circuits but checking here keeps
+      // the dataUrl read path identical for small images (no canvas decode
+      // overhead at all).
+      if (file.size > MAX_IMAGE_TARGET_BYTES) {
+        try {
+          compressedFile = await compressImageToFit(
+            file,
+            MAX_IMAGE_TARGET_BYTES,
+          );
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          errors.push({
+            code:
+              msg === "image-uncompressible" || msg === "image-decode-failed"
+                ? "image-uncompressible"
+                : "read-failed",
+            filename: name,
+            detail: msg,
+          });
+          continue;
+        }
+      }
+
       try {
-        const dataUrl = await readAsDataUrl(file);
+        const dataUrl = await readAsDataUrl(compressedFile);
         attachments.push({
           id: newId(),
           kind: "image",
           name,
-          mime,
-          size: file.size,
+          mime: compressedFile.type || mime,
+          size: compressedFile.size,
           dataUrl,
+          // Only set when we actually transcoded — preserves the chip's
+          // simple "5.2 MB" display for unmodified attachments and adds
+          // the "from N MB" hint only when the user lost some quality.
+          ...(compressedFile !== file ? { originalSize } : {}),
         });
       } catch (err) {
         errors.push({

--- a/src/renderer/src/screens/Chat/attachmentUtils.ts
+++ b/src/renderer/src/screens/Chat/attachmentUtils.ts
@@ -84,18 +84,22 @@ function readAsBase64(file: File): Promise<string> {
 // user decide whether to send the static thumbnail.
 
 function loadHtmlImage(file: File): Promise<HTMLImageElement> {
+  // Round-trip through FileReader → data URL → Image.src rather than
+  // `URL.createObjectURL` + `revokeObjectURL`. Data URLs are slightly
+  // more memory (~33% base64 overhead during decode) but they survive
+  // automation/CDP contexts where blob URLs sometimes fail to decode,
+  // and they avoid the URL lifecycle entirely (no race between revoke
+  // and decode-complete).
   return new Promise((resolve, reject) => {
-    const url = URL.createObjectURL(file);
-    const img = new Image();
-    img.onload = (): void => {
-      URL.revokeObjectURL(url);
-      resolve(img);
+    const reader = new FileReader();
+    reader.onload = (): void => {
+      const img = new Image();
+      img.onload = (): void => resolve(img);
+      img.onerror = (): void => reject(new Error("image-decode-failed"));
+      img.src = String(reader.result || "");
     };
-    img.onerror = (): void => {
-      URL.revokeObjectURL(url);
-      reject(new Error("image-decode-failed"));
-    };
-    img.src = url;
+    reader.onerror = (): void => reject(new Error("image-decode-failed"));
+    reader.readAsDataURL(file);
   });
 }
 

--- a/src/renderer/src/screens/Chat/attachmentUtils.ts
+++ b/src/renderer/src/screens/Chat/attachmentUtils.ts
@@ -183,39 +183,45 @@ export async function compressImageToFit(
   probeCtx.drawImage(img, 0, 0);
   const hasAlpha = canvasHasTransparency(probeCanvas);
 
-  // Output-format choice:
-  //   - Alpha images: stay PNG (the lossless format with transparency).
-  //     We could try WebP-lossless, but PNG is universally accepted by
-  //     vision endpoints and WebP-lossless rarely beats it.
-  //   - Opaque images: prefer WebP (~25-30% smaller than JPEG at the
-  //     same perceptual quality), with JPEG as a runtime fallback.
-  //     WebP is accepted by all major vision providers (OpenAI,
-  //     Anthropic via OpenAI-compat, Google, OpenRouter), but Chromium
-  //     versions in extremely old Electron builds occasionally fail
-  //     to encode it — that's why we probe before committing.
+  // Candidate output formats. The base64 4/3× wire inflation is fixed
+  // by the OpenAI chat-completions content shape — what we control is
+  // the binary that gets inflated. So we encode each candidate at the
+  // current quality and pick the smallest blob:
   //
-  // The base64 inflation that goes on the wire (4/3×) is fixed by the
-  // OpenAI chat-completions content shape, but the binary that gets
-  // inflated is whatever we choose here, so smaller binary = smaller
-  // request body = more headroom under the gateway's 10 MB cap.
-  let outputType: string;
-  let outputExt: string;
+  //   - Alpha images: PNG only (the lossless format that preserves
+  //     transparency). We could try WebP-lossless too but it rarely
+  //     beats PNG for screenshot-style content and adds complexity.
+  //   - Opaque images: BOTH WebP and JPEG, pick the smaller. WebP is
+  //     usually ~25-50% smaller for screenshots/photos, but JPEG
+  //     marginally wins on high-frequency noise/grain content.
+  //     Running both costs ~2× encoding time per iteration but
+  //     guarantees the smallest wire payload regardless of content.
+  //
+  // WebP availability is probed once up-front — Chromium's `toBlob`
+  // silently produces PNG when it can't honour an unsupported type,
+  // so we explicitly check the returned blob type.
+  type Candidate = {
+    type: string;
+    ext: string;
+    quality: number | undefined; // undefined = lossless / format default
+  };
+  const candidates: Candidate[] = [];
   if (hasAlpha) {
-    outputType = "image/png";
-    outputExt = "png";
-  } else if (await canvasSupportsType(probeCanvas, "image/webp")) {
-    outputType = "image/webp";
-    outputExt = "webp";
+    candidates.push({ type: "image/png", ext: "png", quality: undefined });
   } else {
-    outputType = "image/jpeg";
-    outputExt = "jpg";
+    const webpOk = await canvasSupportsType(probeCanvas, "image/webp");
+    if (webpOk) {
+      candidates.push({ type: "image/webp", ext: "webp", quality: 0.85 });
+    }
+    candidates.push({ type: "image/jpeg", ext: "jpg", quality: 0.85 });
   }
-  const isLossy = outputType === "image/webp" || outputType === "image/jpeg";
+  const isLossy = !hasAlpha;
 
   // Compression loop:
-  //   Phase 1 — lossy format: step quality down from 0.85 to 0.5.
-  //   Phase 2 — PNG path or lossy still too big: scale dimensions down
-  //     by 20% per step, resetting quality to 0.85 each round.
+  //   Phase 1 — lossy formats: step quality down from 0.85 to 0.5
+  //     across all candidates, keeping the smallest blob ≤ target.
+  //   Phase 2 — PNG path or all lossy still too big: scale dimensions
+  //     down by 20% per step, resetting quality to 0.85 each round.
   let scale = 1.0;
   let quality = 0.85;
   // Reuse the probe canvas at scale=1 to skip a re-decode for the first
@@ -227,14 +233,34 @@ export async function compressImageToFit(
   // for any input we can decode (worst case: ~3 quality drops × ~6 scale
   // drops = 18 iters).
   for (let i = 0; i < 20; i++) {
-    const blob = await canvasToBlob(
-      workingCanvas,
-      outputType,
-      isLossy ? quality : undefined,
-    );
-    if (blob.size <= targetBytes) {
-      const newName = file.name.replace(/\.[^.]+$/, "") + "." + outputExt;
-      return new File([blob], newName, { type: outputType });
+    // Encode every candidate at the current quality and remember the
+    // smallest blob.  Skip candidates whose encode produces a blob of
+    // the wrong type (Chromium fallback to PNG) — those don't count.
+    let bestBlob: Blob | null = null;
+    let bestCandidate: Candidate | null = null;
+    for (const cand of candidates) {
+      let blob: Blob;
+      try {
+        blob = await canvasToBlob(
+          workingCanvas,
+          cand.type,
+          cand.quality === undefined ? undefined : quality,
+        );
+      } catch {
+        continue;
+      }
+      if (blob.type !== cand.type) continue;
+      if (!bestBlob || blob.size < bestBlob.size) {
+        bestBlob = blob;
+        bestCandidate = cand;
+      }
+    }
+    if (!bestBlob || !bestCandidate) throw new Error("canvas-unavailable");
+
+    if (bestBlob.size <= targetBytes) {
+      const newName =
+        file.name.replace(/\.[^.]+$/, "") + "." + bestCandidate.ext;
+      return new File([bestBlob], newName, { type: bestCandidate.type });
     }
 
     // For lossy formats: drop quality before scaling — visually preferable.

--- a/src/renderer/src/screens/Chat/attachmentUtils.ts
+++ b/src/renderer/src/screens/Chat/attachmentUtils.ts
@@ -173,7 +173,8 @@ export async function compressImageToFit(
   }
 
   // Render once at full resolution to probe for alpha — decides whether
-  // we can switch to JPEG (huge size win) or must stay on PNG.
+  // we can switch to lossy compression (huge size win) or must stay on
+  // a lossless format that preserves transparency.
   const probeCanvas = document.createElement("canvas");
   probeCanvas.width = img.naturalWidth;
   probeCanvas.height = img.naturalHeight;
@@ -181,12 +182,40 @@ export async function compressImageToFit(
   if (!probeCtx) throw new Error("canvas-unavailable");
   probeCtx.drawImage(img, 0, 0);
   const hasAlpha = canvasHasTransparency(probeCanvas);
-  const outputType = hasAlpha ? "image/png" : "image/jpeg";
+
+  // Output-format choice:
+  //   - Alpha images: stay PNG (the lossless format with transparency).
+  //     We could try WebP-lossless, but PNG is universally accepted by
+  //     vision endpoints and WebP-lossless rarely beats it.
+  //   - Opaque images: prefer WebP (~25-30% smaller than JPEG at the
+  //     same perceptual quality), with JPEG as a runtime fallback.
+  //     WebP is accepted by all major vision providers (OpenAI,
+  //     Anthropic via OpenAI-compat, Google, OpenRouter), but Chromium
+  //     versions in extremely old Electron builds occasionally fail
+  //     to encode it — that's why we probe before committing.
+  //
+  // The base64 inflation that goes on the wire (4/3×) is fixed by the
+  // OpenAI chat-completions content shape, but the binary that gets
+  // inflated is whatever we choose here, so smaller binary = smaller
+  // request body = more headroom under the gateway's 10 MB cap.
+  let outputType: string;
+  let outputExt: string;
+  if (hasAlpha) {
+    outputType = "image/png";
+    outputExt = "png";
+  } else if (await canvasSupportsType(probeCanvas, "image/webp")) {
+    outputType = "image/webp";
+    outputExt = "webp";
+  } else {
+    outputType = "image/jpeg";
+    outputExt = "jpg";
+  }
+  const isLossy = outputType === "image/webp" || outputType === "image/jpeg";
 
   // Compression loop:
-  //   Phase 1 — JPEG only: step quality down from 0.85 to 0.5.
-  //   Phase 2 — PNG path or JPEG still too big: scale dimensions down
-  //     by 20% per step, resetting quality to 0.85 for JPEG each round.
+  //   Phase 1 — lossy format: step quality down from 0.85 to 0.5.
+  //   Phase 2 — PNG path or lossy still too big: scale dimensions down
+  //     by 20% per step, resetting quality to 0.85 each round.
   let scale = 1.0;
   let quality = 0.85;
   // Reuse the probe canvas at scale=1 to skip a re-decode for the first
@@ -201,16 +230,15 @@ export async function compressImageToFit(
     const blob = await canvasToBlob(
       workingCanvas,
       outputType,
-      hasAlpha ? undefined : quality,
+      isLossy ? quality : undefined,
     );
     if (blob.size <= targetBytes) {
-      const ext = hasAlpha ? "png" : "jpg";
-      const newName = file.name.replace(/\.[^.]+$/, "") + "." + ext;
+      const newName = file.name.replace(/\.[^.]+$/, "") + "." + outputExt;
       return new File([blob], newName, { type: outputType });
     }
 
-    // For JPEG: drop quality before scaling — visually preferable.
-    if (!hasAlpha && quality > 0.5) {
+    // For lossy formats: drop quality before scaling — visually preferable.
+    if (isLossy && quality > 0.5) {
       quality -= 0.15;
       continue;
     }
@@ -230,10 +258,38 @@ export async function compressImageToFit(
     if (!sctx) throw new Error("canvas-unavailable");
     sctx.drawImage(img, 0, 0, scaled.width, scaled.height);
     workingCanvas = scaled;
-    quality = 0.85; // reset for next JPEG attempt
+    quality = 0.85; // reset for next quality attempt
   }
 
   throw new Error("image-uncompressible");
+}
+
+/**
+ * Runtime feature probe: does this canvas's `toBlob` actually produce
+ * the requested MIME type? Chromium's toBlob silently falls back to
+ * PNG when it can't honour the requested type (no error, just a
+ * misleading output blob), so the only reliable check is to ask for a
+ * tiny encode and inspect the result.  Cheap (<5 ms for a 1×1 canvas)
+ * and we only call it once per compression session.
+ */
+async function canvasSupportsType(
+  source: HTMLCanvasElement,
+  type: string,
+): Promise<boolean> {
+  // Use a 1×1 probe canvas rather than `source` so the probe is fast
+  // regardless of the source's pixel area (a 4000×4000 source would
+  // otherwise burn dozens of MB encoding the probe).
+  const probe = document.createElement("canvas");
+  probe.width = 1;
+  probe.height = 1;
+  const ctx = probe.getContext("2d");
+  if (ctx) ctx.drawImage(source, 0, 0, 1, 1);
+  try {
+    const blob = await canvasToBlob(probe, type, 0.5);
+    return blob.type === type;
+  } catch {
+    return false;
+  }
 }
 
 export interface ProcessFilesResult {

--- a/src/renderer/src/screens/Chat/attachmentUtils.ts
+++ b/src/renderer/src/screens/Chat/attachmentUtils.ts
@@ -71,17 +71,17 @@ function readAsBase64(file: File): Promise<string> {
 // (misleading) error "Invalid JSON in request body".
 //
 // Rather than reject oversized images, the desktop downscales them client-
-// side to fit under `MAX_IMAGE_TARGET_BYTES`. The loop drops JPEG quality
-// first (cheap, perceptually fine to ~0.5) then scales down by 20% steps
-// (lossier but bounded). Images already under the target pass through
+// side to fit under `MAX_IMAGE_TARGET_BYTES`. The loop drops lossy encoder
+// quality first (cheap, perceptually fine to ~0.5) then scales down by 20%
+// steps (lossier but bounded). Images already under the target pass through
 // untouched — no quality loss, no recompression.
 //
 // Format strategy: transparent PNGs (alpha channel detected via canvas
-// pixel sampling) stay as PNG so transparency survives; everything else
-// becomes JPEG which compresses photos ~10× better at imperceptible
-// quality loss. Animated GIFs only have their first frame captured by
-// canvas, so we explicitly bail with `image-uncompressible` and let the
-// user decide whether to send the static thumbnail.
+// pixel sampling) stay as PNG so transparency survives; opaque images are
+// encoded as WebP and JPEG and the smaller result wins. Animated GIFs only
+// have their first frame captured by canvas, so we explicitly bail with
+// `image-uncompressible` and let the user decide whether to send the static
+// thumbnail.
 
 function loadHtmlImage(file: File): Promise<HTMLImageElement> {
   // Round-trip through FileReader → data URL → Image.src rather than
@@ -400,7 +400,7 @@ export async function processFiles(
         attachments.push({
           id: newId(),
           kind: "image",
-          name,
+          name: compressedFile.name || name,
           mime: compressedFile.type || mime,
           size: compressedFile.size,
           dataUrl,

--- a/src/shared/attachments.ts
+++ b/src/shared/attachments.ts
@@ -11,6 +11,12 @@ export interface Attachment {
   size: number;
   // Images: data:image/<mime>;base64,<...>
   dataUrl?: string;
+  // Images: present iff the renderer transcoded/downsampled the source
+  // before pushing the attachment (e.g. a 12 MB photo compressed to fit
+  // the gateway's 10 MB request-body cap — see #405). UI uses this to
+  // surface the size delta in the attachment chip so the user knows
+  // quality changed.
+  originalSize?: number;
   // Text files: raw UTF-8 contents (already validated to be text)
   text?: string;
   // Path-ref attachments (PDFs, docx, etc.): absolute filesystem path.
@@ -19,7 +25,37 @@ export interface Attachment {
   path?: string;
 }
 
-export const MAX_IMAGE_BYTES = 20 * 1024 * 1024; // 20 MB
+/**
+ * Sanity cap on accepted image input. Set generously — the renderer
+ * compresses anything between this and `MAX_IMAGE_TARGET_BYTES` to fit.
+ * The only purpose of this cap is to bail before loading a pathologically
+ * large file into the renderer's canvas (which has its own pixel ceiling
+ * around 16M px and would OOM or stall before the decode completes).
+ *
+ * Was 20 MB pre-#405 with no compression; users with >20 MB photos got
+ * a hard reject. Now: anything up to 50 MB original is accepted, and
+ * compression brings the encoded body under the gateway's limit.
+ */
+export const MAX_IMAGE_INPUT_BYTES = 50 * 1024 * 1024; // 50 MB
+
+/**
+ * Target size for the binary payload of an image attachment after
+ * (optional) compression. Chosen so the base64-inflated payload (~4/3×)
+ * plus history and JSON overhead stays under the gateway's 10 MB
+ * request-body cap (`MAX_REQUEST_BYTES` in `gateway/platforms/api_server.py`).
+ *
+ *   5 MB binary × 4/3 ≈ 6.67 MB base64 → ~3.3 MB headroom for history.
+ *
+ * `attachmentUtils.compressImageToFit` only runs when `file.size`
+ * exceeds this target. Files already under the target pass through
+ * untouched (no quality loss, no recompression).
+ */
+export const MAX_IMAGE_TARGET_BYTES = 5 * 1024 * 1024; // 5 MB
+
+// Kept under the old name for backwards-compat with existing imports
+// (notably tests). Equivalent to the new INPUT cap — same semantics.
+export const MAX_IMAGE_BYTES = MAX_IMAGE_INPUT_BYTES;
+
 export const MAX_TEXT_BYTES = 256 * 1024; // 256 KB
 export const MAX_ATTACHMENTS_PER_MESSAGE = 10;
 

--- a/src/shared/i18n/locales/en/chat.ts
+++ b/src/shared/i18n/locales/en/chat.ts
@@ -33,7 +33,9 @@ export default {
   removeAttachment: "Remove attachment",
   dropToAttach: "Drop files to attach",
   attachUnsupported: "{{name}}: file type not supported",
-  attachImageTooLarge: "{{name}}: image too large (max 20 MB)",
+  attachImageTooLarge: "{{name}}: image too large (max 50 MB)",
+  attachImageUncompressible:
+    "{{name}}: couldn't compress image to fit (animated GIFs or unsupported format). Try a static screenshot.",
   attachTextTooLarge: "{{name}}: file too large (max 256 KB)",
   attachTooMany: "Too many attachments (max 10 per message)",
   attachReadFailed: "{{name}}: could not be read",

--- a/src/shared/i18n/locales/es/chat.ts
+++ b/src/shared/i18n/locales/es/chat.ts
@@ -30,7 +30,9 @@ export default {
   removeAttachment: "Quitar adjunto",
   dropToAttach: "Suelta los archivos para adjuntarlos",
   attachUnsupported: "{{name}}: tipo de archivo no admitido",
-  attachImageTooLarge: "{{name}}: imagen demasiado grande (máx. 20 MB)",
+  attachImageTooLarge: "{{name}}: imagen demasiado grande (máx. 50 MB)",
+  attachImageUncompressible:
+    "{{name}}: no se pudo comprimir la imagen lo suficiente (GIF animado o formato no compatible). Prueba con una captura estática.",
   attachTextTooLarge: "{{name}}: archivo demasiado grande (máx. 256 KB)",
   attachTooMany: "Demasiados adjuntos (máx. 10 por mensaje)",
   attachReadFailed: "{{name}}: no se pudo leer",

--- a/src/shared/i18n/locales/id/chat.ts
+++ b/src/shared/i18n/locales/id/chat.ts
@@ -30,7 +30,9 @@ export default {
   removeAttachment: "Hapus lampiran",
   dropToAttach: "Lepaskan file untuk dilampirkan",
   attachUnsupported: "{{name}}: tipe file tidak didukung",
-  attachImageTooLarge: "{{name}}: gambar terlalu besar (maks. 20 MB)",
+  attachImageTooLarge: "{{name}}: gambar terlalu besar (maks. 50 MB)",
+  attachImageUncompressible:
+    "{{name}}: gambar tidak dapat dikompresi agar muat (GIF animasi atau format tidak didukung). Coba tangkapan layar statis.",
   attachTextTooLarge: "{{name}}: file terlalu besar (maks. 256 KB)",
   attachTooMany: "Terlalu banyak lampiran (maks. 10 per pesan)",
   attachReadFailed: "{{name}}: tidak dapat dibaca",

--- a/src/shared/i18n/locales/ja/chat.ts
+++ b/src/shared/i18n/locales/ja/chat.ts
@@ -28,7 +28,9 @@ export default {
   removeAttachment: "添付を削除",
   dropToAttach: "ファイルをドロップして添付",
   attachUnsupported: "{{name}}: 対応していないファイル形式です",
-  attachImageTooLarge: "{{name}}: 画像が大きすぎます（最大 20 MB）",
+  attachImageTooLarge: "{{name}}: 画像が大きすぎます（最大 50 MB）",
+  attachImageUncompressible:
+    "{{name}}: サイズに収まるよう画像を圧縮できませんでした（アニメーション GIF または非対応フォーマット）。静止画のスクリーンショットをお試しください。",
   attachTextTooLarge: "{{name}}: ファイルが大きすぎます（最大 256 KB）",
   attachTooMany: "添付が多すぎます（1 メッセージにつき最大 10 件）",
   attachReadFailed: "{{name}}: 読み込めませんでした",

--- a/src/shared/i18n/locales/pt-BR/chat.ts
+++ b/src/shared/i18n/locales/pt-BR/chat.ts
@@ -30,7 +30,9 @@ export default {
   removeAttachment: "Remover anexo",
   dropToAttach: "Solte os arquivos para anexar",
   attachUnsupported: "{{name}}: tipo de arquivo não suportado",
-  attachImageTooLarge: "{{name}}: imagem muito grande (máx. 20 MB)",
+  attachImageTooLarge: "{{name}}: imagem muito grande (máx. 50 MB)",
+  attachImageUncompressible:
+    "{{name}}: não foi possível comprimir a imagem para caber (GIF animado ou formato não suportado). Tente uma captura de tela estática.",
   attachTextTooLarge: "{{name}}: arquivo muito grande (máx. 256 KB)",
   attachTooMany: "Anexos demais (máx. 10 por mensagem)",
   attachReadFailed: "{{name}}: não foi possível ler",

--- a/src/shared/i18n/locales/pt-PT/chat.ts
+++ b/src/shared/i18n/locales/pt-PT/chat.ts
@@ -30,7 +30,9 @@ export default {
   removeAttachment: "Remover anexo",
   dropToAttach: "Largue ficheiros para anexar",
   attachUnsupported: "{{name}}: tipo de ficheiro não suportado",
-  attachImageTooLarge: "{{name}}: imagem demasiado grande (máx. 20 MB)",
+  attachImageTooLarge: "{{name}}: imagem demasiado grande (máx. 50 MB)",
+  attachImageUncompressible:
+    "{{name}}: não foi possível comprimir a imagem para caber (GIF animado ou formato não suportado). Tenta uma captura de ecrã estática.",
   attachTextTooLarge: "{{name}}: ficheiro demasiado grande (máx. 256 KB)",
   attachTooMany: "Demasiados anexos (máx. 10 por mensagem)",
   attachReadFailed: "{{name}}: não foi possível ler",

--- a/src/shared/i18n/locales/zh-CN/chat.ts
+++ b/src/shared/i18n/locales/zh-CN/chat.ts
@@ -28,7 +28,9 @@ export default {
   removeAttachment: "移除附件",
   dropToAttach: "拖放文件以添加附件",
   attachUnsupported: "{{name}}：不支持的文件类型",
-  attachImageTooLarge: "{{name}}：图片过大（最大 20 MB）",
+  attachImageTooLarge: "{{name}}：图片过大（最大 50 MB）",
+  attachImageUncompressible:
+    "{{name}}：无法将图片压缩到合适大小（动画 GIF 或不支持的格式）。请尝试使用静态截图。",
   attachTextTooLarge: "{{name}}：文件过大（最大 256 KB）",
   attachTooMany: "附件数量过多（每条消息最多 10 个）",
   attachReadFailed: "{{name}}：无法读取",


### PR DESCRIPTION
## Problem

Closes #405.

Lemonseaa reports that pasting an image in Hermes Desktop returns `400 Invalid JSON in request body`. The gateway's error message is misleading — the real cause is the **request body is too large** for the gateway's 10 MB cap (`MAX_REQUEST_BYTES`), but two compounding bugs hide the real failure mode from the user.

## Diagnosis

After live reproduction against an aiohttp instance with the same `client_max_size=10_000_000`:

| Body size + framing | Status | Error |
|---|---|---|
| 5 MB body, Content-Length set | 200 | OK |
| 12 MB body, Content-Length set | 413 | `body_too_large` (correct) |
| 12 MB body, chunked encoding | **400** | **`Invalid JSON in request body`** ← #405 symptom |

The chunked path is the bug. `hermes.ts` was using `req.write(string); req.end();` which Node frames as `Transfer-Encoding: chunked` with **no Content-Length**. The gateway's `body_limit_middleware` only checks Content-Length, so it became a no-op for the desktop's requests, and oversized bodies fell through to aiohttp's `client_max_size` overflow — caught by a broad `except (json.JSONDecodeError, Exception):` that returns the misleading "Invalid JSON" 400.

Compounding it: the desktop accepted up to 20 MB images even though base64 inflation puts the encoded body well past the 10 MB gateway cap. So any photo over ~7 MB hit this consistently.

## Fix

### Wire-level (the actual #405-causing bug)

**`src/main/hermes.ts`** — encode the JSON body to a `Buffer` and set `Content-Length` explicitly on the request headers. Done for both the streaming chat path and the non-streaming probe-error path. Node won't fall back to chunked once Content-Length is present.

Verified live via Node-level capture:
- Pre-fix pattern (`req.write(string)`): no Content-Length, `Transfer-Encoding: chunked` — reproduces the bug
- Post-fix pattern (`req.write(buffer)` + explicit CL): Content-Length set correctly, no chunked framing → gateway's size middleware now catches oversized payloads with a clean 413

### Renderer-level (avoid hitting the cap in the first place)

**`src/renderer/src/screens/Chat/attachmentUtils.ts`** — new `compressImageToFit(file, targetBytes)` using HTML Canvas. Iteratively drops JPEG quality (0.85 → 0.5 in 0.15 steps), then scales dimensions down by 20% per round until under cap. Short-circuits and returns the original `File` reference if `file.size <= targetBytes`, so the 99% of pastes that don't need compression incur zero decode/re-encode overhead.

- **Opaque images** → re-encoded as JPEG (huge size win)
- **Images with alpha** (detected via strided pixel sampling) → kept as PNG, downsampled only
- **Animated GIFs** → rejected with the new `image-uncompressible` error (canvas would only capture the first frame; silently emitting a static thumbnail would be worse UX than a clear error)

**`src/shared/attachments.ts`** constants:
- `MAX_IMAGE_INPUT_BYTES = 50 MB` — sanity cap on input (only rejects pathologically large files; was 20 MB and rejected immediately)
- `MAX_IMAGE_TARGET_BYTES = 5 MB` — compression target (sized so `× 4/3` base64 inflation fits the gateway's 10 MB cap with headroom for history)

**`AttachmentChip.tsx`** — tooltip now shows "12 MB → 4.2 MB, compressed" when compression ran, so users know quality changed.

**i18n** — `attachImageTooLarge` cap bumped to 50 MB; new `attachImageUncompressible` string. 7 locales (en, es, id, ja, pt-BR, pt-PT, zh-CN).

## Testing

- **Unit tests:** short-circuit path (1 MB image passes through untouched, no `originalSize` set), input-cap path (>50 MB rejected without attempting compression). Existing tests for text/path-ref attachments still pass.
- **Wire-level live test:** confirmed via Node http capture that the post-fix `req.write(Buffer) + Content-Length` pattern lands a real `Content-Length` header and disables chunked encoding. Repro file: `.personal/verify-405-content-length.js`.
- **Compression algorithm:** the canvas-based loop isn't testable from JSDOM (no real canvas), so it's covered by visual inspection in the dev electron + integration via the wire-level path. If the algorithm has a bug, the worst case is the new Content-Length still gives a clean 413 — strict improvement over the pre-fix state.

## Upstream follow-up (separate, non-blocking)

The gateway's `except (json.JSONDecodeError, Exception):` clause should be split so future clients get a descriptive error rather than the "Invalid JSON" red herring. Worth filing on `NousResearch/hermes-agent` — but this desktop fix doesn't depend on it.

## CI flake note

Two tests (`Skills.test.tsx > surfaces the CLI error...` and `locale-persistence.test.ts > reloads the saved locale...`) are flaky on full-suite runs and pass in isolation. Same flake documented on PRs #403 and #404. Unrelated to packaging or this PR's surface.


## Side-effect: clears up "empty conversation" noise in the Sessions list

A separate user-reported puzzle was that the Sessions tab fills up with "0 msgs" rows tagged `New conversation` after a chat session. Diagnosis traced this to `agent/conversation_loop.py:2606-2628` in the engine: **when the gateway returns 413 Payload Too Large, the engine triggers `_compress_context` as recovery, which closes the running session with `end_reason='compression'` and spawns a fresh session ID**. Every pre-fix oversized-image attempt produced one of these compression-tagged rows.

Post-this-PR, the 413 cascade is gone (Content-Length is set so the gateway can actually decide if it's too big; image compression keeps the body under the cap anyway), so the conversation-compression-as-413-recovery code path stops firing for image attachments. Users who repeatedly attempt big image attachments today see a state.db full of these orphan rows; on the fix they won't.

(Existing rows in state.db from before this lands aren't cleaned up automatically — a follow-up PR for #408 adds an explicit delete button to the Sessions tab for that.)



---

## Maintainer Merge Note

Suggested full-stack order from the pre-release rebuild:

#383 -> #369 -> #400 -> #402 -> #404 -> #415 -> #419 -> #421 -> #422 -> #417 -> #430 -> #434 -> #437 -> #439 -> #440 -> #441

Suggested position: before #422.

Known stacked overlap: #422 also touches prompt attachment rendering. Merging #415 first lets #422 keep the compression tooltip/metadata behavior while adding prompt-image restore/preview behavior.

