### PR TITLE
feat(sessions): add per-row delete button to Sessions tab (#408)

### DIFF
--- a/src/main/sessions.ts
+++ b/src/main/sessions.ts
@@ -3,6 +3,7 @@ import { existsSync } from "fs";
 import { activeStateDbPath } from "./utils";
 import type { Attachment } from "../shared/attachments";
 import { isImageMime } from "../shared/attachments";
+import { clearStagedAttachments } from "./attachment-staging";
 import { removeSessionFromCache } from "./session-cache";
 
 // Sentinel prefix used by hermes-agent's hermes_state.py to mark
@@ -495,17 +496,19 @@ export function getSessionMessages(sessionId: string): HistoryItem[] {
 
 export function deleteSession(sessionId: string): void {
   const db = getDb(false);
-  if (!db) return;
 
-  try {
-    const tx = db.transaction((id: string) => {
-      db.prepare("DELETE FROM messages WHERE session_id = ?").run(id);
-      db.prepare("DELETE FROM sessions WHERE id = ?").run(id);
-    });
-    tx(sessionId);
-  } finally {
-    db.close();
+  if (db) {
+    try {
+      const tx = db.transaction((id: string) => {
+        db.prepare("DELETE FROM messages WHERE session_id = ?").run(id);
+        db.prepare("DELETE FROM sessions WHERE id = ?").run(id);
+      });
+      tx(sessionId);
+    } finally {
+      db.close();
+    }
   }
 
+  clearStagedAttachments(sessionId);
   removeSessionFromCache(sessionId);
 }

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -3488,6 +3488,64 @@ body {
   opacity: 1;
 }
 
+.sessions-confirm-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 120;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(0, 0, 0, 0.58);
+  animation: fadeIn 0.15s ease;
+}
+
+.sessions-confirm-modal {
+  width: min(440px, 100%);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-primary);
+  box-shadow: var(--shadow-lg);
+  animation: slideUp 0.2s ease;
+}
+
+.sessions-confirm-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px 18px;
+  border-bottom: 1px solid var(--border);
+}
+
+.sessions-confirm-header h3 {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.sessions-confirm-close {
+  padding: 6px;
+}
+
+.sessions-confirm-body {
+  padding: 18px;
+}
+
+.sessions-confirm-body p {
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.sessions-confirm-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 14px 18px 16px;
+  border-top: 1px solid var(--border);
+}
+
 .sessions-tag {
   font-size: 11px;
   color: var(--text-muted);

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -3455,6 +3455,39 @@ body {
   flex-wrap: wrap;
 }
 
+/* Delete (trash) button on each session card — #408.
+ * Slides into the right side of the tags row so it doesn't fight the
+ * card's main click target. Stays subtle until hover so the row doesn't
+ * look cluttered when the user is just browsing. */
+.sessions-card-delete {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  opacity: 0.45;
+  transition:
+    opacity var(--transition),
+    background var(--transition),
+    color var(--transition);
+}
+
+.sessions-card:hover .sessions-card-delete {
+  opacity: 1;
+}
+
+.sessions-card-delete:hover,
+.sessions-card-delete:focus-visible {
+  background: var(--bg-tertiary);
+  color: var(--danger, #e06c75);
+  opacity: 1;
+}
+
 .sessions-tag {
   font-size: 11px;
   color: var(--text-muted);

--- a/src/renderer/src/screens/Sessions/Sessions.test.tsx
+++ b/src/renderer/src/screens/Sessions/Sessions.test.tsx
@@ -124,7 +124,6 @@ describe("Sessions tab — delete affordance (#408)", () => {
       },
     ];
     const api = installHermesAPI(sessions);
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
 
     render(<Sessions {...baseProps} visible={true} />);
     await act(async () => {});
@@ -136,9 +135,18 @@ describe("Sessions tab — delete affordance (#408)", () => {
       fireEvent.click(deleteBtn);
     });
 
-    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("dialog")).toHaveTextContent(
+      "sessions.deleteConfirm",
+    );
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: "sessions.deleteConfirmAction",
+        }),
+      );
+    });
+
     expect(api.deleteSession).toHaveBeenCalledWith("sess-abc-123");
-    confirmSpy.mockRestore();
   });
 
   it("does NOT call deleteSession when the confirm is cancelled", async () => {
@@ -153,7 +161,6 @@ describe("Sessions tab — delete affordance (#408)", () => {
       },
     ];
     const api = installHermesAPI(sessions);
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
 
     render(<Sessions {...baseProps} visible={true} />);
     await act(async () => {});
@@ -165,9 +172,15 @@ describe("Sessions tab — delete affordance (#408)", () => {
       fireEvent.click(deleteBtn);
     });
 
-    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "sessions.deleteCancel" }),
+      );
+    });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     expect(api.deleteSession).not.toHaveBeenCalled();
-    confirmSpy.mockRestore();
   });
 
   it("stops click propagation so the card's resume handler doesn't fire", async () => {
@@ -186,7 +199,6 @@ describe("Sessions tab — delete affordance (#408)", () => {
     ];
     installHermesAPI(sessions);
     const onResume = vi.fn();
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
 
     render(
       <Sessions {...baseProps} onResumeSession={onResume} visible={true} />,
@@ -201,6 +213,6 @@ describe("Sessions tab — delete affordance (#408)", () => {
     });
 
     expect(onResume).not.toHaveBeenCalled();
-    confirmSpy.mockRestore();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
   });
 });

--- a/src/renderer/src/screens/Sessions/Sessions.test.tsx
+++ b/src/renderer/src/screens/Sessions/Sessions.test.tsx
@@ -1,4 +1,4 @@
-import { act, render } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // useI18n needs an I18nProvider; the Sessions tab only uses `t` for labels,
@@ -19,15 +19,17 @@ const baseProps = {
   currentSessionId: null,
 };
 
-function installHermesAPI(): {
+function installHermesAPI(initialSessions: unknown[] = []): {
   listCachedSessions: ReturnType<typeof vi.fn>;
   syncSessionCache: ReturnType<typeof vi.fn>;
   searchSessions: ReturnType<typeof vi.fn>;
+  deleteSession: ReturnType<typeof vi.fn>;
 } {
   const api = {
-    listCachedSessions: vi.fn().mockResolvedValue([]),
-    syncSessionCache: vi.fn().mockResolvedValue([]),
+    listCachedSessions: vi.fn().mockResolvedValue(initialSessions),
+    syncSessionCache: vi.fn().mockResolvedValue(initialSessions),
     searchSessions: vi.fn().mockResolvedValue([]),
+    deleteSession: vi.fn().mockResolvedValue(undefined),
   };
   Object.defineProperty(window, "hermesAPI", {
     configurable: true,
@@ -102,5 +104,103 @@ describe("Sessions tab live refresh (#322)", () => {
       window.dispatchEvent(new Event("focus"));
     });
     expect(api.syncSessionCache.mock.calls.length).toBe(afterMount + 1);
+  });
+});
+
+describe("Sessions tab — delete affordance (#408)", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("calls deleteSession when the trash button is clicked + confirmed", async () => {
+    const sessions = [
+      {
+        id: "sess-abc-123",
+        title: "First chat",
+        startedAt: Math.floor(Date.now() / 1000),
+        source: "api_server",
+        messageCount: 3,
+        model: "gpt-4",
+      },
+    ];
+    const api = installHermesAPI(sessions);
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    render(<Sessions {...baseProps} visible={true} />);
+    await act(async () => {});
+
+    const deleteBtn = screen.getByRole("button", {
+      name: "sessions.delete",
+    });
+    await act(async () => {
+      fireEvent.click(deleteBtn);
+    });
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(api.deleteSession).toHaveBeenCalledWith("sess-abc-123");
+    confirmSpy.mockRestore();
+  });
+
+  it("does NOT call deleteSession when the confirm is cancelled", async () => {
+    const sessions = [
+      {
+        id: "sess-abc-123",
+        title: "First chat",
+        startedAt: Math.floor(Date.now() / 1000),
+        source: "api_server",
+        messageCount: 3,
+        model: "gpt-4",
+      },
+    ];
+    const api = installHermesAPI(sessions);
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    render(<Sessions {...baseProps} visible={true} />);
+    await act(async () => {});
+
+    const deleteBtn = screen.getByRole("button", {
+      name: "sessions.delete",
+    });
+    await act(async () => {
+      fireEvent.click(deleteBtn);
+    });
+
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(api.deleteSession).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  it("stops click propagation so the card's resume handler doesn't fire", async () => {
+    // Regression: the trash button is nested inside a clickable card.
+    // Clicking trash must NOT also resume the session (would open the chat
+    // the user is trying to delete).
+    const sessions = [
+      {
+        id: "sess-abc-123",
+        title: "First chat",
+        startedAt: Math.floor(Date.now() / 1000),
+        source: "api_server",
+        messageCount: 3,
+        model: "gpt-4",
+      },
+    ];
+    installHermesAPI(sessions);
+    const onResume = vi.fn();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    render(
+      <Sessions {...baseProps} onResumeSession={onResume} visible={true} />,
+    );
+    await act(async () => {});
+
+    const deleteBtn = screen.getByRole("button", {
+      name: "sessions.delete",
+    });
+    await act(async () => {
+      fireEvent.click(deleteBtn);
+    });
+
+    expect(onResume).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
   });
 });

--- a/src/renderer/src/screens/Sessions/Sessions.tsx
+++ b/src/renderer/src/screens/Sessions/Sessions.tsx
@@ -202,6 +202,12 @@ function Sessions({
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
   const [isSearching, setIsSearching] = useState(false);
+  const [pendingDeleteSessionId, setPendingDeleteSessionId] = useState<
+    string | null
+  >(null);
+  const [deletingSessionId, setDeletingSessionId] = useState<string | null>(
+    null,
+  );
   const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const searchRef = useRef<HTMLInputElement>(null);
 
@@ -235,19 +241,23 @@ function Sessions({
     loadSessions();
   }, [loadSessions]);
 
-  // Delete a session — confirm first, then remove via IPC and refresh the
-  // list. We use the browser-native `window.confirm` rather than a custom
-  // modal: the desktop's existing Clear-chat flow does the same, and a
-  // custom confirm component adds maintenance burden for a one-line UX
-  // we'd otherwise build identical to the OS-native dialog. Closes #408.
-  const handleDelete = useCallback(
+  const handleDelete = useCallback((sessionId: string): void => {
+    setPendingDeleteSessionId(sessionId);
+  }, []);
+
+  const cancelDelete = useCallback((): void => {
+    if (deletingSessionId) return;
+    setPendingDeleteSessionId(null);
+  }, [deletingSessionId]);
+
+  const confirmDelete = useCallback(
     async (sessionId: string): Promise<void> => {
-      if (!window.confirm(t("sessions.deleteConfirm"))) return;
       // Optimistic UI update: drop the row from both the main list and
       // any active search results so the user sees instant feedback even
       // if the SQLite write or cache rewrite has any latency.  The
       // subsequent refresh re-syncs from state.db so we recover if the
       // backend deletion failed.
+      setDeletingSessionId(sessionId);
       setSessions((prev) => prev.filter((s) => s.id !== sessionId));
       setSearchResults((prev) =>
         prev.filter((r) => r.sessionId !== sessionId),
@@ -256,11 +266,25 @@ function Sessions({
         await window.hermesAPI.deleteSession(sessionId);
       } catch (err) {
         console.error("Failed to delete session", sessionId, err);
+      } finally {
+        await refreshSessions();
+        setDeletingSessionId(null);
+        setPendingDeleteSessionId(null);
       }
-      await refreshSessions();
     },
-    [refreshSessions, t],
+    [refreshSessions],
   );
+
+  useEffect(() => {
+    if (!pendingDeleteSessionId || deletingSessionId) return;
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") {
+        setPendingDeleteSessionId(null);
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [deletingSessionId, pendingDeleteSessionId]);
 
   // Refresh sessions whenever the Sessions view becomes visible.
   // This ensures new sessions created in the Chat view (via "+")
@@ -414,7 +438,7 @@ function Sessions({
                     className="sessions-card-delete"
                     onClick={(e) => {
                       e.stopPropagation();
-                      void handleDelete(r.sessionId);
+                      handleDelete(r.sessionId);
                     }}
                     onKeyDown={(e) => e.stopPropagation()}
                     title={t("sessions.delete")}
@@ -455,6 +479,59 @@ function Sessions({
               ))}
             </div>
           ))}
+        </div>
+      )}
+      {pendingDeleteSessionId && (
+        <div
+          className="sessions-confirm-overlay"
+          onClick={cancelDelete}
+          role="presentation"
+        >
+          <div
+            className="sessions-confirm-modal"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="sessions-delete-confirm-title"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="sessions-confirm-header">
+              <h3 id="sessions-delete-confirm-title">
+                {t("sessions.deleteConfirmTitle")}
+              </h3>
+              <button
+                type="button"
+                className="btn-ghost sessions-confirm-close"
+                onClick={cancelDelete}
+                disabled={!!deletingSessionId}
+                aria-label={t("sessions.deleteClose")}
+              >
+                <X size={16} />
+              </button>
+            </div>
+            <div className="sessions-confirm-body">
+              <p>{t("sessions.deleteConfirm")}</p>
+            </div>
+            <div className="sessions-confirm-footer">
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={cancelDelete}
+                disabled={!!deletingSessionId}
+              >
+                {t("sessions.deleteCancel")}
+              </button>
+              <button
+                type="button"
+                className="btn btn-danger"
+                onClick={() => void confirmDelete(pendingDeleteSessionId)}
+                disabled={!!deletingSessionId}
+              >
+                {deletingSessionId
+                  ? t("sessions.deleteDeleting")
+                  : t("sessions.deleteConfirmAction")}
+              </button>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/src/renderer/src/screens/Sessions/Sessions.tsx
+++ b/src/renderer/src/screens/Sessions/Sessions.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef, useCallback, memo } from "react";
-import { Plus, Search, X, ChatBubble } from "../../assets/icons";
+import { Plus, Search, X, ChatBubble, Trash } from "../../assets/icons";
 import { useI18n } from "../../components/useI18n";
 
 interface CachedSession {
@@ -110,16 +110,33 @@ const SessionCard = memo(function SessionCard({
   isActive,
   showFullDate,
   onClick,
+  onDelete,
+  deleteTitle,
 }: {
   session: CachedSession;
   isActive: boolean;
   showFullDate: boolean;
   onClick: () => void;
+  // When provided, renders a trash icon button on the card. Closes #408.
+  onDelete?: (id: string) => void;
+  deleteTitle?: string;
 }) {
+  // `div` instead of `button` because nesting a button-inside-button is
+  // invalid HTML and many a11y / interaction layers (focus trap, keyboard
+  // navigation) break on it. Click + Enter/Space behavior matches the
+  // previous semantics via explicit role + onKeyDown.
   return (
-    <button
+    <div
+      role="button"
+      tabIndex={0}
       className={`sessions-card ${isActive ? "sessions-card--active" : ""}`}
       onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onClick();
+        }
+      }}
     >
       <div className="sessions-card-main">
         <span className="sessions-card-title">
@@ -143,8 +160,28 @@ const SessionCard = memo(function SessionCard({
             {formatModel(session.model)}
           </span>
         )}
+        {onDelete && (
+          <button
+            type="button"
+            className="sessions-card-delete"
+            onClick={(e) => {
+              // Stop propagation so the parent card's onClick (which
+              // resumes the session) doesn't also fire — clicking the
+              // trash must NEVER take the user into the chat they're
+              // trying to delete.
+              e.stopPropagation();
+              onDelete(session.id);
+            }}
+            // Block keyboard activation of the parent card-as-button too.
+            onKeyDown={(e) => e.stopPropagation()}
+            title={deleteTitle}
+            aria-label={deleteTitle}
+          >
+            <Trash size={14} />
+          </button>
+        )}
       </div>
-    </button>
+    </div>
   );
 });
 
@@ -197,6 +234,33 @@ function Sessions({
   useEffect(() => {
     loadSessions();
   }, [loadSessions]);
+
+  // Delete a session — confirm first, then remove via IPC and refresh the
+  // list. We use the browser-native `window.confirm` rather than a custom
+  // modal: the desktop's existing Clear-chat flow does the same, and a
+  // custom confirm component adds maintenance burden for a one-line UX
+  // we'd otherwise build identical to the OS-native dialog. Closes #408.
+  const handleDelete = useCallback(
+    async (sessionId: string): Promise<void> => {
+      if (!window.confirm(t("sessions.deleteConfirm"))) return;
+      // Optimistic UI update: drop the row from both the main list and
+      // any active search results so the user sees instant feedback even
+      // if the SQLite write or cache rewrite has any latency.  The
+      // subsequent refresh re-syncs from state.db so we recover if the
+      // backend deletion failed.
+      setSessions((prev) => prev.filter((s) => s.id !== sessionId));
+      setSearchResults((prev) =>
+        prev.filter((r) => r.sessionId !== sessionId),
+      );
+      try {
+        await window.hermesAPI.deleteSession(sessionId);
+      } catch (err) {
+        console.error("Failed to delete session", sessionId, err);
+      }
+      await refreshSessions();
+    },
+    [refreshSessions, t],
+  );
 
   // Refresh sessions whenever the Sessions view becomes visible.
   // This ensures new sessions created in the Chat view (via "+")
@@ -303,10 +367,18 @@ function Sessions({
         ) : (
           <div className="sessions-list">
             {searchResults.map((r) => (
-              <button
+              <div
                 key={r.sessionId}
+                role="button"
+                tabIndex={0}
                 className={`sessions-card ${currentSessionId === r.sessionId ? "sessions-card--active" : ""}`}
                 onClick={() => onResumeSession(r.sessionId)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    onResumeSession(r.sessionId);
+                  }
+                }}
               >
                 <div className="sessions-card-main">
                   <span className="sessions-card-title">
@@ -337,8 +409,21 @@ function Sessions({
                       {formatModel(r.model)}
                     </span>
                   )}
+                  <button
+                    type="button"
+                    className="sessions-card-delete"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      void handleDelete(r.sessionId);
+                    }}
+                    onKeyDown={(e) => e.stopPropagation()}
+                    title={t("sessions.delete")}
+                    aria-label={t("sessions.delete")}
+                  >
+                    <Trash size={14} />
+                  </button>
                 </div>
-              </button>
+              </div>
             ))}
           </div>
         )
@@ -364,6 +449,8 @@ function Sessions({
                     group.label === "thisWeek" || group.label === "earlier"
                   }
                   onClick={() => onResumeSession(s.id)}
+                  onDelete={handleDelete}
+                  deleteTitle={t("sessions.delete")}
                 />
               ))}
             </div>

--- a/src/shared/i18n/locales/en/sessions.ts
+++ b/src/shared/i18n/locales/en/sessions.ts
@@ -14,6 +14,11 @@ export default {
   messages: "msg",
   messageSingular: "msg",
   delete: "Delete conversation",
+  deleteConfirmTitle: "Delete conversation",
   deleteConfirm:
     "Delete this conversation? This cannot be undone — both the messages and the session record will be permanently removed.",
+  deleteClose: "Close delete confirmation",
+  deleteCancel: "Cancel",
+  deleteConfirmAction: "Delete",
+  deleteDeleting: "Deleting...",
 } as const;

--- a/src/shared/i18n/locales/en/sessions.ts
+++ b/src/shared/i18n/locales/en/sessions.ts
@@ -13,4 +13,7 @@ export default {
   emptyHint: "Start chatting to create your first session",
   messages: "msg",
   messageSingular: "msg",
+  delete: "Delete conversation",
+  deleteConfirm:
+    "Delete this conversation? This cannot be undone — both the messages and the session record will be permanently removed.",
 } as const;

--- a/src/shared/i18n/locales/es/sessions.ts
+++ b/src/shared/i18n/locales/es/sessions.ts
@@ -14,6 +14,11 @@ export default {
   messages: "msg",
   messageSingular: "msg",
   delete: "Eliminar conversación",
+  deleteConfirmTitle: "Eliminar conversación",
   deleteConfirm:
     "¿Eliminar esta conversación? Esta acción no se puede deshacer — los mensajes y el registro de la sesión se eliminarán permanentemente.",
+  deleteClose: "Cerrar confirmación de eliminación",
+  deleteCancel: "Cancelar",
+  deleteConfirmAction: "Eliminar",
+  deleteDeleting: "Eliminando...",
 } as const;

--- a/src/shared/i18n/locales/es/sessions.ts
+++ b/src/shared/i18n/locales/es/sessions.ts
@@ -13,4 +13,7 @@ export default {
   emptyHint: "Empieza a chatear para crear tu primera sesión",
   messages: "msg",
   messageSingular: "msg",
+  delete: "Eliminar conversación",
+  deleteConfirm:
+    "¿Eliminar esta conversación? Esta acción no se puede deshacer — los mensajes y el registro de la sesión se eliminarán permanentemente.",
 } as const;

--- a/src/shared/i18n/locales/id/sessions.ts
+++ b/src/shared/i18n/locales/id/sessions.ts
@@ -14,6 +14,11 @@ export default {
   messages: "pesan",
   messageSingular: "pesan",
   delete: "Hapus percakapan",
+  deleteConfirmTitle: "Hapus percakapan",
   deleteConfirm:
     "Hapus percakapan ini? Tindakan ini tidak dapat dibatalkan — pesan dan catatan sesi akan dihapus secara permanen.",
+  deleteClose: "Tutup konfirmasi penghapusan",
+  deleteCancel: "Batal",
+  deleteConfirmAction: "Hapus",
+  deleteDeleting: "Menghapus...",
 } as const;

--- a/src/shared/i18n/locales/id/sessions.ts
+++ b/src/shared/i18n/locales/id/sessions.ts
@@ -13,4 +13,7 @@ export default {
   emptyHint: "Mulai chat untuk membuat sesi pertama Anda",
   messages: "pesan",
   messageSingular: "pesan",
+  delete: "Hapus percakapan",
+  deleteConfirm:
+    "Hapus percakapan ini? Tindakan ini tidak dapat dibatalkan — pesan dan catatan sesi akan dihapus secara permanen.",
 } as const;

--- a/src/shared/i18n/locales/ja/sessions.ts
+++ b/src/shared/i18n/locales/ja/sessions.ts
@@ -14,6 +14,11 @@ export default {
   messages: "件",
   messageSingular: "件",
   delete: "会話を削除",
+  deleteConfirmTitle: "会話を削除",
   deleteConfirm:
     "この会話を削除しますか？この操作は取り消せません — メッセージとセッション記録は完全に削除されます。",
+  deleteClose: "削除確認を閉じる",
+  deleteCancel: "キャンセル",
+  deleteConfirmAction: "削除",
+  deleteDeleting: "削除中...",
 } as const;

--- a/src/shared/i18n/locales/ja/sessions.ts
+++ b/src/shared/i18n/locales/ja/sessions.ts
@@ -13,4 +13,7 @@ export default {
   emptyHint: "チャットを始めて最初のセッションを作りましょう",
   messages: "件",
   messageSingular: "件",
+  delete: "会話を削除",
+  deleteConfirm:
+    "この会話を削除しますか？この操作は取り消せません — メッセージとセッション記録は完全に削除されます。",
 } as const;

--- a/src/shared/i18n/locales/pt-BR/sessions.ts
+++ b/src/shared/i18n/locales/pt-BR/sessions.ts
@@ -14,6 +14,11 @@ export default {
   messages: "msg",
   messageSingular: "msg",
   delete: "Excluir conversa",
+  deleteConfirmTitle: "Excluir conversa",
   deleteConfirm:
     "Excluir esta conversa? Essa ação não pode ser desfeita — as mensagens e o registro da sessão serão removidos permanentemente.",
+  deleteClose: "Fechar confirmação de exclusão",
+  deleteCancel: "Cancelar",
+  deleteConfirmAction: "Excluir",
+  deleteDeleting: "Excluindo...",
 } as const;

--- a/src/shared/i18n/locales/pt-BR/sessions.ts
+++ b/src/shared/i18n/locales/pt-BR/sessions.ts
@@ -13,4 +13,7 @@ export default {
   emptyHint: "Comece a conversar para criar sua primeira sessão",
   messages: "msg",
   messageSingular: "msg",
+  delete: "Excluir conversa",
+  deleteConfirm:
+    "Excluir esta conversa? Essa ação não pode ser desfeita — as mensagens e o registro da sessão serão removidos permanentemente.",
 } as const;

--- a/src/shared/i18n/locales/pt-PT/sessions.ts
+++ b/src/shared/i18n/locales/pt-PT/sessions.ts
@@ -14,6 +14,11 @@ export default {
   messages: "msg",
   messageSingular: "msg",
   delete: "Eliminar conversa",
+  deleteConfirmTitle: "Eliminar conversa",
   deleteConfirm:
     "Eliminar esta conversa? Esta ação não pode ser revertida — as mensagens e o registo da sessão vão ser removidos permanentemente.",
+  deleteClose: "Fechar confirmação de eliminação",
+  deleteCancel: "Cancelar",
+  deleteConfirmAction: "Eliminar",
+  deleteDeleting: "A eliminar...",
 } as const;

--- a/src/shared/i18n/locales/pt-PT/sessions.ts
+++ b/src/shared/i18n/locales/pt-PT/sessions.ts
@@ -13,4 +13,7 @@ export default {
   emptyHint: "Comece a conversar para criar a sua primeira sessão",
   messages: "msg",
   messageSingular: "msg",
+  delete: "Eliminar conversa",
+  deleteConfirm:
+    "Eliminar esta conversa? Esta ação não pode ser revertida — as mensagens e o registo da sessão vão ser removidos permanentemente.",
 } as const;

--- a/src/shared/i18n/locales/zh-CN/sessions.ts
+++ b/src/shared/i18n/locales/zh-CN/sessions.ts
@@ -14,6 +14,11 @@ export default {
   messages: "条消息",
   messageSingular: "条消息",
   delete: "删除会话",
+  deleteConfirmTitle: "删除会话",
   deleteConfirm:
     "删除此会话？此操作无法撤销——消息和会话记录都将被永久删除。",
+  deleteClose: "关闭删除确认",
+  deleteCancel: "取消",
+  deleteConfirmAction: "删除",
+  deleteDeleting: "正在删除...",
 } as const;

--- a/src/shared/i18n/locales/zh-CN/sessions.ts
+++ b/src/shared/i18n/locales/zh-CN/sessions.ts
@@ -13,4 +13,7 @@ export default {
   emptyHint: "开始聊天以创建第一条会话",
   messages: "条消息",
   messageSingular: "条消息",
+  delete: "删除会话",
+  deleteConfirm:
+    "删除此会话？此操作无法撤销——消息和会话记录都将被永久删除。",
 } as const;

--- a/src/shared/i18n/locales/zh-TW/sessions.ts
+++ b/src/shared/i18n/locales/zh-TW/sessions.ts
@@ -13,4 +13,11 @@ export default {
   emptyHint: "開始聊天以建立第一個工作階段",
   messages: "則訊息",
   messageSingular: "則訊息",
+  delete: "刪除對話",
+  deleteConfirmTitle: "刪除對話",
+  deleteConfirm: "刪除此對話？此操作無法復原 — 訊息和工作階段記錄將永久移除。",
+  deleteClose: "關閉刪除確認",
+  deleteCancel: "取消",
+  deleteConfirmAction: "刪除",
+  deleteDeleting: "正在刪除...",
 } as const;

--- a/tests/sessions-delete-session.test.ts
+++ b/tests/sessions-delete-session.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdirSync, rmSync, existsSync } from "fs";
+import { mkdirSync, rmSync, existsSync, writeFileSync } from "fs";
+import { join } from "path";
 
 const { TEST_HOME, DB_PATH } = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -335,6 +336,32 @@ describe("deleteSession", () => {
 
     const deletedMessages = getSessionMessages("session-to-delete");
     expect(deletedMessages).toHaveLength(0);
+  });
+
+  it("clears staged attachment files for the deleted session", () => {
+    const now = Math.floor(Date.now() / 1000);
+    seedDb([
+      {
+        id: "session-with-staged-files",
+        started_at: now,
+        message_count: 1,
+        messages: [{ role: "user", content: "see attached", timestamp: now }],
+      },
+    ]);
+    const stagingDir = join(
+      TEST_HOME,
+      "desktop-staging",
+      "session-with-staged-files",
+    );
+    mkdirSync(stagingDir, { recursive: true });
+    writeFileSync(join(stagingDir, "pasted.png"), "image bytes");
+
+    expect(existsSync(stagingDir)).toBe(true);
+
+    deleteSession("session-with-staged-files");
+
+    expect(existsSync(stagingDir)).toBe(false);
+    expect(getSessionMessages("session-with-staged-files")).toHaveLength(0);
   });
 
   it("does nothing when deleting a non-existent session", () => {


### PR DESCRIPTION
## Dependency

Depends on #419 and #422.

Merge order should be:
1. #419
2. #421
3. #422
4. this PR

#419 prevents new mixed/split session IDs before this PR makes session deletion easier from the Sessions list. #422 owns the desktop sidecar prompt-image persistence and DB-row cleanup, so merging this after #422 keeps all image/session deletion cleanup in the final `deleteSession()` path instead of splitting the responsibility across merge order.

## Problem

Closes #408.

Users have no way to delete individual past conversations from the Sessions list. The backend deletion path is fully wired — `sessions.ts::deleteSession`, the `delete-session` IPC handler, the preload bridge — but only the Chat tab's "Clear chat" calls into it (and only for the *current* chat).

Old conversations could only be cleaned up by:
- Opening each one and using Clear chat from inside, or
- Editing `state.db` directly with a SQLite client

Both are painful for users wanting to tidy up.

## Fix

Per-row trash button on each session card and on search-result rows, with an app-styled confirmation modal, optimistic removal, backend delete via the existing IPC, and re-sync to recover if anything went wrong.

### Implementation

- **`Sessions.tsx`** — `SessionCard` now takes an optional `onDelete` prop. When provided, renders a trash icon on the right of the tags row. `stopPropagation()` on the trash button's click handler prevents the parent card's "resume conversation" handler from firing.

- Card root changed from `<button>` to `<div role="button">` because nesting a real button inside another button is invalid HTML. Enter/Space keyboard activation is preserved via `onKeyDown`.

- Search-result inline cards got the same delete affordance while keeping their highlighted snippet layout.

- Delete confirmation now uses a themed in-app modal instead of `window.confirm`, so the destructive action matches the rest of the app shell.

- `deleteSession()` also clears the matching `%LOCALAPPDATA%/hermes/desktop-staging/<sessionId>` directory. That staging path already exists on `main`; PR #422 separately adds sidecar DB prompt-image cleanup and should land first so the final merged delete path cleans up both stores.

- **CSS** — `.sessions-card-delete` is subtle by default and uses danger coloring on hover/focus; `.sessions-confirm-*` styles the app-native confirmation modal.

- **i18n** — delete labels and confirmation strings are available across the session locales.

- **Tests** — coverage includes happy-path delete, cancelled modal, propagation-stop, and staged attachment cleanup.

## Testing

- `npm test -- --run tests/sessions-delete-session.test.ts src/renderer/src/screens/Sessions/Sessions.test.tsx tests/preload-api-surface.test.ts` — 148 passed.
- `npm run typecheck` — passed.
- `npm run build` — passed.
- Live Electron/CDP test: seeded a synthetic session plus a staged `desktop-staging/<sessionId>/pasted.png`, deleted it through the Sessions tab modal, and verified no native dialog appeared; the session row, messages, and staged folder were removed.

## Stack note

This branch is still based on `main` plus the Sessions delete work. After #419/#421/#422 merge, this PR should be refreshed on top of updated `main` so the `deleteSession()` hunk combines staged-directory cleanup with #422's sidecar prompt-image row cleanup.

## CI flake note

The `Skills.test.tsx` and `locale-persistence.test.ts` tests still flake intermittently on full-suite runs and pass in isolation — same flake documented on PRs #403, #404, #415. Unrelated to this PR.



---

## Maintainer Merge Note

Suggested full-stack order from the pre-release rebuild:

#383 -> #369 -> #400 -> #402 -> #404 -> #415 -> #419 -> #421 -> #422 -> #417 -> #430 -> #434 -> #437 -> #439 -> #440 -> #441

Suggested position: after #419, #421, and #422.

Known stacked overlap: this PR's session deletion path should be merged after the session split/replay/image-storage fixes so delete cleanup can remove DB messages, prompt-image attachments, staged attachments, and cache entries together. In the pre-release rebuild this was the important ordering constraint.

