### PR TITLE
Fix chat session split on cold gateway start

### DIFF
--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -199,6 +199,19 @@ function isApiServerReady(): Promise<boolean> {
   });
 }
 
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForApiServerReady(timeoutMs = 8000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await isApiServerReady()) return true;
+    await delay(250);
+  }
+  return false;
+}
+
 // ────────────────────────────────────────────────────
 //  Ensure API server is enabled in config
 // ────────────────────────────────────────────────────
@@ -874,12 +887,16 @@ function sendMessageViaCli(
   let capturedSessionId = "";
   let outputBuffer = "";
 
+  function captureSessionId(text: string): void {
+    const sidMatch = text.match(/session_id:\s*(\S+)/);
+    if (sidMatch) capturedSessionId = sidMatch[1];
+  }
+
   function processOutput(raw: Buffer): void {
     const text = stripAnsi(raw.toString());
     outputBuffer += text;
 
-    const sidMatch = outputBuffer.match(/session_id:\s*(\S+)/);
-    if (sidMatch) capturedSessionId = sidMatch[1];
+    captureSessionId(outputBuffer);
 
     const cleaned = text.replace(/session_id:\s*\S+\n?/g, "");
     const lines = cleaned.split("\n");
@@ -902,6 +919,7 @@ function sendMessageViaCli(
   let stderrBuffer = "";
   proc.stderr?.on("data", (data: Buffer) => {
     const text = stripAnsi(data.toString());
+    captureSessionId(text);
     if (
       !text.trim() ||
       text.includes("UserWarning") ||
@@ -980,9 +998,19 @@ export async function sendMessage(
     );
   }
 
-  // Check API server availability (cache the result, re-check periodically)
-  if (apiServerAvailable === null || apiServerAvailable === false) {
+  // Check API server availability. In local mode, a running gateway process
+  // can still be in its startup window (or the cached ready state can be stale
+  // after an external stop/start), so verify health before taking the API path.
+  const localGatewayRunning = !isRemoteMode() && isGatewayRunning();
+  if (
+    apiServerAvailable === null ||
+    apiServerAvailable === false ||
+    localGatewayRunning
+  ) {
     apiServerAvailable = await isApiServerReady();
+    if (!apiServerAvailable && localGatewayRunning) {
+      apiServerAvailable = await waitForApiServerReady();
+    }
   }
 
   if (apiServerAvailable) {

--- a/src/renderer/src/screens/Chat/sessionHistory.ts
+++ b/src/renderer/src/screens/Chat/sessionHistory.ts
@@ -233,19 +233,32 @@ export function reconcileStreamedWithDb(
   // result, skip it — it's a near-duplicate that slipped past the
   // key-based match (e.g. trailing-whitespace drift, one-frame delta
   // that didn't round-trip through the DB identically).
-  const seenBubbleKeys = new Set<string>();
-  for (const m of result) {
-    if (!("kind" in m)) {
-      const bubble = m as ChatBubbleMessage;
-      seenBubbleKeys.add(
-        `${bubble.role}:${normalizeWhitespace(bubble.content || "")}`,
-      );
-    }
-  }
-
   const consumedIds = new Set(result.map((m) => m.id));
-  for (const m of streamed) {
-    if (consumedIds.has(m.id)) continue;
+  const consumedStreamIndexes: number[] = [];
+  for (let i = 0; i < streamed.length; i++) {
+    if (consumedIds.has(streamed[i].id)) consumedStreamIndexes.push(i);
+  }
+  const firstConsumedIndex =
+    consumedStreamIndexes.length > 0 ? Math.min(...consumedStreamIndexes) : -1;
+
+  const seedSeenBubbleKeys = (
+    seen: Set<string>,
+    items: ReadonlyArray<ChatMessage>,
+  ): void => {
+    for (const m of items) {
+      if (!("kind" in m)) {
+        const bubble = m as ChatBubbleMessage;
+        seen.add(`${bubble.role}:${normalizeWhitespace(bubble.content || "")}`);
+      }
+    }
+  };
+
+  const appendIfUnique = (
+    target: ChatMessage[],
+    m: ChatMessage,
+    seen: Set<string>,
+  ): boolean => {
+    if (consumedIds.has(m.id)) return false;
     // For bubble messages, check if an equivalent already exists in the
     // result set.  Non-bubble messages (tool_call, tool_result, reasoning)
     // always pass through — they're either matched by callId above or are
@@ -253,11 +266,31 @@ export function reconcileStreamedWithDb(
     if (!("kind" in m)) {
       const bubble = m as ChatBubbleMessage;
       const contentKey = `${bubble.role}:${normalizeWhitespace(bubble.content || "")}`;
-      if (seenBubbleKeys.has(contentKey)) continue;
-      seenBubbleKeys.add(contentKey);
+      if (seen.has(contentKey)) return false;
+      seen.add(contentKey);
     }
-    result.push(m);
+    target.push(m);
+    return true;
+  };
+
+  const prefix: ChatMessage[] = [];
+  const seenPrefixBubbleKeys = new Set<string>();
+  for (let i = 0; i < streamed.length; i++) {
+    const m = streamed[i];
+    if (firstConsumedIndex >= 0 && i < firstConsumedIndex) {
+      appendIfUnique(prefix, m, seenPrefixBubbleKeys);
+    }
   }
 
-  return result;
+  const suffix: ChatMessage[] = [];
+  const seenSuffixBubbleKeys = new Set<string>();
+  seedSeenBubbleKeys(seenSuffixBubbleKeys, prefix);
+  seedSeenBubbleKeys(seenSuffixBubbleKeys, result);
+  for (let i = 0; i < streamed.length; i++) {
+    const m = streamed[i];
+    if (firstConsumedIndex >= 0 && i < firstConsumedIndex) continue;
+    appendIfUnique(suffix, m, seenSuffixBubbleKeys);
+  }
+
+  return [...prefix, ...result, ...suffix];
 }

--- a/tests/hermes-cli-session-id.test.ts
+++ b/tests/hermes-cli-session-id.test.ts
@@ -1,0 +1,260 @@
+import { EventEmitter } from "events";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+
+const { spawned, TEST_HOME, healthStatuses, apiBodies } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const path = require("path");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const os = require("os");
+  return {
+    spawned: [] as Array<
+      EventEmitter & {
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+        killed: boolean;
+        kill: ReturnType<typeof vi.fn>;
+        unref: ReturnType<typeof vi.fn>;
+      }
+    >,
+    TEST_HOME: path.join(os.tmpdir(), `hermes-cli-session-test-${Date.now()}`),
+    healthStatuses: [] as number[],
+    apiBodies: [] as string[],
+  };
+});
+
+vi.mock("http", () => ({
+  default: {
+    request: (
+      _url: string,
+      _options: Record<string, unknown>,
+      cb?: (res: {
+        statusCode: number;
+        headers?: Record<string, string>;
+        resume?: () => void;
+        on?: (event: string, handler: (...args: unknown[]) => void) => void;
+      }) => void,
+    ) => {
+      let body = "";
+      const handlers = new Map<string, (...args: unknown[]) => void>();
+      const req = {
+        write: (chunk: string | Buffer) => {
+          body += chunk.toString();
+        },
+        end: () => {
+          if (_url.endsWith("/health")) {
+            cb?.({
+              statusCode: healthStatuses.shift() ?? 503,
+              resume: () => {},
+            });
+            return;
+          }
+
+          if (_url.endsWith("/v1/chat/completions")) {
+            apiBodies.push(body);
+            const res = new EventEmitter() as EventEmitter & {
+              statusCode: number;
+              headers: Record<string, string>;
+            };
+            res.statusCode = 200;
+            res.headers = { "x-hermes-session-id": "desk-cold-gateway" };
+            cb?.(res);
+            queueMicrotask(() => {
+              res.emit(
+                "data",
+                Buffer.from(
+                  'data: {"choices":[{"delta":{"content":"Hi from API"}}]}\n\n',
+                ),
+              );
+              res.emit("data", Buffer.from("data: [DONE]\n\n"));
+              res.emit("end");
+            });
+          }
+        },
+        on: (event: string, handler: (...args: unknown[]) => void) => {
+          handlers.set(event, handler);
+          return req;
+        },
+        destroy: () => {
+          handlers.get("error")?.(new Error("destroyed"));
+        },
+      };
+      return req;
+    },
+  },
+}));
+
+vi.mock("https", () => ({
+  default: {
+    request: () => ({
+      write: () => {},
+      end: () => {},
+      on: () => {},
+      destroy: () => {},
+    }),
+  },
+}));
+
+vi.mock("child_process", () => ({
+  default: {
+    spawn: vi.fn(() => {
+      const proc = Object.assign(new EventEmitter(), {
+        stdout: new EventEmitter(),
+        stderr: new EventEmitter(),
+        killed: false,
+        kill: vi.fn(),
+        unref: vi.fn(),
+      });
+      spawned.push(proc);
+      return proc;
+    }),
+  },
+  spawn: vi.fn(() => {
+    const proc = Object.assign(new EventEmitter(), {
+      stdout: new EventEmitter(),
+      stderr: new EventEmitter(),
+      killed: false,
+      kill: vi.fn(),
+      unref: vi.fn(),
+    });
+    spawned.push(proc);
+    return proc;
+  }),
+}));
+
+vi.mock("../src/main/installer", () => ({
+  HERMES_HOME: TEST_HOME,
+  HERMES_PYTHON: "/usr/bin/python3",
+  HERMES_REPO: "/dev/null",
+  hermesCliArgs: (extra?: string[]) => ["/dev/null", ...(extra || [])],
+  getEnhancedPath: () => process.env.PATH || "",
+}));
+
+vi.mock("../src/main/config", () => ({
+  getModelConfig: () => ({ model: "test-model", provider: "openrouter" }),
+  readEnv: () => ({}),
+  getApiServerKey: () => "",
+  getConnectionConfig: () => ({ mode: "local" as const }),
+}));
+
+vi.mock("../src/main/ssh-tunnel", () => ({
+  getSshTunnelUrl: () => null,
+  isSshTunnelActive: () => false,
+  isSshTunnelHealthy: () => Promise.resolve(false),
+  startSshTunnel: () => Promise.resolve(),
+}));
+
+vi.mock("../src/main/utils", () => ({
+  stripAnsi: (s: string) => s,
+  pidIsAliveAs: () => false,
+}));
+
+vi.mock("../src/main/models", () => ({
+  readModels: () => [],
+}));
+
+vi.mock("../src/main/process-options", () => ({
+  HIDDEN_SUBPROCESS_OPTIONS: {},
+}));
+
+import {
+  sendMessage,
+  startGateway,
+  stopGateway,
+  stopHealthPolling,
+} from "../src/main/hermes";
+
+describe("CLI fallback session id propagation", () => {
+  beforeEach(() => {
+    healthStatuses.length = 0;
+    apiBodies.length = 0;
+  });
+
+  afterEach(() => {
+    stopGateway(true);
+    stopHealthPolling();
+    spawned.length = 0;
+  });
+
+  it("captures the quiet CLI session id from stderr so the next desktop turn can resume it", async () => {
+    const done = new Promise<string | undefined>((resolve) => {
+      sendMessage("hi", {
+        onChunk: () => {},
+        onDone: resolve,
+        onError: () => {},
+      }).then(() => {
+        const proc = spawned[0];
+        proc.stdout.emit("data", Buffer.from("Hi there"));
+        proc.stderr.emit(
+          "data",
+          Buffer.from("\nsession_id: 20260527_143413_10df4c\n"),
+        );
+        proc.emit("close", 0);
+      });
+    });
+
+    await expect(done).resolves.toBe("20260527_143413_10df4c");
+  });
+
+  it("waits for a cold gateway to become API-ready instead of falling back to CLI", async () => {
+    healthStatuses.push(503, 200);
+
+    expect(startGateway()).toBe(true);
+    expect(spawned).toHaveLength(1);
+
+    const chunks: string[] = [];
+    const done = new Promise<string | undefined>((resolve, reject) => {
+      sendMessage("hi", {
+        onChunk: (chunk) => chunks.push(chunk),
+        onDone: resolve,
+        onError: reject,
+      }).catch(reject);
+    });
+
+    await expect(done).resolves.toBe("desk-cold-gateway");
+    expect(chunks.join("")).toBe("Hi from API");
+    expect(spawned).toHaveLength(1);
+    expect(apiBodies).toHaveLength(1);
+    expect(JSON.parse(apiBodies[0])).toMatchObject({
+      messages: [{ role: "user", content: "hi" }],
+      stream: true,
+    });
+  });
+
+  it("re-checks health when a previously-ready local gateway is restarted cold", async () => {
+    healthStatuses.push(200);
+
+    await expect(
+      new Promise<string | undefined>((resolve, reject) => {
+        sendMessage("warmup", {
+          onChunk: () => {},
+          onDone: resolve,
+          onError: reject,
+        }).catch(reject);
+      }),
+    ).resolves.toBe("desk-cold-gateway");
+    expect(apiBodies).toHaveLength(1);
+
+    expect(startGateway()).toBe(true);
+    expect(spawned).toHaveLength(1);
+    healthStatuses.push(503, 200);
+
+    const chunks: string[] = [];
+    await expect(
+      new Promise<string | undefined>((resolve, reject) => {
+        sendMessage("hi after restart", {
+          onChunk: (chunk) => chunks.push(chunk),
+          onDone: resolve,
+          onError: reject,
+        }).catch(reject);
+      }),
+    ).resolves.toBe("desk-cold-gateway");
+
+    expect(chunks.join("")).toBe("Hi from API");
+    expect(spawned).toHaveLength(1);
+    expect(apiBodies).toHaveLength(2);
+    expect(JSON.parse(apiBodies[1])).toMatchObject({
+      messages: [{ role: "user", content: "hi after restart" }],
+      stream: true,
+    });
+  });
+});

--- a/tests/hermes-cli-session-id.test.ts
+++ b/tests/hermes-cli-session-id.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from "events";
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 
-const { spawned, TEST_HOME, healthStatuses, apiBodies } = vi.hoisted(() => {
+const { spawned, TEST_HOME, healthStatuses, apiRequests } = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const path = require("path");
   // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -18,7 +18,10 @@ const { spawned, TEST_HOME, healthStatuses, apiBodies } = vi.hoisted(() => {
     >,
     TEST_HOME: path.join(os.tmpdir(), `hermes-cli-session-test-${Date.now()}`),
     healthStatuses: [] as number[],
-    apiBodies: [] as string[],
+    apiRequests: [] as Array<{
+      body: string;
+      headers: Record<string, string>;
+    }>,
   };
 });
 
@@ -50,7 +53,10 @@ vi.mock("http", () => ({
           }
 
           if (_url.endsWith("/v1/chat/completions")) {
-            apiBodies.push(body);
+            apiRequests.push({
+              body,
+              headers: (_options.headers as Record<string, string>) || {},
+            });
             const res = new EventEmitter() as EventEmitter & {
               statusCode: number;
               headers: Record<string, string>;
@@ -166,7 +172,7 @@ import {
 describe("CLI fallback session id propagation", () => {
   beforeEach(() => {
     healthStatuses.length = 0;
-    apiBodies.length = 0;
+    apiRequests.length = 0;
   });
 
   afterEach(() => {
@@ -195,6 +201,48 @@ describe("CLI fallback session id propagation", () => {
     await expect(done).resolves.toBe("20260527_143413_10df4c");
   });
 
+  it("continues a CLI-created timestamp session over the API instead of minting a desk id", async () => {
+    const cliSessionId = "20260527_143413_10df4c";
+    const firstDone = new Promise<string | undefined>((resolve) => {
+      sendMessage("hi", {
+        onChunk: () => {},
+        onDone: resolve,
+        onError: () => {},
+      }).then(() => {
+        const proc = spawned[0];
+        proc.stdout.emit("data", Buffer.from("Hi there"));
+        proc.stderr.emit("data", Buffer.from(`\nsession_id: ${cliSessionId}\n`));
+        proc.emit("close", 0);
+      });
+    });
+
+    await expect(firstDone).resolves.toBe(cliSessionId);
+
+    healthStatuses.push(200);
+    await expect(
+      new Promise<string | undefined>((resolve, reject) => {
+        sendMessage(
+          "what time is it?",
+          {
+            onChunk: () => {},
+            onDone: resolve,
+            onError: reject,
+          },
+          undefined,
+          cliSessionId,
+        ).catch(reject);
+      }),
+    ).resolves.toBe("desk-cold-gateway");
+
+    expect(apiRequests).toHaveLength(1);
+    expect(apiRequests[0].headers["X-Hermes-Session-Id"]).toBe(cliSessionId);
+    expect(JSON.parse(apiRequests[0].body)).toMatchObject({
+      session_id: cliSessionId,
+      messages: [{ role: "user", content: "what time is it?" }],
+      stream: true,
+    });
+  });
+
   it("waits for a cold gateway to become API-ready instead of falling back to CLI", async () => {
     healthStatuses.push(503, 200);
 
@@ -213,8 +261,8 @@ describe("CLI fallback session id propagation", () => {
     await expect(done).resolves.toBe("desk-cold-gateway");
     expect(chunks.join("")).toBe("Hi from API");
     expect(spawned).toHaveLength(1);
-    expect(apiBodies).toHaveLength(1);
-    expect(JSON.parse(apiBodies[0])).toMatchObject({
+    expect(apiRequests).toHaveLength(1);
+    expect(JSON.parse(apiRequests[0].body)).toMatchObject({
       messages: [{ role: "user", content: "hi" }],
       stream: true,
     });
@@ -232,7 +280,7 @@ describe("CLI fallback session id propagation", () => {
         }).catch(reject);
       }),
     ).resolves.toBe("desk-cold-gateway");
-    expect(apiBodies).toHaveLength(1);
+    expect(apiRequests).toHaveLength(1);
 
     expect(startGateway()).toBe(true);
     expect(spawned).toHaveLength(1);
@@ -251,8 +299,8 @@ describe("CLI fallback session id propagation", () => {
 
     expect(chunks.join("")).toBe("Hi from API");
     expect(spawned).toHaveLength(1);
-    expect(apiBodies).toHaveLength(2);
-    expect(JSON.parse(apiBodies[1])).toMatchObject({
+    expect(apiRequests).toHaveLength(2);
+    expect(JSON.parse(apiRequests[1].body)).toMatchObject({
       messages: [{ role: "user", content: "hi after restart" }],
       stream: true,
     });

--- a/tests/reconcile-streamed-with-db.test.ts
+++ b/tests/reconcile-streamed-with-db.test.ts
@@ -264,4 +264,35 @@ describe("reconcileStreamedWithDb", () => {
     // DB row takes precedence; the duplicate streamed row is dropped.
     expect(merged[0].id).toBe("a-1");
   });
+
+  it("keeps earlier streamed turns before a DB suffix from a split session", () => {
+    // Regression: a cold desktop send briefly fell back to the CLI path,
+    // which created a timestamp-style session id. The next send used the
+    // API path and generated a fresh desk-* id. At chat-done, the DB fetch
+    // returned only the desk-* suffix, and the old reconciliation appended
+    // the unmatched first turn after the latest answer.
+    const streamed: ChatMessage[] = [
+      STREAMED_USER("hi", "u-old"),
+      STREAMED_AGENT("Hi! What can I help you with today?", "a-old"),
+      STREAMED_USER("what time is it?", "u-new"),
+      STREAMED_AGENT("It's Wed, May 27, 2026, 2:34 PM.", "a-new"),
+    ];
+    const db: ChatMessage[] = [
+      DB_USER("what time is it?", 30),
+      DB_TOOL_CALL("call-time", "terminal", '{"command":"date"}', 31),
+      DB_TOOL_RESULT("call-time", "terminal", "Wed, May 27, 2026 2:34 PM", 32),
+      DB_AGENT("It's Wed, May 27, 2026, 2:34 PM.", 33),
+    ];
+
+    const merged = reconcileStreamedWithDb(streamed, db);
+
+    expect(merged.map((m) => m.id)).toEqual([
+      "u-old",
+      "a-old",
+      "u-new",
+      "db-tc-31-call-time",
+      "db-tr-32",
+      "a-new",
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #411.

Fixes a cold-gateway edge case where the first desktop message could split one visible chat across two Hermes Agent sessions:

- first send starts/falls through while the local gateway API is not ready
- desktop uses the CLI fallback, which creates a timestamp-style session id
- the CLI prints `session_id:` on stderr, so desktop did not capture it
- the next send uses the now-ready API path and creates a new `desk-*` session
- end-of-stream DB reconciliation then fetched only the `desk-*` suffix and appended the unmatched first turn at the bottom

This keeps the chat on one session by waiting for a running gateway to become API-ready, re-checking health even if the local API-ready cache says ready, and preserving CLI fallback session ids when fallback still happens.

## Root Cause Notes

I checked both windows around #357:

- **#357 posted -> #357 merged / v0.5.1:** I do not see a later merge into v0.5.1 that broke this. The issue appears to be a latent edge in the combination of #357's end-of-stream DB merge and late-added `desk-*` API session ids: `desk-*` covered the API path, but a cold first send could still use CLI and create a different session id format.
- **v0.5.1 -> current main:** `main` is 27 commits ahead of v0.5.1. The relevant post-release changes are stream-to-DB reconciliation dedupe/ID-preservation, queued messages, SSH auth, session-cache sync, provider/key UI, and window sizing. None changes the local API/CLI routing decision that produced the mixed session ids. The reconciliation changes could affect how duplicate/reconciled rows render, but they do not create the split DB sessions.

So this PR treats the durable bug as the mixed routing/session identity problem: one visible desktop chat could start as a CLI timestamp session and continue as an API `desk-*` session when the gateway was cold or the API-ready cache was stale.

Old-format session ids can still exist legitimately (legacy rows, CLI-originated sessions, or last-resort CLI fallback), but they should no longer split a visible desktop chat. The new regression test simulates a CLI-created timestamp session followed by an API turn and asserts the API request continues the timestamp id via both `X-Hermes-Session-Id` and `session_id` instead of minting a fresh `desk-*` id.

## Changes

- Wait briefly for the local gateway API when a gateway process is running but `/health` is not ready yet.
- Re-check local gateway health before taking the API path so stale readiness cache does not produce `ECONNREFUSED` after a gateway restart.
- Capture CLI fallback `session_id:` from stderr as well as stdout.
- Preserve unmatched streamed prefix rows before DB suffix rows during reconciliation, avoiding visible reorder if a split-session suffix is encountered.
- Add regression coverage for CLI stderr session ids, old-format session continuation over API, cold gateway readiness, stale ready-cache restart, and split-session reconciliation order.

## Verification

- Live cold-gateway test on Windows:
  - stopped the Hermes gateway process from `%LOCALAPPDATA%\\hermes\\gateway.pid`
  - confirmed `/health` was cold
  - sent `hi` as the first message in the patched dev app
  - sent `what time is it?`
  - confirmed no `ECONNREFUSED`, no reorder, and one `desk-*` `api_server` DB session containing all six rows in order
- Simulated old-format continuation test: CLI timestamp session id is reused by the next API request instead of minting `desk-*`
- `npm test` - 677 passed, 3 skipped
- `npm run build` - passed

Refs #420 — this also addresses the observed “messages jump to earlier positions” behavior when it is caused by split Desktop session IDs followed by end-of-stream DB reconciliation. The same behavior was reproducible before this fix and has not reproduced on the current pre-release stack.



---

## Maintainer Merge Note

Suggested full-stack order from the pre-release rebuild:

#383 -> #369 -> #400 -> #402 -> #404 -> #415 -> #419 -> #421 -> #422 -> #417 -> #430 -> #434 -> #437 -> #439 -> #440 -> #441

Suggested position: before #421, #422, and #417.

Why: this is the base session-routing fix for the cold-gateway/session-split family. The later image replay/restore and delete-cleanup PRs are easier to validate once the session id/routing behavior is stable.

