### PR TITLE
Restore prompt images when reopening sessions

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -18,7 +18,12 @@ import type { Attachment } from "../shared/attachments";
 import { stageAttachment, clearStagedAttachments } from "./attachment-staging";
 import { persistPromptImageAttachments } from "./session-attachment-store";
 import { discoverProviderModels } from "./model-discovery";
-import { readMediaAsDataUrl, saveMedia, mediaFileExists } from "./media";
+import {
+  materializeDataUrlToTemp,
+  readMediaAsDataUrl,
+  saveMedia,
+  mediaFileExists,
+} from "./media";
 import { openTerminalInDirectory } from "./terminal-launcher";
 import {
   checkInstallStatus,
@@ -1030,23 +1035,21 @@ function setupIPC(): void {
       const isUrl = /^https?:\/\//i.test(src);
       const isData = src.startsWith("data:");
       const template: Electron.MenuItemConstructorOptions[] = [];
-      // "Open" needs a real target — a local file or a web URL. A data:
-      // URL is inline bytes with nothing to hand to the OS, so it is
-      // save-only.
-      if (!isData) {
-        template.push({
-          label: labels.open,
-          click: () => {
-            if (isUrl) {
-              openExternalUrl(src);
-            } else {
-              shell.openPath(src).then((err) => {
-                if (err) console.error("[media] open failed:", err);
-              });
-            }
-          },
-        });
-      }
+      template.push({
+        label: labels.open,
+        click: () => {
+          if (isUrl) {
+            openExternalUrl(src);
+            return;
+          }
+
+          const target = isData ? materializeDataUrlToTemp(src, name) : src;
+          if (!target) return;
+          shell.openPath(target).then((err) => {
+            if (err) console.error("[media] open failed:", err);
+          });
+        },
+      });
       template.push({
         label: labels.saveAs,
         click: () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -19,6 +19,7 @@ import { stageAttachment, clearStagedAttachments } from "./attachment-staging";
 import { persistPromptImageAttachments } from "./session-attachment-store";
 import { discoverProviderModels } from "./model-discovery";
 import {
+  cleanupTempMediaFiles,
   materializeDataUrlToTemp,
   readMediaAsDataUrl,
   saveMedia,
@@ -2126,6 +2127,7 @@ if (process.env.ENABLE_CDP === "1") {
 app.whenReady().then(() => {
   app.name = "Hermes";
   electronApp.setAppUserModelId("com.nousresearch.hermes");
+  cleanupTempMediaFiles();
 
   // Allow microphone access for the app's own renderer (voice input). Without
   // a handler Electron denies getUserMedia by default. Scoped to the `media`
@@ -2187,6 +2189,7 @@ app.on("window-all-closed", () => {
 });
 
 app.on("before-quit", () => {
+  cleanupTempMediaFiles();
   stopHealthPolling();
   if (currentChatAbort) {
     currentChatAbort();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -16,6 +16,7 @@ import type { AppUpdater } from "electron-updater";
 import icon from "../../resources/icon.png?asset";
 import type { Attachment } from "../shared/attachments";
 import { stageAttachment, clearStagedAttachments } from "./attachment-staging";
+import { persistPromptImageAttachments } from "./session-attachment-store";
 import { discoverProviderModels } from "./model-discovery";
 import { readMediaAsDataUrl, saveMedia, mediaFileExists } from "./media";
 import { openTerminalInDirectory } from "./terminal-launcher";
@@ -930,6 +931,11 @@ function setupIPC(): void {
           },
           onDone: (sessionId) => {
             currentChatAbort = null;
+            try {
+              persistPromptImageAttachments(sessionId, message, attachments);
+            } catch (err) {
+              console.warn("[sessions] Failed to persist prompt image attachments:", err);
+            }
             safeSend("chat-done", sessionId || "");
             resolveChat({ response: fullResponse, sessionId });
             // Desktop notification when window is not focused and response took >10s

--- a/src/main/media.ts
+++ b/src/main/media.ts
@@ -8,12 +8,14 @@
 
 import {
   existsSync,
+  mkdirSync,
   readFileSync,
   writeFileSync,
   copyFileSync,
   statSync,
 } from "fs";
-import { extname } from "path";
+import { join, extname } from "path";
+import { tmpdir } from "os";
 import { BrowserWindow, dialog } from "electron";
 
 const MAX_MEDIA_BYTES = 25 * 1024 * 1024;
@@ -28,6 +30,51 @@ const MIME_BY_EXT: Record<string, string> = {
   ".bmp": "image/bmp",
   ".avif": "image/avif",
 };
+
+const EXT_BY_MIME: Record<string, string> = Object.fromEntries(
+  Object.entries(MIME_BY_EXT).map(([ext, mime]) => [mime, ext]),
+);
+
+function sanitizeFilename(name: string): string {
+  const cleaned = (name || "image")
+    .replace(/[\x00-\x1F<>:"/\\|?*]/g, "")
+    .replace(/\s+/g, "_")
+    .replace(/\.{2,}/g, ".")
+    .trim();
+  return (cleaned || "image").slice(0, 160);
+}
+
+function decodeDataUrl(src: string): { mime: string; buffer: Buffer } | null {
+  const match = /^data:([^;,]+);base64,(.*)$/s.exec(src || "");
+  if (!match) return null;
+  const mime = match[1].toLowerCase();
+  const buffer = Buffer.from(match[2], "base64");
+  if (buffer.length <= 0 || buffer.length > MAX_MEDIA_BYTES) return null;
+  return { mime, buffer };
+}
+
+export function materializeDataUrlToTemp(
+  src: string,
+  suggestedName: string,
+): string | null {
+  try {
+    const decoded = decodeDataUrl(src);
+    if (!decoded) return null;
+
+    const dir = join(tmpdir(), "hermes-desktop-media");
+    mkdirSync(dir, { recursive: true });
+
+    let filename = sanitizeFilename(suggestedName);
+    if (!extname(filename)) {
+      filename += EXT_BY_MIME[decoded.mime] || ".bin";
+    }
+    const target = join(dir, `${Date.now()}-${filename}`);
+    writeFileSync(target, decoded.buffer);
+    return target;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Read a local image file and return it as a `data:` URL. Returns null when
@@ -78,9 +125,9 @@ export async function saveMedia(
     const dest = result.filePath;
 
     if (src.startsWith("data:")) {
-      const comma = src.indexOf(",");
-      if (comma === -1) return false;
-      writeFileSync(dest, Buffer.from(src.slice(comma + 1), "base64"));
+      const decoded = decodeDataUrl(src);
+      if (!decoded) return false;
+      writeFileSync(dest, decoded.buffer);
       return true;
     }
 

--- a/src/main/media.ts
+++ b/src/main/media.ts
@@ -9,16 +9,22 @@
 import {
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   writeFileSync,
   copyFileSync,
   statSync,
+  rmSync,
 } from "fs";
 import { join, extname } from "path";
 import { tmpdir } from "os";
+import { createHash } from "crypto";
 import { BrowserWindow, dialog } from "electron";
 
 const MAX_MEDIA_BYTES = 25 * 1024 * 1024;
+const TEMP_MEDIA_DIR = join(tmpdir(), "hermes-desktop-media");
+const TEMP_MEDIA_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const TEMP_MEDIA_MAX_FILES = 100;
 
 const MIME_BY_EXT: Record<string, string> = {
   ".png": "image/png",
@@ -53,6 +59,38 @@ function decodeDataUrl(src: string): { mime: string; buffer: Buffer } | null {
   return { mime, buffer };
 }
 
+export function cleanupTempMediaFiles({
+  maxAgeMs = 0,
+  maxFiles = 0,
+}: {
+  maxAgeMs?: number;
+  maxFiles?: number;
+} = {}): void {
+  try {
+    if (!existsSync(TEMP_MEDIA_DIR)) return;
+    const now = Date.now();
+    const entries = readdirSync(TEMP_MEDIA_DIR, { withFileTypes: true })
+      .filter((entry) => entry.isFile())
+      .map((entry) => {
+        const path = join(TEMP_MEDIA_DIR, entry.name);
+        return { path, mtimeMs: statSync(path).mtimeMs };
+      })
+      .sort((a, b) => a.mtimeMs - b.mtimeMs);
+
+    const keepNewestFrom = Math.max(0, entries.length - maxFiles);
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i];
+      const expired = maxAgeMs <= 0 || now - entry.mtimeMs > maxAgeMs;
+      const overLimit = maxFiles <= 0 || i < keepNewestFrom;
+      if (expired || overLimit) {
+        rmSync(entry.path, { force: true });
+      }
+    }
+  } catch {
+    // Best-effort cleanup only. Failure should never block opening media.
+  }
+}
+
 export function materializeDataUrlToTemp(
   src: string,
   suggestedName: string,
@@ -61,15 +99,21 @@ export function materializeDataUrlToTemp(
     const decoded = decodeDataUrl(src);
     if (!decoded) return null;
 
-    const dir = join(tmpdir(), "hermes-desktop-media");
-    mkdirSync(dir, { recursive: true });
+    mkdirSync(TEMP_MEDIA_DIR, { recursive: true });
+    cleanupTempMediaFiles({
+      maxAgeMs: TEMP_MEDIA_MAX_AGE_MS,
+      maxFiles: TEMP_MEDIA_MAX_FILES,
+    });
 
     let filename = sanitizeFilename(suggestedName);
     if (!extname(filename)) {
       filename += EXT_BY_MIME[decoded.mime] || ".bin";
     }
-    const target = join(dir, `${Date.now()}-${filename}`);
-    writeFileSync(target, decoded.buffer);
+    const hash = createHash("sha256").update(decoded.buffer).digest("hex");
+    const target = join(TEMP_MEDIA_DIR, `${hash.slice(0, 16)}-${filename}`);
+    if (!existsSync(target)) {
+      writeFileSync(target, decoded.buffer);
+    }
     return target;
   } catch {
     return null;

--- a/src/main/session-attachment-store.ts
+++ b/src/main/session-attachment-store.ts
@@ -1,0 +1,197 @@
+import Database from "better-sqlite3";
+import { existsSync } from "fs";
+import { activeStateDbPath } from "./utils";
+import type { Attachment } from "../shared/attachments";
+import { isImageMime, MAX_IMAGE_BYTES } from "../shared/attachments";
+
+const TABLE = "desktop_message_attachments";
+
+interface StoredAttachmentRow {
+  message_id: number;
+  ordinal: number;
+  name: string;
+  mime: string;
+  size: number;
+  data: Buffer;
+}
+
+function ensureTable(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS ${TABLE} (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      message_id INTEGER NOT NULL,
+      session_id TEXT NOT NULL,
+      ordinal INTEGER NOT NULL,
+      kind TEXT NOT NULL DEFAULT 'image',
+      name TEXT NOT NULL,
+      mime TEXT NOT NULL,
+      size INTEGER NOT NULL DEFAULT 0,
+      data BLOB NOT NULL,
+      created_at REAL NOT NULL DEFAULT (strftime('%s', 'now')),
+      UNIQUE(message_id, ordinal)
+    );
+    CREATE INDEX IF NOT EXISTS idx_${TABLE}_session
+      ON ${TABLE}(session_id);
+    CREATE INDEX IF NOT EXISTS idx_${TABLE}_message
+      ON ${TABLE}(message_id);
+  `);
+}
+
+function tableExists(db: Database.Database): boolean {
+  const row = db
+    .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = ?")
+    .get(TABLE) as { name: string } | undefined;
+  return !!row;
+}
+
+export function stripTrailingImagePlaceholders(text: string): string {
+  let out = text || "";
+  for (;;) {
+    const next = out.replace(/(?:\s*\[(?:screenshot|image)\]\s*)$/i, "");
+    if (next === out) return out.trim();
+    out = next;
+  }
+}
+
+function normalizedPromptText(text: string): string {
+  return stripTrailingImagePlaceholders(text).replace(/\s+/g, " ").trim();
+}
+
+function hasTrailingImagePlaceholder(text: string): boolean {
+  return /\[(?:screenshot|image)\]\s*$/i.test(text || "");
+}
+
+function parseImageDataUrl(dataUrl: string): { mime: string; data: Buffer } | null {
+  const match = /^data:([^;,]+);base64,(.*)$/s.exec(dataUrl || "");
+  if (!match) return null;
+  const mime = match[1].toLowerCase();
+  if (!isImageMime(mime)) return null;
+  const data = Buffer.from(match[2], "base64");
+  if (data.length <= 0 || data.length > MAX_IMAGE_BYTES) return null;
+  return { mime, data };
+}
+
+function imageAttachments(attachments?: Attachment[]): Attachment[] {
+  return (attachments || []).filter(
+    (a) => a.kind === "image" && typeof a.dataUrl === "string",
+  );
+}
+
+function findMatchingUserMessageId(
+  db: Database.Database,
+  sessionId: string,
+  promptText: string,
+): number | null {
+  const target = normalizedPromptText(promptText);
+
+  const rows = db
+    .prepare(
+      `SELECT id, content
+       FROM messages
+       WHERE session_id = ? AND role = 'user'
+       ORDER BY id DESC
+       LIMIT 50`,
+    )
+    .all(sessionId) as Array<{ id: number; content: string | null }>;
+
+  const hasAttachments = db.prepare(
+    `SELECT 1 FROM ${TABLE} WHERE message_id = ? LIMIT 1`,
+  );
+
+  for (const row of rows) {
+    const content = row.content || "";
+    if (content.startsWith("\x00json:")) continue;
+    if (normalizedPromptText(content) !== target) continue;
+    if (!target && !hasTrailingImagePlaceholder(content)) continue;
+    if (hasAttachments.get(row.id)) continue;
+    return row.id;
+  }
+
+  return null;
+}
+
+export function persistPromptImageAttachments(
+  sessionId: string | undefined,
+  promptText: string,
+  attachments?: Attachment[],
+): void {
+  if (!sessionId) return;
+  const images = imageAttachments(attachments);
+  if (images.length === 0) return;
+
+  const dbPath = activeStateDbPath();
+  if (!existsSync(dbPath)) return;
+
+  const db = new Database(dbPath);
+  try {
+    ensureTable(db);
+    const messageId = findMatchingUserMessageId(db, sessionId, promptText);
+    if (!messageId) return;
+
+    const insert = db.prepare(
+      `INSERT OR REPLACE INTO ${TABLE}
+       (message_id, session_id, ordinal, kind, name, mime, size, data)
+       VALUES (?, ?, ?, 'image', ?, ?, ?, ?)`,
+    );
+
+    const tx = db.transaction(() => {
+      images.forEach((attachment, index) => {
+        const parsed = parseImageDataUrl(attachment.dataUrl || "");
+        if (!parsed) return;
+        insert.run(
+          messageId,
+          sessionId,
+          index,
+          attachment.name || `image-${index + 1}`,
+          parsed.mime,
+          attachment.size || parsed.data.length,
+          parsed.data,
+        );
+      });
+    });
+    tx();
+  } finally {
+    db.close();
+  }
+}
+
+export function loadPromptImageAttachments(
+  db: Database.Database,
+  sessionId: string,
+): Map<number, Attachment[]> {
+  const byMessageId = new Map<number, Attachment[]>();
+  if (!tableExists(db)) return byMessageId;
+
+  const rows = db
+    .prepare(
+      `SELECT message_id, ordinal, name, mime, size, data
+       FROM ${TABLE}
+       WHERE session_id = ? AND kind = 'image'
+       ORDER BY message_id, ordinal`,
+    )
+    .all(sessionId) as StoredAttachmentRow[];
+
+  for (const row of rows) {
+    if (!isImageMime(row.mime)) continue;
+    const bucket = byMessageId.get(row.message_id) || [];
+    bucket.push({
+      id: `db-att-${row.message_id}-${row.ordinal}`,
+      kind: "image",
+      name: row.name,
+      mime: row.mime,
+      size: row.size,
+      dataUrl: `data:${row.mime};base64,${Buffer.from(row.data).toString("base64")}`,
+    });
+    byMessageId.set(row.message_id, bucket);
+  }
+
+  return byMessageId;
+}
+
+export function deletePromptImageAttachmentsForSession(
+  db: Database.Database,
+  sessionId: string,
+): void {
+  if (!tableExists(db)) return;
+  db.prepare(`DELETE FROM ${TABLE} WHERE session_id = ?`).run(sessionId);
+}

--- a/src/main/sessions.ts
+++ b/src/main/sessions.ts
@@ -5,6 +5,11 @@ import type { Attachment } from "../shared/attachments";
 import { isImageMime } from "../shared/attachments";
 import { clearStagedAttachments } from "./attachment-staging";
 import { removeSessionFromCache } from "./session-cache";
+import {
+  deletePromptImageAttachmentsForSession,
+  loadPromptImageAttachments,
+  stripTrailingImagePlaceholders,
+} from "./session-attachment-store";
 
 // Sentinel prefix used by hermes-agent's hermes_state.py to mark
 // JSON-encoded multimodal content in the messages.content column.
@@ -567,6 +572,27 @@ export function expandRowsToHistory(rows: RawMessageRow[]): HistoryItem[] {
   return items;
 }
 
+export function mergeStoredPromptImageAttachments(
+  items: HistoryItem[],
+  attachmentsByMessageId: Map<number, Attachment[]>,
+): HistoryItem[] {
+  if (attachmentsByMessageId.size === 0) return items;
+
+  return items.map((item) => {
+    if (item.kind !== "user") return item;
+    const stored = attachmentsByMessageId.get(item.id);
+    if (!stored || stored.length === 0) return item;
+    return {
+      ...item,
+      content: stripTrailingImagePlaceholders(item.content),
+      attachments:
+        item.attachments && item.attachments.length > 0
+          ? item.attachments
+          : stored,
+    };
+  });
+}
+
 export function getSessionMessages(sessionId: string): HistoryItem[] {
   const db = getDb();
   if (!db) return [];
@@ -583,7 +609,11 @@ export function getSessionMessages(sessionId: string): HistoryItem[] {
       )
       .all(sessionId) as RawMessageRow[];
 
-    return expandRowsToHistory(rows);
+    const items = expandRowsToHistory(rows);
+    return mergeStoredPromptImageAttachments(
+      items,
+      loadPromptImageAttachments(db, sessionId),
+    );
   } finally {
     db.close();
   }
@@ -607,6 +637,38 @@ function normalizeSessionIds(sessionIds: string[]): string[] {
   return normalized;
 }
 
+function deleteSessionRows(db: Database.Database, sessionId: string): number {
+  deletePromptImageAttachmentsForSession(db, sessionId);
+  db.prepare("DELETE FROM messages WHERE session_id = ?").run(sessionId);
+  const result = db.prepare("DELETE FROM sessions WHERE id = ?").run(sessionId);
+  return result.changes;
+}
+
+function cleanupDeletedSession(sessionId: string): void {
+  clearStagedAttachments(sessionId);
+  removeSessionFromCache(sessionId);
+}
+
+export function deleteSession(sessionId: string): void {
+  const id = normalizeSessionIds([sessionId])[0];
+  if (!id) return;
+
+  const db = getDb(false);
+
+  if (db) {
+    try {
+      const tx = db.transaction((sessionIdToDelete: string) => {
+        deleteSessionRows(db, sessionIdToDelete);
+      });
+      tx(id);
+    } finally {
+      db.close();
+    }
+  }
+
+  cleanupDeletedSession(id);
+}
+
 export function deleteSessions(sessionIds: string[]): DeleteSessionsResult {
   const ids = normalizeSessionIds(sessionIds);
   let deleted = 0;
@@ -616,17 +678,8 @@ export function deleteSessions(sessionIds: string[]): DeleteSessionsResult {
   if (db) {
     try {
       const tx = db.transaction((idsToDelete: string[]) => {
-        const deleteMessages = db.prepare(
-          "DELETE FROM messages WHERE session_id = ?",
-        );
-        const deleteSessionRow = db.prepare(
-          "DELETE FROM sessions WHERE id = ?",
-        );
-
         for (const id of idsToDelete) {
-          deleteMessages.run(id);
-          const result = deleteSessionRow.run(id);
-          if (result.changes > 0) deleted += result.changes;
+          deleted += deleteSessionRows(db, id);
         }
       });
       tx(ids);
@@ -636,13 +689,8 @@ export function deleteSessions(sessionIds: string[]): DeleteSessionsResult {
   }
 
   for (const id of ids) {
-    clearStagedAttachments(id);
-    removeSessionFromCache(id);
+    cleanupDeletedSession(id);
   }
 
   return { requested: ids.length, deleted };
-}
-
-export function deleteSession(sessionId: string): void {
-  deleteSessions([sessionId]);
 }

--- a/src/renderer/src/components/AttachmentChip.tsx
+++ b/src/renderer/src/components/AttachmentChip.tsx
@@ -1,4 +1,5 @@
-import { FileText, X } from "lucide-react";
+import { Download, FileText, X } from "lucide-react";
+import { useState } from "react";
 import type { Attachment } from "../../../shared/attachments";
 import { useI18n } from "./useI18n";
 
@@ -16,6 +17,7 @@ export function AttachmentChip({
   onPreview,
 }: AttachmentChipProps): React.JSX.Element {
   const { t } = useI18n();
+  const [zoomed, setZoomed] = useState(false);
   const isImage = attachment.kind === "image";
   const showImageMenu = (event: React.MouseEvent): void => {
     if (!isImage || !attachment.dataUrl) return;
@@ -25,6 +27,11 @@ export function AttachmentChip({
       saveAs: t("chat.media.saveAs"),
     });
   };
+  const previewImage = (): void => {
+    if (!isImage || !attachment.dataUrl) return;
+    onPreview?.(attachment);
+    setZoomed(true);
+  };
 
   // When the renderer compressed the image down to fit the gateway's
   // request-body cap (#405), surface the size delta in the tooltip so the
@@ -32,41 +39,83 @@ export function AttachmentChip({
   // version appearing in the chat transcript.
   const tooltip =
     attachment.originalSize && attachment.originalSize > attachment.size
-      ? `${attachment.name} (${formatSize(attachment.originalSize)} → ${formatSize(attachment.size)}, compressed)`
+      ? `${attachment.name} (${formatSize(attachment.originalSize)} -> ${formatSize(attachment.size)}, compressed)`
       : `${attachment.name} (${formatSize(attachment.size)})`;
 
   return (
-    <div
-      className={`attachment-chip attachment-chip-${attachment.kind}`}
-      title={tooltip}
-    >
-      {isImage && attachment.dataUrl ? (
-        <button
-          type="button"
-          className="attachment-chip-thumb"
-          onClick={() => onPreview?.(attachment)}
-          onContextMenu={showImageMenu}
-          aria-label={attachment.name}
+    <>
+      <div
+        className={`attachment-chip attachment-chip-${attachment.kind}`}
+        title={tooltip}
+      >
+        {isImage && attachment.dataUrl ? (
+          <button
+            type="button"
+            className="attachment-chip-thumb"
+            onClick={previewImage}
+            onContextMenu={showImageMenu}
+            aria-label={attachment.name}
+          >
+            <img src={attachment.dataUrl} alt={attachment.name} />
+          </button>
+        ) : (
+          <div className="attachment-chip-file">
+            <FileText size={14} />
+            <span className="attachment-chip-name">{attachment.name}</span>
+          </div>
+        )}
+        {onRemove && (
+          <button
+            type="button"
+            className="attachment-chip-remove"
+            onClick={onRemove}
+            aria-label={`Remove ${attachment.name}`}
+          >
+            <X size={12} />
+          </button>
+        )}
+      </div>
+      {zoomed && isImage && attachment.dataUrl && (
+        <div
+          className="chat-image-preview-backdrop"
+          role="dialog"
+          aria-modal="true"
+          onClick={() => setZoomed(false)}
         >
-          <img src={attachment.dataUrl} alt={attachment.name} />
-        </button>
-      ) : (
-        <div className="attachment-chip-file">
-          <FileText size={14} />
-          <span className="attachment-chip-name">{attachment.name}</span>
+          <img
+            className="chat-image-preview-image"
+            src={attachment.dataUrl}
+            alt={attachment.name}
+            onClick={(e) => e.stopPropagation()}
+            onContextMenu={showImageMenu}
+          />
+          <div
+            className="chat-image-preview-actions"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              className="chat-image-preview-btn"
+              onClick={() =>
+                window.hermesAPI.saveMediaFile(
+                  attachment.dataUrl!,
+                  attachment.name,
+                )
+              }
+            >
+              <Download size={14} />
+              Save image
+            </button>
+            <button
+              className="chat-image-preview-btn"
+              onClick={() => setZoomed(false)}
+              aria-label="Close"
+            >
+              <X size={14} />
+            </button>
+          </div>
         </div>
       )}
-      {onRemove && (
-        <button
-          type="button"
-          className="attachment-chip-remove"
-          onClick={onRemove}
-          aria-label={`Remove ${attachment.name}`}
-        >
-          <X size={12} />
-        </button>
-      )}
-    </div>
+    </>
   );
 }
 

--- a/src/renderer/src/components/AttachmentChip.tsx
+++ b/src/renderer/src/components/AttachmentChip.tsx
@@ -1,5 +1,6 @@
 import { FileText, X } from "lucide-react";
 import type { Attachment } from "../../../shared/attachments";
+import { useI18n } from "./useI18n";
 
 interface AttachmentChipProps {
   attachment: Attachment;
@@ -14,7 +15,16 @@ export function AttachmentChip({
   onRemove,
   onPreview,
 }: AttachmentChipProps): React.JSX.Element {
+  const { t } = useI18n();
   const isImage = attachment.kind === "image";
+  const showImageMenu = (event: React.MouseEvent): void => {
+    if (!isImage || !attachment.dataUrl) return;
+    event.preventDefault();
+    window.hermesAPI.showMediaMenu(attachment.dataUrl, attachment.name, {
+      open: t("chat.media.open"),
+      saveAs: t("chat.media.saveAs"),
+    });
+  };
 
   // When the renderer compressed the image down to fit the gateway's
   // request-body cap (#405), surface the size delta in the tooltip so the
@@ -35,6 +45,7 @@ export function AttachmentChip({
           type="button"
           className="attachment-chip-thumb"
           onClick={() => onPreview?.(attachment)}
+          onContextMenu={showImageMenu}
           aria-label={attachment.name}
         >
           <img src={attachment.dataUrl} alt={attachment.name} />

--- a/src/renderer/src/components/AttachmentChip.tsx
+++ b/src/renderer/src/components/AttachmentChip.tsx
@@ -103,7 +103,7 @@ export function AttachmentChip({
               }
             >
               <Download size={14} />
-              Save image
+              {t("chat.media.saveImage")}
             </button>
             <button
               className="chat-image-preview-btn"

--- a/src/renderer/src/components/MediaImage.tsx
+++ b/src/renderer/src/components/MediaImage.tsx
@@ -27,13 +27,14 @@ function useMediaContextMenu(
  * Renders an agent-delivered image (issue #299). Data URLs and http(s)
  * URLs render directly; local filesystem paths are resolved to a data URL
  * through the main process. Clicking the image opens a zoom/lightbox
- * overlay with a "Save image" action.
+ * overlay with a localized save action.
  */
 export function MediaImage({
   token,
 }: {
   token: MediaToken;
 }): React.JSX.Element {
+  const { t } = useI18n();
   const isDirect =
     token.src.startsWith("data:") || /^https?:\/\//i.test(token.src);
   const [resolved, setResolved] = useState<string | null>(
@@ -106,7 +107,7 @@ export function MediaImage({
               }
             >
               <Download size={14} />
-              Save image
+              {t("chat.media.saveImage")}
             </button>
             <button
               className="chat-image-preview-btn"

--- a/src/renderer/src/screens/Chat/MessageRow.tsx
+++ b/src/renderer/src/screens/Chat/MessageRow.tsx
@@ -1,11 +1,11 @@
-import { memo, useMemo, useState } from "react";
+import { memo, useMemo } from "react";
 import icon from "../../assets/icon.png";
 import { AgentMarkdown } from "../../components/AgentMarkdown";
 import { AttachmentChip } from "../../components/AttachmentChip";
 import { MediaSegmentView } from "../../components/MediaImage";
 import { useI18n } from "../../components/useI18n";
 import { parseMediaTokens, cleanLeakedToolTags } from "./mediaUtils";
-import type { Attachment, ChatBubbleMessage, ChatMessage } from "./types";
+import type { ChatBubbleMessage, ChatMessage } from "./types";
 
 export const APPROVAL_RE =
   /⚠️.*dangerous|requires? (your )?approval|\/approve.*\/deny|do you want (me )?to (proceed|continue|run|execute)/i;
@@ -60,9 +60,6 @@ export const MessageRow = memo(function MessageRow({
   showAvatar = true,
 }: MessageRowProps): React.JSX.Element {
   const { t } = useI18n();
-  const [previewAttachment, setPreviewAttachment] = useState<Attachment | null>(
-    null,
-  );
 
   // MessageRow is wrapped in memo() but still re-renders on any prop change
   // (e.g. isLoading toggling at the end of a stream), and `parseMediaTokens`
@@ -120,11 +117,7 @@ export const MessageRow = memo(function MessageRow({
         {hasAttachments && (
           <div className="chat-message-attachments">
             {msg.attachments!.map((att) => (
-              <AttachmentChip
-                key={att.id}
-                attachment={att}
-                onPreview={(a) => a.kind === "image" && setPreviewAttachment(a)}
-              />
+              <AttachmentChip key={att.id} attachment={att} />
             ))}
           </div>
         )}
@@ -164,21 +157,6 @@ export const MessageRow = memo(function MessageRow({
           <button className="chat-approval-btn chat-deny" onClick={onDeny}>
             {t("chat.deny")}
           </button>
-        </div>
-      )}
-      {previewAttachment && previewAttachment.dataUrl && (
-        <div
-          className="chat-image-preview-backdrop"
-          onClick={() => setPreviewAttachment(null)}
-          role="dialog"
-          aria-modal="true"
-        >
-          <img
-            src={previewAttachment.dataUrl}
-            alt={previewAttachment.name}
-            className="chat-image-preview-image"
-            onClick={(e) => e.stopPropagation()}
-          />
         </div>
       )}
     </div>

--- a/src/shared/i18n/locales/en/chat.ts
+++ b/src/shared/i18n/locales/en/chat.ts
@@ -74,6 +74,7 @@ export default {
   media: {
     open: "Open",
     saveAs: "Save as…",
+    saveImage: "Save image",
   },
   commands: {
     new: "Start a new chat",

--- a/src/shared/i18n/locales/es/chat.ts
+++ b/src/shared/i18n/locales/es/chat.ts
@@ -75,6 +75,7 @@ export default {
   media: {
     open: "Abrir",
     saveAs: "Guardar como…",
+    saveImage: "Guardar imagen",
   },
   commands: {
     new: "Iniciar un nuevo chat",

--- a/src/shared/i18n/locales/id/chat.ts
+++ b/src/shared/i18n/locales/id/chat.ts
@@ -53,6 +53,7 @@ export default {
   media: {
     open: "Buka",
     saveAs: "Simpan sebagai…",
+    saveImage: "Simpan gambar",
   },
   commands: {
     new: "Mulai chat baru",

--- a/src/shared/i18n/locales/ja/chat.ts
+++ b/src/shared/i18n/locales/ja/chat.ts
@@ -52,6 +52,7 @@ export default {
   media: {
     open: "開く",
     saveAs: "名前を付けて保存…",
+    saveImage: "画像を保存",
   },
   commands: {
     new: "新しいチャットを開始",

--- a/src/shared/i18n/locales/pl/chat.ts
+++ b/src/shared/i18n/locales/pl/chat.ts
@@ -57,6 +57,7 @@ export default {
   media: {
     open: "Otwórz",
     saveAs: "Zapisz jako…",
+    saveImage: "Zapisz obraz",
   },
   commands: {
     new: "Rozpocznij nowy czat",

--- a/src/shared/i18n/locales/pt-BR/chat.ts
+++ b/src/shared/i18n/locales/pt-BR/chat.ts
@@ -53,6 +53,7 @@ export default {
   media: {
     open: "Abrir",
     saveAs: "Salvar como…",
+    saveImage: "Salvar imagem",
   },
   commands: {
     new: "Iniciar um novo chat",

--- a/src/shared/i18n/locales/pt-PT/chat.ts
+++ b/src/shared/i18n/locales/pt-PT/chat.ts
@@ -62,6 +62,7 @@ export default {
   media: {
     open: "Abrir",
     saveAs: "Guardar como…",
+    saveImage: "Guardar imagem",
   },
   commands: {
     new: "Iniciar um novo chat",

--- a/src/shared/i18n/locales/tr/chat.ts
+++ b/src/shared/i18n/locales/tr/chat.ts
@@ -75,6 +75,7 @@ export default {
   media: {
     open: "Aç",
     saveAs: "Farklı kaydet…",
+    saveImage: "Görseli kaydet",
   },
   commands: {
     new: "Yeni bir sohbet başlat",

--- a/src/shared/i18n/locales/zh-CN/chat.ts
+++ b/src/shared/i18n/locales/zh-CN/chat.ts
@@ -49,6 +49,7 @@ export default {
   media: {
     open: "打开",
     saveAs: "另存为…",
+    saveImage: "保存图片",
   },
   commands: {
     new: "开始新对话",

--- a/src/shared/i18n/locales/zh-TW/chat.ts
+++ b/src/shared/i18n/locales/zh-TW/chat.ts
@@ -37,6 +37,7 @@ export default {
   media: {
     open: "開啟",
     saveAs: "另存新檔…",
+    saveImage: "儲存圖片",
   },
   commands: {
     new: "開始新對話",

--- a/tests/media.test.ts
+++ b/tests/media.test.ts
@@ -1,0 +1,28 @@
+import { existsSync, readFileSync, rmSync } from "fs";
+import { extname } from "path";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({
+  BrowserWindow: class {},
+  dialog: {
+    showSaveDialog: vi.fn(),
+  },
+}));
+
+import { materializeDataUrlToTemp } from "../src/main/media";
+
+describe("materializeDataUrlToTemp", () => {
+  it("writes a data URL to a temporary image file that can be opened", () => {
+    const path = materializeDataUrlToTemp(
+      "data:image/png;base64,SGVybWVz",
+      "prompt-image",
+    );
+
+    expect(path).toBeTruthy();
+    expect(extname(path || "")).toBe(".png");
+    expect(existsSync(path || "")).toBe(true);
+    expect(readFileSync(path || "", "utf-8")).toBe("Hermes");
+
+    if (path) rmSync(path, { force: true });
+  });
+});

--- a/tests/media.test.ts
+++ b/tests/media.test.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, rmSync } from "fs";
 import { extname } from "path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("electron", () => ({
   BrowserWindow: class {},
@@ -9,9 +9,16 @@ vi.mock("electron", () => ({
   },
 }));
 
-import { materializeDataUrlToTemp } from "../src/main/media";
+import {
+  cleanupTempMediaFiles,
+  materializeDataUrlToTemp,
+} from "../src/main/media";
 
 describe("materializeDataUrlToTemp", () => {
+  afterEach(() => {
+    cleanupTempMediaFiles();
+  });
+
   it("writes a data URL to a temporary image file that can be opened", () => {
     const path = materializeDataUrlToTemp(
       "data:image/png;base64,SGVybWVz",
@@ -24,5 +31,33 @@ describe("materializeDataUrlToTemp", () => {
     expect(readFileSync(path || "", "utf-8")).toBe("Hermes");
 
     if (path) rmSync(path, { force: true });
+  });
+
+  it("reuses the same temporary file for the same image data", () => {
+    const first = materializeDataUrlToTemp(
+      "data:image/png;base64,SGVybWVz",
+      "prompt-image",
+    );
+    const second = materializeDataUrlToTemp(
+      "data:image/png;base64,SGVybWVz",
+      "prompt-image",
+    );
+
+    expect(first).toBeTruthy();
+    expect(second).toBe(first);
+  });
+
+  it("cleans up temporary media files", () => {
+    const path = materializeDataUrlToTemp(
+      "data:image/png;base64,SGVybWVz",
+      "prompt-image",
+    );
+
+    expect(path).toBeTruthy();
+    expect(existsSync(path || "")).toBe(true);
+
+    cleanupTempMediaFiles();
+
+    expect(existsSync(path || "")).toBe(false);
   });
 });

--- a/tests/sessions-delete-session.test.ts
+++ b/tests/sessions-delete-session.test.ts
@@ -204,9 +204,8 @@ vi.mock("better-sqlite3", () => {
       throw new Error(`Unhandled fake all SQL: ${this.sql}`);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     get(..._args: unknown[]): unknown {
-      if (this.sql.includes("sqlite_master") && this.sql.includes("messages_fts")) {
+      if (this.sql.includes("FROM sqlite_master")) {
         return undefined;
       }
 

--- a/tests/sessions-delete-session.test.ts
+++ b/tests/sessions-delete-session.test.ts
@@ -152,7 +152,7 @@ vi.mock("better-sqlite3", () => {
     all(...args: unknown[]): unknown[] {
       if (
         this.sql.includes("FROM sessions s") &&
-        this.sql.includes("LOWER(COALESCE")
+        this.sql.includes("LOWER(COALESCE(s.title")
       ) {
         const titlePattern = String(args[0])
           .replace(/^%/, "")

--- a/tests/sessions-history-items.test.ts
+++ b/tests/sessions-history-items.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, it } from "vitest";
 import {
   expandRowsToHistory,
   dedupeSearchRowsBySession,
+  mergeStoredPromptImageAttachments,
   pickReasoning,
   parseToolCalls,
   type RawMessageRow,
@@ -315,5 +316,44 @@ describe("expandRowsToHistory", () => {
     expect((items[0] as Extract<HistoryItem, { kind: "user" }>).content).toBe(
       "real",
     );
+  });
+
+  it("rehydrates desktop-stored prompt images and hides the DB placeholder", () => {
+    const items = expandRowsToHistory([
+      row({
+        id: 10,
+        role: "user",
+        content: "describe this image\n[screenshot]",
+        timestamp: 1,
+      }),
+      row({ id: 11, role: "assistant", content: "a logo", timestamp: 2 }),
+    ]);
+
+    const merged = mergeStoredPromptImageAttachments(
+      items,
+      new Map([
+        [
+          10,
+          [
+            {
+              id: "db-att-10-0",
+              kind: "image",
+              name: "logo.png",
+              mime: "image/png",
+              size: 3,
+              dataUrl: "data:image/png;base64,AAA=",
+            },
+          ],
+        ],
+      ]),
+    );
+
+    expect(merged[0]).toMatchObject({
+      kind: "user",
+      content: "describe this image",
+    });
+    expect(
+      "attachments" in merged[0] ? merged[0].attachments?.[0].dataUrl : "",
+    ).toBe("data:image/png;base64,AAA=");
   });
 });


### PR DESCRIPTION
## Summary
- persist sent prompt images in a desktop-owned sidecar table keyed by session/message id
- rehydrate those prompt images when restoring session history, while leaving Hermes Agent's canonical `[screenshot]` message text untouched
- clean up sidecar prompt-image rows when a session is deleted
- add the native Open / Save as… media menu to prompt-image thumbnails; data URLs are materialized to a temp file for Open

## Stack / merge order
This PR is stacked after:
1. #419
2. #421

Please merge #419 first, then #421, then this PR. Until the earlier PRs land, this PR's diff will include their commits when viewed against `main`.

## Verification
- `npm test -- --run tests/sessions-history-items.test.ts tests/session-history-mapping.test.ts tests/reconcile-streamed-with-db.test.ts`
- `npm test -- --run tests/media.test.ts tests/sessions-history-items.test.ts tests/session-history-mapping.test.ts tests/reconcile-streamed-with-db.test.ts`
- `npm run build`
- Live tested: image prompt sessions restore with images after app/session reload.
- Live tested: restored prompt images expose the right-click Open / Save as… menu.


---

## Maintainer Merge Note

Suggested full-stack order from the pre-release rebuild:

#383 -> #369 -> #400 -> #402 -> #404 -> #415 -> #419 -> #421 -> #422 -> #417 -> #430 -> #434 -> #437 -> #439 -> #440 -> #441

Suggested position: after #415, #419, and #421; before #417.

Known stacked overlap: #415 and #422 both touch `AttachmentChip.tsx`. The tested combined behavior keeps #415's compression tooltip while adding #422's prompt-image preview/context menu/restore behavior. #417 should come later so session deletion can clean up the prompt images introduced here.

