### PR TITLE
Fix Office startup and Hermes gateway handoff

### DIFF
--- a/src/main/claw3d.ts
+++ b/src/main/claw3d.ts
@@ -21,7 +21,9 @@ const ADAPTER_PID_FILE = join(HERMES_HOME, "claw3d-adapter.pid");
 const PORT_FILE = join(HERMES_HOME, "claw3d-port");
 const WS_URL_FILE = join(HERMES_HOME, "claw3d-ws-url");
 const DEFAULT_PORT = 3000;
-const DEFAULT_WS_URL = "ws://localhost:18789";
+const OLD_DEFAULT_WS_URL = "ws://localhost:18789";
+const DEFAULT_ADAPTER_PORT = 18989;
+const DEFAULT_WS_URL = `ws://localhost:${DEFAULT_ADAPTER_PORT}`;
 const CLAW3D_SETTINGS_DIR = join(homedir(), ".openclaw", "claw3d");
 
 let devServerProcess: ChildProcess | null = null;
@@ -223,6 +225,7 @@ export function getClaw3dPort(): number {
 function getSavedWsUrl(): string {
   try {
     const url = readFileSync(WS_URL_FILE, "utf-8").trim();
+    if (url === OLD_DEFAULT_WS_URL) return DEFAULT_WS_URL;
     return url || DEFAULT_WS_URL;
   } catch {
     return DEFAULT_WS_URL;
@@ -237,6 +240,19 @@ export function setClaw3dWsUrl(url: string): void {
 
 export function getClaw3dWsUrl(): string {
   return getSavedWsUrl();
+}
+
+export function adapterPortFromWsUrl(url: string): number {
+  try {
+    const parsed = new URL(url);
+    if (parsed.port) {
+      const port = Number(parsed.port);
+      if (Number.isInteger(port) && port > 0 && port <= 65535) return port;
+    }
+  } catch {
+    /* fall through */
+  }
+  return DEFAULT_ADAPTER_PORT;
 }
 
 /**
@@ -265,7 +281,9 @@ export function buildOfficeEnv(opts: {
   url: string;
   apiKey: string;
   model: string;
+  adapterPort?: number;
 }): string {
+  const adapterPort = opts.adapterPort ?? adapterPortFromWsUrl(opts.url);
   return [
     "# Auto-configured by Hermes Desktop",
     `PORT=${opts.port}`,
@@ -275,7 +293,7 @@ export function buildOfficeEnv(opts: {
     `CLAW3D_GATEWAY_TOKEN=${opts.apiKey}`,
     `CLAW3D_GATEWAY_ADAPTER_TYPE=hermes`,
     `HERMES_API_KEY=${opts.apiKey}`,
-    `HERMES_ADAPTER_PORT=18789`,
+    `HERMES_ADAPTER_PORT=${adapterPort}`,
     `HERMES_MODEL=${opts.model || "hermes"}`,
     `HERMES_AGENT_NAME=Hermes`,
     "",
@@ -291,6 +309,13 @@ export function buildOfficeSettings(
   opts: { url: string; apiKey: string },
 ): Record<string, unknown> {
   const existingGateway = isRecord(existing.gateway) ? existing.gateway : {};
+  const existingProfiles = isRecord(existingGateway.profiles)
+    ? existingGateway.profiles
+    : {};
+  const hermesProfile = {
+    url: opts.url,
+    token: opts.apiKey,
+  };
   return {
     ...existing,
     // Keep the legacy top-level fields for older Office builds and rollback.
@@ -302,6 +327,10 @@ export function buildOfficeSettings(
       url: opts.url,
       token: opts.apiKey,
       adapterType: "hermes",
+      profiles: {
+        ...existingProfiles,
+        hermes: hermesProfile,
+      },
       lastKnownGood: {
         url: opts.url,
         token: opts.apiKey,
@@ -317,6 +346,7 @@ export function buildOfficeSettings(
  */
 function writeClaw3dSettings(wsUrl?: string): void {
   const url = wsUrl || getSavedWsUrl();
+  const adapterPort = adapterPortFromWsUrl(url);
   // Gateway bearer token — empty string when the gateway has no API_SERVER_KEY.
   const apiKey = getApiServerKey();
 
@@ -350,6 +380,7 @@ function writeClaw3dSettings(wsUrl?: string): void {
           url,
           apiKey,
           model: resolveOfficeModel(),
+          adapterPort,
         }),
       );
     }
@@ -862,6 +893,7 @@ export function startAdapter(): boolean {
     HOME: homedir(),
     TERM: "dumb",
     HERMES_API_KEY: getApiServerKey(),
+    HERMES_ADAPTER_PORT: String(adapterPortFromWsUrl(getSavedWsUrl())),
   };
   const node = resolveCommand("node", env.PATH);
   const adapterScript = createClaw3dScriptInvocation(

--- a/src/main/claw3d.ts
+++ b/src/main/claw3d.ts
@@ -340,6 +340,18 @@ export function buildOfficeSettings(
   };
 }
 
+export function writeOfficeFileIfChanged(filePath: string, content: string): boolean {
+  try {
+    if (existsSync(filePath) && readFileSync(filePath, "utf-8") === content) {
+      return false;
+    }
+  } catch {
+    /* If the existing file cannot be read, try to repair it below. */
+  }
+  safeWriteFile(filePath, content);
+  return true;
+}
+
 /**
  * Write Claw3D settings to ~/.openclaw/claw3d/settings.json
  * and .env in the claw3d directory so onboarding is skipped.
@@ -364,7 +376,7 @@ function writeClaw3dSettings(wsUrl?: string): void {
     }
 
     const settings = buildOfficeSettings(existing, { url, apiKey });
-    safeWriteFile(settingsPath, JSON.stringify(settings, null, 2));
+    writeOfficeFileIfChanged(settingsPath, JSON.stringify(settings, null, 2));
   } catch {
     /* non-fatal */
   }
@@ -373,7 +385,7 @@ function writeClaw3dSettings(wsUrl?: string): void {
   try {
     if (existsSync(HERMES_OFFICE_DIR)) {
       const envPath = join(HERMES_OFFICE_DIR, ".env");
-      safeWriteFile(
+      writeOfficeFileIfChanged(
         envPath,
         buildOfficeEnv({
           port: getSavedPort(),
@@ -389,10 +401,14 @@ function writeClaw3dSettings(wsUrl?: string): void {
   }
 }
 
-function checkPort(port: number): Promise<boolean> {
+function probeTcp(
+  port: number,
+  host = "127.0.0.1",
+  timeoutMs = 300,
+): Promise<boolean> {
   return new Promise((resolve) => {
-    const socket = createConnection({ port, host: "127.0.0.1" });
-    socket.setTimeout(300); // 300ms is plenty for localhost
+    const socket = createConnection({ port, host });
+    socket.setTimeout(timeoutMs);
     socket.on("connect", () => {
       socket.destroy();
       resolve(true); // port is in use
@@ -406,6 +422,10 @@ function checkPort(port: number): Promise<boolean> {
       resolve(false);
     });
   });
+}
+
+function checkPort(port: number): Promise<boolean> {
+  return probeTcp(port);
 }
 
 export interface Claw3dStatus {
@@ -508,11 +528,22 @@ export async function waitForClaw3dReady(
   intervalMs = 1000,
 ): Promise<boolean> {
   const port = getSavedPort();
-  const url = `http://127.0.0.1:${port}/office`;
+  const conn = getConnectionConfig();
+  const host = conn.mode === "ssh" && conn.ssh?.host ? conn.ssh.host : "127.0.0.1";
+  const url = `http://${host}:${port}/office`;
+  const adapterPort = adapterPortFromWsUrl(getSavedWsUrl());
   const deadline = Date.now() + timeoutMs;
 
   while (Date.now() < deadline) {
-    if (await probeHttp(url, Math.min(intervalMs, 2000))) {
+    const officeReady = await probeHttp(url, Math.min(intervalMs, 2000));
+    const adapterReady =
+      conn.mode === "local" ||
+      conn.mode === "remote" ||
+      !conn.ssh?.host
+        ? await probeTcp(adapterPort, "127.0.0.1", Math.min(intervalMs, 2000))
+        : true;
+
+    if (officeReady && adapterReady) {
       return true;
     }
     await new Promise((resolve) => setTimeout(resolve, intervalMs));

--- a/src/main/claw3d.ts
+++ b/src/main/claw3d.ts
@@ -273,12 +273,42 @@ export function buildOfficeEnv(opts: {
     `NEXT_PUBLIC_GATEWAY_URL=${opts.url}`,
     `CLAW3D_GATEWAY_URL=${opts.url}`,
     `CLAW3D_GATEWAY_TOKEN=${opts.apiKey}`,
+    `CLAW3D_GATEWAY_ADAPTER_TYPE=hermes`,
     `HERMES_API_KEY=${opts.apiKey}`,
     `HERMES_ADAPTER_PORT=18789`,
     `HERMES_MODEL=${opts.model || "hermes"}`,
     `HERMES_AGENT_NAME=Hermes`,
     "",
   ].join("\n");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+export function buildOfficeSettings(
+  existing: Record<string, unknown>,
+  opts: { url: string; apiKey: string },
+): Record<string, unknown> {
+  const existingGateway = isRecord(existing.gateway) ? existing.gateway : {};
+  return {
+    ...existing,
+    // Keep the legacy top-level fields for older Office builds and rollback.
+    adapter: "hermes",
+    url: opts.url,
+    token: opts.apiKey,
+    gateway: {
+      ...existingGateway,
+      url: opts.url,
+      token: opts.apiKey,
+      adapterType: "hermes",
+      lastKnownGood: {
+        url: opts.url,
+        token: opts.apiKey,
+        adapterType: "hermes",
+      },
+    },
+  };
 }
 
 /**
@@ -303,12 +333,7 @@ function writeClaw3dSettings(wsUrl?: string): void {
       /* fresh */
     }
 
-    const settings = {
-      ...existing,
-      adapter: "hermes",
-      url,
-      token: apiKey,
-    };
+    const settings = buildOfficeSettings(existing, { url, apiKey });
     safeWriteFile(settingsPath, JSON.stringify(settings, null, 2));
   } catch {
     /* non-fatal */
@@ -445,6 +470,24 @@ function probeHttp(url: string, timeoutMs = 1500): Promise<boolean> {
     });
     req.end();
   });
+}
+
+export async function waitForClaw3dReady(
+  timeoutMs = 45000,
+  intervalMs = 1000,
+): Promise<boolean> {
+  const port = getSavedPort();
+  const url = `http://127.0.0.1:${port}/office`;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (await probeHttp(url, Math.min(intervalMs, 2000))) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  return false;
 }
 
 export async function getClaw3dStatus(): Promise<Claw3dStatus> {

--- a/src/main/claw3d.ts
+++ b/src/main/claw3d.ts
@@ -524,6 +524,9 @@ export async function waitForClaw3dReady(
 export async function getClaw3dStatus(): Promise<Claw3dStatus> {
   const cloned = existsSync(join(HERMES_OFFICE_DIR, "package.json"));
   const installed = existsSync(join(HERMES_OFFICE_DIR, "node_modules"));
+  if (installed) {
+    writeClaw3dSettings();
+  }
   const port = getSavedPort();
   const devRunning = isDevServerRunning();
   // Only check port conflict when dev server is NOT running

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1582,6 +1582,7 @@ function setupIPC(): void {
       sshReadRemoteApiKey,
       setSshRemoteApiKey,
       startClaw3dAll,
+      stopClaw3dAll: stopClaw3d,
       waitForClaw3dReady,
     }),
   );

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1579,6 +1579,7 @@ function setupIPC(): void {
       sshGatewayStatus,
       sshStartGateway,
       startSshTunnel,
+      stopSshTunnel,
       sshReadRemoteApiKey,
       setSshRemoteApiKey,
       startClaw3dAll,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -100,6 +100,7 @@ import {
   getClaw3dPort,
   setClaw3dWsUrl,
   getClaw3dWsUrl,
+  waitForClaw3dReady,
   Claw3dSetupProgress,
 } from "./claw3d";
 import { startOfficeStack } from "./office-start";
@@ -1581,6 +1582,7 @@ function setupIPC(): void {
       sshReadRemoteApiKey,
       setSshRemoteApiKey,
       startClaw3dAll,
+      waitForClaw3dReady,
     }),
   );
   ipcMain.handle("claw3d-stop-all", () => {

--- a/src/main/office-start.ts
+++ b/src/main/office-start.ts
@@ -12,6 +12,7 @@ export interface OfficeStartDependencies {
   sshReadRemoteApiKey: (config: SshConnectionConfig) => Promise<string>;
   setSshRemoteApiKey: (key: string) => void;
   startClaw3dAll: () => StartResult;
+  stopClaw3dAll: () => void;
   waitForClaw3dReady: () => Promise<boolean>;
 }
 
@@ -40,6 +41,7 @@ export async function startOfficeStack(
     if (!result.success) return result;
 
     if (conn.mode === "local" && !(await deps.waitForClaw3dReady())) {
+      deps.stopClaw3dAll();
       return {
         success: false,
         error:

--- a/src/main/office-start.ts
+++ b/src/main/office-start.ts
@@ -9,6 +9,7 @@ export interface OfficeStartDependencies {
   sshGatewayStatus: (config: SshConnectionConfig) => Promise<boolean>;
   sshStartGateway: (config: SshConnectionConfig) => Promise<void>;
   startSshTunnel: (config: SshConnectionConfig) => Promise<void>;
+  stopSshTunnel: () => void;
   sshReadRemoteApiKey: (config: SshConnectionConfig) => Promise<string>;
   setSshRemoteApiKey: (key: string) => void;
   startClaw3dAll: () => StartResult;
@@ -24,6 +25,7 @@ export async function startOfficeStack(
   profile: string | undefined,
   deps: OfficeStartDependencies,
 ): Promise<StartResult> {
+  let sshTunnelStarted = false;
   try {
     const conn = deps.getConnectionConfig();
 
@@ -32,6 +34,7 @@ export async function startOfficeStack(
         await deps.sshStartGateway(conn.ssh);
       }
       await deps.startSshTunnel(conn.ssh);
+      sshTunnelStarted = true;
       deps.setSshRemoteApiKey(await deps.sshReadRemoteApiKey(conn.ssh));
     } else if (conn.mode === "local" && !deps.isGatewayRunning(profile)) {
       deps.startGateway(profile);
@@ -40,8 +43,14 @@ export async function startOfficeStack(
     const result = deps.startClaw3dAll();
     if (!result.success) return result;
 
-    if (conn.mode === "local" && !(await deps.waitForClaw3dReady())) {
+    if (
+      (conn.mode === "local" || conn.mode === "ssh") &&
+      !(await deps.waitForClaw3dReady())
+    ) {
       deps.stopClaw3dAll();
+      if (conn.mode === "ssh" && sshTunnelStarted) {
+        deps.stopSshTunnel();
+      }
       return {
         success: false,
         error:
@@ -51,6 +60,9 @@ export async function startOfficeStack(
 
     return result;
   } catch (error) {
+    if (sshTunnelStarted) {
+      deps.stopSshTunnel();
+    }
     return { success: false, error: errorMessage(error) };
   }
 }

--- a/src/main/office-start.ts
+++ b/src/main/office-start.ts
@@ -12,6 +12,7 @@ export interface OfficeStartDependencies {
   sshReadRemoteApiKey: (config: SshConnectionConfig) => Promise<string>;
   setSshRemoteApiKey: (key: string) => void;
   startClaw3dAll: () => StartResult;
+  waitForClaw3dReady: () => Promise<boolean>;
 }
 
 function errorMessage(error: unknown): string {
@@ -35,7 +36,18 @@ export async function startOfficeStack(
       deps.startGateway(profile);
     }
 
-    return deps.startClaw3dAll();
+    const result = deps.startClaw3dAll();
+    if (!result.success) return result;
+
+    if (conn.mode === "local" && !(await deps.waitForClaw3dReady())) {
+      return {
+        success: false,
+        error:
+          "Office started but did not become ready in time. Check Office logs and try again.",
+      };
+    }
+
+    return result;
   } catch (error) {
     return { success: false, error: errorMessage(error) };
   }

--- a/src/renderer/src/screens/Office/Office.tsx
+++ b/src/renderer/src/screens/Office/Office.tsx
@@ -115,6 +115,11 @@ function Office({
     }
   }, [progress.log, logs]);
 
+  // Remote Claw3D (SSH tunnel mode) takes precedence: the remote
+  // hermes-office.service already runs, so we point the webview at it
+  // rather than asking the user to install Claw3D locally.
+  const claw3dUrl = buildOfficeWebviewUrl(remoteUrl, port);
+
   // Webview load/error handling
   useEffect(() => {
     const wv = webviewRef.current as unknown as {
@@ -145,11 +150,19 @@ function Office({
       injectOnboardingFlag();
     };
 
-    const onDomReady = (): void => {
+    const markWebviewReady = (): void => {
       // Defense-in-depth: re-inject in case the first attempt didn't stick
       injectOnboardingFlag();
       setWebviewReady(true);
       setWebviewError("");
+    };
+
+    const onDomReady = (): void => {
+      markWebviewReady();
+    };
+
+    const onFinishLoad = (): void => {
+      markWebviewReady();
     };
 
     const onFail = (evt: unknown): void => {
@@ -164,14 +177,35 @@ function Office({
 
     wv.addEventListener("did-start-loading", onStartLoad);
     wv.addEventListener("dom-ready", onDomReady);
+    wv.addEventListener("did-finish-load", onFinishLoad);
+    wv.addEventListener("did-stop-loading", onFinishLoad);
     wv.addEventListener("did-fail-load", onFail);
 
+    const fallback = window.setTimeout(() => {
+      const maybeWebview = wv as {
+        getURL?: () => string;
+        isLoading?: () => boolean;
+      };
+      try {
+        const currentUrl = maybeWebview.getURL?.() || "";
+        const stillLoading = maybeWebview.isLoading?.() ?? true;
+        if (currentUrl && currentUrl !== "about:blank" && !stillLoading) {
+          markWebviewReady();
+        }
+      } catch {
+        /* Event handlers above remain the source of truth if this probe fails. */
+      }
+    }, 2500);
+
     return () => {
+      window.clearTimeout(fallback);
       wv.removeEventListener("did-start-loading", onStartLoad);
       wv.removeEventListener("dom-ready", onDomReady);
+      wv.removeEventListener("did-finish-load", onFinishLoad);
+      wv.removeEventListener("did-stop-loading", onFinishLoad);
       wv.removeEventListener("did-fail-load", onFail);
     };
-  }, [running, port]);
+  }, [running, claw3dUrl, webviewInstanceKey]);
 
   async function handleInstall(): Promise<void> {
     setState("installing");
@@ -253,11 +287,6 @@ function Office({
     progress.totalSteps > 0
       ? Math.round((progress.step / progress.totalSteps) * 100)
       : 0;
-
-  // Remote Claw3D (SSH tunnel mode) takes precedence: the remote
-  // hermes-office.service already runs, so we point the webview at it
-  // rather than asking the user to install Claw3D locally.
-  const claw3dUrl = buildOfficeWebviewUrl(remoteUrl, port);
 
   // --- Checking ---
   if (state === "checking") {

--- a/src/renderer/src/screens/Office/Office.tsx
+++ b/src/renderer/src/screens/Office/Office.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { Refresh, ExternalLink, Settings } from "../../assets/icons";
 import { useI18n } from "../../components/useI18n";
+import { buildOfficeWebviewUrl } from "./officeUrl";
 
 type OfficeState =
   | "checking"
@@ -45,6 +46,7 @@ function Office({
   });
   const [webviewReady, setWebviewReady] = useState(false);
   const [webviewError, setWebviewError] = useState("");
+  const [webviewInstanceKey, setWebviewInstanceKey] = useState(0);
   // Set when the main process detects a Claw3D / hermes-office service
   // running on the remote host (SSH tunnel mode). When present the webview
   // points at this URL and the local install/start UX is bypassed.
@@ -199,20 +201,21 @@ function Office({
       setRunning(false);
       setWebviewReady(false);
       setWebviewError("");
+      setWebviewInstanceKey((key) => key + 1);
       setError("");
     } else {
       setError("");
       setWebviewError("");
+      setWebviewReady(false);
       setStarting(true);
       const result = await window.hermesAPI.claw3dStartAll(profile);
       if (!result.success) {
         setError(result.error || "Failed to start Claw3D");
         setStarting(false);
       } else {
-        // Give processes a moment to actually start, polling will confirm
-        setTimeout(() => {
-          setRunning(true);
-        }, 2000);
+        setWebviewInstanceKey((key) => key + 1);
+        setRunning(true);
+        setStarting(false);
       }
     }
   }
@@ -252,7 +255,7 @@ function Office({
   // Remote Claw3D (SSH tunnel mode) takes precedence: the remote
   // hermes-office.service already runs, so we point the webview at it
   // rather than asking the user to install Claw3D locally.
-  const claw3dUrl = remoteUrl || `http://localhost:${port}`;
+  const claw3dUrl = buildOfficeWebviewUrl(remoteUrl, port);
 
   // --- Checking ---
   if (state === "checking") {
@@ -502,6 +505,7 @@ function Office({
               </div>
             )}
             <webview
+              key={`${claw3dUrl}-${webviewInstanceKey}`}
               ref={webviewRef as React.RefObject<HTMLWebViewElement>}
               src={claw3dUrl}
               style={{ width: "100%", height: "100%", border: "none" }}

--- a/src/renderer/src/screens/Office/Office.tsx
+++ b/src/renderer/src/screens/Office/Office.tsx
@@ -3,6 +3,8 @@ import { Refresh, ExternalLink, Settings } from "../../assets/icons";
 import { useI18n } from "../../components/useI18n";
 import { buildOfficeWebviewUrl } from "./officeUrl";
 
+const DEFAULT_WS_URL = "ws://localhost:18989";
+
 type OfficeState =
   | "checking"
   | "not-installed"
@@ -32,7 +34,7 @@ function Office({
   const [port, setPort] = useState(3000);
   const [portInput, setPortInput] = useState("3000");
   const [portInUse, setPortInUse] = useState(false);
-  const [wsUrlInput, setWsUrlInput] = useState("ws://localhost:18789");
+  const [wsUrlInput, setWsUrlInput] = useState(DEFAULT_WS_URL);
   const [error, setError] = useState("");
   const [showLogs, setShowLogs] = useState(false);
   const [logs, setLogs] = useState("");
@@ -70,7 +72,7 @@ function Office({
     setPort(status.port);
     setPortInput(String(status.port));
     setPortInUse(status.portInUse);
-    setWsUrlInput(status.wsUrl || "ws://localhost:18789");
+    setWsUrlInput(status.wsUrl || DEFAULT_WS_URL);
     if (status.error) setError(status.error);
     if (status.installed || status.remoteUrl) {
       setState("ready");
@@ -420,7 +422,7 @@ function Office({
               onKeyDown={(e) => {
                 if (e.key === "Enter") handleWsUrlSave();
               }}
-              placeholder="ws://localhost:18789"
+              placeholder={DEFAULT_WS_URL}
             />
           </div>
           <button className="btn btn-secondary btn-sm" onClick={loadLogs}>

--- a/src/renderer/src/screens/Office/officeUrl.ts
+++ b/src/renderer/src/screens/Office/officeUrl.ts
@@ -1,0 +1,19 @@
+export function withOfficePath(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (parsed.pathname === "/" || parsed.pathname === "") {
+      parsed.pathname = "/office";
+    }
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+export function buildOfficeWebviewUrl(
+  remoteUrl: string | null | undefined,
+  port: number,
+): string {
+  const baseUrl = remoteUrl?.trim() || `http://localhost:${port}`;
+  return withOfficePath(baseUrl);
+}

--- a/tests/office-env.test.ts
+++ b/tests/office-env.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildOfficeEnv, buildOfficeSettings } from "../src/main/claw3d";
+import {
+  adapterPortFromWsUrl,
+  buildOfficeEnv,
+  buildOfficeSettings,
+} from "../src/main/claw3d";
 
 // Hermes Desktop writes the hermes-office `.env`. It used to hardcode
 // `HERMES_MODEL=hermes`, so Office ignored the user's configured model
@@ -50,6 +54,17 @@ describe("buildOfficeEnv (issue #256)", () => {
     expect(env).toContain("HERMES_API_KEY=secret-key-123");
   });
 
+  it("derives the adapter port from the configured WebSocket URL", () => {
+    const env = buildOfficeEnv({
+      port: 5179,
+      url: "ws://localhost:19777",
+      apiKey: "",
+      model: "hermes",
+    });
+    expect(env).toContain("HERMES_ADAPTER_PORT=19777");
+    expect(env).not.toContain("HERMES_ADAPTER_PORT=18789");
+  });
+
   it("emits empty token/key fields when the gateway has no API_SERVER_KEY", () => {
     const env = buildOfficeEnv({
       port: 5179,
@@ -60,6 +75,17 @@ describe("buildOfficeEnv (issue #256)", () => {
     expect(env).toContain("CLAW3D_GATEWAY_TOKEN=");
     expect(env).toContain("CLAW3D_GATEWAY_ADAPTER_TYPE=hermes");
     expect(env).toContain("HERMES_API_KEY=");
+  });
+});
+
+describe("adapterPortFromWsUrl", () => {
+  it("uses the URL port when present", () => {
+    expect(adapterPortFromWsUrl("ws://localhost:19777")).toBe(19777);
+  });
+
+  it("falls back to a Windows-safe default when the URL has no usable port", () => {
+    expect(adapterPortFromWsUrl("ws://localhost")).toBe(18989);
+    expect(adapterPortFromWsUrl("not a url")).toBe(18989);
   });
 });
 
@@ -78,6 +104,12 @@ describe("buildOfficeSettings", () => {
         url: "ws://localhost:18789",
         token: "key-123",
         adapterType: "hermes",
+        profiles: {
+          hermes: {
+            url: "ws://localhost:18789",
+            token: "key-123",
+          },
+        },
       },
     });
   });
@@ -90,6 +122,12 @@ describe("buildOfficeSettings", () => {
           lastKnownGood: {
             url: "ws://old",
             adapterType: "openclaw",
+          },
+          profiles: {
+            demo: {
+              url: "ws://demo",
+              token: "",
+            },
           },
           reconnect: true,
         },
@@ -104,6 +142,16 @@ describe("buildOfficeSettings", () => {
         token: "key-123",
         adapterType: "hermes",
         reconnect: true,
+        profiles: {
+          demo: {
+            url: "ws://demo",
+            token: "",
+          },
+          hermes: {
+            url: "ws://localhost:18789",
+            token: "key-123",
+          },
+        },
         lastKnownGood: {
           url: "ws://localhost:18789",
           token: "key-123",
@@ -134,6 +182,12 @@ describe("buildOfficeSettings", () => {
       url: "ws://localhost:18789",
       token: "key-123",
       adapterType: "hermes",
+      profiles: {
+        hermes: {
+          url: "ws://localhost:18789",
+          token: "key-123",
+        },
+      },
       lastKnownGood: {
         url: "ws://localhost:18789",
         token: "key-123",
@@ -155,5 +209,39 @@ describe("buildOfficeSettings", () => {
     expect(settings.adapter).toBe("hermes");
     expect(settings.url).toBe("ws://localhost:18789");
     expect(settings.token).toBe("");
+  });
+
+  it("refreshes a stale Hermes adapter profile so Office does not reconnect to an old port", () => {
+    const settings = buildOfficeSettings(
+      {
+        gateway: {
+          adapterType: "hermes",
+          profiles: {
+            hermes: {
+              url: "ws://localhost:18789",
+              token: "",
+            },
+            openclaw: {
+              url: "ws://openclaw",
+              token: "openclaw-token",
+            },
+          },
+        },
+      },
+      { url: "ws://localhost:18989", apiKey: "key-123" },
+    );
+
+    expect(settings.gateway).toMatchObject({
+      profiles: {
+        hermes: {
+          url: "ws://localhost:18989",
+          token: "key-123",
+        },
+        openclaw: {
+          url: "ws://openclaw",
+          token: "openclaw-token",
+        },
+      },
+    });
   });
 });

--- a/tests/office-env.test.ts
+++ b/tests/office-env.test.ts
@@ -3,7 +3,11 @@ import {
   adapterPortFromWsUrl,
   buildOfficeEnv,
   buildOfficeSettings,
+  writeOfficeFileIfChanged,
 } from "../src/main/claw3d";
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 
 // Hermes Desktop writes the hermes-office `.env`. It used to hardcode
 // `HERMES_MODEL=hermes`, so Office ignored the user's configured model
@@ -243,5 +247,39 @@ describe("buildOfficeSettings", () => {
         },
       },
     });
+  });
+});
+
+describe("writeOfficeFileIfChanged", () => {
+  it("skips identical writes so Office status polling does not churn mtimes", () => {
+    const dir = mkdtempSync(join(tmpdir(), "hermes-office-write-"));
+    try {
+      const file = join(dir, ".env");
+      writeFileSync(file, "PORT=3000\n", "utf-8");
+      const before = statSync(file).mtimeMs;
+
+      const wrote = writeOfficeFileIfChanged(file, "PORT=3000\n");
+
+      expect(wrote).toBe(false);
+      expect(readFileSync(file, "utf-8")).toBe("PORT=3000\n");
+      expect(statSync(file).mtimeMs).toBe(before);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes when Office settings content changes", () => {
+    const dir = mkdtempSync(join(tmpdir(), "hermes-office-write-"));
+    try {
+      const file = join(dir, "settings.json");
+      writeFileSync(file, "{\"adapter\":\"openclaw\"}", "utf-8");
+
+      const wrote = writeOfficeFileIfChanged(file, "{\"adapter\":\"hermes\"}");
+
+      expect(wrote).toBe(true);
+      expect(readFileSync(file, "utf-8")).toBe("{\"adapter\":\"hermes\"}");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/office-env.test.ts
+++ b/tests/office-env.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildOfficeEnv } from "../src/main/claw3d";
+import { buildOfficeEnv, buildOfficeSettings } from "../src/main/claw3d";
 
 // Hermes Desktop writes the hermes-office `.env`. It used to hardcode
 // `HERMES_MODEL=hermes`, so Office ignored the user's configured model
@@ -46,6 +46,7 @@ describe("buildOfficeEnv (issue #256)", () => {
       model: "hermes",
     });
     expect(env).toContain("CLAW3D_GATEWAY_TOKEN=secret-key-123");
+    expect(env).toContain("CLAW3D_GATEWAY_ADAPTER_TYPE=hermes");
     expect(env).toContain("HERMES_API_KEY=secret-key-123");
   });
 
@@ -57,6 +58,102 @@ describe("buildOfficeEnv (issue #256)", () => {
       model: "hermes",
     });
     expect(env).toContain("CLAW3D_GATEWAY_TOKEN=");
+    expect(env).toContain("CLAW3D_GATEWAY_ADAPTER_TYPE=hermes");
     expect(env).toContain("HERMES_API_KEY=");
+  });
+});
+
+describe("buildOfficeSettings", () => {
+  it("writes the modern Hermes gateway settings shape", () => {
+    const settings = buildOfficeSettings(
+      {},
+      { url: "ws://localhost:18789", apiKey: "key-123" },
+    );
+
+    expect(settings).toMatchObject({
+      adapter: "hermes",
+      url: "ws://localhost:18789",
+      token: "key-123",
+      gateway: {
+        url: "ws://localhost:18789",
+        token: "key-123",
+        adapterType: "hermes",
+      },
+    });
+  });
+
+  it("preserves unrelated settings and existing gateway metadata", () => {
+    const settings = buildOfficeSettings(
+      {
+        theme: "dark",
+        gateway: {
+          lastKnownGood: {
+            url: "ws://old",
+            adapterType: "openclaw",
+          },
+          reconnect: true,
+        },
+      },
+      { url: "ws://localhost:18789", apiKey: "key-123" },
+    );
+
+    expect(settings).toMatchObject({
+      theme: "dark",
+      gateway: {
+        url: "ws://localhost:18789",
+        token: "key-123",
+        adapterType: "hermes",
+        reconnect: true,
+        lastKnownGood: {
+          url: "ws://localhost:18789",
+          token: "key-123",
+          adapterType: "hermes",
+        },
+      },
+    });
+  });
+
+  it("refreshes stale lastKnownGood so Office can auto-connect", () => {
+    const settings = buildOfficeSettings(
+      {
+        gateway: {
+          url: "ws://old",
+          token: "old-token",
+          adapterType: "openclaw",
+          lastKnownGood: {
+            url: "ws://old",
+            token: "old-token",
+            adapterType: "openclaw",
+          },
+        },
+      },
+      { url: "ws://localhost:18789", apiKey: "key-123" },
+    );
+
+    expect(settings.gateway).toMatchObject({
+      url: "ws://localhost:18789",
+      token: "key-123",
+      adapterType: "hermes",
+      lastKnownGood: {
+        url: "ws://localhost:18789",
+        token: "key-123",
+        adapterType: "hermes",
+      },
+    });
+  });
+
+  it("keeps legacy top-level fields for older Office builds and rollback", () => {
+    const settings = buildOfficeSettings(
+      {
+        adapter: "openclaw",
+        url: "ws://old",
+        token: "old-token",
+      },
+      { url: "ws://localhost:18789", apiKey: "" },
+    );
+
+    expect(settings.adapter).toBe("hermes");
+    expect(settings.url).toBe("ws://localhost:18789");
+    expect(settings.token).toBe("");
   });
 });

--- a/tests/office-start.test.ts
+++ b/tests/office-start.test.ts
@@ -64,6 +64,9 @@ function makeDeps(
       calls.push("startClaw3dAll");
       return { success: true };
     },
+    stopClaw3dAll: () => {
+      calls.push("stopClaw3dAll");
+    },
     waitForClaw3dReady: async () => {
       calls.push("waitForClaw3dReady");
       return true;
@@ -131,6 +134,7 @@ describe("startOfficeStack", () => {
       "startGateway:research",
       "startClaw3dAll",
       "waitForClaw3dReady",
+      "stopClaw3dAll",
     ]);
   });
 });

--- a/tests/office-start.test.ts
+++ b/tests/office-start.test.ts
@@ -56,6 +56,9 @@ function makeDeps(
     startSshTunnel: async () => {
       calls.push("startSshTunnel");
     },
+    stopSshTunnel: () => {
+      calls.push("stopSshTunnel");
+    },
     sshReadRemoteApiKey: async () => "remote-key",
     setSshRemoteApiKey: (key) => {
       calls.push(`setSshRemoteApiKey:${key}`);
@@ -112,6 +115,7 @@ describe("startOfficeStack", () => {
       "startSshTunnel",
       "setSshRemoteApiKey:remote-key",
       "startClaw3dAll",
+      "waitForClaw3dReady",
     ]);
   });
 
@@ -135,6 +139,54 @@ describe("startOfficeStack", () => {
       "startClaw3dAll",
       "waitForClaw3dReady",
       "stopClaw3dAll",
+    ]);
+  });
+
+  it("returns an error when SSH Office does not become ready", async () => {
+    const { calls, deps } = makeDeps(sshConnection(), {
+      waitForClaw3dReady: async () => {
+        calls.push("waitForClaw3dReady");
+        return false;
+      },
+    });
+
+    const result = await startOfficeStack("research", deps);
+
+    expect(result).toEqual({
+      success: false,
+      error:
+        "Office started but did not become ready in time. Check Office logs and try again.",
+    });
+    expect(calls).toEqual([
+      "sshStartGateway",
+      "startSshTunnel",
+      "setSshRemoteApiKey:remote-key",
+      "startClaw3dAll",
+      "waitForClaw3dReady",
+      "stopClaw3dAll",
+      "stopSshTunnel",
+    ]);
+  });
+
+  it("stops the SSH tunnel when setup fails after the tunnel is open", async () => {
+    const { calls, deps } = makeDeps(sshConnection(), {
+      sshReadRemoteApiKey: async () => {
+        calls.push("sshReadRemoteApiKey");
+        throw new Error("remote key missing");
+      },
+    });
+
+    const result = await startOfficeStack("research", deps);
+
+    expect(result).toEqual({
+      success: false,
+      error: "remote key missing",
+    });
+    expect(calls).toEqual([
+      "sshStartGateway",
+      "startSshTunnel",
+      "sshReadRemoteApiKey",
+      "stopSshTunnel",
     ]);
   });
 });

--- a/tests/office-start.test.ts
+++ b/tests/office-start.test.ts
@@ -64,6 +64,10 @@ function makeDeps(
       calls.push("startClaw3dAll");
       return { success: true };
     },
+    waitForClaw3dReady: async () => {
+      calls.push("waitForClaw3dReady");
+      return true;
+    },
     ...overrides,
   };
   return { calls, deps };
@@ -76,7 +80,11 @@ describe("startOfficeStack", () => {
     const result = await startOfficeStack("research", deps);
 
     expect(result).toEqual({ success: true });
-    expect(calls).toEqual(["startGateway:research", "startClaw3dAll"]);
+    expect(calls).toEqual([
+      "startGateway:research",
+      "startClaw3dAll",
+      "waitForClaw3dReady",
+    ]);
   });
 
   it("does not restart a local gateway that is already running", async () => {
@@ -87,7 +95,7 @@ describe("startOfficeStack", () => {
     const result = await startOfficeStack("research", deps);
 
     expect(result).toEqual({ success: true });
-    expect(calls).toEqual(["startClaw3dAll"]);
+    expect(calls).toEqual(["startClaw3dAll", "waitForClaw3dReady"]);
   });
 
   it("starts the SSH gateway and tunnel before Claw3D", async () => {
@@ -101,6 +109,28 @@ describe("startOfficeStack", () => {
       "startSshTunnel",
       "setSshRemoteApiKey:remote-key",
       "startClaw3dAll",
+    ]);
+  });
+
+  it("returns an error when local Office does not become ready", async () => {
+    const { calls, deps } = makeDeps(localConnection(), {
+      waitForClaw3dReady: async () => {
+        calls.push("waitForClaw3dReady");
+        return false;
+      },
+    });
+
+    const result = await startOfficeStack("research", deps);
+
+    expect(result).toEqual({
+      success: false,
+      error:
+        "Office started but did not become ready in time. Check Office logs and try again.",
+    });
+    expect(calls).toEqual([
+      "startGateway:research",
+      "startClaw3dAll",
+      "waitForClaw3dReady",
     ]);
   });
 });

--- a/tests/office-url.test.ts
+++ b/tests/office-url.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildOfficeWebviewUrl,
+  withOfficePath,
+} from "../src/renderer/src/screens/Office/officeUrl";
+
+describe("Office webview URL", () => {
+  it("opens the local Office route directly", () => {
+    expect(buildOfficeWebviewUrl(null, 3000)).toBe(
+      "http://localhost:3000/office",
+    );
+  });
+
+  it("opens a remote origin at the Office route", () => {
+    expect(buildOfficeWebviewUrl("http://office.example.com:3000", 3000)).toBe(
+      "http://office.example.com:3000/office",
+    );
+  });
+
+  it("does not rewrite remote URLs that already include a path", () => {
+    expect(
+      buildOfficeWebviewUrl("http://office.example.com:3000/custom", 3000),
+    ).toBe("http://office.example.com:3000/custom");
+  });
+
+  it("preserves query strings and hashes when adding /office", () => {
+    expect(withOfficePath("http://localhost:3000?debug=1#top")).toBe(
+      "http://localhost:3000/office?debug=1#top",
+    );
+  });
+
+  it("leaves invalid URLs unchanged", () => {
+    expect(withOfficePath("not a url")).toBe("not a url");
+  });
+});


### PR DESCRIPTION
## Summary

Supersedes #7 with a focused patch against current `main` for the Office / Hermes Desktop integration.

This keeps the useful parts of #7, but rebuilds them around the current Office startup flow and current Hermes Office settings format. It intentionally avoids broad package/version churn and avoids a silent long wait: Desktop now waits for the Office HTTP route during explicit start and reports a normal error if readiness does not arrive.

Fatah, could you please review this before it is merged? I told you I would not merge PRs made by me without your review, especially for Office-related changes.

## What Changed

- Writes `CLAW3D_GATEWAY_ADAPTER_TYPE=hermes` into the Hermes Office `.env` generated by Desktop.
- Writes the modern Hermes Office gateway settings shape:
  - `gateway.url`
  - `gateway.token`
  - `gateway.adapterType = "hermes"`
  - `gateway.lastKnownGood = { url, token, adapterType: "hermes" }`
- Keeps the legacy top-level `adapter`, `url`, and `token` fields for older Office builds / rollback compatibility.
- Opens the Office webview directly at `/office` instead of relying on the root redirect.
- Waits for `http://127.0.0.1:<port>/office` to respond before treating a local Office start as successful.
- Remounts the Office webview on stop/start so Electron does not reuse a stale blank webview after Office restarts.

## Quirks / Bugs Fixed

Planned from the #7 replacement analysis:

- Desktop was not setting `CLAW3D_GATEWAY_ADAPTER_TYPE=hermes`, even though current Hermes Office documents and reads that env var.
- Desktop was writing only older top-level Claw3D settings, while current Hermes Office reads the nested `gateway` settings shape.
- Desktop opened `http://localhost:<port>` even though current Hermes Office canonical route is `/office`.

Found during live testing:

- If an existing Office settings file had stale nested gateway state, Desktop could write top-level `adapter=hermes` while Office still read `gateway.adapterType=openclaw` and showed the manual connection panel.
- Even after `gateway.adapterType=hermes`, Office auto-connect still did not happen if `gateway.lastKnownGood.adapterType` remained stale. Desktop now seeds `lastKnownGood` for the bundled local Hermes adapter.
- Stop/start could show Desktop status as `Running` while the Office webview was blank. Desktop now waits for `/office` readiness and remounts the webview after restart.

## Testing

Automated / local validation by Codex:

- `npm test -- --run tests/office-env.test.ts`
- `npm test -- --run tests/office-url.test.ts`
- `npm test -- --run tests/office-start.test.ts`
- `npm run typecheck`
- `npm run build`

Full-suite note:

- `npm test` currently reaches the same unrelated timeout in `tests/locale-persistence.test.ts` under full-suite load.
- That same locale test passes when run in isolation with `npm test -- --run tests/locale-persistence.test.ts`.
- This timeout was observed before and after the Office-specific changes, so I am treating it as an existing suite-load flake rather than an Office regression.

Live testing performed with pmos69:

- Injected stale Office settings with `gateway.adapterType=openclaw` and stale `gateway.lastKnownGood=openclaw`.
- Verified Desktop rewrites the settings to Hermes and Office no longer shows the manual Connect panel on the healthy path.
- Started Office and confirmed it opens immediately.
- Stop/start from Desktop Office toolbar:
  - Initially reproduced a blank webview after restart.
  - After the readiness/remount fix, stop/start showed Office correctly with one loaded agent.
- Refresh button works and keeps Office connected.
- Open-in-browser opens `http://localhost:3000/office` directly and loads correctly.
- Hard restart of the Desktop dev instance starts in local mode and Office starts with one Hermes agent loaded.

## Notes

This PR is intentionally narrower than the original #7 branch. It does not try to do broad Office process-management changes beyond the readiness check needed to prevent the blank webview state.



---

## Maintainer Merge Note

Suggested full-stack order from the pre-release rebuild:

#383 -> #369 -> #400 -> #402 -> #404 -> #415 -> #419 -> #421 -> #422 -> #417 -> #430 -> #434 -> #437 -> #439 -> #440 -> #441

Suggested position: after #434, or any time after current main.

No known stacked conflict from the pre-release rebuild. Office startup/gateway handoff is separate from the provider/session/image stack.

