### PR TITLE
fix chat image prompt replay after DB refresh

### DIFF
--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -199,6 +199,19 @@ function isApiServerReady(): Promise<boolean> {
   });
 }
 
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForApiServerReady(timeoutMs = 8000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await isApiServerReady()) return true;
+    await delay(250);
+  }
+  return false;
+}
+
 // ────────────────────────────────────────────────────
 //  Ensure API server is enabled in config
 // ────────────────────────────────────────────────────
@@ -874,12 +887,16 @@ function sendMessageViaCli(
   let capturedSessionId = "";
   let outputBuffer = "";
 
+  function captureSessionId(text: string): void {
+    const sidMatch = text.match(/session_id:\s*(\S+)/);
+    if (sidMatch) capturedSessionId = sidMatch[1];
+  }
+
   function processOutput(raw: Buffer): void {
     const text = stripAnsi(raw.toString());
     outputBuffer += text;
 
-    const sidMatch = outputBuffer.match(/session_id:\s*(\S+)/);
-    if (sidMatch) capturedSessionId = sidMatch[1];
+    captureSessionId(outputBuffer);
 
     const cleaned = text.replace(/session_id:\s*\S+\n?/g, "");
     const lines = cleaned.split("\n");
@@ -902,6 +919,7 @@ function sendMessageViaCli(
   let stderrBuffer = "";
   proc.stderr?.on("data", (data: Buffer) => {
     const text = stripAnsi(data.toString());
+    captureSessionId(text);
     if (
       !text.trim() ||
       text.includes("UserWarning") ||
@@ -980,9 +998,19 @@ export async function sendMessage(
     );
   }
 
-  // Check API server availability (cache the result, re-check periodically)
-  if (apiServerAvailable === null || apiServerAvailable === false) {
+  // Check API server availability. In local mode, a running gateway process
+  // can still be in its startup window (or the cached ready state can be stale
+  // after an external stop/start), so verify health before taking the API path.
+  const localGatewayRunning = !isRemoteMode() && isGatewayRunning();
+  if (
+    apiServerAvailable === null ||
+    apiServerAvailable === false ||
+    localGatewayRunning
+  ) {
     apiServerAvailable = await isApiServerReady();
+    if (!apiServerAvailable && localGatewayRunning) {
+      apiServerAvailable = await waitForApiServerReady();
+    }
   }
 
   if (apiServerAvailable) {

--- a/src/renderer/src/screens/Chat/sessionHistory.ts
+++ b/src/renderer/src/screens/Chat/sessionHistory.ts
@@ -233,19 +233,32 @@ export function reconcileStreamedWithDb(
   // result, skip it — it's a near-duplicate that slipped past the
   // key-based match (e.g. trailing-whitespace drift, one-frame delta
   // that didn't round-trip through the DB identically).
-  const seenBubbleKeys = new Set<string>();
-  for (const m of result) {
-    if (!("kind" in m)) {
-      const bubble = m as ChatBubbleMessage;
-      seenBubbleKeys.add(
-        `${bubble.role}:${normalizeWhitespace(bubble.content || "")}`,
-      );
-    }
-  }
-
   const consumedIds = new Set(result.map((m) => m.id));
-  for (const m of streamed) {
-    if (consumedIds.has(m.id)) continue;
+  const consumedStreamIndexes: number[] = [];
+  for (let i = 0; i < streamed.length; i++) {
+    if (consumedIds.has(streamed[i].id)) consumedStreamIndexes.push(i);
+  }
+  const firstConsumedIndex =
+    consumedStreamIndexes.length > 0 ? Math.min(...consumedStreamIndexes) : -1;
+
+  const seedSeenBubbleKeys = (
+    seen: Set<string>,
+    items: ReadonlyArray<ChatMessage>,
+  ): void => {
+    for (const m of items) {
+      if (!("kind" in m)) {
+        const bubble = m as ChatBubbleMessage;
+        seen.add(`${bubble.role}:${normalizeWhitespace(bubble.content || "")}`);
+      }
+    }
+  };
+
+  const appendIfUnique = (
+    target: ChatMessage[],
+    m: ChatMessage,
+    seen: Set<string>,
+  ): boolean => {
+    if (consumedIds.has(m.id)) return false;
     // For bubble messages, check if an equivalent already exists in the
     // result set.  Non-bubble messages (tool_call, tool_result, reasoning)
     // always pass through — they're either matched by callId above or are
@@ -253,11 +266,31 @@ export function reconcileStreamedWithDb(
     if (!("kind" in m)) {
       const bubble = m as ChatBubbleMessage;
       const contentKey = `${bubble.role}:${normalizeWhitespace(bubble.content || "")}`;
-      if (seenBubbleKeys.has(contentKey)) continue;
-      seenBubbleKeys.add(contentKey);
+      if (seen.has(contentKey)) return false;
+      seen.add(contentKey);
     }
-    result.push(m);
+    target.push(m);
+    return true;
+  };
+
+  const prefix: ChatMessage[] = [];
+  const seenPrefixBubbleKeys = new Set<string>();
+  for (let i = 0; i < streamed.length; i++) {
+    const m = streamed[i];
+    if (firstConsumedIndex >= 0 && i < firstConsumedIndex) {
+      appendIfUnique(prefix, m, seenPrefixBubbleKeys);
+    }
   }
 
-  return result;
+  const suffix: ChatMessage[] = [];
+  const seenSuffixBubbleKeys = new Set<string>();
+  seedSeenBubbleKeys(seenSuffixBubbleKeys, prefix);
+  seedSeenBubbleKeys(seenSuffixBubbleKeys, result);
+  for (let i = 0; i < streamed.length; i++) {
+    const m = streamed[i];
+    if (firstConsumedIndex >= 0 && i < firstConsumedIndex) continue;
+    appendIfUnique(suffix, m, seenSuffixBubbleKeys);
+  }
+
+  return [...prefix, ...result, ...suffix];
 }

--- a/src/renderer/src/screens/Chat/sessionHistory.ts
+++ b/src/renderer/src/screens/Chat/sessionHistory.ts
@@ -129,6 +129,13 @@ function normalizeWhitespace(s: string): string {
   return s.replace(/\s+/g, " ").trim();
 }
 
+function normalizeBubbleContentForMatch(s: string): string {
+  return normalizeWhitespace(s).replace(
+    /(?:\s+\[(?:screenshot|image)\])+$/i,
+    "",
+  );
+}
+
 function reconciliationKey(m: ChatMessage): string | null {
   if ("kind" in m) {
     switch (m.kind) {
@@ -143,7 +150,7 @@ function reconciliationKey(m: ChatMessage): string | null {
     }
   }
   const bubble = m as ChatBubbleMessage;
-  return `${bubble.role}:${normalizeWhitespace(bubble.content || "").slice(0, 200)}`;
+  return `${bubble.role}:${normalizeBubbleContentForMatch(bubble.content || "").slice(0, 200)}`;
 }
 
 /**
@@ -161,7 +168,11 @@ function mergeDbMetadataIntoStreamed(
   const s = streamed as ChatBubbleMessage;
   const d = db as ChatBubbleMessage;
   // Attachments from the DB that the stream didn't deliver.
-  if (d.attachments && d.attachments.length > 0 && (!s.attachments || s.attachments.length === 0)) {
+  if (
+    d.attachments &&
+    d.attachments.length > 0 &&
+    (!s.attachments || s.attachments.length === 0)
+  ) {
     return { ...s, attachments: d.attachments };
   }
   return s;
@@ -248,7 +259,9 @@ export function reconcileStreamedWithDb(
     for (const m of items) {
       if (!("kind" in m)) {
         const bubble = m as ChatBubbleMessage;
-        seen.add(`${bubble.role}:${normalizeWhitespace(bubble.content || "")}`);
+        seen.add(
+          `${bubble.role}:${normalizeBubbleContentForMatch(bubble.content || "")}`,
+        );
       }
     }
   };
@@ -265,7 +278,7 @@ export function reconcileStreamedWithDb(
     // genuinely new.
     if (!("kind" in m)) {
       const bubble = m as ChatBubbleMessage;
-      const contentKey = `${bubble.role}:${normalizeWhitespace(bubble.content || "")}`;
+      const contentKey = `${bubble.role}:${normalizeBubbleContentForMatch(bubble.content || "")}`;
       if (seen.has(contentKey)) return false;
       seen.add(contentKey);
     }

--- a/tests/hermes-cli-session-id.test.ts
+++ b/tests/hermes-cli-session-id.test.ts
@@ -1,0 +1,260 @@
+import { EventEmitter } from "events";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+
+const { spawned, TEST_HOME, healthStatuses, apiBodies } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const path = require("path");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const os = require("os");
+  return {
+    spawned: [] as Array<
+      EventEmitter & {
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+        killed: boolean;
+        kill: ReturnType<typeof vi.fn>;
+        unref: ReturnType<typeof vi.fn>;
+      }
+    >,
+    TEST_HOME: path.join(os.tmpdir(), `hermes-cli-session-test-${Date.now()}`),
+    healthStatuses: [] as number[],
+    apiBodies: [] as string[],
+  };
+});
+
+vi.mock("http", () => ({
+  default: {
+    request: (
+      _url: string,
+      _options: Record<string, unknown>,
+      cb?: (res: {
+        statusCode: number;
+        headers?: Record<string, string>;
+        resume?: () => void;
+        on?: (event: string, handler: (...args: unknown[]) => void) => void;
+      }) => void,
+    ) => {
+      let body = "";
+      const handlers = new Map<string, (...args: unknown[]) => void>();
+      const req = {
+        write: (chunk: string | Buffer) => {
+          body += chunk.toString();
+        },
+        end: () => {
+          if (_url.endsWith("/health")) {
+            cb?.({
+              statusCode: healthStatuses.shift() ?? 503,
+              resume: () => {},
+            });
+            return;
+          }
+
+          if (_url.endsWith("/v1/chat/completions")) {
+            apiBodies.push(body);
+            const res = new EventEmitter() as EventEmitter & {
+              statusCode: number;
+              headers: Record<string, string>;
+            };
+            res.statusCode = 200;
+            res.headers = { "x-hermes-session-id": "desk-cold-gateway" };
+            cb?.(res);
+            queueMicrotask(() => {
+              res.emit(
+                "data",
+                Buffer.from(
+                  'data: {"choices":[{"delta":{"content":"Hi from API"}}]}\n\n',
+                ),
+              );
+              res.emit("data", Buffer.from("data: [DONE]\n\n"));
+              res.emit("end");
+            });
+          }
+        },
+        on: (event: string, handler: (...args: unknown[]) => void) => {
+          handlers.set(event, handler);
+          return req;
+        },
+        destroy: () => {
+          handlers.get("error")?.(new Error("destroyed"));
+        },
+      };
+      return req;
+    },
+  },
+}));
+
+vi.mock("https", () => ({
+  default: {
+    request: () => ({
+      write: () => {},
+      end: () => {},
+      on: () => {},
+      destroy: () => {},
+    }),
+  },
+}));
+
+vi.mock("child_process", () => ({
+  default: {
+    spawn: vi.fn(() => {
+      const proc = Object.assign(new EventEmitter(), {
+        stdout: new EventEmitter(),
+        stderr: new EventEmitter(),
+        killed: false,
+        kill: vi.fn(),
+        unref: vi.fn(),
+      });
+      spawned.push(proc);
+      return proc;
+    }),
+  },
+  spawn: vi.fn(() => {
+    const proc = Object.assign(new EventEmitter(), {
+      stdout: new EventEmitter(),
+      stderr: new EventEmitter(),
+      killed: false,
+      kill: vi.fn(),
+      unref: vi.fn(),
+    });
+    spawned.push(proc);
+    return proc;
+  }),
+}));
+
+vi.mock("../src/main/installer", () => ({
+  HERMES_HOME: TEST_HOME,
+  HERMES_PYTHON: "/usr/bin/python3",
+  HERMES_REPO: "/dev/null",
+  hermesCliArgs: (extra?: string[]) => ["/dev/null", ...(extra || [])],
+  getEnhancedPath: () => process.env.PATH || "",
+}));
+
+vi.mock("../src/main/config", () => ({
+  getModelConfig: () => ({ model: "test-model", provider: "openrouter" }),
+  readEnv: () => ({}),
+  getApiServerKey: () => "",
+  getConnectionConfig: () => ({ mode: "local" as const }),
+}));
+
+vi.mock("../src/main/ssh-tunnel", () => ({
+  getSshTunnelUrl: () => null,
+  isSshTunnelActive: () => false,
+  isSshTunnelHealthy: () => Promise.resolve(false),
+  startSshTunnel: () => Promise.resolve(),
+}));
+
+vi.mock("../src/main/utils", () => ({
+  stripAnsi: (s: string) => s,
+  pidIsAliveAs: () => false,
+}));
+
+vi.mock("../src/main/models", () => ({
+  readModels: () => [],
+}));
+
+vi.mock("../src/main/process-options", () => ({
+  HIDDEN_SUBPROCESS_OPTIONS: {},
+}));
+
+import {
+  sendMessage,
+  startGateway,
+  stopGateway,
+  stopHealthPolling,
+} from "../src/main/hermes";
+
+describe("CLI fallback session id propagation", () => {
+  beforeEach(() => {
+    healthStatuses.length = 0;
+    apiBodies.length = 0;
+  });
+
+  afterEach(() => {
+    stopGateway(true);
+    stopHealthPolling();
+    spawned.length = 0;
+  });
+
+  it("captures the quiet CLI session id from stderr so the next desktop turn can resume it", async () => {
+    const done = new Promise<string | undefined>((resolve) => {
+      sendMessage("hi", {
+        onChunk: () => {},
+        onDone: resolve,
+        onError: () => {},
+      }).then(() => {
+        const proc = spawned[0];
+        proc.stdout.emit("data", Buffer.from("Hi there"));
+        proc.stderr.emit(
+          "data",
+          Buffer.from("\nsession_id: 20260527_143413_10df4c\n"),
+        );
+        proc.emit("close", 0);
+      });
+    });
+
+    await expect(done).resolves.toBe("20260527_143413_10df4c");
+  });
+
+  it("waits for a cold gateway to become API-ready instead of falling back to CLI", async () => {
+    healthStatuses.push(503, 200);
+
+    expect(startGateway()).toBe(true);
+    expect(spawned).toHaveLength(1);
+
+    const chunks: string[] = [];
+    const done = new Promise<string | undefined>((resolve, reject) => {
+      sendMessage("hi", {
+        onChunk: (chunk) => chunks.push(chunk),
+        onDone: resolve,
+        onError: reject,
+      }).catch(reject);
+    });
+
+    await expect(done).resolves.toBe("desk-cold-gateway");
+    expect(chunks.join("")).toBe("Hi from API");
+    expect(spawned).toHaveLength(1);
+    expect(apiBodies).toHaveLength(1);
+    expect(JSON.parse(apiBodies[0])).toMatchObject({
+      messages: [{ role: "user", content: "hi" }],
+      stream: true,
+    });
+  });
+
+  it("re-checks health when a previously-ready local gateway is restarted cold", async () => {
+    healthStatuses.push(200);
+
+    await expect(
+      new Promise<string | undefined>((resolve, reject) => {
+        sendMessage("warmup", {
+          onChunk: () => {},
+          onDone: resolve,
+          onError: reject,
+        }).catch(reject);
+      }),
+    ).resolves.toBe("desk-cold-gateway");
+    expect(apiBodies).toHaveLength(1);
+
+    expect(startGateway()).toBe(true);
+    expect(spawned).toHaveLength(1);
+    healthStatuses.push(503, 200);
+
+    const chunks: string[] = [];
+    await expect(
+      new Promise<string | undefined>((resolve, reject) => {
+        sendMessage("hi after restart", {
+          onChunk: (chunk) => chunks.push(chunk),
+          onDone: resolve,
+          onError: reject,
+        }).catch(reject);
+      }),
+    ).resolves.toBe("desk-cold-gateway");
+
+    expect(chunks.join("")).toBe("Hi from API");
+    expect(spawned).toHaveLength(1);
+    expect(apiBodies).toHaveLength(2);
+    expect(JSON.parse(apiBodies[1])).toMatchObject({
+      messages: [{ role: "user", content: "hi after restart" }],
+      stream: true,
+    });
+  });
+});

--- a/tests/hermes-cli-session-id.test.ts
+++ b/tests/hermes-cli-session-id.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from "events";
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 
-const { spawned, TEST_HOME, healthStatuses, apiBodies } = vi.hoisted(() => {
+const { spawned, TEST_HOME, healthStatuses, apiRequests } = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const path = require("path");
   // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -18,7 +18,10 @@ const { spawned, TEST_HOME, healthStatuses, apiBodies } = vi.hoisted(() => {
     >,
     TEST_HOME: path.join(os.tmpdir(), `hermes-cli-session-test-${Date.now()}`),
     healthStatuses: [] as number[],
-    apiBodies: [] as string[],
+    apiRequests: [] as Array<{
+      body: string;
+      headers: Record<string, string>;
+    }>,
   };
 });
 
@@ -50,7 +53,10 @@ vi.mock("http", () => ({
           }
 
           if (_url.endsWith("/v1/chat/completions")) {
-            apiBodies.push(body);
+            apiRequests.push({
+              body,
+              headers: (_options.headers as Record<string, string>) || {},
+            });
             const res = new EventEmitter() as EventEmitter & {
               statusCode: number;
               headers: Record<string, string>;
@@ -166,7 +172,7 @@ import {
 describe("CLI fallback session id propagation", () => {
   beforeEach(() => {
     healthStatuses.length = 0;
-    apiBodies.length = 0;
+    apiRequests.length = 0;
   });
 
   afterEach(() => {
@@ -195,6 +201,48 @@ describe("CLI fallback session id propagation", () => {
     await expect(done).resolves.toBe("20260527_143413_10df4c");
   });
 
+  it("continues a CLI-created timestamp session over the API instead of minting a desk id", async () => {
+    const cliSessionId = "20260527_143413_10df4c";
+    const firstDone = new Promise<string | undefined>((resolve) => {
+      sendMessage("hi", {
+        onChunk: () => {},
+        onDone: resolve,
+        onError: () => {},
+      }).then(() => {
+        const proc = spawned[0];
+        proc.stdout.emit("data", Buffer.from("Hi there"));
+        proc.stderr.emit("data", Buffer.from(`\nsession_id: ${cliSessionId}\n`));
+        proc.emit("close", 0);
+      });
+    });
+
+    await expect(firstDone).resolves.toBe(cliSessionId);
+
+    healthStatuses.push(200);
+    await expect(
+      new Promise<string | undefined>((resolve, reject) => {
+        sendMessage(
+          "what time is it?",
+          {
+            onChunk: () => {},
+            onDone: resolve,
+            onError: reject,
+          },
+          undefined,
+          cliSessionId,
+        ).catch(reject);
+      }),
+    ).resolves.toBe("desk-cold-gateway");
+
+    expect(apiRequests).toHaveLength(1);
+    expect(apiRequests[0].headers["X-Hermes-Session-Id"]).toBe(cliSessionId);
+    expect(JSON.parse(apiRequests[0].body)).toMatchObject({
+      session_id: cliSessionId,
+      messages: [{ role: "user", content: "what time is it?" }],
+      stream: true,
+    });
+  });
+
   it("waits for a cold gateway to become API-ready instead of falling back to CLI", async () => {
     healthStatuses.push(503, 200);
 
@@ -213,8 +261,8 @@ describe("CLI fallback session id propagation", () => {
     await expect(done).resolves.toBe("desk-cold-gateway");
     expect(chunks.join("")).toBe("Hi from API");
     expect(spawned).toHaveLength(1);
-    expect(apiBodies).toHaveLength(1);
-    expect(JSON.parse(apiBodies[0])).toMatchObject({
+    expect(apiRequests).toHaveLength(1);
+    expect(JSON.parse(apiRequests[0].body)).toMatchObject({
       messages: [{ role: "user", content: "hi" }],
       stream: true,
     });
@@ -232,7 +280,7 @@ describe("CLI fallback session id propagation", () => {
         }).catch(reject);
       }),
     ).resolves.toBe("desk-cold-gateway");
-    expect(apiBodies).toHaveLength(1);
+    expect(apiRequests).toHaveLength(1);
 
     expect(startGateway()).toBe(true);
     expect(spawned).toHaveLength(1);
@@ -251,8 +299,8 @@ describe("CLI fallback session id propagation", () => {
 
     expect(chunks.join("")).toBe("Hi from API");
     expect(spawned).toHaveLength(1);
-    expect(apiBodies).toHaveLength(2);
-    expect(JSON.parse(apiBodies[1])).toMatchObject({
+    expect(apiRequests).toHaveLength(2);
+    expect(JSON.parse(apiRequests[1].body)).toMatchObject({
       messages: [{ role: "user", content: "hi after restart" }],
       stream: true,
     });

--- a/tests/reconcile-streamed-with-db.test.ts
+++ b/tests/reconcile-streamed-with-db.test.ts
@@ -264,4 +264,35 @@ describe("reconcileStreamedWithDb", () => {
     // DB row takes precedence; the duplicate streamed row is dropped.
     expect(merged[0].id).toBe("a-1");
   });
+
+  it("keeps earlier streamed turns before a DB suffix from a split session", () => {
+    // Regression: a cold desktop send briefly fell back to the CLI path,
+    // which created a timestamp-style session id. The next send used the
+    // API path and generated a fresh desk-* id. At chat-done, the DB fetch
+    // returned only the desk-* suffix, and the old reconciliation appended
+    // the unmatched first turn after the latest answer.
+    const streamed: ChatMessage[] = [
+      STREAMED_USER("hi", "u-old"),
+      STREAMED_AGENT("Hi! What can I help you with today?", "a-old"),
+      STREAMED_USER("what time is it?", "u-new"),
+      STREAMED_AGENT("It's Wed, May 27, 2026, 2:34 PM.", "a-new"),
+    ];
+    const db: ChatMessage[] = [
+      DB_USER("what time is it?", 30),
+      DB_TOOL_CALL("call-time", "terminal", '{"command":"date"}', 31),
+      DB_TOOL_RESULT("call-time", "terminal", "Wed, May 27, 2026 2:34 PM", 32),
+      DB_AGENT("It's Wed, May 27, 2026, 2:34 PM.", 33),
+    ];
+
+    const merged = reconcileStreamedWithDb(streamed, db);
+
+    expect(merged.map((m) => m.id)).toEqual([
+      "u-old",
+      "a-old",
+      "u-new",
+      "db-tc-31-call-time",
+      "db-tr-32",
+      "a-new",
+    ]);
+  });
 });

--- a/tests/reconcile-streamed-with-db.test.ts
+++ b/tests/reconcile-streamed-with-db.test.ts
@@ -30,6 +30,22 @@ const STREAMED_USER = (content: string, id = "u-1"): ChatMessage => ({
   content,
 });
 
+const STREAMED_IMAGE_USER = (content: string, id = "u-img"): ChatMessage => ({
+  id,
+  role: "user",
+  content,
+  attachments: [
+    {
+      id: "img-1",
+      kind: "image",
+      name: "pasted-image.png",
+      mime: "image/png",
+      size: 3,
+      dataUrl: "data:image/png;base64,AAA=",
+    },
+  ],
+});
+
 const STREAMED_AGENT = (content: string, id = "a-1"): ChatMessage => ({
   id,
   role: "agent",
@@ -294,5 +310,61 @@ describe("reconcileStreamedWithDb", () => {
       "db-tr-32",
       "a-new",
     ]);
+  });
+
+  it("matches a streamed image user bubble to the DB screenshot placeholder", () => {
+    const streamed: ChatMessage[] = [
+      STREAMED_IMAGE_USER("describe this image", "u-img"),
+      STREAMED_AGENT("It is a simple cartoon image.", "a-img"),
+    ];
+    const db: ChatMessage[] = [
+      DB_USER("describe this image\n[screenshot]", 40),
+      DB_AGENT("It is a simple cartoon image.", 41),
+    ];
+
+    const merged = reconcileStreamedWithDb(streamed, db);
+
+    expect(merged).toHaveLength(2);
+    expect(merged[0].id).toBe("u-img");
+    expect(merged[0]).toMatchObject({
+      role: "user",
+      content: "describe this image",
+    });
+    expect(
+      ("attachments" in merged[0] && merged[0].attachments) || [],
+    ).toHaveLength(1);
+    expect(merged[1].id).toBe("a-img");
+  });
+
+  it("does not append an old streamed image turn after later DB-only rows", () => {
+    const streamed: ChatMessage[] = [
+      STREAMED_IMAGE_USER("describe this image", "u-img"),
+      STREAMED_AGENT("It is a simple cartoon image.", "a-img"),
+      STREAMED_USER("what time is it", "u-time"),
+      STREAMED_AGENT("It's Wed, May 27, 2026, 3:51 PM.", "a-time"),
+    ];
+    const db: ChatMessage[] = [
+      DB_USER("describe this image\n[screenshot]", 50),
+      DB_AGENT("It is a simple cartoon image.", 51),
+      DB_USER("what time is it", 52),
+      DB_TOOL_CALL("call-time", "terminal", '{"command":"date"}', 53),
+      DB_TOOL_RESULT("call-time", "terminal", "Wed, May 27, 2026 3:51 PM", 54),
+      DB_AGENT("It's Wed, May 27, 2026, 3:51 PM.", 55),
+    ];
+
+    const merged = reconcileStreamedWithDb(streamed, db);
+
+    expect(merged.map((m) => m.id)).toEqual([
+      "u-img",
+      "a-img",
+      "u-time",
+      "db-tc-53-call-time",
+      "db-tr-54",
+      "a-time",
+    ]);
+    expect(merged.filter((m) => m.id === "u-img")).toHaveLength(1);
+    expect(
+      ("attachments" in merged[0] && merged[0].attachments) || [],
+    ).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Merge order
This PR is now stacked on top of #419 and should be merged **after #419**. The head branch intentionally contains the #419 commits so the reconciliation conflict is already resolved. Once #419 lands in `main`, this PR should collapse down to the image-placeholder commit.

## Summary
- Reconcile DB image prompt placeholders like `[screenshot]` with the live streamed user bubble that still owns the real image attachment.
- Reuse the streamed image bubble when it matches the DB placeholder row, so chat history keeps showing the thumbnail instead of a placeholder.
- Deduplicate later DB refreshes with the same placeholder-aware key so an old image prompt is not appended again after subsequent answers.

## Diagnosis
When a pasted image is sent, the renderer immediately holds a user bubble with `content: "describe this image"` plus an image attachment. The persisted DB row can come back as plain text like `describe this image\n[screenshot]` and no attachment. Literal text reconciliation treats those copies as different unless the placeholder is normalized away for matching.

This is separate from the cold gateway/session split fix in #419: it happens inside one `desk-*` session and is caused by placeholder text mismatch for image turns. The current branch is stacked only so the two reconciliation changes merge cleanly in order.

## Verification
- `npm test -- --run tests/reconcile-streamed-with-db.test.ts tests/hermes-cli-session-id.test.ts`
- live-tested on local pre-release branch `codex/pre-release-session-image-fixes` containing #419 + this fix


---

## Maintainer Merge Note

Suggested full-stack order from the pre-release rebuild:

#383 -> #369 -> #400 -> #402 -> #404 -> #415 -> #419 -> #421 -> #422 -> #417 -> #430 -> #434 -> #437 -> #439 -> #440 -> #441

Suggested position: after #419 and before #422.

Why: #421 fixes image prompt replay after DB refresh. #422 then builds on the restored session image path; keeping this order matched the successful pre-release rebuild.

