### PR TITLE
fix(cron): pass schedule prompts positionally

### DIFF
--- a/src/main/cronjobs.ts
+++ b/src/main/cronjobs.ts
@@ -201,14 +201,10 @@ export async function createCronJob(
     }
   }
 
-  // Use -- to prevent prompt from being parsed as a flag
   const args = ["create", schedule];
+  if (prompt) args.push(prompt);
   if (name) args.push("--name", name);
   if (deliver) args.push("--deliver", deliver);
-  if (prompt) {
-    args.push("--");
-    args.push(prompt);
-  }
 
   const result = await runCronCommand(args, profile);
   return { success: result.success, error: result.error };

--- a/tests/cronjobs.test.ts
+++ b/tests/cronjobs.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { execFileSpy } = vi.hoisted(() => ({
+  execFileSpy: vi.fn(
+    (
+      _file: string,
+      _args: string[],
+      _options: Record<string, unknown>,
+      callback: (err: Error | null, stdout: string, stderr: string) => void,
+    ) => callback(null, "ok", ""),
+  ),
+}));
+
+vi.mock("child_process", () => ({
+  execFile: execFileSpy,
+  default: { execFile: execFileSpy },
+}));
+
+vi.mock("../src/main/utils", () => ({
+  profileHome: () => "C:/hermes",
+}));
+
+vi.mock("../src/main/hermes", () => ({
+  isRemoteMode: () => false,
+  getApiUrl: () => "http://127.0.0.1:8642",
+  getRemoteAuthHeader: () => ({}),
+}));
+
+vi.mock("../src/main/installer", () => ({
+  HERMES_HOME: "C:/hermes",
+  HERMES_PYTHON: "C:/hermes/hermes-agent/venv/Scripts/pythonw.exe",
+  hermesCliArgs: (args: string[] = []) => ["-m", "hermes_cli.main", ...args],
+}));
+
+describe("createCronJob", () => {
+  beforeEach(() => {
+    execFileSpy.mockClear();
+  });
+
+  it("passes the prompt as the cron create positional argument before flags", async () => {
+    const { createCronJob } = await import("../src/main/cronjobs");
+
+    await createCronJob(
+      "7 17 * * *",
+      "Create a daily brief with local news, weather, and quotes.",
+      "Daily brief",
+      "telegram",
+    );
+
+    expect(execFileSpy).toHaveBeenCalledTimes(1);
+    expect(execFileSpy.mock.calls[0][1]).toEqual([
+      "-m",
+      "hermes_cli.main",
+      "cron",
+      "create",
+      "7 17 * * *",
+      "Create a daily brief with local news, weather, and quotes.",
+      "--name",
+      "Daily brief",
+      "--deliver",
+      "telegram",
+    ]);
+    expect(execFileSpy.mock.calls[0][1]).not.toContain("--");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #413.

Desktop's local Schedules flow was invoking `hermes cron create` as:

```text
hermes cron create <schedule> --name <name> -- <prompt>
```

The Hermes Agent cron parser expects the prompt as the optional positional argument (`schedule [prompt]`). When Desktop adds `--` after flags, the CLI can reject it with `unrecognized arguments: -- <prompt>`, matching the issue report.

This changes Desktop to pass the prompt positionally immediately after the schedule, then append flags such as `--name` and `--deliver`.

## Verification

- Reproduced the issue through the #383 CDP harness before the fix: `window.hermesAPI.createCronJob(...)` returned the reported `unrecognized arguments: -- <prompt>` error.
- Verified after the fix through the same harness: created, listed, and removed a temporary cron job successfully.
- `npm test -- --run tests/cronjobs.test.ts`


---

## Maintainer Merge Note

Suggested full-stack order from the pre-release rebuild:

#383 -> #369 -> #400 -> #402 -> #404 -> #415 -> #419 -> #421 -> #422 -> #417 -> #430 -> #434 -> #437 -> #439 -> #440 -> #441

Suggested position: after #417, or any time after current main.

No known stacked conflict from the pre-release rebuild. This PR is narrow and independent from the session/image/provider sequence.

