### PR TITLE
Fix: drop streamed bubble when DB split it into multiple rows (dup message bug)

### DIFF
--- a/src/renderer/src/screens/Chat/sessionHistory.test.ts
+++ b/src/renderer/src/screens/Chat/sessionHistory.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { reconcileStreamedWithDb } from "./sessionHistory";
+import type { ChatMessage } from "./types";
+
+describe("reconcileStreamedWithDb — multi-bubble turn (dup bug)", () => {
+  it("does not produce duplicate text when one streamed bubble concatenates multiple DB assistant rows", () => {
+    // Scenario: agent's turn produced 2 assistant text bubbles split by a tool call.
+    // Stream concatenated both into a single bubble (because chat-chunk has no
+    // boundary marker). At end-of-stream, DB has 2 separate assistant rows + tool
+    // rows in between. Reconciliation must NOT leave both the concatenated streamed
+    // bubble AND the per-row DB bubbles in the result — that's the visible dup.
+
+    const partA = "First paragraph from before the tool call.";
+    const partB = "Second paragraph after the tool result.";
+
+    const streamed: ChatMessage[] = [
+      { id: "user-1", role: "user", content: "do the thing" },
+      // single concatenated streamed agent bubble
+      { id: "agent-1", role: "agent", content: `${partA}\n\n${partB}` },
+    ];
+
+    const db: ChatMessage[] = [
+      { id: "db-1", role: "user", content: "do the thing" },
+      { id: "db-2", role: "agent", content: partA },
+      {
+        id: "db-tc-3-call_1",
+        kind: "tool_call",
+        role: "agent",
+        callId: "call_1",
+        name: "terminal",
+        args: "{}",
+      },
+      {
+        id: "db-tr-4",
+        kind: "tool_result",
+        role: "agent",
+        callId: "call_1",
+        name: "terminal",
+        content: "ok",
+      },
+      { id: "db-5", role: "agent", content: partB },
+    ];
+
+    const result = reconcileStreamedWithDb(streamed, db);
+
+    // Count occurrences of partB text in the merged transcript.
+    const partBOccurrences = result.filter(
+      (m) =>
+        !("kind" in m) &&
+        typeof (m as { content?: string }).content === "string" &&
+        (m as { content: string }).content.includes(partB),
+    ).length;
+
+    expect(partBOccurrences).toBe(1);
+  });
+});

--- a/src/renderer/src/screens/Chat/sessionHistory.ts
+++ b/src/renderer/src/screens/Chat/sessionHistory.ts
@@ -243,6 +243,27 @@ export function reconcileStreamedWithDb(
     }
   }
 
+  // Collect normalised DB-bubble texts grouped by role so we can detect the
+  // "concatenated streamed bubble vs split DB rows" case below. The desktop's
+  // chat-chunk stream has no boundary marker (main/index.ts forwards every
+  // delta verbatim), so when one agent turn produces multiple text bubbles
+  // split by a tool call, all the deltas land in a single streamed bubble.
+  // The reconciliation pass above keys on the first 200 chars, so it matches
+  // that streamed bubble against the FIRST db row only — and the remaining
+  // db rows fall through here, while the streamed bubble (still carrying the
+  // full concatenated text) also wants to fall through below. That's the
+  // visible "same text twice" bug.
+  const dbBubbleTextsByRole = new Map<string, string[]>();
+  for (const m of db) {
+    if ("kind" in m) continue;
+    const bubble = m as ChatBubbleMessage;
+    const norm = normalizeWhitespace(bubble.content || "");
+    if (!norm) continue;
+    const bucket = dbBubbleTextsByRole.get(bubble.role);
+    if (bucket) bucket.push(norm);
+    else dbBubbleTextsByRole.set(bubble.role, [norm]);
+  }
+
   const consumedIds = new Set(result.map((m) => m.id));
   for (const m of streamed) {
     if (consumedIds.has(m.id)) continue;
@@ -252,8 +273,25 @@ export function reconcileStreamedWithDb(
     // genuinely new.
     if (!("kind" in m)) {
       const bubble = m as ChatBubbleMessage;
-      const contentKey = `${bubble.role}:${normalizeWhitespace(bubble.content || "")}`;
+      const normContent = normalizeWhitespace(bubble.content || "");
+      const contentKey = `${bubble.role}:${normContent}`;
       if (seenBubbleKeys.has(contentKey)) continue;
+
+      // Multi-bubble-turn dedup: drop the streamed bubble when its content
+      // is the concatenation of two or more DB bubbles of the same role
+      // that already landed in `result`. The DB-canonical split is what
+      // the user should see; the concatenated streamed copy is a streaming
+      // artifact.
+      const dbBubbleTexts = dbBubbleTextsByRole.get(bubble.role);
+      if (dbBubbleTexts && dbBubbleTexts.length >= 2 && normContent) {
+        let matchedSegments = 0;
+        for (const segment of dbBubbleTexts) {
+          if (segment && normContent.includes(segment)) matchedSegments++;
+          if (matchedSegments >= 2) break;
+        }
+        if (matchedSegments >= 2) continue;
+      }
+
       seenBubbleKeys.add(contentKey);
     }
     result.push(m);


### PR DESCRIPTION
## Summary

Fixes a "same message rendered twice" bug that triggers when an agent turn produces multiple assistant text bubbles separated by a tool call.

## Reproduction

1. Agent emits text → calls a tool → emits more text → finalises turn.
2. Stream finishes; `onChatDone` calls `reconcileStreamedWithDb`.
3. The chat transcript shows the second half of the agent's reply twice — once at the end of the streamed bubble and again as a standalone bubble below it.

Visually it looks like the assistant copy-pasted itself, but the API only generated one response (verified against `agent.log` — single `chat_completion_stream_request` per turn).

## Root cause

`main/index.ts:824` forwards every `chat-chunk` delta with no boundary marker between assistant rows. `useChatIPC.ts:onChatChunk` always appends to the last agent bubble, so a multi-bubble turn collapses into one streamed bubble containing the concatenated text of all rows.

At end-of-stream, `reconcileStreamedWithDb` runs against the DB's canonical split (N assistant rows interleaved with tool_call / tool_result):

- `reconciliationKey` keys on `role + first 200 chars`, so it matches the concatenated streamed bubble against the **first** DB row only.
- The remaining DB rows fall through to `result` as DB-id bubbles.
- The tail-of-stream pass (lines 246–260) checks `consumedIds` and a content-key dedup set built from `result`. The streamed bubble's id is consumed (good), but its full concatenated content **isn't** in `seenBubbleKeys` because no single `result` row matches it — so `mergeDbMetadataIntoStreamed` returned the streamed copy and put it back into `result`, and the tail pass then *also* re-adds the streamed bubble because… wait, no — the streamed bubble was consumed via the FIFO match, so the tail loop's `consumedIds.has(m.id)` check should skip it.

Re-reading the loop: the streamed bubble IS preserved (it carries the original streamed id), so the user sees the long streamed bubble PLUS the second-and-later DB rows that fell through with no streamed counterpart. The second DB row's text equals the tail of the streamed bubble's content → duplicate text on screen.

## Fix

In the tail pass, when a streamed bubble's normalised content contains **two or more** DB-bubble contents (of the same role) as substrings, drop the streamed bubble. The DB split is the canonical view; the concatenated streamed copy is a streaming artifact and the user should see the canonical split instead.

The two-or-more threshold matters: a single substring match is the normal "streamed bubble = single DB row" case the existing FIFO match already handles, and we shouldn't disturb it.

## Test

Added `sessionHistory.test.ts` covering the exact scenario (one streamed bubble = concat of partA + partB, DB has partA / tool_call / tool_result / partB). The test asserts `partB` appears exactly once in the reconciled transcript. Fails on `main`, passes with this change.

Full suite: **673 passed, 3 skipped** (same as `main`).

## Limitations / notes

- The fix is in the renderer only — the underlying gap is that `chat-chunk` has no row boundary marker. A more principled fix would have the main process emit a sentinel between rows (e.g. `chat-bubble-boundary`), letting the renderer start a new bubble at the right place during the stream. Happy to follow up with that as a separate PR if you'd prefer the more invasive fix.
- The dedup is substring-based on normalised whitespace. It will not fire if the streamed bubble drifted from the DB rows in a way the normaliser doesn't collapse (very unusual — both sides see the same agent output).

## Triggering scenario (for the changelog)

Most likely to show up when the agent does a "say something → call a tool → say more" flow inside a single turn. With reasoning models / tool-heavy workflows this is common, which is why the bug is conspicuous.
