### PR TITLE
feat(local): add Atomic Chat local provider preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ sudo dnf install ./hermes-desktop-<version>.rpm
 
 - **Guided first-run install** for Hermes Agent with progress tracking and dependency resolution
 - **Local or remote backend** — run Hermes locally on `127.0.0.1:8642`, or connect the desktop app to a remote Hermes API server with URL + API key
-- **Multi-provider support** — OpenRouter, Anthropic, OpenAI, Google (Gemini), xAI (Grok), Nous Portal, Qwen, MiniMax, Hugging Face, Groq, and local OpenAI-compatible endpoints (LM Studio, Ollama, vLLM, llama.cpp)
+- **Multi-provider support** — OpenRouter, Anthropic, OpenAI, Google (Gemini), xAI (Grok), Nous Portal, Qwen, MiniMax, Hugging Face, Groq, and local OpenAI-compatible endpoints (LM Studio, Atomic Chat, Ollama, vLLM, llama.cpp)
 - **Streaming chat UI** with SSE streaming, tool progress indicators, markdown rendering, and syntax highlighting
 - **Token usage tracking** — live prompt/completion token counts and cost display in the chat footer, plus a `/usage` slash command
 - **22 slash commands** — `/new`, `/clear`, `/fast`, `/web`, `/image`, `/browse`, `/code`, `/shell`, `/usage`, `/help`, `/tools`, `/skills`, `/model`, `/memory`, `/persona`, `/version`, `/compact`, `/compress`, `/undo`, `/retry`, `/debug`, `/status`, and more
@@ -151,7 +151,7 @@ In local mode, chat requests go through `http://127.0.0.1:8642` with SSE streami
 | **Groq**            | Fast inference (voice/STT)               |
 | **Local/Custom**    | Any OpenAI-compatible endpoint           |
 
-Local presets are included for LM Studio, Ollama, vLLM, and llama.cpp.
+Local presets are included for LM Studio, Atomic Chat, Ollama, vLLM, and llama.cpp.
 
 ### Messaging Platforms
 
@@ -224,6 +224,7 @@ Supported setup paths in the UI:
 Local presets are included for:
 
 - LM Studio
+- Atomic Chat
 - Ollama
 - vLLM
 - llama.cpp

--- a/src/renderer/src/constants.ts
+++ b/src/renderer/src/constants.ts
@@ -247,6 +247,12 @@ export const LOCAL_PRESETS: LocalPreset[] = [
     group: "local",
   },
   {
+    id: "atomicchat",
+    name: "constants.atomicchat",
+    baseUrl: "http://localhost:1337/v1",
+    group: "local",
+  },
+  {
     id: "ollama",
     name: "constants.ollama",
     baseUrl: "http://localhost:11434/v1",

--- a/src/renderer/src/screens/Models/detect-provider.ts
+++ b/src/renderer/src/screens/Models/detect-provider.ts
@@ -29,9 +29,9 @@ export function detectProviderFromUrl(rawUrl: string): string | null {
   if (host && isPrivateOrLoopback(host)) return "custom";
 
   // Well-known local-LLM ports on any host — Ollama 11434, LM Studio 1234,
-  // vLLM 8000, llama.cpp 8080. These run on LAN VMs too, so we don't
+  // Atomic Chat 1337, vLLM 8000, llama.cpp 8080. These run on LAN VMs too, so we don't
   // require a private-IP match for the port-only heuristic.
-  if (/:(11434|1234|8000|8080)(\/|$)/.test(url)) return "custom";
+  if (/:(11434|1234|1337|8000|8080)(\/|$)/.test(url)) return "custom";
 
   return null;
 }

--- a/src/shared/i18n/locales/en/constants.ts
+++ b/src/shared/i18n/locales/en/constants.ts
@@ -25,6 +25,7 @@ export default {
   customOpenAICompatibleName: "OpenAI Compatible / Local",
   // Local presets
   lmstudio: "LM Studio",
+  atomicchat: "Atomic Chat",
   ollama: "Ollama",
   vllm: "vLLM",
   llamacpp: "llama.cpp",

--- a/src/shared/i18n/locales/en/setup.ts
+++ b/src/shared/i18n/locales/en/setup.ts
@@ -13,6 +13,7 @@ export default {
   },
   localPresets: {
     lmstudio: "LM Studio",
+    atomicchat: "Atomic Chat",
     ollama: "Ollama",
     vllm: "vLLM",
     llamacpp: "llama.cpp",

--- a/tests/detect-provider.test.ts
+++ b/tests/detect-provider.test.ts
@@ -50,6 +50,10 @@ describe("detectProviderFromUrl", () => {
     expect(
       detectProviderFromUrl("http://my-workstation.example.com:1234/v1"),
     ).toBe("custom");
+    // Atomic Chat
+    expect(
+      detectProviderFromUrl("http://atomic-box.example.com:1337/v1"),
+    ).toBe("custom");
     // vLLM
     expect(detectProviderFromUrl("http://gpu-rig.example.com:8000")).toBe(
       "custom",


### PR DESCRIPTION
## Summary
- add an `Atomic Chat` local preset in setup/provider constants with default base URL `http://localhost:1337/v1`
- include `Atomic Chat` in English locale preset labels so it appears next to LM Studio/Ollama in the Local list
- extend local provider URL detection and tests to treat port `1337` as a local OpenAI-compatible endpoint
- update README local preset references to include Atomic Chat

## Test plan
- [x] Run `npm run test -- detect-provider.test.ts`
- [ ] Open Setup screen and verify `Atomic Chat` appears in Local presets
- [ ] Select `Atomic Chat` and verify Base URL autofills to `http://localhost:1337/v1`

Made with [Cursor](https://cursor.com)