### PR TITLE
fix: support Docker-backed Hermes installs in SSH mode

### DIFF
--- a/docs/SSH-TUNNEL-VPS.md
+++ b/docs/SSH-TUNNEL-VPS.md
@@ -117,6 +117,36 @@ SSH in as the `hermes` user. Two things to set up:
 Don't. If it currently does, migrate it to a dedicated user before
 exposing SSH to it.
 
+### Case D — Hermes runs in a Docker container (Coolify, Compose, NAS)
+
+A containerized `nousresearch/hermes-agent` deployment is fully
+supported, but the host has no `hermes` binary and no real `~/.hermes` —
+the CLI lives inside the container and the data lives in the volume
+mounted at the container's `/opt/data`. Without setup, chat works (the
+API port is reachable through the tunnel) while Sessions, Models, Logs,
+and Doctor come up empty.
+
+The desktop can set this up for you. In **Settings → Connection → SSH**
+(or the first-run SSH screen), use **Detect remote install**. The
+desktop lists running Hermes containers; pick one (required when several
+run) and click **Set up Docker access**. This writes two files on the
+SSH host, as the SSH user:
+
+- `~/.config/hermes-desktop/remote-hermes` — a launcher that runs the
+  Hermes CLI inside the selected container via `docker exec`. This is
+  the standard per-user launcher hook the desktop already probes first
+  for every remote CLI call, so gateway controls, Doctor, skills, and
+  profile listing all route into the container automatically.
+- `~/.hermes` → symlink to the container's data volume (for example
+  `/data/hermes`), so session lists, config, logs, and memory read the
+  real Hermes home.
+
+Requirements: the SSH user must be able to run `docker` (root or a user
+in the `docker` group), and the container must mount a host directory at
+`/opt/data`. Nothing inside the container is modified, and an existing
+hand-written launcher or a real `~/.hermes` directory is never
+overwritten — the setup refuses and tells you what to move.
+
 ## Step-by-step setup
 
 ### 1. Verify SSH works exactly as the desktop will call it
@@ -234,6 +264,11 @@ The directory should contain `SOUL.md`, `config.yaml`, `auth.json`,
 `memories/`, `profiles/`, etc. If you see `No such file or directory`,
 you're in the wrong account — re-read the **"Which user account"**
 section above.
+
+If Hermes runs in a Docker container on the remote (Doctor reports
+`hermes CLI not found on remote PATH…`), no user has a real `~/.hermes`
+— use **Detect remote install** in the SSH settings and run the Docker
+setup (see **Case D** above).
 
 ### Settings → Hermes Agent shows blank Engine / Released / Python / OpenAI SDK
 

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -38,6 +38,10 @@ export interface SshConnectionConfig {
   keyPath: string;
   remotePort: number;
   localPort: number;
+  // Docker container on the SSH host that runs Hermes (issue #432). Used by
+  // the Settings/Welcome target inspection UI; the runtime itself routes
+  // through the provisioned remote launcher hook, not this name.
+  dockerContainerName?: string;
 }
 
 export type RemoteChatTransport = "auto" | "dashboard" | "legacy";
@@ -117,6 +121,7 @@ export function getConnectionConfig(): ConnectionConfig {
       keyPath: (ssh.keyPath as string) || "",
       remotePort: (ssh.remotePort as number) || 8642,
       localPort: (ssh.localPort as number) || 18642,
+      dockerContainerName: (ssh.dockerContainerName as string) || "",
     },
   };
 }

--- a/src/main/ipc/register.ts
+++ b/src/main/ipc/register.ts
@@ -403,6 +403,10 @@ import {
   sshRunDump,
   sshDiscoverMemoryProviders,
 } from "../ssh-remote";
+import {
+  sshInspectHermesTarget,
+  sshProvisionDockerTarget,
+} from "../ssh-docker";
 
 export interface IpcContext {
   activeRuns: Map<string, () => void>;
@@ -1277,12 +1281,21 @@ export function registerIpcHandlers(context: IpcContext): void {
       keyPath: string,
       remotePort: number,
       localPort: number,
+      dockerContainerName?: string,
     ) => {
       const current = getConnectionConfig();
       setConnectionConfig({
         ...current,
         mode: "ssh",
-        ssh: { host, port, username, keyPath, remotePort, localPort },
+        ssh: {
+          host,
+          port,
+          username,
+          keyPath,
+          remotePort,
+          localPort,
+          dockerContainerName: dockerContainerName?.trim() || "",
+        },
       });
       resetSshDashboardAvailability();
       notifyConnectionConfigChanged();
@@ -1363,6 +1376,52 @@ export function registerIpcHandlers(context: IpcContext): void {
         remotePort,
         localPort: 19642,
       }),
+  );
+
+  // Docker-backed SSH targets (issue #432): survey the remote (host install,
+  // ~/.hermes state, launcher hook, running Hermes containers) and provision
+  // the launcher hook + ~/.hermes symlink for a selected container. Both take
+  // explicit connection params so Settings/Welcome can inspect a draft config
+  // before saving it.
+  ipcMain.handle(
+    "inspect-ssh-hermes-target",
+    (
+      _event,
+      host: string,
+      port: number,
+      username: string,
+      keyPath: string,
+      remotePort: number,
+      dockerContainerName?: string,
+    ) =>
+      sshInspectHermesTarget(
+        { host, port, username, keyPath, remotePort, localPort: 19642 },
+        dockerContainerName?.trim() || "",
+      ),
+  );
+
+  ipcMain.handle(
+    "provision-ssh-docker-target",
+    async (
+      _event,
+      host: string,
+      port: number,
+      username: string,
+      keyPath: string,
+      remotePort: number,
+      dockerContainerName: string,
+    ) => {
+      const result = await sshProvisionDockerTarget(
+        { host, port, username, keyPath, remotePort, localPort: 19642 },
+        dockerContainerName,
+      );
+      if (result.ok) {
+        // The remote just gained a launcher/home it did not have — retry the
+        // dashboard probe immediately instead of waiting out the negative TTL.
+        resetSshDashboardAvailability();
+      }
+      return result;
+    },
   );
 
   ipcMain.handle("start-ssh-tunnel", async () => {

--- a/src/main/ssh-docker.ts
+++ b/src/main/ssh-docker.ts
@@ -2,6 +2,7 @@ import {
   sshExec,
   shellQuote,
   buildRemoteHermesCmd,
+  sshWaitGatewayApiReady,
   REMOTE_HERMES_CLI_CANDIDATES,
   REMOTE_HERMES_LAUNCHER_CANDIDATES,
 } from "./ssh-remote";
@@ -345,19 +346,32 @@ print(json.dumps({"ok": True, "dataHome": data_home, "execUser": exec_user, "cli
 }
 
 /**
- * Remote python that writes the launcher hook and the ~/.hermes symlink, then
+ * Remote python that writes the launcher hook and the ~/.hermes symlink,
+ * seeds the API server settings from the container's environment, then
  * verifies the launcher answers `--version`. Refuses to overwrite a
  * user-authored launcher or a real (non-empty) ~/.hermes directory. The
  * launcher script text is built locally (buildDockerLauncherScript) and passed
  * through as data. Exported for unit tests.
+ *
+ * The .env seeding matters for the first connect: Coolify-style deployments
+ * often set API_SERVER_KEY / API_SERVER_ENABLED as container env vars only.
+ * Without them in the Hermes home .env, the desktop's connect flow generates
+ * its own values and restarts the gateway mid-connect — which fails the first
+ * attempt on a supervised container. Seeding here (with the container's own
+ * key, which never leaves the remote) makes the later connect a no-op.
  */
 export function buildApplySshDockerTargetCommand(
+  containerName: string,
   launcherScript: string,
   dataHome: string,
 ): string {
+  if (!isValidDockerContainerName(containerName)) {
+    throw new Error(`Invalid Docker container name: ${containerName}`);
+  }
   return `
-import json, os, subprocess, sys, tempfile
+import json, os, re, secrets, subprocess, sys, tempfile
 
+container = ${pythonJson(containerName)}
 launcher_path = ${pythonJson(MANAGED_LAUNCHER_PATH)}
 marker_prefix = ${pythonJson(LAUNCHER_MARKER_PREFIX)}
 launcher_script = ${pythonJson(launcherScript)}
@@ -410,6 +424,51 @@ version = subprocess.run([launcher, "--version"], check=False, text=True, captur
 if version.returncode != 0:
     fail("Launcher verification failed: " + (version.stderr.strip() or "hermes --version failed"))
 
+# Seed API server settings into the Hermes home .env so the desktop's connect
+# flow finds them and does not have to write + restart the gateway mid-connect.
+# Prefer the container's own values; the key never leaves this host.
+env_file = os.path.join(home, ".env")
+env_content = ""
+if os.path.exists(env_file):
+    try:
+        with open(env_file) as f:
+            env_content = f.read()
+    except Exception:
+        env_content = ""
+
+def has_env_line(name):
+    return re.search("^%s=" % re.escape(name), env_content, re.M) is not None
+
+need_key = not has_env_line("API_SERVER_KEY")
+need_enabled = not has_env_line("API_SERVER_ENABLED")
+if need_key or need_enabled:
+    cenv = {}
+    proc = subprocess.run(["docker", "exec", container, "sh", "-c", "env"], check=False, text=True, capture_output=True, timeout=15)
+    if proc.returncode == 0:
+        for line in proc.stdout.splitlines():
+            if "=" in line:
+                k, v = line.split("=", 1)
+                cenv[k] = v
+    lines = []
+    if need_key:
+        key = (cenv.get("API_SERVER_KEY") or "").strip()
+        if key:
+            warnings.append("Copied the container's API server key into the Hermes .env so the desktop can use it.")
+        else:
+            key = secrets.token_hex(24)
+            warnings.append("Generated an API server key in the Hermes .env - the gateway restarts once to load it.")
+        lines.append("API_SERVER_KEY=%s" % key)
+    if need_enabled:
+        enabled = (cenv.get("API_SERVER_ENABLED") or "").strip().lower()
+        lines.append("API_SERVER_ENABLED=%s" % (enabled if enabled in ("true", "1", "yes") else "true"))
+    try:
+        with open(env_file, "a") as f:
+            if env_content and not env_content.endswith("\\n"):
+                f.write("\\n")
+            f.write("\\n".join(lines) + "\\n")
+    except Exception as exc:
+        warnings.append("Could not update the Hermes .env: %s" % exc)
+
 if not os.path.exists(os.path.join(home, "config.yaml")):
     warnings.append("No config.yaml in the Hermes home yet - run setup once the connection is saved.")
 
@@ -459,7 +518,7 @@ export async function sshProvisionDockerTarget(
     );
     const applyOut = await sshPython(
       config,
-      buildApplySshDockerTargetCommand(launcherScript, probe.dataHome),
+      buildApplySshDockerTargetCommand(name, launcherScript, probe.dataHome),
       90000,
     );
     const applied = JSON.parse(applyOut.trim() || "{}") as {
@@ -491,6 +550,26 @@ export async function sshProvisionDockerTarget(
         "Launcher was written but the Hermes CLI probe still returned nothing.",
       );
     }
+
+    // First-connect readiness: if the gateway API is not answering (fresh key
+    // just seeded, or api_server disabled at container start), restart the
+    // container NOW — while the user watches the setup spinner — instead of
+    // letting the first chat attempt hit the connect flow's short restart
+    // window and fail.
+    const warnings = Array.isArray(applied.warnings) ? applied.warnings : [];
+    if (!(await sshWaitGatewayApiReady(config, config.remotePort, 5000))) {
+      await sshExec(config, `docker restart ${shellQuote(name)}`, undefined, 90000);
+      if (await sshWaitGatewayApiReady(config, config.remotePort, 120000)) {
+        warnings.push(
+          "Restarted the container so the gateway loads the API server settings.",
+        );
+      } else {
+        warnings.push(
+          `Gateway API did not answer on port ${config.remotePort} after a container restart — check the container logs before connecting.`,
+        );
+      }
+    }
+
     return {
       ok: true,
       containerName: name,
@@ -498,7 +577,7 @@ export async function sshProvisionDockerTarget(
       execUser: probe.execUser || "",
       cliPath: probe.cliPath,
       version: version.trim() || applied.version || "",
-      warnings: Array.isArray(applied.warnings) ? applied.warnings : [],
+      warnings,
     };
   } catch (error) {
     return failure(error instanceof Error ? error.message : String(error));

--- a/src/main/ssh-docker.ts
+++ b/src/main/ssh-docker.ts
@@ -305,7 +305,7 @@ container = ${pythonJson(containerName)}
 data_dir = ${pythonJson(HERMES_CONTAINER_DATA_DIR)}
 image_name = ${pythonJson(HERMES_DOCKER_IMAGE)}
 image_re = r"(^|/)nousresearch/hermes-agent(:|@|$)"
-cli_candidates = ["/opt/hermes/.venv/bin/hermes", "/opt/hermes/venv/bin/hermes", "hermes"]
+cli_candidates = ["hermes", "/opt/hermes/bin/hermes", "/opt/hermes/.venv/bin/hermes", "/opt/hermes/venv/bin/hermes"]
 
 def fail(msg):
     print(json.dumps({"ok": False, "error": msg}))
@@ -331,10 +331,10 @@ data_home = run([
 if not data_home:
     fail('Container "%s" has no host mount for %s, so its Hermes home is not reachable over SSH.' % (container, data_dir))
 
-# Resolve which docker-exec user can use the Hermes home inside the container:
-# container default first, then the official image's service user.
+# Prefer the official service user and public CLI shim. Current images default
+# docker exec to root; bypassing the shim can leave root-owned state behind.
 exec_user, cli_path = None, None
-for candidate_user in (None, "hermes"):
+for candidate_user in ("hermes", None):
     user_args = ["-u", candidate_user] if candidate_user else []
     probe = run(["docker", "exec"] + user_args + [container, "sh", "-c", "test -r %s && test -w %s" % (data_dir, data_dir)])
     if probe.returncode != 0:

--- a/src/main/ssh-docker.ts
+++ b/src/main/ssh-docker.ts
@@ -133,10 +133,15 @@ host_install_found = any(
 )
 
 home = expanded("$HOME/.hermes")
+home_empty = False
 if os.path.islink(home):
     home_state, home_target = "symlink", os.readlink(home)
 elif os.path.exists(home):
     home_state, home_target = "directory", None
+    try:
+        home_empty = os.path.isdir(home) and not os.listdir(home)
+    except Exception:
+        home_empty = False
 else:
     home_state, home_target = "missing", None
 
@@ -209,6 +214,7 @@ if docker_available:
 print(json.dumps({
     "hostInstallFound": bool(host_install_found and host_home_found),
     "hermesHomeState": home_state,
+    "hermesHomeEmpty": bool(home_empty),
     "hermesHomeTarget": home_target,
     "launcherState": launcher_state,
     "launcherContainerName": launcher_container,
@@ -239,6 +245,7 @@ export function parseSshHermesTargetInspection(
   return {
     hostInstallFound: Boolean(parsed.hostInstallFound),
     hermesHomeState: parsed.hermesHomeState || "missing",
+    hermesHomeEmpty: Boolean(parsed.hermesHomeEmpty),
     hermesHomeTarget: parsed.hermesHomeTarget || null,
     launcherState: parsed.launcherState || "missing",
     launcherContainerName: parsed.launcherContainerName || null,
@@ -269,6 +276,7 @@ export async function sshInspectHermesTarget(
     return {
       hostInstallFound: false,
       hermesHomeState: "missing",
+      hermesHomeEmpty: false,
       hermesHomeTarget: null,
       launcherState: "missing",
       launcherContainerName: null,

--- a/src/main/ssh-docker.ts
+++ b/src/main/ssh-docker.ts
@@ -1,0 +1,506 @@
+import {
+  sshExec,
+  shellQuote,
+  buildRemoteHermesCmd,
+  REMOTE_HERMES_CLI_CANDIDATES,
+  REMOTE_HERMES_LAUNCHER_CANDIDATES,
+} from "./ssh-remote";
+import type { SshConfig } from "./ssh-tunnel";
+
+// Docker-backed Hermes installs (issue #432): a valid deployment where the
+// Hermes Agent runs inside a container (Coolify, compose, NAS app stores) and
+// the host has no `hermes` binary and no real `~/.hermes`. Instead of teaching
+// every SSH code path about containers, Desktop provisions the two host-side
+// artifacts the EXISTING SSH machinery already understands:
+//
+//   1. the per-user launcher hook (`~/.config/hermes-desktop/remote-hermes`,
+//      first probe in buildRemoteHermesCmd) — a `docker exec` wrapper that
+//      routes the Hermes CLI into the selected container, and
+//   2. a `~/.hermes` symlink to the container's mounted data volume, so every
+//      remote file read/write (config, .env, sessions, logs, profiles) sees
+//      the real Hermes home.
+//
+// After provisioning, CLI execution, gateway lifecycle, dashboard ensure, and
+// all file access work unchanged — no container plumbing in the core paths.
+
+export const HERMES_DOCKER_IMAGE = "nousresearch/hermes-agent";
+
+// Mount destination the official image keeps its Hermes home at.
+export const HERMES_CONTAINER_DATA_DIR = "/opt/data";
+
+// The launcher hook Desktop manages. First entry of the probe list so a
+// provisioned Docker target wins over PATH fallbacks; the second entry stays
+// reserved for user-managed wrappers.
+const MANAGED_LAUNCHER_PATH = REMOTE_HERMES_LAUNCHER_CANDIDATES[0];
+
+// Marker parsed back during inspection to show which container the hook
+// currently routes to, and to distinguish Desktop-managed hooks from
+// user-authored ones (which provisioning must not overwrite).
+const LAUNCHER_MARKER_PREFIX = "# managed by Hermes Desktop (docker:";
+
+// docker container names: [a-zA-Z0-9][a-zA-Z0-9_.-]*. Names reach us from
+// `docker ps` output relayed through the renderer, so validate before
+// embedding into any remote script.
+export function isValidDockerContainerName(name: string): boolean {
+  return /^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/.test(name);
+}
+
+export type {
+  SshHermesDockerContainer,
+  SshHermesTargetInspection,
+  SshDockerProvisionResult,
+} from "../shared/ssh-docker";
+import type {
+  SshHermesTargetInspection,
+  SshDockerProvisionResult,
+} from "../shared/ssh-docker";
+
+function pythonJson(payload: unknown): string {
+  return JSON.stringify(payload);
+}
+
+function sshPython(
+  config: SshConfig,
+  script: string,
+  timeoutMs = 30000,
+): Promise<string> {
+  return sshExec(config, "python3 -", script, timeoutMs);
+}
+
+/**
+ * The launcher hook provisioning writes to the remote. TTY flags mirror what
+ * an interactive `ssh -t` session needs (`hermes setup`) while keeping
+ * non-interactive pipes clean; HOME/HERMES_HOME pin the CLI to the container's
+ * data dir regardless of the exec user's passwd entry.
+ */
+export function buildDockerLauncherScript(
+  containerName: string,
+  cliPath: string,
+  execUser: string,
+): string {
+  if (!isValidDockerContainerName(containerName)) {
+    throw new Error(`Invalid Docker container name: ${containerName}`);
+  }
+  const userArgs = execUser ? `-u ${shellQuote(execUser)} ` : "";
+  return [
+    "#!/bin/sh",
+    `${LAUNCHER_MARKER_PREFIX}${containerName})`,
+    "# Routes the Hermes CLI into the Docker container running Hermes Agent.",
+    "# Regenerate from Hermes Desktop: Settings -> Connection -> SSH.",
+    "set -eu",
+    `container=${shellQuote(containerName)}`,
+    'tty_args=""',
+    'if [ -t 0 ] && [ -t 1 ]; then tty_args="-it"; elif [ -t 0 ]; then tty_args="-i"; fi',
+    `exec docker exec $tty_args ${userArgs}-e HOME=${HERMES_CONTAINER_DATA_DIR} -e HERMES_HOME=${HERMES_CONTAINER_DATA_DIR} "$container" ${shellQuote(cliPath)} "$@"`,
+    "",
+  ].join("\n");
+}
+
+/**
+ * Remote python that surveys the SSH target in one round trip: host install,
+ * ~/.hermes state, launcher hook state, and running official Hermes
+ * containers with their data mounts. Exported for unit tests.
+ */
+export function buildInspectSshHermesTargetCommand(
+  remotePort?: number,
+  selectedDockerContainerName = "",
+): string {
+  return `
+import json, os, re, shutil, subprocess
+
+remote_port = ${Number.isFinite(remotePort) ? String(remotePort) : "None"}
+selected_name = ${pythonJson(selectedDockerContainerName)}
+cli_candidates = ${pythonJson(REMOTE_HERMES_CLI_CANDIDATES)}
+launcher_path = ${pythonJson(MANAGED_LAUNCHER_PATH)}
+marker_prefix = ${pythonJson(LAUNCHER_MARKER_PREFIX)}
+image_re = r"(^|/)nousresearch/hermes-agent(:|@|$)"
+
+def run(args, timeout=8):
+    try:
+        return subprocess.run(
+            args, check=False, text=True, capture_output=True, timeout=timeout
+        ).stdout.strip()
+    except Exception:
+        return ""
+
+def expanded(path):
+    return os.path.expandvars(os.path.expanduser(path))
+
+host_install_found = any(
+    os.path.isfile(expanded(p)) and os.access(expanded(p), os.X_OK)
+    for p in cli_candidates
+)
+
+home = expanded("$HOME/.hermes")
+if os.path.islink(home):
+    home_state, home_target = "symlink", os.readlink(home)
+elif os.path.exists(home):
+    home_state, home_target = "directory", None
+else:
+    home_state, home_target = "missing", None
+
+host_home_found = home_state == "directory" and any(
+    os.path.exists(os.path.join(home, name))
+    for name in ("config.yaml", "state.db", ".env", "profiles")
+)
+
+launcher = expanded(launcher_path)
+launcher_state, launcher_container = "missing", None
+if os.path.isfile(launcher) and os.access(launcher, os.X_OK):
+    launcher_state = "custom"
+    try:
+        with open(launcher) as f:
+            head = f.read(4096)
+        for line in head.splitlines():
+            if line.startswith(marker_prefix) and line.endswith(")"):
+                launcher_state = "docker"
+                launcher_container = line[len(marker_prefix):-1]
+                break
+    except Exception:
+        pass
+
+def matches_published_port(ports, port):
+    if not port:
+        return False
+    for entry in (ports or "").split(","):
+        entry = entry.strip()
+        if "->" not in entry:
+            continue
+        published = entry.split("->", 1)[0].strip()
+        if published.rsplit(":", 1)[-1] == str(port):
+            return True
+    return False
+
+containers, seen = [], set()
+docker_available = bool(shutil.which("docker"))
+if docker_available:
+    ancestor_names = set(run([
+        "docker", "ps",
+        "--filter", "ancestor=" + ${pythonJson(HERMES_DOCKER_IMAGE)},
+        "--format", "{{.Names}}",
+    ]).splitlines())
+    rows = run(["docker", "ps", "--format", "{{.ID}}\\t{{.Names}}\\t{{.Image}}\\t{{.Ports}}"])
+    for row in rows.splitlines():
+        parts = row.split("\\t", 3)
+        if len(parts) < 4:
+            continue
+        cid, name, image, ports = parts
+        if name in seen:
+            continue
+        if name not in ancestor_names and not re.search(image_re, image or ""):
+            continue
+        seen.add(name)
+        data_home = run([
+            "docker", "inspect", name, "--format",
+            '{{range .Mounts}}{{if eq .Destination "' + ${pythonJson(
+              HERMES_CONTAINER_DATA_DIR,
+            )} + '"}}{{.Source}}{{end}}{{end}}',
+        ])
+        containers.append({
+            "id": cid,
+            "name": name,
+            "image": image,
+            "ports": ports,
+            "dataHome": data_home,
+            "matchesRemotePort": matches_published_port(ports, remote_port),
+        })
+
+print(json.dumps({
+    "hostInstallFound": bool(host_install_found and host_home_found),
+    "hermesHomeState": home_state,
+    "hermesHomeTarget": home_target,
+    "launcherState": launcher_state,
+    "launcherContainerName": launcher_container,
+    "dockerAvailable": docker_available,
+    "dockerContainers": containers,
+    "selectedDockerContainerName": selected_name,
+}))
+`.trim();
+}
+
+/** Map raw remote inspection JSON to a typed result. Exported for unit tests. */
+export function parseSshHermesTargetInspection(
+  raw: string,
+  selectedDockerContainerName: string,
+): SshHermesTargetInspection {
+  const parsed = JSON.parse(raw.trim() || "{}") as Partial<
+    SshHermesTargetInspection
+  >;
+  const dockerContainers = Array.isArray(parsed.dockerContainers)
+    ? parsed.dockerContainers
+    : [];
+  const selected = selectedDockerContainerName.trim();
+  const selectedContainerMissing =
+    selected.length > 0 && !dockerContainers.some((c) => c.name === selected);
+  const selectedContainer = dockerContainers.find((c) => c.name === selected);
+  const missingDockerHome =
+    selectedContainer !== undefined && !selectedContainer.dataHome;
+  return {
+    hostInstallFound: Boolean(parsed.hostInstallFound),
+    hermesHomeState: parsed.hermesHomeState || "missing",
+    hermesHomeTarget: parsed.hermesHomeTarget || null,
+    launcherState: parsed.launcherState || "missing",
+    launcherContainerName: parsed.launcherContainerName || null,
+    dockerAvailable: Boolean(parsed.dockerAvailable),
+    dockerContainers,
+    selectedDockerContainerName: selected,
+    error: selectedContainerMissing
+      ? `Configured Hermes Docker container "${selected}" is not running or is not ${HERMES_DOCKER_IMAGE}`
+      : missingDockerHome
+        ? `Hermes Docker container "${selected}" has no host mount for ${HERMES_CONTAINER_DATA_DIR}`
+        : undefined,
+  };
+}
+
+export async function sshInspectHermesTarget(
+  config: SshConfig,
+  selectedDockerContainerName = "",
+): Promise<SshHermesTargetInspection> {
+  const selected = selectedDockerContainerName.trim();
+  try {
+    const out = await sshPython(
+      config,
+      buildInspectSshHermesTargetCommand(config.remotePort, selected),
+      15000,
+    );
+    return parseSshHermesTargetInspection(out, selected);
+  } catch (error) {
+    return {
+      hostInstallFound: false,
+      hermesHomeState: "missing",
+      hermesHomeTarget: null,
+      launcherState: "missing",
+      launcherContainerName: null,
+      dockerAvailable: false,
+      dockerContainers: [],
+      selectedDockerContainerName: selected,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Remote python that validates one container and probes how to execute the
+ * Hermes CLI inside it: which docker-exec user can use the data dir and where
+ * the CLI lives. Read-only — writes happen in the apply step. Exported for
+ * unit tests.
+ */
+export function buildProbeSshDockerTargetCommand(containerName: string): string {
+  if (!isValidDockerContainerName(containerName)) {
+    throw new Error(`Invalid Docker container name: ${containerName}`);
+  }
+  return `
+import json, re, subprocess, sys
+
+container = ${pythonJson(containerName)}
+data_dir = ${pythonJson(HERMES_CONTAINER_DATA_DIR)}
+image_name = ${pythonJson(HERMES_DOCKER_IMAGE)}
+image_re = r"(^|/)nousresearch/hermes-agent(:|@|$)"
+cli_candidates = ["/opt/hermes/.venv/bin/hermes", "/opt/hermes/venv/bin/hermes", "hermes"]
+
+def fail(msg):
+    print(json.dumps({"ok": False, "error": msg}))
+    sys.exit(0)
+
+def run(args, timeout=15):
+    return subprocess.run(args, check=False, text=True, capture_output=True, timeout=timeout)
+
+running = run(["docker", "ps", "--format", "{{.Names}}"])
+if running.returncode != 0:
+    fail("Docker is not available for this SSH user: " + (running.stderr.strip() or "docker ps failed"))
+if container not in running.stdout.splitlines():
+    fail('Container "%s" is not running.' % container)
+
+image = run(["docker", "inspect", container, "--format", "{{.Config.Image}}"]).stdout.strip()
+if not re.search(image_re, image):
+    fail('Container "%s" does not run the official %s image (found: %s).' % (container, image_name, image or "unknown"))
+
+data_home = run([
+    "docker", "inspect", container, "--format",
+    '{{range .Mounts}}{{if eq .Destination "' + data_dir + '"}}{{.Source}}{{end}}{{end}}',
+]).stdout.strip()
+if not data_home:
+    fail('Container "%s" has no host mount for %s, so its Hermes home is not reachable over SSH.' % (container, data_dir))
+
+# Resolve which docker-exec user can use the Hermes home inside the container:
+# container default first, then the official image's service user.
+exec_user, cli_path = None, None
+for candidate_user in (None, "hermes"):
+    user_args = ["-u", candidate_user] if candidate_user else []
+    probe = run(["docker", "exec"] + user_args + [container, "sh", "-c", "test -r %s && test -w %s" % (data_dir, data_dir)])
+    if probe.returncode != 0:
+        continue
+    for candidate_cli in cli_candidates:
+        found = run(["docker", "exec"] + user_args + [container, "sh", "-c", "command -v %s" % candidate_cli])
+        if found.returncode == 0 and found.stdout.strip():
+            exec_user, cli_path = candidate_user or "", found.stdout.strip()
+            break
+    if cli_path:
+        break
+if cli_path is None:
+    fail('Could not find a usable Hermes CLI inside container "%s".' % container)
+
+print(json.dumps({"ok": True, "dataHome": data_home, "execUser": exec_user, "cliPath": cli_path}))
+`.trim();
+}
+
+/**
+ * Remote python that writes the launcher hook and the ~/.hermes symlink, then
+ * verifies the launcher answers `--version`. Refuses to overwrite a
+ * user-authored launcher or a real (non-empty) ~/.hermes directory. The
+ * launcher script text is built locally (buildDockerLauncherScript) and passed
+ * through as data. Exported for unit tests.
+ */
+export function buildApplySshDockerTargetCommand(
+  launcherScript: string,
+  dataHome: string,
+): string {
+  return `
+import json, os, subprocess, sys, tempfile
+
+launcher_path = ${pythonJson(MANAGED_LAUNCHER_PATH)}
+marker_prefix = ${pythonJson(LAUNCHER_MARKER_PREFIX)}
+launcher_script = ${pythonJson(launcherScript)}
+data_home = ${pythonJson(dataHome)}
+warnings = []
+
+def fail(msg):
+    print(json.dumps({"ok": False, "error": msg, "warnings": warnings}))
+    sys.exit(0)
+
+def expanded(path):
+    return os.path.expandvars(os.path.expanduser(path))
+
+launcher = expanded(launcher_path)
+if os.path.exists(launcher):
+    managed = False
+    try:
+        with open(launcher) as f:
+            managed = any(line.startswith(marker_prefix) for line in f.read(4096).splitlines())
+    except Exception:
+        pass
+    if not managed:
+        fail("A custom launcher already exists at %s. Remove it or point it at the container yourself." % launcher)
+
+os.makedirs(os.path.dirname(launcher), exist_ok=True)
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(launcher))
+with os.fdopen(fd, "w") as f:
+    f.write(launcher_script)
+os.chmod(tmp, 0o755)
+os.replace(tmp, launcher)
+
+home = expanded("$HOME/.hermes")
+if os.path.islink(home):
+    old = os.readlink(home)
+    if os.path.realpath(home) != os.path.realpath(data_home):
+        os.remove(home)
+        os.symlink(data_home, home)
+        warnings.append("Re-pointed the ~/.hermes symlink from %s to %s." % (old, data_home))
+elif os.path.isdir(home):
+    if os.listdir(home):
+        fail("~/.hermes already exists as a real directory on the host. Move it aside (e.g. mv ~/.hermes ~/.hermes.host-backup) and set up again.")
+    os.rmdir(home)
+    os.symlink(data_home, home)
+elif os.path.exists(home):
+    fail("~/.hermes already exists and is not a directory or symlink.")
+else:
+    os.symlink(data_home, home)
+
+version = subprocess.run([launcher, "--version"], check=False, text=True, capture_output=True, timeout=60)
+if version.returncode != 0:
+    fail("Launcher verification failed: " + (version.stderr.strip() or "hermes --version failed"))
+
+if not os.path.exists(os.path.join(home, "config.yaml")):
+    warnings.append("No config.yaml in the Hermes home yet - run setup once the connection is saved.")
+
+print(json.dumps({"ok": True, "version": version.stdout.strip(), "warnings": warnings}))
+`.trim();
+}
+
+export async function sshProvisionDockerTarget(
+  config: SshConfig,
+  containerName: string,
+): Promise<SshDockerProvisionResult> {
+  const name = containerName.trim();
+  const failure = (error: string): SshDockerProvisionResult => ({
+    ok: false,
+    containerName: name,
+    dataHome: "",
+    execUser: "",
+    cliPath: "",
+    version: "",
+    warnings: [],
+    error,
+  });
+  if (!isValidDockerContainerName(name)) {
+    return failure(`Invalid Docker container name: ${name}`);
+  }
+  try {
+    const probeOut = await sshPython(
+      config,
+      buildProbeSshDockerTargetCommand(name),
+      60000,
+    );
+    const probe = JSON.parse(probeOut.trim() || "{}") as {
+      ok?: boolean;
+      error?: string;
+      dataHome?: string;
+      execUser?: string;
+      cliPath?: string;
+    };
+    if (!probe.ok || !probe.dataHome || !probe.cliPath) {
+      return failure(probe.error || "Could not probe the Docker container.");
+    }
+
+    const launcherScript = buildDockerLauncherScript(
+      name,
+      probe.cliPath,
+      probe.execUser || "",
+    );
+    const applyOut = await sshPython(
+      config,
+      buildApplySshDockerTargetCommand(launcherScript, probe.dataHome),
+      90000,
+    );
+    const applied = JSON.parse(applyOut.trim() || "{}") as {
+      ok?: boolean;
+      error?: string;
+      version?: string;
+      warnings?: string[];
+    };
+    if (!applied.ok) {
+      return {
+        ...failure(applied.error || "Could not set up the Docker target."),
+        dataHome: probe.dataHome,
+        execUser: probe.execUser || "",
+        cliPath: probe.cliPath,
+        warnings: Array.isArray(applied.warnings) ? applied.warnings : [],
+      };
+    }
+
+    // End-to-end check through the REAL runtime path: the same probe chain
+    // every SSH feature uses must now resolve to the provisioned launcher.
+    const version = await sshExec(
+      config,
+      buildRemoteHermesCmd(["--version"], " 2>/dev/null"),
+      undefined,
+      30000,
+    );
+    if (!version.trim()) {
+      return failure(
+        "Launcher was written but the Hermes CLI probe still returned nothing.",
+      );
+    }
+    return {
+      ok: true,
+      containerName: name,
+      dataHome: probe.dataHome,
+      execUser: probe.execUser || "",
+      cliPath: probe.cliPath,
+      version: version.trim() || applied.version || "",
+      warnings: Array.isArray(applied.warnings) ? applied.warnings : [],
+    };
+  } catch (error) {
+    return failure(error instanceof Error ? error.message : String(error));
+  }
+}

--- a/src/main/ssh-remote.ts
+++ b/src/main/ssh-remote.ts
@@ -2062,8 +2062,21 @@ export function buildGatewayStopCommand(profile?: string): string {
  * gateway this is the unit's `is-active` state (`active` when up); otherwise
  * it is a liveness check on the recorded pid. Prints `active` or `running`
  * when up, anything else when not.
+ *
+ * `healthPort` (issue #432): Docker-backed installs record the pid in the
+ * CONTAINER's pid namespace, so a host-side `kill -0` reports a healthy
+ * gateway as stopped — and the desktop then nohups a second `gateway run`
+ * into the container. When the recorded pid is not visible on the host, fall
+ * back to probing the gateway's loopback health endpoint, which is
+ * namespace-agnostic.
  */
-export function buildGatewayStatusCommand(profile?: string): string {
+export function buildGatewayStatusCommand(
+  profile?: string,
+  healthPort?: number,
+): string {
+  const healthProbe = Number.isInteger(healthPort)
+    ? `python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:${healthPort}/health', timeout=3)" >/dev/null 2>&1 && echo "running" || echo "stopped"`
+    : `echo "stopped"`;
   if (profile && profile !== "default") {
     const pidPath = remoteGatewayPidPath(profile);
     return (
@@ -2079,8 +2092,8 @@ export function buildGatewayStatusCommand(profile?: string): string {
     `else ` +
     `if [ -f $HOME/.hermes/gateway.pid ]; then ` +
     `pid=$(python3 -c "import json,sys; d=json.load(open('$HOME/.hermes/gateway.pid')); print(d.get('pid',d) if isinstance(d,dict) else d)" 2>/dev/null || cat $HOME/.hermes/gateway.pid); ` +
-    `kill -0 $pid 2>/dev/null && echo "running" || echo "stopped"; ` +
-    `else echo "stopped"; fi; ` +
+    `kill -0 $pid 2>/dev/null && echo "running" || { ${healthProbe}; }; ` +
+    `else ${healthProbe}; fi; ` +
     `fi`
   );
 }
@@ -2090,7 +2103,15 @@ export async function sshGatewayStatus(
   profile?: string,
 ): Promise<boolean> {
   try {
-    const out = await sshExec(config, buildGatewayStatusCommand(profile));
+    // The health fallback targets the connection's configured gateway API
+    // port. Named profiles run their own gateways on ports this function
+    // cannot infer, so only the default-profile status uses it.
+    const healthPort =
+      !profile || profile === "default" ? config.remotePort : undefined;
+    const out = await sshExec(
+      config,
+      buildGatewayStatusCommand(profile, healthPort),
+    );
     const state = out.trim();
     return state === "running" || state === "active";
   } catch {

--- a/src/main/ssh-remote.ts
+++ b/src/main/ssh-remote.ts
@@ -144,7 +144,7 @@ function sanitizeSshError(stderr: string): string {
   return cleaned;
 }
 
-function shellQuote(value: string): string {
+export function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\"'\"'")}'`;
 }
 
@@ -1702,7 +1702,7 @@ export function parseHermesProfileListOutput(output: string): SshProfileInfo[] {
 // Per-user launcher hooks a managed deployment can drop in to wrap the real
 // Hermes CLI (custom HERMES_HOME, service user, unusual filesystem layout).
 // Kept in sync with the launcher probe order in buildRemoteHermesCmd.
-const REMOTE_HERMES_LAUNCHER_CANDIDATES = [
+export const REMOTE_HERMES_LAUNCHER_CANDIDATES = [
   "$HOME/.config/hermes-desktop/remote-hermes",
   "$HOME/.hermes/desktop-remote-hermes",
 ];
@@ -3266,17 +3266,21 @@ export async function sshListCachedSessions(
 // are not visible.
 //
 // Exported for unit testing the probe list without a live remote host.
+// Shared with the SSH target inspection in ssh-docker.ts so "is Hermes
+// installed on the host?" uses the exact same probe list as command execution.
+export const REMOTE_HERMES_CLI_CANDIDATES = [
+  "$HOME/hermes-agent/.venv/bin/hermes",
+  "$HOME/hermes-agent/venv/bin/hermes",
+  "$HOME/.hermes/hermes-agent/.venv/bin/hermes",
+  "$HOME/.hermes/hermes-agent/venv/bin/hermes",
+  "/opt/hermes/hermes-agent/.venv/bin/hermes",
+  "/opt/hermes/hermes-agent/venv/bin/hermes",
+  "$HOME/.local/bin/hermes",
+];
+
 export function buildRemoteHermesCmd(args: string[], extraShell = ""): string {
   const launcherCandidates = REMOTE_HERMES_LAUNCHER_CANDIDATES;
-  const candidates = [
-    "$HOME/hermes-agent/.venv/bin/hermes",
-    "$HOME/hermes-agent/venv/bin/hermes",
-    "$HOME/.hermes/hermes-agent/.venv/bin/hermes",
-    "$HOME/.hermes/hermes-agent/venv/bin/hermes",
-    "/opt/hermes/hermes-agent/.venv/bin/hermes",
-    "/opt/hermes/hermes-agent/venv/bin/hermes",
-    "$HOME/.local/bin/hermes",
-  ];
+  const candidates = REMOTE_HERMES_CLI_CANDIDATES;
   const quotedArgs = args.map((a) => shellQuote(a)).join(" ");
   const launcherProbe = launcherCandidates
     .map((p) => `[ -x ${p} ] && exec ${p} ${quotedArgs}${extraShell}`)

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -357,7 +357,7 @@ interface HermesAPI {
       keyPath: string;
       remotePort: number;
       localPort: number;
-        dockerContainerName?: string;
+      dockerContainerName?: string;
     };
   }>;
   setConnectionConfig: (

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -357,6 +357,7 @@ interface HermesAPI {
       keyPath: string;
       remotePort: number;
       localPort: number;
+        dockerContainerName?: string;
     };
   }>;
   setConnectionConfig: (
@@ -384,6 +385,7 @@ interface HermesAPI {
         keyPath: string;
         remotePort: number;
         localPort: number;
+        dockerContainerName?: string;
       };
     }) => void,
   ) => () => void;
@@ -394,7 +396,24 @@ interface HermesAPI {
     keyPath: string,
     remotePort: number,
     localPort: number,
+    dockerContainerName?: string,
   ) => Promise<boolean>;
+  inspectSshHermesTarget: (
+    host: string,
+    port: number,
+    username: string,
+    keyPath: string,
+    remotePort: number,
+    dockerContainerName?: string,
+  ) => Promise<import("../shared/ssh-docker").SshHermesTargetInspection>;
+  provisionSshDockerTarget: (
+    host: string,
+    port: number,
+    username: string,
+    keyPath: string,
+    remotePort: number,
+    dockerContainerName: string,
+  ) => Promise<import("../shared/ssh-docker").SshDockerProvisionResult>;
   testRemoteConnection: (url: string, apiKey?: string) => Promise<boolean>;
   probeRemoteAuthMode: (
     url: string,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -338,7 +338,7 @@ const hermesAPI = {
       keyPath: string;
       remotePort: number;
       localPort: number;
-            dockerContainerName?: string;
+      dockerContainerName?: string;
     };
   }> => ipcRenderer.invoke("get-connection-config"),
 
@@ -375,7 +375,7 @@ const hermesAPI = {
         keyPath: string;
         remotePort: number;
         localPort: number;
-            dockerContainerName?: string;
+        dockerContainerName?: string;
       };
     }) => void,
   ): (() => void) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -29,6 +29,10 @@ import type {
 } from "../shared/account";
 import type { AgentSyncResult, AgentSyncStatus } from "../shared/agent-sync";
 import type { GpuPreferenceMode, GpuStatus } from "../shared/gpu";
+import type {
+  SshHermesTargetInspection,
+  SshDockerProvisionResult,
+} from "../shared/ssh-docker";
 
 /**
  * Mirror of the renderer-side `CredentialPoolEntry` ambient type
@@ -334,6 +338,7 @@ const hermesAPI = {
       keyPath: string;
       remotePort: number;
       localPort: number;
+            dockerContainerName?: string;
     };
   }> => ipcRenderer.invoke("get-connection-config"),
 
@@ -370,6 +375,7 @@ const hermesAPI = {
         keyPath: string;
         remotePort: number;
         localPort: number;
+            dockerContainerName?: string;
       };
     }) => void,
   ): (() => void) => {
@@ -393,6 +399,7 @@ const hermesAPI = {
             keyPath: string;
             remotePort: number;
             localPort: number;
+            dockerContainerName?: string;
           };
         },
       );
@@ -408,6 +415,7 @@ const hermesAPI = {
     keyPath: string,
     remotePort: number,
     localPort: number,
+    dockerContainerName?: string,
   ): Promise<boolean> =>
     ipcRenderer.invoke(
       "set-ssh-config",
@@ -417,6 +425,43 @@ const hermesAPI = {
       keyPath,
       remotePort,
       localPort,
+      dockerContainerName,
+    ),
+
+  inspectSshHermesTarget: (
+    host: string,
+    port: number,
+    username: string,
+    keyPath: string,
+    remotePort: number,
+    dockerContainerName?: string,
+  ): Promise<SshHermesTargetInspection> =>
+    ipcRenderer.invoke(
+      "inspect-ssh-hermes-target",
+      host,
+      port,
+      username,
+      keyPath,
+      remotePort,
+      dockerContainerName,
+    ),
+
+  provisionSshDockerTarget: (
+    host: string,
+    port: number,
+    username: string,
+    keyPath: string,
+    remotePort: number,
+    dockerContainerName: string,
+  ): Promise<SshDockerProvisionResult> =>
+    ipcRenderer.invoke(
+      "provision-ssh-docker-target",
+      host,
+      port,
+      username,
+      keyPath,
+      remotePort,
+      dockerContainerName,
     ),
 
   testRemoteConnection: (url: string, apiKey?: string): Promise<boolean> =>

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -7284,6 +7284,47 @@ body:has(.shell-vibrant),
   color: var(--warning, #f59e0b);
 }
 
+.ssh-docker-container-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.ssh-docker-container-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-primary);
+  cursor: pointer;
+}
+
+.ssh-docker-container-option input {
+  margin-top: 3px;
+}
+
+.ssh-docker-container-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.ssh-docker-container-name {
+  font-weight: 600;
+  font-size: 12px;
+}
+
+.ssh-docker-container-meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  word-break: break-all;
+}
+
 .settings-input-row {
   display: flex;
   gap: 8px;

--- a/src/renderer/src/components/settings/ConnectionPane.tsx
+++ b/src/renderer/src/components/settings/ConnectionPane.tsx
@@ -2,6 +2,7 @@ import { Laptop, Server, Terminal, Wifi } from "lucide-react";
 import { useI18n } from "../useI18n";
 import { useSettings } from "./SettingsDataContext";
 import { CHAT_TRANSPORT_OPTIONS } from "./settingsHelpers";
+import SshDockerTargetSection from "./SshDockerTargetSection";
 
 /**
  * Local / Remote / SSH connection mode, chat transport, server config, and the
@@ -45,6 +46,8 @@ export default function ConnectionPane(): React.JSX.Element {
     setSshKeyPath,
     sshRemotePort,
     setSshRemotePort,
+    sshDockerContainer,
+    setSshDockerContainer,
     handleSaveConnection,
     handleTestConnection,
     handleRemoteOAuthLogin,
@@ -350,6 +353,18 @@ export default function ConnectionPane(): React.JSX.Element {
               })}
             </div>
           </div>
+          <SshDockerTargetSection
+            draft={{
+              host: sshHost,
+              port: parseInt(sshPort, 10) || 22,
+              username: sshUser,
+              keyPath: sshKeyPath,
+              remotePort: parseInt(sshRemotePort, 10) || 8642,
+            }}
+            value={sshDockerContainer}
+            onChange={setSshDockerContainer}
+            onProvisioned={() => void handleSaveConnection()}
+          />
           <div className="settings-field">
             <label className="settings-field-label">Chat transport</label>
             <div className="settings-theme-options">

--- a/src/renderer/src/components/settings/SshDockerTargetSection.tsx
+++ b/src/renderer/src/components/settings/SshDockerTargetSection.tsx
@@ -124,9 +124,12 @@ export default function SshDockerTargetSection({
     inspection?.launcherState === "docker" &&
     inspection.launcherContainerName === selected &&
     inspection.hermesHomeState === "symlink";
+  // An EMPTY ~/.hermes directory is not a conflict — setup replaces it with
+  // the data-volume symlink.
   const homeDirConflict =
     inspection !== null &&
     inspection.hermesHomeState === "directory" &&
+    !inspection.hermesHomeEmpty &&
     !inspection.hostInstallFound &&
     containers.length > 0;
 

--- a/src/renderer/src/components/settings/SshDockerTargetSection.tsx
+++ b/src/renderer/src/components/settings/SshDockerTargetSection.tsx
@@ -1,0 +1,298 @@
+import { useCallback, useState } from "react";
+import { Container } from "lucide-react";
+import { useI18n } from "../useI18n";
+import type {
+  SshHermesTargetInspection,
+  SshDockerProvisionResult,
+} from "../../../../shared/ssh-docker";
+
+export interface SshDockerDraft {
+  host: string;
+  port: number;
+  username: string;
+  keyPath: string;
+  remotePort: number;
+}
+
+interface Props {
+  draft: SshDockerDraft;
+  /** Selected container name (persisted with the SSH config by the parent). */
+  value: string;
+  onChange: (containerName: string) => void;
+  /** Called after a successful remote setup so the parent can persist. */
+  onProvisioned?: (result: SshDockerProvisionResult) => void;
+}
+
+/**
+ * SSH target inspection + Docker setup (issue #432). Detects Hermes running
+ * inside a Docker container on the SSH host, lets the user pick a container
+ * when several run, and provisions the remote launcher hook + ~/.hermes
+ * symlink that the rest of SSH mode already understands. Shared by Settings
+ * and the first-run Welcome flow.
+ */
+export default function SshDockerTargetSection({
+  draft,
+  value,
+  onChange,
+  onProvisioned,
+}: Props): React.JSX.Element {
+  const { t } = useI18n();
+  const [inspection, setInspection] =
+    useState<SshHermesTargetInspection | null>(null);
+  const [inspecting, setInspecting] = useState(false);
+  const [provisioning, setProvisioning] = useState(false);
+  const [provisionResult, setProvisionResult] =
+    useState<SshDockerProvisionResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const draftReady = draft.host.trim().length > 0;
+
+  const inspect = useCallback(async (): Promise<void> => {
+    setInspecting(true);
+    setError(null);
+    setProvisionResult(null);
+    try {
+      const result = await window.hermesAPI.inspectSshHermesTarget(
+        draft.host.trim(),
+        draft.port,
+        draft.username.trim(),
+        draft.keyPath.trim(),
+        draft.remotePort,
+        value.trim(),
+      );
+      setInspection(result);
+      if (result.error) setError(result.error);
+      // Exactly one container and nothing selected yet — preselect it so the
+      // common single-container host is one click away from setup.
+      if (
+        !value.trim() &&
+        result.dockerContainers.length === 1 &&
+        !result.hostInstallFound
+      ) {
+        onChange(result.dockerContainers[0].name);
+      }
+    } catch (err) {
+      setInspection(null);
+      setError(
+        t("settings.sshDockerInspectFailed", {
+          msg: err instanceof Error ? err.message : String(err),
+        }),
+      );
+    } finally {
+      setInspecting(false);
+    }
+  }, [draft, value, onChange, t]);
+
+  const provision = useCallback(async (): Promise<void> => {
+    const container = value.trim();
+    if (!container) return;
+    setProvisioning(true);
+    setError(null);
+    setProvisionResult(null);
+    try {
+      const result = await window.hermesAPI.provisionSshDockerTarget(
+        draft.host.trim(),
+        draft.port,
+        draft.username.trim(),
+        draft.keyPath.trim(),
+        draft.remotePort,
+        container,
+      );
+      setProvisionResult(result);
+      if (result.ok) {
+        onProvisioned?.(result);
+        // Refresh the status line so "configured" reflects the new remote state.
+        void inspect();
+      } else if (result.error) {
+        setError(t("settings.sshDockerSetupFailed", { msg: result.error }));
+      }
+    } catch (err) {
+      setError(
+        t("settings.sshDockerSetupFailed", {
+          msg: err instanceof Error ? err.message : String(err),
+        }),
+      );
+    } finally {
+      setProvisioning(false);
+    }
+  }, [draft, value, onProvisioned, inspect, t]);
+
+  const containers = inspection?.dockerContainers ?? [];
+  const selected = value.trim();
+  const selectedContainer = containers.find((c) => c.name === selected);
+  const configuredForSelected =
+    inspection?.launcherState === "docker" &&
+    inspection.launcherContainerName === selected &&
+    inspection.hermesHomeState === "symlink";
+  const homeDirConflict =
+    inspection !== null &&
+    inspection.hermesHomeState === "directory" &&
+    !inspection.hostInstallFound &&
+    containers.length > 0;
+
+  return (
+    <div className="settings-subsection">
+      <div className="settings-subsection-head">
+        <Container size={14} />
+        <span>{t("settings.sshDockerTitle")}</span>
+      </div>
+
+      <div className="settings-field">
+        <button
+          className="btn btn-secondary"
+          onClick={() => void inspect()}
+          disabled={inspecting || provisioning || !draftReady}
+        >
+          {inspecting
+            ? t("settings.sshDockerDetecting")
+            : t("settings.sshDockerDetect")}
+        </button>
+        <div className="settings-field-hint">
+          {t("settings.sshDockerDetectHint")}
+        </div>
+      </div>
+
+      {inspection && (
+        <>
+          {inspection.hostInstallFound && (
+            <div className="settings-transport-status settings-transport-status--ok">
+              <span>{t("settings.sshDockerHostInstall")}</span>
+            </div>
+          )}
+
+          {!inspection.hostInstallFound &&
+            containers.length === 0 &&
+            !error && (
+              <div className="settings-transport-status settings-transport-status--warn">
+                <span>
+                  {inspection.dockerAvailable
+                    ? t("settings.sshDockerNoContainers")
+                    : t("settings.sshDockerNoDocker")}
+                </span>
+              </div>
+            )}
+
+          {containers.length > 0 && (
+            <div className="settings-field">
+              <label className="settings-field-label">
+                {t("settings.sshDockerContainersFound")}
+              </label>
+              {containers.length > 1 && !selected && (
+                <div className="settings-field-hint">
+                  {t("settings.sshDockerSelectPrompt")}
+                </div>
+              )}
+              <div className="ssh-docker-container-list">
+                {containers.map((c) => (
+                  <label key={c.name} className="ssh-docker-container-option">
+                    <input
+                      type="radio"
+                      name="ssh-docker-container"
+                      checked={selected === c.name}
+                      onChange={() => {
+                        setProvisionResult(null);
+                        onChange(c.name);
+                      }}
+                    />
+                    <span className="ssh-docker-container-info">
+                      <span className="ssh-docker-container-name">
+                        {c.name}
+                      </span>
+                      <span className="ssh-docker-container-meta">
+                        {c.image}
+                        {" · "}
+                        {c.dataHome || t("settings.sshDockerNoDataMount")}
+                        {c.matchesRemotePort &&
+                          ` · ${t("settings.sshDockerPortMatch", {
+                            port: String(draft.remotePort),
+                          })}`}
+                      </span>
+                    </span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {inspection.launcherState === "custom" && (
+            <div className="settings-transport-status settings-transport-status--muted">
+              <span>{t("settings.sshDockerCustomLauncher")}</span>
+            </div>
+          )}
+
+          {configuredForSelected && (
+            <div className="settings-transport-status settings-transport-status--ok">
+              <span>
+                {t("settings.sshDockerConfigured", { name: selected })}
+              </span>
+            </div>
+          )}
+
+          {inspection.launcherState === "docker" &&
+            inspection.launcherContainerName !== null &&
+            selected.length > 0 &&
+            inspection.launcherContainerName !== selected && (
+              <div className="settings-transport-status settings-transport-status--warn">
+                <span>
+                  {t("settings.sshDockerConfiguredOther", {
+                    name: inspection.launcherContainerName,
+                  })}
+                </span>
+              </div>
+            )}
+
+          {homeDirConflict && (
+            <div className="settings-transport-status settings-transport-status--warn">
+              <span>{t("settings.sshDockerHomeDirConflict")}</span>
+            </div>
+          )}
+
+          {selectedContainer &&
+            inspection.launcherState !== "custom" &&
+            !configuredForSelected && (
+              <div className="settings-field">
+                <button
+                  className="btn btn-primary"
+                  onClick={() => void provision()}
+                  disabled={
+                    provisioning ||
+                    inspecting ||
+                    !selectedContainer.dataHome ||
+                    homeDirConflict
+                  }
+                >
+                  {provisioning
+                    ? t("settings.sshDockerSettingUp")
+                    : t("settings.sshDockerSetup")}
+                </button>
+                <div className="settings-field-hint">
+                  {t("settings.sshDockerSetupHint", {
+                    user: draft.username.trim() || "the SSH user",
+                  })}
+                </div>
+              </div>
+            )}
+        </>
+      )}
+
+      {provisionResult?.ok && (
+        <div className="settings-transport-status settings-transport-status--ok">
+          <span>
+            {t("settings.sshDockerSetupDone", {
+              version: provisionResult.version.split("\n")[0],
+            })}
+          </span>
+          {provisionResult.warnings.length > 0 && (
+            <code>{provisionResult.warnings.join(" ")}</code>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <div className="settings-transport-status settings-transport-status--warn">
+          <span>{error}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/src/components/settings/useSettingsData.ts
+++ b/src/renderer/src/components/settings/useSettingsData.ts
@@ -89,6 +89,7 @@ export function useSettingsData(profile?: string) {
   const [sshKeyPath, setSshKeyPath] = useState("");
   const [sshRemotePort, setSshRemotePort] = useState("");
   const [sshLocalPort, setSshLocalPort] = useState("");
+  const [sshDockerContainer, setSshDockerContainer] = useState("");
   const [transportProbe, setTransportProbe] = useState<TransportProbe | null>(
     null,
   );
@@ -179,6 +180,7 @@ export function useSettingsData(profile?: string) {
     setSshKeyPath(conn.ssh?.keyPath || "");
     setSshRemotePort(conn.ssh?.remotePort ? String(conn.ssh.remotePort) : "");
     setSshLocalPort(conn.ssh?.localPort ? String(conn.ssh.localPort) : "");
+    setSshDockerContainer(conn.ssh?.dockerContainerName || "");
     setApiServerKeyMissing(!keyStatus.hasKey);
     setAutoUpgradeEnabled(autoUpgrade);
     connLoaded.current = true;
@@ -411,6 +413,7 @@ export function useSettingsData(profile?: string) {
       sshKeyPath.trim(),
       parseInt(sshRemotePort, 10) || 8642,
       parseInt(sshLocalPort, 10) || 18642,
+      sshDockerContainer.trim(),
     );
   }
 
@@ -882,6 +885,8 @@ export function useSettingsData(profile?: string) {
     setSshKeyPath,
     sshRemotePort,
     setSshRemotePort,
+    sshDockerContainer,
+    setSshDockerContainer,
     // backup / data
     backingUp,
     backupResult,

--- a/src/renderer/src/screens/Welcome/Welcome.tsx
+++ b/src/renderer/src/screens/Welcome/Welcome.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../assets/icons";
 import { getInstallCmd } from "../../constants";
 import { useI18n } from "../../components/useI18n";
+import SshDockerTargetSection from "../../components/settings/SshDockerTargetSection";
 
 interface WelcomeProps {
   error: string | null;
@@ -43,6 +44,7 @@ function Welcome({
   const [sshUser, setSshUser] = useState("");
   const [sshKeyPath, setSshKeyPath] = useState("");
   const [sshRemotePort, setSshRemotePort] = useState("");
+  const [sshDockerContainer, setSshDockerContainer] = useState("");
   const [sshError, setSshError] = useState<string | null>(null);
   const [sshTesting, setSshTesting] = useState(false);
 
@@ -97,6 +99,7 @@ function Welcome({
           sshKeyPath.trim(),
           remotePort,
           18642,
+          sshDockerContainer.trim(),
         );
         onRecheck();
       } else {
@@ -266,6 +269,18 @@ function Welcome({
             placeholder="8642"
             value={sshRemotePort}
             onChange={(e) => setSshRemotePort(e.target.value)}
+          />
+
+          <SshDockerTargetSection
+            draft={{
+              host: sshHost,
+              port: parseInt(sshPort, 10) || 22,
+              username: sshUser,
+              keyPath: sshKeyPath,
+              remotePort: parseInt(sshRemotePort, 10) || 8642,
+            }}
+            value={sshDockerContainer}
+            onChange={setSshDockerContainer}
           />
 
           <div className="welcome-remote-row" style={{ marginTop: 16 }}>

--- a/src/shared/i18n/locales/en/settings.ts
+++ b/src/shared/i18n/locales/en/settings.ts
@@ -237,6 +237,36 @@ export default {
   remoteErrorFailed: "Connection test failed.",
   sshSuccess: "SSH tunnel connected!",
   sshErrorRequiredSimple: "Host and username are required",
+  sshDockerTitle: "Remote Hermes install",
+  sshDockerDetect: "Detect remote install",
+  sshDockerDetecting: "Detecting…",
+  sshDockerDetectHint:
+    "Checks the SSH host for a Hermes install — including Hermes running inside a Docker container (Coolify, Compose, NAS).",
+  sshDockerHostInstall: "Hermes CLI found on the host — no extra setup needed.",
+  sshDockerNoDocker:
+    "No host Hermes install found, and Docker is not available for this SSH user.",
+  sshDockerNoContainers:
+    "No host Hermes install found, and no running Hermes Docker containers were detected.",
+  sshDockerContainersFound: "Hermes Docker containers on this host:",
+  sshDockerSelectPrompt:
+    "Several Hermes containers are running — pick the one this connection should use.",
+  sshDockerNoDataMount: "no data volume mounted at /opt/data",
+  sshDockerPortMatch: "publishes port {{port}}",
+  sshDockerConfigured:
+    'Docker access is set up for container "{{name}}" — the Hermes CLI and data are reachable over SSH.',
+  sshDockerConfiguredOther:
+    'The remote launcher currently routes to container "{{name}}". Run setup again to switch it.',
+  sshDockerCustomLauncher:
+    "A custom remote launcher exists on this host (~/.config/hermes-desktop/remote-hermes). Hermes Desktop will use it as-is and won't overwrite it.",
+  sshDockerHomeDirConflict:
+    "~/.hermes exists as a real directory on the host, so it can't be linked to the container data volume. Move it aside (e.g. mv ~/.hermes ~/.hermes.host-backup) and detect again.",
+  sshDockerSetup: "Set up Docker access",
+  sshDockerSettingUp: "Setting up…",
+  sshDockerSetupHint:
+    "Writes two files on the SSH host as {{user}}: a launcher at ~/.config/hermes-desktop/remote-hermes that runs the Hermes CLI inside the selected container, and a ~/.hermes symlink to the container's data volume. Nothing inside the container is modified.",
+  sshDockerSetupDone: "Docker access ready — {{version}}",
+  sshDockerSetupFailed: "Setup failed: {{msg}}",
+  sshDockerInspectFailed: "Could not inspect the remote host: {{msg}}",
   remoteSuccess: "Connected successfully!",
   remoteErrorRequiredSimple: "Please enter a URL",
   remoteErrorFailedSimple: "Could not reach server",

--- a/src/shared/ssh-docker.ts
+++ b/src/shared/ssh-docker.ts
@@ -18,6 +18,12 @@ export interface SshHermesTargetInspection {
   hostInstallFound: boolean;
   /** State of ~/.hermes on the host: missing | directory | symlink. */
   hermesHomeState: "missing" | "directory" | "symlink";
+  /**
+   * True when hermesHomeState is "directory" and the directory is empty —
+   * setup can replace it with the data-volume symlink, so it is not a
+   * conflict.
+   */
+  hermesHomeEmpty: boolean;
   /** Symlink target when hermesHomeState is "symlink". */
   hermesHomeTarget: string | null;
   /** Desktop-managed docker hook, some other executable, or none. */

--- a/src/shared/ssh-docker.ts
+++ b/src/shared/ssh-docker.ts
@@ -1,0 +1,46 @@
+// Docker-backed SSH target types (issue #432), shared by the main-process
+// inspection/provisioning in src/main/ssh-docker.ts, the preload bridge, and
+// the renderer target-selection UI.
+
+export interface SshHermesDockerContainer {
+  id: string;
+  name: string;
+  image: string;
+  ports: string;
+  /** Host path mounted at /opt/data, "" when the container has no data mount. */
+  dataHome: string;
+  /** True when the container publishes the configured remote API port. */
+  matchesRemotePort: boolean;
+}
+
+export interface SshHermesTargetInspection {
+  /** A host-level CLI install plus a real ~/.hermes were found. */
+  hostInstallFound: boolean;
+  /** State of ~/.hermes on the host: missing | directory | symlink. */
+  hermesHomeState: "missing" | "directory" | "symlink";
+  /** Symlink target when hermesHomeState is "symlink". */
+  hermesHomeTarget: string | null;
+  /** Desktop-managed docker hook, some other executable, or none. */
+  launcherState: "missing" | "docker" | "custom";
+  /** Container the managed hook routes to (launcherState "docker"). */
+  launcherContainerName: string | null;
+  dockerAvailable: boolean;
+  dockerContainers: SshHermesDockerContainer[];
+  selectedDockerContainerName: string;
+  error?: string;
+}
+
+export interface SshDockerProvisionResult {
+  ok: boolean;
+  containerName: string;
+  /** Host path of the container's /opt/data mount. */
+  dataHome: string;
+  /** `docker exec` user flag baked into the hook ("" = container default). */
+  execUser: string;
+  /** Hermes CLI path inside the container. */
+  cliPath: string;
+  /** `hermes --version` output through the provisioned launcher. */
+  version: string;
+  warnings: string[];
+  error?: string;
+}

--- a/tests/ssh-docker.test.ts
+++ b/tests/ssh-docker.test.ts
@@ -218,20 +218,45 @@ describe("buildApplySshDockerTargetCommand", () => {
   );
 
   it("passes the launcher script and data home as data, not code", () => {
-    const cmd = buildApplySshDockerTargetCommand(launcher, "/data/it's home");
+    const cmd = buildApplySshDockerTargetCommand(
+      "hermes-1",
+      launcher,
+      "/data/it's home",
+    );
     expect(cmd).toContain(JSON.stringify(launcher));
     expect(cmd).toContain('"/data/it\'s home"');
   });
 
+  it("validates the container name before building the script", () => {
+    expect(() =>
+      buildApplySshDockerTargetCommand("bad name", launcher, "/data/hermes"),
+    ).toThrow("Invalid Docker container name");
+  });
+
   it("refuses to clobber non-managed launchers and real home directories", () => {
-    const cmd = buildApplySshDockerTargetCommand(launcher, "/data/hermes");
+    const cmd = buildApplySshDockerTargetCommand(
+      "hermes-1",
+      launcher,
+      "/data/hermes",
+    );
     expect(cmd).toContain("A custom launcher already exists");
     expect(cmd).toContain("~/.hermes already exists as a real directory");
   });
 
+  it("seeds API server settings from the container env, not fresh values first", () => {
+    const cmd = buildApplySshDockerTargetCommand(
+      "hermes-1",
+      launcher,
+      "/data/hermes",
+    );
+    expect(cmd).toContain('cenv.get("API_SERVER_KEY")');
+    expect(cmd).toContain("API_SERVER_ENABLED");
+    expect(cmd).toContain("secrets.token_hex(24)");
+  });
+
   itPython("generates python that compiles", () => {
     assertPythonCompiles(
-      buildApplySshDockerTargetCommand(launcher, "/data/hermes"),
+      buildApplySshDockerTargetCommand("hermes-1", launcher, "/data/hermes"),
     );
   });
 });

--- a/tests/ssh-docker.test.ts
+++ b/tests/ssh-docker.test.ts
@@ -214,12 +214,14 @@ describe("buildProbeSshDockerTargetCommand", () => {
     );
   });
 
-  it("verifies image, data mount, exec user, and CLI location", () => {
+  it("prefers the service user and public CLI before legacy fallbacks", () => {
     const cmd = buildProbeSshDockerTargetCommand("hermes-1");
     expect(cmd).toContain('container = "hermes-1"');
     expect(cmd).toContain("nousresearch/hermes-agent");
-    expect(cmd).toContain('"/opt/hermes/.venv/bin/hermes"');
-    expect(cmd).toContain('(None, "hermes")');
+    expect(cmd).toContain(
+      'cli_candidates = ["hermes", "/opt/hermes/bin/hermes", "/opt/hermes/.venv/bin/hermes", "/opt/hermes/venv/bin/hermes"]',
+    );
+    expect(cmd).toContain('for candidate_user in ("hermes", None):');
   });
 
   itPython("generates python that compiles", () => {

--- a/tests/ssh-docker.test.ts
+++ b/tests/ssh-docker.test.ts
@@ -184,9 +184,26 @@ describe("parseSshHermesTargetInspection", () => {
     const parsed = parseSshHermesTargetInspection("", "");
     expect(parsed.hostInstallFound).toBe(false);
     expect(parsed.hermesHomeState).toBe("missing");
+    expect(parsed.hermesHomeEmpty).toBe(false);
     expect(parsed.launcherState).toBe("missing");
     expect(parsed.dockerContainers).toEqual([]);
     expect(parsed.error).toBeUndefined();
+  });
+
+  it("distinguishes an empty ~/.hermes directory from a real one", () => {
+    // An empty directory is replaceable by the setup symlink, so the UI must
+    // not report it as a conflict (greptile P1 on PR #435).
+    const parsed = parseSshHermesTargetInspection(
+      JSON.stringify({
+        hermesHomeState: "directory",
+        hermesHomeEmpty: true,
+        dockerAvailable: true,
+        dockerContainers: [container],
+      }),
+      "",
+    );
+    expect(parsed.hermesHomeState).toBe("directory");
+    expect(parsed.hermesHomeEmpty).toBe(true);
   });
 });
 

--- a/tests/ssh-docker.test.ts
+++ b/tests/ssh-docker.test.ts
@@ -1,0 +1,237 @@
+import { execFileSync } from "child_process";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/main/locale", () => ({
+  getAppLocale: () => "en",
+}));
+
+import {
+  buildApplySshDockerTargetCommand,
+  buildDockerLauncherScript,
+  buildInspectSshHermesTargetCommand,
+  buildProbeSshDockerTargetCommand,
+  isValidDockerContainerName,
+  parseSshHermesTargetInspection,
+} from "../src/main/ssh-docker";
+
+// The generated remote scripts are python; validating that they at least
+// compile catches template/quoting regressions. python3 is not part of the
+// repo's supported dev toolchain on Windows, so these compile checks skip
+// there (and anywhere python3 is missing) — the string assertions below run
+// on every platform.
+function resolvePython3(): string | null {
+  if (process.platform === "win32") return null;
+  try {
+    const out = execFileSync("/bin/sh", ["-c", "command -v python3"], {
+      encoding: "utf8",
+    }).trim();
+    return out || null;
+  } catch {
+    return null;
+  }
+}
+const python3Path = resolvePython3();
+const itPython = python3Path ? it : it.skip;
+
+function assertPythonCompiles(script: string): void {
+  // compile() only parses — nothing in the script is executed.
+  execFileSync(python3Path as string, ["-c", "import sys; compile(sys.stdin.read(), '<script>', 'exec')"], {
+    input: script,
+  });
+}
+
+describe("isValidDockerContainerName", () => {
+  it("accepts docker's documented name charset", () => {
+    expect(isValidDockerContainerName("hermes-kk5any7517jzgl9y19mrabul")).toBe(
+      true,
+    );
+    expect(isValidDockerContainerName("Hermes_1.2-x")).toBe(true);
+  });
+
+  it.each([
+    ["empty", ""],
+    ["leading dash", "-hermes"],
+    ["whitespace", "hermes agent"],
+    ["shell metacharacters", "hermes;rm -rf /"],
+    ["command substitution", "$(reboot)"],
+    ["quote", "hermes'quote"],
+  ])("rejects %s", (_name, value) => {
+    expect(isValidDockerContainerName(value)).toBe(false);
+  });
+});
+
+describe("buildDockerLauncherScript", () => {
+  it("embeds the container, CLI path, and management marker", () => {
+    const script = buildDockerLauncherScript(
+      "hermes-abc",
+      "/opt/hermes/.venv/bin/hermes",
+      "",
+    );
+    expect(script).toContain("# managed by Hermes Desktop (docker:hermes-abc)");
+    expect(script).toContain("container='hermes-abc'");
+    expect(script).toContain("'/opt/hermes/.venv/bin/hermes' \"$@\"");
+    expect(script).toContain("-e HOME=/opt/data -e HERMES_HOME=/opt/data");
+    expect(script.startsWith("#!/bin/sh\n")).toBe(true);
+    // No exec user flag when the container default user works.
+    expect(script).not.toContain("-u ");
+  });
+
+  it("adds the exec user flag when a non-default user is required", () => {
+    const script = buildDockerLauncherScript(
+      "hermes-abc",
+      "/opt/hermes/.venv/bin/hermes",
+      "hermes",
+    );
+    expect(script).toContain("docker exec $tty_args -u 'hermes' ");
+  });
+
+  it("keeps interactive and piped stdin working", () => {
+    const script = buildDockerLauncherScript("c1", "/bin/hermes", "");
+    expect(script).toContain(
+      'if [ -t 0 ] && [ -t 1 ]; then tty_args="-it"; elif [ -t 0 ]; then tty_args="-i"; fi',
+    );
+  });
+
+  it("refuses container names that could break out of the script", () => {
+    expect(() =>
+      buildDockerLauncherScript("bad name", "/bin/hermes", ""),
+    ).toThrow("Invalid Docker container name");
+    expect(() =>
+      buildDockerLauncherScript("$(evil)", "/bin/hermes", ""),
+    ).toThrow("Invalid Docker container name");
+  });
+});
+
+describe("buildInspectSshHermesTargetCommand", () => {
+  it("scopes container matching to the configured remote port", () => {
+    const cmd = buildInspectSshHermesTargetCommand(8642, "");
+    expect(cmd).toContain("remote_port = 8642");
+    expect(cmd).toContain("nousresearch/hermes-agent");
+  });
+
+  it("passes the selected container name as data, not code", () => {
+    const cmd = buildInspectSshHermesTargetCommand(8642, 'evil"; import os');
+    expect(cmd).toContain('selected_name = "evil\\"; import os"');
+  });
+
+  it("omits port matching when no remote port is configured", () => {
+    expect(buildInspectSshHermesTargetCommand(undefined, "")).toContain(
+      "remote_port = None",
+    );
+  });
+
+  itPython("generates python that compiles", () => {
+    assertPythonCompiles(buildInspectSshHermesTargetCommand(8642, "sel'ected"));
+  });
+});
+
+describe("parseSshHermesTargetInspection", () => {
+  const container = {
+    id: "abc123",
+    name: "hermes-1",
+    image: "nousresearch/hermes-agent:latest",
+    ports: "127.0.0.1:8642->8642/tcp",
+    dataHome: "/data/hermes",
+    matchesRemotePort: true,
+  };
+
+  it("maps a full inspection payload", () => {
+    const parsed = parseSshHermesTargetInspection(
+      JSON.stringify({
+        hostInstallFound: false,
+        hermesHomeState: "symlink",
+        hermesHomeTarget: "/data/hermes",
+        launcherState: "docker",
+        launcherContainerName: "hermes-1",
+        dockerAvailable: true,
+        dockerContainers: [container],
+        selectedDockerContainerName: "hermes-1",
+      }),
+      "hermes-1",
+    );
+    expect(parsed.error).toBeUndefined();
+    expect(parsed.launcherState).toBe("docker");
+    expect(parsed.launcherContainerName).toBe("hermes-1");
+    expect(parsed.dockerContainers).toHaveLength(1);
+  });
+
+  it("reports a selected container that is no longer running", () => {
+    const parsed = parseSshHermesTargetInspection(
+      JSON.stringify({
+        hostInstallFound: false,
+        hermesHomeState: "missing",
+        launcherState: "missing",
+        dockerAvailable: true,
+        dockerContainers: [container],
+      }),
+      "hermes-gone",
+    );
+    expect(parsed.error).toContain('"hermes-gone" is not running');
+  });
+
+  it("reports a selected container without a data mount", () => {
+    const parsed = parseSshHermesTargetInspection(
+      JSON.stringify({
+        dockerAvailable: true,
+        dockerContainers: [{ ...container, dataHome: "" }],
+      }),
+      "hermes-1",
+    );
+    expect(parsed.error).toContain("no host mount for /opt/data");
+  });
+
+  it("defaults sanely on empty remote output", () => {
+    const parsed = parseSshHermesTargetInspection("", "");
+    expect(parsed.hostInstallFound).toBe(false);
+    expect(parsed.hermesHomeState).toBe("missing");
+    expect(parsed.launcherState).toBe("missing");
+    expect(parsed.dockerContainers).toEqual([]);
+    expect(parsed.error).toBeUndefined();
+  });
+});
+
+describe("buildProbeSshDockerTargetCommand", () => {
+  it("validates the container name before building the script", () => {
+    expect(() => buildProbeSshDockerTargetCommand("bad name")).toThrow(
+      "Invalid Docker container name",
+    );
+  });
+
+  it("verifies image, data mount, exec user, and CLI location", () => {
+    const cmd = buildProbeSshDockerTargetCommand("hermes-1");
+    expect(cmd).toContain('container = "hermes-1"');
+    expect(cmd).toContain("nousresearch/hermes-agent");
+    expect(cmd).toContain('"/opt/hermes/.venv/bin/hermes"');
+    expect(cmd).toContain('(None, "hermes")');
+  });
+
+  itPython("generates python that compiles", () => {
+    assertPythonCompiles(buildProbeSshDockerTargetCommand("hermes-1"));
+  });
+});
+
+describe("buildApplySshDockerTargetCommand", () => {
+  const launcher = buildDockerLauncherScript(
+    "hermes-1",
+    "/opt/hermes/.venv/bin/hermes",
+    "hermes",
+  );
+
+  it("passes the launcher script and data home as data, not code", () => {
+    const cmd = buildApplySshDockerTargetCommand(launcher, "/data/it's home");
+    expect(cmd).toContain(JSON.stringify(launcher));
+    expect(cmd).toContain('"/data/it\'s home"');
+  });
+
+  it("refuses to clobber non-managed launchers and real home directories", () => {
+    const cmd = buildApplySshDockerTargetCommand(launcher, "/data/hermes");
+    expect(cmd).toContain("A custom launcher already exists");
+    expect(cmd).toContain("~/.hermes already exists as a real directory");
+  });
+
+  itPython("generates python that compiles", () => {
+    assertPythonCompiles(
+      buildApplySshDockerTargetCommand(launcher, "/data/hermes"),
+    );
+  });
+});

--- a/tests/ssh-remote.test.ts
+++ b/tests/ssh-remote.test.ts
@@ -53,7 +53,16 @@ const sshConfig: SshConfig = {
   localPort: 18642,
 };
 
+// The shim-execution tests below run the generated command through a real
+// POSIX shell. A clean Windows dev environment has no `bash` on PATH (and the
+// shim/PATH model is POSIX-specific), so they skip there — the portable string
+// assertions in this file still run on every platform.
+const itPosix = process.platform === "win32" ? it.skip : it;
+
 function runWithHermesShim(command: string): Buffer {
+  if (process.platform === "win32") {
+    throw new Error("POSIX-only helper — guard the calling test with itPosix");
+  }
   const home = mkdtempSync(join(tmpdir(), "hermes-ssh-cmd-home-"));
   // Install the shim at a path buildRemoteHermesCmd PROBES BY ABSOLUTE PATH
   // ($HOME/.local/bin/hermes), not just on PATH. The command runs under
@@ -130,7 +139,7 @@ describe("ssh Hermes command quoting", () => {
     );
   });
 
-  it.each([
+  itPosix.each([
     [
       "multi-word title",
       ["kanban", "create", "My task title", "--triage", "--json"],
@@ -160,7 +169,7 @@ describe("ssh Hermes command quoting", () => {
     30000,
   );
 
-  it("preserves existing extraShell redirects", () => {
+  itPosix("preserves existing extraShell redirects", () => {
     const output = runWithHermesShim(
       buildRemoteHermesCmd(["doctor"], " 2>&1"),
     ).toString("utf8");

--- a/tests/ssh-remote.test.ts
+++ b/tests/ssh-remote.test.ts
@@ -220,6 +220,26 @@ describe("ssh gateway commands (issue #285)", () => {
     expect(cmd).toContain("gateway.pid");
     expect(systemdBranch(cmd)).not.toContain("gateway.pid");
   });
+
+  it("status falls back to a loopback health probe for container pids (issue #432)", () => {
+    // Docker-backed installs record the container-namespace pid, so a host
+    // `kill -0` reports a healthy gateway as stopped; the health probe is the
+    // namespace-agnostic tiebreaker.
+    const cmd = buildGatewayStatusCommand(undefined, 8642);
+    expect(cmd).toContain("http://127.0.0.1:8642/health");
+    expect(cmd).toContain('kill -0 $pid 2>/dev/null && echo "running"');
+  });
+
+  it("status without a health port keeps the plain pid check", () => {
+    const cmd = buildGatewayStatusCommand();
+    expect(cmd).not.toContain("/health");
+  });
+
+  it("status ignores non-integer health ports", () => {
+    expect(buildGatewayStatusCommand(undefined, 8642.5)).not.toContain(
+      "/health",
+    );
+  });
 });
 
 describe("buildRemoteHermesCmd venv probe (issue #284)", () => {


### PR DESCRIPTION
## Problem

A Docker/Coolify deployment of `nousresearch/hermes-agent` is a valid Hermes install, but SSH mode assumes a host-level one. Chat works through the tunnel while Doctor fails with `hermes CLI not found on remote PATH or in any known venv location`, and Sessions, Models, Logs, and Config come up empty (#432).

## Root cause

The CLI lives inside the container (`/opt/hermes/.venv/bin/hermes`) and the Hermes home is the volume mounted at the container's `/opt/data` (for example `/data/hermes` on the host). Neither is visible to the host-path CLI probes and `~/.hermes` file reads SSH mode uses.

## Fix

Re-implemented on top of #786 (this replaces the pre-#786 revision of this branch; core-path footprint dropped from +720 to +55 lines in `ssh-remote.ts`). Instead of threading container awareness through the SSH code paths, the desktop provisions the two host-side artifacts the existing machinery already understands:

- the per-user launcher hook `~/.config/hermes-desktop/remote-hermes` — already the first probe in `buildRemoteHermesCmd` — generated as a `docker exec` wrapper that routes the Hermes CLI into the selected container, and
- a `~/.hermes` symlink to the container's data volume, so every remote file read/write sees the real Hermes home.

After setup, CLI execution, gateway lifecycle, dashboard ensure, profiles, sessions, logs, and config all work through the unchanged post-#786 code paths — everything still routes through `prepareSshTunnel` / `sshEnsureDashboard`; there are no parallel command builders.

New surface:

- `src/main/ssh-docker.ts` — remote inspection (host install, `~/.hermes` state, launcher state, running official Hermes containers with their data mounts and published ports) and provisioning (validate container → probe exec user and CLI path → write launcher + symlink → verify `--version` through the real probe chain). Refuses to overwrite a user-authored launcher or a non-empty real `~/.hermes` directory.
- Settings → Connection → SSH and the first-run Welcome SSH screen gain "Detect remote install", a container selector (an explicit choice is required when several containers run), and "Set up Docker access" that states exactly which two files are written where. Nothing inside the container is modified.
- `dockerContainerName` is persisted with the SSH config for the selector/drift display only; runtime routing needs no container name because it rides the launcher hook.
- `buildGatewayStatusCommand` gains a loopback health-probe fallback: a containerized gateway records its pid in the container's pid namespace, so the host-side `kill -0` reported a healthy gateway as stopped — and the desktop then tried to nohup a second `gateway run` into the container.
- `tests/ssh-remote.test.ts`: the shim-execution tests (which spawn a real bash) now skip on Windows behind an explicit `itPosix` guard, and the shim helper itself throws on win32 so an unguarded call cannot slip back in. All string-assertion coverage still runs on every platform. The new `tests/ssh-docker.test.ts` uses string/JSON assertions only (plus python-compile checks that skip where python3 is absent).

Known limitation, proposed as a follow-up: the dashboard chat transport falls back to legacy `/v1` on container remotes. `sshResolveDashboardRoot` / `sshEnsureDashboardDist` look for the web dist on the host filesystem and cannot see `/opt/hermes` inside the container, and `sshStartDashboard`'s token env would need forwarding through the launcher. Chat, gateway ops, and all data screens work through the gateway path in the meantime.

## Validation

- `npm run typecheck`, targeted ESLint, `npm run build`, `git diff --check` — clean.
- `npm test`: 148 files pass on Node 22. (Locally on Node 26, 3 pre-existing `ConfigHealthBanner` failures reproduce on clean `main` — unrelated.)
- Windows: full suite green on `windows-latest` / Node 22, including the focused SSH suites from review: https://github.com/dergachoff/hermes-desktop/actions/runs/28779668876
- Live against a Coolify VPS running `nousresearch/hermes-agent` (host networking, API on loopback):
  - inspection finds the container and maps `/opt/data` → `/data/hermes`;
  - provisioning from a clean host (no launcher, no symlink) writes both artifacts, is idempotent on re-run, and refuses conflict states;
  - setup seeds `API_SERVER_KEY` / `API_SERVER_ENABLED` into the Hermes home `.env` from the container's environment, so the first connect performs no mid-connect gateway restart (validated by recreating the missing-`.env`-settings state);
  - `hermes --version` and `hermes doctor` resolve through the launcher via the standard probe chain (the exact #432 failure);
  - sessions, model config, profiles, and gateway status read the container's real data;
  - unpacked-app smoke test: the app-created SSH tunnel serves `/health` 200, and `/v1/models` returns 200 with the remote API key and 401 without.
