### PR TITLE
chore(testing): add tester build scripts and guide

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+*.sh text eol=lf

--- a/TESTING-GUIDE.md
+++ b/TESTING-GUIDE.md
@@ -1,0 +1,92 @@
+# Hermes Desktop - Testing Guide (Easy 1-2-3)
+
+> For testers who just want to run the app without any technical setup
+
+---
+
+## Option 1: Download Pre-built Release (Easiest)
+
+### Step 1: Download the Right File for Your Computer
+
+| Your Computer | Download This File | Install Method |
+|--------------|-------------------|----------------|
+| **Mac (Apple Silicon - M1/M2/M3)** | `hermes-desktop-X.X.X-arm64-mac.dmg` | Open DMG, drag to Applications |
+| **Mac (Intel)** | `hermes-desktop-X.X.X-x64-mac.dmg` | Open DMG, drag to Applications |
+| **Windows** | `hermes-desktop-X.X.X-setup.exe` | Double-click, click "Run anyway" if Windows warns |
+| **Linux (Ubuntu/Debian)** | `hermes-desktop-X.X.X.deb` | Double-click to install |
+| **Linux (Fedora/RHEL)** | `hermes-desktop-X.X.X.rpm` | `sudo dnf install ./hermes-desktop-X.X.X.rpm` |
+| **Linux (Any - Portable)** | `hermes-desktop-X.X.X.AppImage` | Double-click to run (no install) |
+
+**Where to download:** https://github.com/fathah/hermes-desktop/releases
+
+### Step 2: Install & Open
+
+- **Mac**: Open the `.dmg`, drag Hermes Agent to Applications, open from Applications folder
+- **Windows**: Run the installer, click "More info" → "Run anyway" if SmartScreen warns
+- **Linux**: Use your package manager or run the AppImage
+
+### Step 3: First-Time Setup
+
+When the app opens:
+1. Choose **"Local Mode"** (recommended for testing)
+2. The app will download and install Hermes Agent automatically (may take 2-5 minutes)
+3. Pick an AI provider (OpenRouter is easiest - just need an API key)
+4. Start chatting!
+
+---
+
+## Option 2: Build From Source (For Developers)
+
+If you have the source code and want to build locally:
+
+```bash
+# 1. Install dependencies
+npm install
+
+# 2. Build the app
+npm run build:mac      # or :win, :linux
+
+# 3. Find the installer in the dist/ folder
+```
+
+---
+
+## What to Test
+
+Once the app is running, try these:
+
+1. **Chat** - Send a message, check if AI responds
+2. **Tools** - Ask it to search the web or run a command
+3. **Sessions** - Close and reopen app, check if history saves
+4. **Profiles** - Create a new profile in Settings → Agents
+5. **Settings** - Change theme, check all tabs load
+
+---
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| "App is damaged" (Mac) | Run: `xattr -cr /Applications/Hermes\ Agent.app` |
+| "Windows protected your PC" | Click "More info" → "Run anyway" |
+| Installer hangs on Linux | Grant passwordless sudo temporarily (see README) |
+| App won't start | Delete `~/.hermes` folder and try again |
+
+---
+
+## Need Help?
+
+- **Telegram**: https://t.me/hermes_agent_desktop
+- **GitHub Issues**: https://github.com/fathah/hermes-desktop/issues
+
+---
+
+## Quick Validation Checklist
+
+- [ ] App opens without errors
+- [ ] First-run installer completes
+- [ ] Can send a chat message
+- [ ] AI responds with text
+- [ ] Can access Settings page
+- [ ] Can view Session history
+- [ ] App closes and reopens properly

--- a/TESTING-GUIDE.md
+++ b/TESTING-GUIDE.md
@@ -10,19 +10,21 @@
 
 | Your Computer | Download This File | Install Method |
 |--------------|-------------------|----------------|
-| **Mac (Apple Silicon - M1/M2/M3)** | `hermes-desktop-X.X.X-arm64-mac.dmg` | Open DMG, drag to Applications |
-| **Mac (Intel)** | `hermes-desktop-X.X.X-x64-mac.dmg` | Open DMG, drag to Applications |
+| **Mac (Apple Silicon - M1/M2/M3)** | `hermes-desktop-X.X.X-arm64.dmg` | Open DMG, drag to Applications |
+| **Mac (Intel)** | `hermes-desktop-X.X.X-x64.dmg` | Open DMG, drag to Applications |
 | **Windows** | `hermes-desktop-X.X.X-setup.exe` | Double-click, click "Run anyway" if Windows warns |
-| **Linux (Ubuntu/Debian)** | `hermes-desktop-X.X.X.deb` | Double-click to install |
+| **Linux (Ubuntu/Debian)** | `hermes-desktop_X.X.X_amd64.deb` | Double-click to install |
 | **Linux (Fedora/RHEL)** | `hermes-desktop-X.X.X.rpm` | `sudo dnf install ./hermes-desktop-X.X.X.rpm` |
 | **Linux (Any - Portable)** | `hermes-desktop-X.X.X.AppImage` | Double-click to run (no install) |
 
 **Where to download:** https://github.com/fathah/hermes-desktop/releases
 
-### Step 2: Install & Open
+### Step 2: Verify, Install & Open
+
+For unofficial tester builds, verify `SHA256SUMS.txt` against a hash shared through a trusted channel before bypassing operating-system warnings.
 
 - **Mac**: Open the `.dmg`, drag Hermes Agent to Applications, open from Applications folder
-- **Windows**: Run the installer, click "More info" → "Run anyway" if SmartScreen warns
+- **Windows**: Run the installer. If SmartScreen warns, verify the hash first, then click "More info" → "Run anyway" only if you trust the build source
 - **Linux**: Use your package manager or run the AppImage
 
 ### Step 3: First-Time Setup
@@ -49,6 +51,8 @@ npm run build:mac      # or :win, :linux
 # 3. Find the installer in the dist/ folder
 ```
 
+The tester packaging scripts require bash-compatible tools. On Windows, use Git Bash or WSL.
+
 ---
 
 ## What to Test
@@ -58,7 +62,7 @@ Once the app is running, try these:
 1. **Chat** - Send a message, check if AI responds
 2. **Tools** - Ask it to search the web or run a command
 3. **Sessions** - Close and reopen app, check if history saves
-4. **Profiles** - Create a new profile in Settings → Agents
+4. **Profiles** - Create a new profile from the top-level Profiles section
 5. **Settings** - Change theme, check all tabs load
 
 ---
@@ -67,10 +71,10 @@ Once the app is running, try these:
 
 | Problem | Solution |
 |---------|----------|
-| "App is damaged" (Mac) | Run: `xattr -cr /Applications/Hermes\ Agent.app` |
-| "Windows protected your PC" | Click "More info" → "Run anyway" |
+| "App is damaged" (Mac) | Verify the hash first, then run: `xattr -cr /Applications/Hermes\ Agent.app` only if you trust the build source |
+| "Windows protected your PC" | Verify the hash first, then click "More info" → "Run anyway" only if you trust the build source |
 | Installer hangs on Linux | Grant passwordless sudo temporarily (see README) |
-| App won't start | Delete `~/.hermes` folder and try again |
+| App won't start | Rename `~/.hermes` to a dated backup first, then try again |
 
 ---
 

--- a/scripts/build-for-tester.sh
+++ b/scripts/build-for-tester.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+#
+# Build Hermes Desktop for a non-technical tester
+# Usage: ./scripts/build-for-tester.sh [mac|win|linux]
+#
+
+set -e
+
+PLATFORM=${1:-"current"}
+VERSION=$(node -p "require('./package.json').version")
+DIST_DIR="dist"
+BUILD_DIR="builds-for-testing"
+
+echo "🏗️  Building Hermes Desktop v$VERSION for platform: $PLATFORM"
+echo ""
+
+# Install dependencies
+echo "📦 Installing dependencies..."
+npm ci
+
+# Rebuild native modules
+echo "🔧 Rebuilding native modules..."
+npx electron-builder install-app-deps
+
+# Build the app
+echo "🚀 Building application..."
+npm run build
+
+# Create output directory
+mkdir -p "$BUILD_DIR"
+
+# Build based on platform
+case "$PLATFORM" in
+  mac|macos|darwin)
+    echo "🍎 Building macOS artifacts..."
+    npx electron-builder --mac dmg zip --publish never
+    cp "$DIST_DIR"/*.dmg "$BUILD_DIR/" 2>/dev/null || true
+    cp "$DIST_DIR"/*-mac.zip "$BUILD_DIR/" 2>/dev/null || true
+    ;;
+  
+  win|windows|win32)
+    echo "🪟 Building Windows artifacts..."
+    npx electron-builder --win nsis portable --x64 --publish never
+    cp "$DIST_DIR"/*-setup.exe "$BUILD_DIR/" 2>/dev/null || true
+    cp "$DIST_DIR"/*-portable.exe "$BUILD_DIR/" 2>/dev/null || true
+    ;;
+  
+  linux)
+    echo "🐧 Building Linux artifacts..."
+    npx electron-builder --linux AppImage deb --publish never
+    cp "$DIST_DIR"/*.AppImage "$BUILD_DIR/" 2>/dev/null || true
+    cp "$DIST_DIR"/*.deb "$BUILD_DIR/" 2>/dev/null || true
+    ;;
+  
+  current|auto)
+    OS=$(uname -s)
+    case "$OS" in
+      Darwin)
+        echo "🍎 Detected macOS, building..."
+        npx electron-builder --mac dmg --publish never
+        cp "$DIST_DIR"/*.dmg "$BUILD_DIR/" 2>/dev/null || true
+        ;;
+      Linux)
+        echo "🐧 Detected Linux, building AppImage..."
+        npx electron-builder --linux AppImage --publish never
+        cp "$DIST_DIR"/*.AppImage "$BUILD_DIR/" 2>/dev/null || true
+        ;;
+      MINGW*|CYGWIN*|MSYS*)
+        echo "🪟 Detected Windows, building..."
+        npx electron-builder --win nsis --x64 --publish never
+        cp "$DIST_DIR"/*-setup.exe "$BUILD_DIR/" 2>/dev/null || true
+        ;;
+      *)
+        echo "❌ Unknown OS: $OS"
+        exit 1
+        ;;
+    esac
+    ;;
+  
+  *)
+    echo "❌ Unknown platform: $PLATFORM"
+    echo "Usage: $0 [mac|win|linux|current]"
+    exit 1
+    ;;
+esac
+
+echo ""
+echo "✅ Build complete!"
+echo ""
+echo "📁 Output files in $BUILD_DIR/:"
+ls -lh "$BUILD_DIR/" 2>/dev/null || echo "   (no files found)"
+echo ""
+echo "📝 Next steps:"
+echo "   1. Copy the file(s) from $BUILD_DIR/ to the tester's computer"
+echo "   2. Include TESTING-GUIDE.md with the files"
+echo "   3. Have them follow the guide!"
+echo ""

--- a/scripts/build-for-tester.sh
+++ b/scripts/build-for-tester.sh
@@ -2,14 +2,50 @@
 #
 # Build Hermes Desktop for a non-technical tester
 # Usage: ./scripts/build-for-tester.sh [mac|win|linux]
+# Requires bash-compatible tooling: bash, npm, npx, cp, mktemp, and uname.
 #
 
-set -e
+set -euo pipefail
 
 PLATFORM=${1:-"current"}
 VERSION=$(node -p "require('./package.json').version")
 DIST_DIR="dist"
 BUILD_DIR="builds-for-testing"
+ARTIFACT_DIR="$BUILD_DIR/artifacts"
+STAGE_DIR=""
+
+cleanup() {
+  if [ -n "$STAGE_DIR" ] && [ -d "$STAGE_DIR" ]; then
+    rm -rf "$STAGE_DIR"
+  fi
+}
+trap cleanup EXIT
+
+prepare_stage() {
+  mkdir -p "$BUILD_DIR"
+  STAGE_DIR=$(mktemp -d "$BUILD_DIR/stage.XXXXXX")
+}
+
+publish_artifacts() {
+  local patterns=("$@")
+  local artifacts=()
+
+  shopt -s nullglob
+  for pattern in "${patterns[@]}"; do
+    artifacts+=( $pattern )
+  done
+  shopt -u nullglob
+
+  if [ "${#artifacts[@]}" -eq 0 ]; then
+    echo "❌ No fresh installer artifacts found in $DIST_DIR"
+    exit 1
+  fi
+
+  cp "${artifacts[@]}" "$STAGE_DIR/"
+  rm -rf "$ARTIFACT_DIR"
+  mkdir -p "$ARTIFACT_DIR"
+  cp "$STAGE_DIR"/* "$ARTIFACT_DIR/"
+}
 
 echo "🏗️  Building Hermes Desktop v$VERSION for platform: $PLATFORM"
 echo ""
@@ -27,29 +63,26 @@ echo "🚀 Building application..."
 npm run build
 
 # Create output directory
-mkdir -p "$BUILD_DIR"
+prepare_stage
 
 # Build based on platform
 case "$PLATFORM" in
   mac|macos|darwin)
     echo "🍎 Building macOS artifacts..."
     npx electron-builder --mac dmg zip --publish never
-    cp "$DIST_DIR"/*.dmg "$BUILD_DIR/" 2>/dev/null || true
-    cp "$DIST_DIR"/*-mac.zip "$BUILD_DIR/" 2>/dev/null || true
+    publish_artifacts "$DIST_DIR"/*.dmg "$DIST_DIR"/*-mac.zip
     ;;
   
   win|windows|win32)
     echo "🪟 Building Windows artifacts..."
     npx electron-builder --win nsis portable --x64 --publish never
-    cp "$DIST_DIR"/*-setup.exe "$BUILD_DIR/" 2>/dev/null || true
-    cp "$DIST_DIR"/*-portable.exe "$BUILD_DIR/" 2>/dev/null || true
+    publish_artifacts "$DIST_DIR"/*-setup.exe "$DIST_DIR"/*-portable.exe
     ;;
   
   linux)
     echo "🐧 Building Linux artifacts..."
     npx electron-builder --linux AppImage deb --publish never
-    cp "$DIST_DIR"/*.AppImage "$BUILD_DIR/" 2>/dev/null || true
-    cp "$DIST_DIR"/*.deb "$BUILD_DIR/" 2>/dev/null || true
+    publish_artifacts "$DIST_DIR"/*.AppImage "$DIST_DIR"/*.deb
     ;;
   
   current|auto)
@@ -58,17 +91,17 @@ case "$PLATFORM" in
       Darwin)
         echo "🍎 Detected macOS, building..."
         npx electron-builder --mac dmg --publish never
-        cp "$DIST_DIR"/*.dmg "$BUILD_DIR/" 2>/dev/null || true
+        publish_artifacts "$DIST_DIR"/*.dmg
         ;;
       Linux)
         echo "🐧 Detected Linux, building AppImage..."
         npx electron-builder --linux AppImage --publish never
-        cp "$DIST_DIR"/*.AppImage "$BUILD_DIR/" 2>/dev/null || true
+        publish_artifacts "$DIST_DIR"/*.AppImage
         ;;
       MINGW*|CYGWIN*|MSYS*)
         echo "🪟 Detected Windows, building..."
         npx electron-builder --win nsis --x64 --publish never
-        cp "$DIST_DIR"/*-setup.exe "$BUILD_DIR/" 2>/dev/null || true
+        publish_artifacts "$DIST_DIR"/*-setup.exe
         ;;
       *)
         echo "❌ Unknown OS: $OS"
@@ -87,11 +120,11 @@ esac
 echo ""
 echo "✅ Build complete!"
 echo ""
-echo "📁 Output files in $BUILD_DIR/:"
-ls -lh "$BUILD_DIR/" 2>/dev/null || echo "   (no files found)"
+echo "📁 Output files in $ARTIFACT_DIR/:"
+ls -lh "$ARTIFACT_DIR/"
 echo ""
 echo "📝 Next steps:"
-echo "   1. Copy the file(s) from $BUILD_DIR/ to the tester's computer"
-echo "   2. Include TESTING-GUIDE.md with the files"
+echo "   1. Copy the file(s) from $ARTIFACT_DIR/ to the tester's computer"
+echo "   2. Include TESTING-GUIDE.md and SHA256 checksums with the files"
 echo "   3. Have them follow the guide!"
 echo ""

--- a/scripts/package-for-tester.sh
+++ b/scripts/package-for-tester.sh
@@ -2,13 +2,15 @@
 #
 # Package Hermes Desktop for easy handoff to a tester
 # Creates a zip with the installer + testing guide
+# Requires bash-compatible tooling: bash, npm, npx, cp, zip, shasum, and uname.
 #
 
-set -e
+set -euo pipefail
 
 PLATFORM=${1:-"current"}
 VERSION=$(node -p "require('./package.json').version")
 BUILD_DIR="builds-for-testing"
+ARTIFACT_DIR="$BUILD_DIR/artifacts"
 
 echo "📦 Packaging Hermes Desktop v$VERSION for testers"
 echo ""
@@ -20,10 +22,26 @@ echo ""
 PKG_NAME="hermes-desktop-v$VERSION-for-testing"
 PKG_DIR="$BUILD_DIR/$PKG_NAME"
 
+rm -rf "$PKG_DIR"
 mkdir -p "$PKG_DIR"
 
 # Copy files
-cp "$BUILD_DIR"/*.{dmg,exe,AppImage,deb,rpm} "$PKG_DIR/" 2>/dev/null || true
+shopt -s nullglob
+ARTIFACTS=(
+  "$ARTIFACT_DIR"/*.dmg
+  "$ARTIFACT_DIR"/*.exe
+  "$ARTIFACT_DIR"/*.AppImage
+  "$ARTIFACT_DIR"/*.deb
+  "$ARTIFACT_DIR"/*.rpm
+)
+shopt -u nullglob
+
+if [ "${#ARTIFACTS[@]}" -eq 0 ]; then
+  echo "❌ No installer artifacts found in $ARTIFACT_DIR"
+  exit 1
+fi
+
+cp "${ARTIFACTS[@]}" "$PKG_DIR/"
 cp TESTING-GUIDE.md "$PKG_DIR/README.txt"
 
 # Create a simple info file
@@ -36,15 +54,43 @@ HERMES DESKTOP - TEST VERSION
    - Windows: .exe file (run installer)
    - Linux: .AppImage (double-click to run)
 
-2. Read TESTING-GUIDE.md for detailed instructions
+2. Read README.txt for detailed instructions
 
-3. Report issues to: https://github.com/fathah/hermes-desktop/issues
+3. Verify installer hashes using SHA256SUMS.txt and a trusted source
+
+4. Report issues to: https://github.com/fathah/hermes-desktop/issues
 
 THANK YOU FOR TESTING!
 EOF
 
+# Provenance files
+(
+  cd "$PKG_DIR"
+  shopt -s nullglob
+  CHECKSUM_FILES=( ./*.dmg ./*.exe ./*.AppImage ./*.deb ./*.rpm )
+  shasum -a 256 -- "${CHECKSUM_FILES[@]}"
+) > "$PKG_DIR/SHA256SUMS.txt"
+
+ARTIFACT_LIST=$(
+  cd "$PKG_DIR"
+  shopt -s nullglob
+  ls -lh -- ./*.dmg ./*.exe ./*.AppImage ./*.deb ./*.rpm
+)
+
+cat > "$PKG_DIR/MANIFEST.txt" << EOF
+Hermes Desktop tester build
+Version: $VERSION
+Platform request: $PLATFORM
+Built: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+Git SHA: $(git rev-parse --short HEAD 2>/dev/null || echo unknown)
+
+Artifacts:
+$ARTIFACT_LIST
+EOF
+
 # Create zip
 OUTPUT_FILE="$BUILD_DIR/$PKG_NAME.zip"
+rm -f "$OUTPUT_FILE"
 cd "$BUILD_DIR"
 zip -r "$PKG_NAME.zip" "$PKG_NAME"
 cd ..
@@ -56,8 +102,7 @@ echo ""
 echo "✅ Package ready: $OUTPUT_FILE"
 echo ""
 echo "📤 To send to tester:"
-echo "   - Email the zip file"
-echo "   - Or upload to Dropbox/Google Drive"
-echo "   - Or use WeTransfer for large files"
+echo "   - Prefer a trusted release channel or access-controlled drive link"
+echo "   - Share SHA256SUMS.txt through a trusted channel before they bypass OS warnings"
 echo ""
 ls -lh "$OUTPUT_FILE"

--- a/scripts/package-for-tester.sh
+++ b/scripts/package-for-tester.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# Package Hermes Desktop for easy handoff to a tester
+# Creates a zip with the installer + testing guide
+#
+
+set -e
+
+PLATFORM=${1:-"current"}
+VERSION=$(node -p "require('./package.json').version")
+BUILD_DIR="builds-for-testing"
+
+echo "📦 Packaging Hermes Desktop v$VERSION for testers"
+echo ""
+
+# Run the build
+./scripts/build-for-tester.sh "$PLATFORM"
+
+# Create package folder
+PKG_NAME="hermes-desktop-v$VERSION-for-testing"
+PKG_DIR="$BUILD_DIR/$PKG_NAME"
+
+mkdir -p "$PKG_DIR"
+
+# Copy files
+cp "$BUILD_DIR"/*.{dmg,exe,AppImage,deb,rpm} "$PKG_DIR/" 2>/dev/null || true
+cp TESTING-GUIDE.md "$PKG_DIR/README.txt"
+
+# Create a simple info file
+cat > "$PKG_DIR/INSTALL.txt" << 'EOF'
+HERMES DESKTOP - TEST VERSION
+==============================
+
+1. Find your installer:
+   - Mac: .dmg file (drag to Applications)
+   - Windows: .exe file (run installer)
+   - Linux: .AppImage (double-click to run)
+
+2. Read TESTING-GUIDE.md for detailed instructions
+
+3. Report issues to: https://github.com/fathah/hermes-desktop/issues
+
+THANK YOU FOR TESTING!
+EOF
+
+# Create zip
+OUTPUT_FILE="$BUILD_DIR/$PKG_NAME.zip"
+cd "$BUILD_DIR"
+zip -r "$PKG_NAME.zip" "$PKG_NAME"
+cd ..
+
+# Cleanup temp folder
+rm -rf "$PKG_DIR"
+
+echo ""
+echo "✅ Package ready: $OUTPUT_FILE"
+echo ""
+echo "📤 To send to tester:"
+echo "   - Email the zip file"
+echo "   - Or upload to Dropbox/Google Drive"
+echo "   - Or use WeTransfer for large files"
+echo ""
+ls -lh "$OUTPUT_FILE"

--- a/scripts/quick-test-build.sh
+++ b/scripts/quick-test-build.sh
@@ -2,9 +2,10 @@
 #
 # One-liner build for current platform - simplest possible
 # Usage: ./scripts/quick-test-build.sh
+# Requires bash-compatible tooling: bash, npm, npx, uname, and ls.
 #
 
-set -e
+set -euo pipefail
 
 echo "🚀 Hermes Desktop - Quick Test Build"
 echo "===================================="

--- a/scripts/quick-test-build.sh
+++ b/scripts/quick-test-build.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+#
+# One-liner build for current platform - simplest possible
+# Usage: ./scripts/quick-test-build.sh
+#
+
+set -e
+
+echo "🚀 Hermes Desktop - Quick Test Build"
+echo "===================================="
+echo ""
+
+# Detect platform
+OS=$(uname -s)
+ARCH=$(uname -m)
+
+case "$OS" in
+  Darwin)
+    PLATFORM="mac"
+    EXT="dmg"
+    ;;
+  Linux)
+    PLATFORM="linux"
+    EXT="AppImage"
+    ;;
+  MINGW*|CYGWIN*|MSYS*)
+    PLATFORM="win"
+    EXT="exe"
+    ;;
+  *)
+    echo "Unknown OS: $OS"
+    exit 1
+    ;;
+esac
+
+echo "📱 Platform: $OS ($ARCH)"
+echo "📦 Target: $PLATFORM (.$EXT)"
+echo ""
+
+# Quick dependency check
+if ! command -v npm &> /dev/null; then
+  echo "❌ npm not found. Install Node.js first: https://nodejs.org"
+  exit 1
+fi
+
+# Install and build
+echo "⏳ Installing dependencies (this may take a minute)..."
+npm ci --silent
+
+echo "🔨 Building app..."
+npm run build --silent
+
+echo "📦 Packaging..."
+case "$PLATFORM" in
+  mac)
+    npx electron-builder --mac dmg --publish never 2>&1 | tail -5
+    ;;
+  linux)
+    npx electron-builder --linux AppImage --publish never 2>&1 | tail -5
+    ;;
+  win)
+    npx electron-builder --win nsis --x64 --publish never 2>&1 | tail -5
+    ;;
+esac
+
+# Find the built file
+VERSION=$(node -p "require('./package.json').version")
+BUILT_FILE=$(ls dist/*.$EXT 2>/dev/null | head -1)
+
+if [ -f "$BUILT_FILE" ]; then
+  echo ""
+  echo "✅ SUCCESS! Built: $BUILT_FILE"
+  echo ""
+  echo "📋 To hand to a tester:"
+  echo "   1. Copy this file: $BUILT_FILE"
+  echo "   2. Copy: TESTING-GUIDE.md"
+  echo "   3. Put both in a folder and send to tester"
+  echo ""
+  ls -lh "$BUILT_FILE"
+else
+  echo "❌ Build may have failed - check dist/ folder"
+  ls -la dist/ 2>/dev/null || echo "No dist folder found"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Adds tester-facing build/packaging scripts (`scripts/build-for-tester.sh`, `scripts/package-for-tester.sh`, `scripts/quick-test-build.sh`)
- Adds `TESTING-GUIDE.md` with step-by-step instructions for non-developer testers (pre-built releases and local build paths)

This is the first slice of a larger feature branch split. It contains **only** tester build tooling — no app source, dependency, or CI changes.

## Test plan

- [ ] `npm run typecheck`
- [ ] `npm run build`
- [ ] Manually run `./scripts/quick-test-build.sh` (or `./scripts/build-for-tester.sh` / `./scripts/package-for-tester.sh`) and confirm artifacts are produced as documented in `TESTING-GUIDE.md`

## Follow-up PRs (planned)

- Native module CI (optional, `.github/workflows/ci.yml`)
- Embedded terminal
- Vault/credentials
- Files/workspace browser
- Profile wizard/migration
- Dashboard/navigation/UI shell


Made with [Cursor](https://cursor.com)