### PR TITLE
feat(ui): add dashboard, MCP hub, swarm, ecosystem, and color themes

### DIFF
--- a/src/main/dashboard.ts
+++ b/src/main/dashboard.ts
@@ -1,0 +1,47 @@
+import { ipcMain } from "electron";
+import { listCachedSessions } from "./session-cache";
+import { getModelConfig } from "./config";
+import { isGatewayRunning } from "./hermes";
+import { listCronJobs } from "./cronjobs";
+
+export function registerDashboardHandlers(): void {
+  ipcMain.handle("dashboard-stats", async (_event, profile?: string) => {
+    const sessions = listCachedSessions(1000, 0);
+    const model = getModelConfig(profile);
+    let cronJobCount = 0;
+    try {
+      const jobs = await listCronJobs(false, profile);
+      cronJobCount = jobs.length;
+    } catch {
+      cronJobCount = 0;
+    }
+
+    return {
+      sessionCount: sessions.length,
+      modelProvider: model.provider,
+      modelName: model.model,
+      gatewayRunning: isGatewayRunning(),
+      cronJobCount,
+    };
+  });
+}
+
+export function registerMcpHandlers(): void {
+  ipcMain.handle("mcp-catalog", async (_event, profile?: string) => {
+    const { listMcpServers } = await import("./installer");
+    const { getActiveProfileNameSync } = await import("./utils");
+    const p = profile || getActiveProfileNameSync();
+    const servers = await listMcpServers(p);
+    const catalog = [
+      { name: "filesystem", description: "Local filesystem access", installed: false },
+      { name: "github", description: "GitHub API integration", installed: false },
+      { name: "postgres", description: "PostgreSQL database queries", installed: false },
+      { name: "brave-search", description: "Web search via Brave", installed: false },
+    ];
+    const installedNames = new Set(servers.map((s) => s.name.toLowerCase()));
+    return catalog.map((c) => ({
+      ...c,
+      installed: installedNames.has(c.name),
+    }));
+  });
+}

--- a/src/main/dashboard.ts
+++ b/src/main/dashboard.ts
@@ -1,12 +1,11 @@
 import { ipcMain } from "electron";
-import { listCachedSessions } from "./session-cache";
+import { countCachedSessions } from "./session-cache";
 import { getModelConfig } from "./config";
 import { isGatewayRunning } from "./hermes";
 import { listCronJobs } from "./cronjobs";
 
 export function registerDashboardHandlers(): void {
   ipcMain.handle("dashboard-stats", async (_event, profile?: string) => {
-    const sessions = listCachedSessions(1000, 0);
     const model = getModelConfig(profile);
     let cronJobCount = 0;
     try {
@@ -17,7 +16,7 @@ export function registerDashboardHandlers(): void {
     }
 
     return {
-      sessionCount: sessions.length,
+      sessionCount: countCachedSessions(),
       modelProvider: model.provider,
       modelName: model.model,
       gatewayRunning: isGatewayRunning(),

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -118,6 +118,7 @@ import {
   deleteProfile,
   setActiveProfile,
 } from "./profiles";
+import { registerDashboardHandlers, registerMcpHandlers } from "./dashboard";
 import {
   readMemory,
   addMemoryEntry,
@@ -1543,6 +1544,9 @@ function setupIPC(): void {
       return sshReadLogs(conn.ssh, logFile, lines);
     return readLogs(logFile, lines);
   });
+
+  registerDashboardHandlers();
+  registerMcpHandlers();
 }
 
 function buildMenu(): void {

--- a/src/main/session-cache.ts
+++ b/src/main/session-cache.ts
@@ -226,6 +226,10 @@ export function listCachedSessions(limit = 50, offset = 0): CachedSession[] {
   return cache.sessions.slice(offset, offset + limit);
 }
 
+export function countCachedSessions(): number {
+  return readCache().sessions.length;
+}
+
 // Update title for a specific session
 export function updateSessionTitle(sessionId: string, title: string): void {
   const cache = readCache();

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -770,6 +770,18 @@ interface HermesAPI {
     logFile?: string,
     lines?: number,
   ) => Promise<{ content: string; path: string }>;
+
+  getDashboardStats: (profile?: string) => Promise<{
+    sessionCount: number;
+    modelProvider: string;
+    modelName: string;
+    gatewayRunning: boolean;
+    cronJobCount: number;
+  }>;
+
+  listMcpCatalog: () => Promise<
+    Array<{ name: string; description: string; installed: boolean }>
+  >;
 }
 
 declare global {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -952,6 +952,17 @@ const hermesAPI = {
     lines?: number,
   ): Promise<{ content: string; path: string }> =>
     ipcRenderer.invoke("read-logs", logFile, lines),
+
+  getDashboardStats: (profile?: string): Promise<{
+    sessionCount: number;
+    modelProvider: string;
+    modelName: string;
+    gatewayRunning: boolean;
+    cronJobCount: number;
+  }> => ipcRenderer.invoke("dashboard-stats", profile),
+
+  listMcpCatalog: (): Promise<Array<{ name: string; description: string; installed: boolean }>> =>
+    ipcRenderer.invoke("mcp-catalog"),
 };
 
 if (process.contextIsolated) {

--- a/src/renderer/src/assets/icons/index.tsx
+++ b/src/renderer/src/assets/icons/index.tsx
@@ -37,3 +37,4 @@ export { Ban } from "lucide-react";
 export { RotateCcw } from "lucide-react";
 export { Loader2 as Spinner } from "lucide-react";
 export { Columns3 as Kanban } from "lucide-react";
+export { LayoutDashboard, Network } from "lucide-react";

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -5959,3 +5959,111 @@ body {
   font-size: 11px;
   color: var(--text-muted);
 }
+
+/* ── Dashboard & workspace screens ───────────────────────────────────── */
+
+.card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.screen-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+}
+
+.screen-title {
+  font-size: 18px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.screen-subtitle {
+  font-size: 13px;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+
+.screen-loading {
+  padding: 40px;
+  text-align: center;
+  color: var(--text-muted);
+}
+
+.btn-primary, .btn-secondary {
+  padding: 8px 14px;
+  border-radius: 6px;
+  font-size: 13px;
+  cursor: pointer;
+  border: none;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: #fff;
+}
+
+.btn-secondary {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.dashboard-screen, .mcp-screen, .swarm-screen, .ecosystem-screen {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.dashboard-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 12px; padding: 16px; }
+.dashboard-stat { font-size: 32px; font-weight: 700; }
+.status-badge { font-size: 12px; padding: 4px 10px; border-radius: 999px; }
+.status-badge.connected { background: rgba(34,197,94,0.15); color: var(--success); }
+.status-badge.disconnected { background: rgba(239,68,68,0.15); color: var(--error); }
+
+.mcp-list { list-style: none; padding: 16px; display: flex; flex-direction: column; gap: 8px; }
+.mcp-item p { margin-top: 4px; color: var(--text-muted); font-size: 13px; }
+
+.theme-preview-grid { display: flex; gap: 8px; flex-wrap: wrap; }
+.theme-preview { padding: 12px 16px; border-radius: 6px; background: var(--bg-tertiary); font-size: 12px; }
+
+[data-color-theme="nous"] { --accent: #6366f1; }
+[data-color-theme="bronze"] { --accent: #b45309; }
+[data-color-theme="slate"] { --accent: #64748b; }
+[data-color-theme="mono"] { --accent: #a3a3a3; }
+
+.empty-state { color: var(--text-muted); padding: 24px; text-align: center; }
+.form-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 12px; }
+.badge { font-size: 10px; padding: 2px 6px; border-radius: 4px; background: var(--bg-tertiary); }
+.badge.installed { background: rgba(34,197,94,0.2); color: var(--success); }
+
+.swarm-worker-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 12px; padding: 0 16px 16px; }
+.swarm-worker { padding: 12px; cursor: pointer; transition: border-color 0.15s; }
+.swarm-worker:hover { border-color: var(--border-bright); }
+.swarm-worker-header { display: flex; justify-content: space-between; align-items: center; }
+.swarm-worker-left { display: flex; align-items: center; gap: 10px; }
+.swarm-worker-name { font-size: 14px; }
+.swarm-worker-role { font-size: 11px; color: var(--text-muted); margin-top: 2px; }
+.swarm-worker-meta { display: flex; align-items: center; gap: 8px; }
+.swarm-status-dot { width: 10px; height: 10px; border-radius: 50%; display: inline-block; flex-shrink: 0; }
+.swarm-status-dot.running { background: var(--success); box-shadow: 0 0 6px var(--success); }
+.swarm-status-dot.idle { background: var(--accent); }
+.swarm-status-dot.error { background: var(--error); }
+.swarm-status-dot.offline { background: var(--text-muted); }
+.swarm-pid { font-size: 10px; color: var(--text-muted); font-family: monospace; }
+.swarm-worker-detail { margin-top: 12px; padding-top: 12px; border-top: 1px solid var(--border); }
+.swarm-detail-row { display: flex; justify-content: space-between; padding: 4px 0; font-size: 12px; }
+.swarm-detail-row code { font-size: 11px; }
+.swarm-worker.error { border-color: var(--error); }
+
+.badge-running { background: rgba(34,197,94,0.2); color: var(--success); }
+.badge-idle { background: rgba(0,63,122,0.2); color: var(--accent-text); }
+.badge-error { background: rgba(239,68,68,0.2); color: var(--error); }
+.badge-offline { background: var(--bg-tertiary); color: var(--text-muted); }

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -5962,14 +5962,20 @@ body {
 
 /* ── Dashboard & workspace screens ───────────────────────────────────── */
 
-.card {
+.dashboard-screen .card,
+.mcp-screen .card,
+.ecosystem-screen .card,
+.swarm-screen .card {
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   border-radius: 8px;
   padding: 16px;
 }
 
-.screen-header {
+.dashboard-screen .screen-header,
+.mcp-screen .screen-header,
+.ecosystem-screen .screen-header,
+.swarm-screen .screen-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -5977,7 +5983,10 @@ body {
   border-bottom: 1px solid var(--border);
 }
 
-.screen-title {
+.dashboard-screen .screen-title,
+.mcp-screen .screen-title,
+.ecosystem-screen .screen-title,
+.swarm-screen .screen-title {
   font-size: 18px;
   font-weight: 600;
   display: flex;
@@ -5985,7 +5994,10 @@ body {
   gap: 8px;
 }
 
-.screen-subtitle {
+.dashboard-screen .screen-subtitle,
+.mcp-screen .screen-subtitle,
+.ecosystem-screen .screen-subtitle,
+.swarm-screen .screen-subtitle {
   font-size: 13px;
   color: var(--text-muted);
   margin-top: 4px;
@@ -5997,24 +6009,6 @@ body {
   color: var(--text-muted);
 }
 
-.btn-primary, .btn-secondary {
-  padding: 8px 14px;
-  border-radius: 6px;
-  font-size: 13px;
-  cursor: pointer;
-  border: none;
-}
-
-.btn-primary {
-  background: var(--accent);
-  color: #fff;
-}
-
-.btn-secondary {
-  background: var(--bg-tertiary);
-  color: var(--text-primary);
-}
-
 .dashboard-screen, .mcp-screen, .swarm-screen, .ecosystem-screen {
   display: flex;
   flex-direction: column;
@@ -6024,9 +6018,18 @@ body {
 
 .dashboard-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 12px; padding: 16px; }
 .dashboard-stat { font-size: 32px; font-weight: 700; }
-.status-badge { font-size: 12px; padding: 4px 10px; border-radius: 999px; }
-.status-badge.connected { background: rgba(34,197,94,0.15); color: var(--success); }
-.status-badge.disconnected { background: rgba(239,68,68,0.15); color: var(--error); }
+.dashboard-screen .status-badge,
+.mcp-screen .status-badge,
+.ecosystem-screen .status-badge,
+.swarm-screen .status-badge { font-size: 12px; padding: 4px 10px; border-radius: 999px; }
+.dashboard-screen .status-badge.connected,
+.mcp-screen .status-badge.connected,
+.ecosystem-screen .status-badge.connected,
+.swarm-screen .status-badge.connected { background: rgba(34,197,94,0.15); color: var(--success); }
+.dashboard-screen .status-badge.disconnected,
+.mcp-screen .status-badge.disconnected,
+.ecosystem-screen .status-badge.disconnected,
+.swarm-screen .status-badge.disconnected { background: rgba(239,68,68,0.15); color: var(--error); }
 
 .mcp-list { list-style: none; padding: 16px; display: flex; flex-direction: column; gap: 8px; }
 .mcp-item p { margin-top: 4px; color: var(--text-muted); font-size: 13px; }
@@ -6039,10 +6042,22 @@ body {
 [data-color-theme="slate"] { --accent: #64748b; }
 [data-color-theme="mono"] { --accent: #a3a3a3; }
 
-.empty-state { color: var(--text-muted); padding: 24px; text-align: center; }
-.form-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 12px; }
-.badge { font-size: 10px; padding: 2px 6px; border-radius: 4px; background: var(--bg-tertiary); }
-.badge.installed { background: rgba(34,197,94,0.2); color: var(--success); }
+.dashboard-screen .empty-state,
+.mcp-screen .empty-state,
+.ecosystem-screen .empty-state,
+.swarm-screen .empty-state { color: var(--text-muted); padding: 24px; text-align: center; }
+.dashboard-screen .form-actions,
+.mcp-screen .form-actions,
+.ecosystem-screen .form-actions,
+.swarm-screen .form-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 12px; }
+.dashboard-screen .badge,
+.mcp-screen .badge,
+.ecosystem-screen .badge,
+.swarm-screen .badge { font-size: 10px; padding: 2px 6px; border-radius: 4px; background: var(--bg-tertiary); }
+.dashboard-screen .badge.installed,
+.mcp-screen .badge.installed,
+.ecosystem-screen .badge.installed,
+.swarm-screen .badge.installed { background: rgba(34,197,94,0.2); color: var(--success); }
 
 .swarm-worker-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 12px; padding: 0 16px 16px; }
 .swarm-worker { padding: 12px; cursor: pointer; transition: border-color 0.15s; }

--- a/src/renderer/src/components/ThemeProvider.tsx
+++ b/src/renderer/src/components/ThemeProvider.tsx
@@ -1,21 +1,28 @@
 import { createContext, useContext, useEffect, useState } from "react";
 
 type Theme = "light" | "dark" | "system";
+type ColorTheme = "hermes" | "nous" | "bronze" | "slate" | "mono";
 type ResolvedTheme = "light" | "dark";
 
 interface ThemeContextValue {
   theme: Theme;
+  colorTheme: ColorTheme;
   resolved: ResolvedTheme;
   setTheme: (theme: Theme) => void;
+  setColorTheme: (colorTheme: ColorTheme) => void;
 }
 
 const ThemeContext = createContext<ThemeContextValue>({
   theme: "system",
+  colorTheme: "hermes",
   resolved: "dark",
   setTheme: () => {},
+  setColorTheme: () => {},
 });
 
 import { THEME_STORAGE_KEY as STORAGE_KEY } from "../constants";
+
+const COLOR_THEME_KEY = "hermes-color-theme";
 
 function getSystemTheme(): ResolvedTheme {
   return window.matchMedia("(prefers-color-scheme: dark)").matches
@@ -38,11 +45,23 @@ export function ThemeProvider({
       return stored;
     return "system";
   });
+  const [colorTheme, setColorThemeState] = useState<ColorTheme>(() => {
+    const stored = localStorage.getItem(COLOR_THEME_KEY);
+    if (stored === "nous" || stored === "bronze" || stored === "slate" || stored === "mono" || stored === "hermes") {
+      return stored;
+    }
+    return "hermes";
+  });
   const [resolved, setResolved] = useState<ResolvedTheme>(() => resolve(theme));
 
   function setTheme(next: Theme): void {
     setThemeState(next);
     localStorage.setItem(STORAGE_KEY, next);
+  }
+
+  function setColorTheme(next: ColorTheme): void {
+    setColorThemeState(next);
+    localStorage.setItem(COLOR_THEME_KEY, next);
   }
 
   // Listen for system preference changes
@@ -67,8 +86,12 @@ export function ThemeProvider({
     document.documentElement.setAttribute("data-theme", resolved);
   }, [resolved]);
 
+  useEffect(() => {
+    document.documentElement.setAttribute("data-color-theme", colorTheme);
+  }, [colorTheme]);
+
   return (
-    <ThemeContext.Provider value={{ theme, resolved, setTheme }}>
+    <ThemeContext.Provider value={{ theme, colorTheme, resolved, setTheme, setColorTheme }}>
       {children}
     </ThemeContext.Provider>
   );

--- a/src/renderer/src/screens/Dashboard/Dashboard.tsx
+++ b/src/renderer/src/screens/Dashboard/Dashboard.tsx
@@ -1,0 +1,53 @@
+import { useState, useEffect } from "react";
+
+function Dashboard({ profile }: { profile: string }): React.JSX.Element {
+  const [stats, setStats] = useState<{
+    sessionCount: number;
+    modelProvider: string;
+    modelName: string;
+    gatewayRunning: boolean;
+    cronJobCount: number;
+  } | null>(null);
+
+  useEffect(() => {
+    window.hermesAPI.getDashboardStats(profile).then(setStats);
+    const id = setInterval(() => {
+      window.hermesAPI.getDashboardStats(profile).then(setStats);
+    }, 15000);
+    return () => clearInterval(id);
+  }, [profile]);
+
+  if (!stats) return <div className="screen-loading">Loading dashboard…</div>;
+
+  return (
+    <div className="dashboard-screen">
+      <header className="screen-header">
+        <h1 className="screen-title">Operations Dashboard</h1>
+        <span className={`status-badge ${stats.gatewayRunning ? "connected" : "disconnected"}`}>
+          {stats.gatewayRunning ? "Gateway connected" : "Gateway disconnected"}
+        </span>
+      </header>
+      <div className="dashboard-grid">
+        <div className="dashboard-card card">
+          <h3>Sessions</h3>
+          <p className="dashboard-stat">{stats.sessionCount}</p>
+        </div>
+        <div className="dashboard-card card">
+          <h3>Active model</h3>
+          <p>{stats.modelProvider} / {stats.modelName || "default"}</p>
+        </div>
+        <div className="dashboard-card card">
+          <h3>Cron jobs</h3>
+          <p className="dashboard-stat">{stats.cronJobCount}</p>
+        </div>
+        <div className="dashboard-card card attention">
+          <h3>Attention</h3>
+          {!stats.gatewayRunning && <p>Gateway is not running — activate a profile or send a chat message.</p>}
+          {stats.gatewayRunning && <p>All systems operational.</p>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Dashboard;

--- a/src/renderer/src/screens/Ecosystem/Ecosystem.tsx
+++ b/src/renderer/src/screens/Ecosystem/Ecosystem.tsx
@@ -1,0 +1,46 @@
+import { useState, useEffect } from "react";
+
+const MEMORY_PROVIDERS = [
+  { name: "Honcho", url: "https://app.honcho.dev" },
+  { name: "Hindsight", url: "https://ui.hindsight.vectorize.io" },
+  { name: "Mem0", url: "https://app.mem0.ai" },
+];
+
+const THEMES = ["Hermes", "Nous", "Bronze", "Slate", "Mono"];
+
+function Ecosystem({ profile }: { profile: string }): React.JSX.Element {
+  const [skillCount, setSkillCount] = useState(0);
+
+  useEffect(() => {
+    window.hermesAPI.listInstalledSkills(profile).then((s) => setSkillCount(s.length));
+  }, [profile]);
+
+  return (
+    <div className="ecosystem-screen">
+      <header className="screen-header">
+        <h1 className="screen-title">Ecosystem Browser</h1>
+        <p className="screen-subtitle">Discover skills, providers, and themes</p>
+      </header>
+      <section className="card">
+        <h2>Skills</h2>
+        <p>{skillCount} skills installed for this profile. Browse and manage in the Skills tab.</p>
+      </section>
+      <section className="card">
+        <h2>Memory providers</h2>
+        <ul>{MEMORY_PROVIDERS.map((p) => (
+          <li key={p.name}><a href={p.url} onClick={(e) => { e.preventDefault(); window.hermesAPI.openExternal(p.url); }}>{p.name}</a></li>
+        ))}</ul>
+      </section>
+      <section className="card">
+        <h2>Themes</h2>
+        <div className="theme-preview-grid">
+          {THEMES.map((t) => (
+            <div key={t} className="theme-preview">{t}</div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default Ecosystem;

--- a/src/renderer/src/screens/Layout/Layout.tsx
+++ b/src/renderer/src/screens/Layout/Layout.tsx
@@ -88,6 +88,13 @@ const NAV_ITEMS: { view: View; icon: LucideIcon; labelKey: string }[] = [
   { view: "settings", icon: SettingsIcon, labelKey: "navigation.settings" },
 ];
 
+const SHOW_SWARM =
+  import.meta.env.DEV || import.meta.env.VITE_EXPERIMENTAL_SWARM === "1";
+
+const VISIBLE_NAV_ITEMS = NAV_ITEMS.filter(
+  (item) => item.view !== "swarm" || SHOW_SWARM,
+);
+
 interface LayoutProps {
   verifyWarning?: boolean;
   onReinstall?: () => void;
@@ -231,7 +238,7 @@ function Layout({
         </div>
 
         <nav className="sidebar-nav">
-          {NAV_ITEMS.map(({ view: v, icon: Icon, labelKey }) => (
+          {VISIBLE_NAV_ITEMS.map(({ view: v, icon: Icon, labelKey }) => (
             <button
               key={v}
               className={`sidebar-nav-item ${view === v ? "active" : ""}`}

--- a/src/renderer/src/screens/Layout/Layout.tsx
+++ b/src/renderer/src/screens/Layout/Layout.tsx
@@ -17,6 +17,10 @@ import Models from "../Models/Models";
 import Providers from "../Providers/Providers";
 import Schedules from "../Schedules/Schedules";
 import Kanban from "../Kanban/Kanban";
+import Dashboard from "../Dashboard/Dashboard";
+import MCP from "../MCP/MCP";
+import Swarm from "../Swarm/Swarm";
+import Ecosystem from "../Ecosystem/Ecosystem";
 import RemoteNotice from "../../components/RemoteNotice";
 import VerifyWarningBanner from "../../components/VerifyWarningBanner";
 import hermeslogo from "../../assets/hermes.png";
@@ -36,6 +40,9 @@ import {
   Timer,
   Kanban as KanbanIcon,
   Download,
+  LayoutDashboard,
+  Network,
+  Globe,
 } from "../../assets/icons";
 import type { LucideIcon } from "lucide-react";
 import { useI18n } from "../../components/useI18n";
@@ -44,6 +51,7 @@ type View =
   | "chat"
   | "sessions"
   | "agents"
+  | "dashboard"
   | "office"
   | "models"
   | "providers"
@@ -53,11 +61,15 @@ type View =
   | "tools"
   | "schedules"
   | "kanban"
+  | "mcp"
+  | "swarm"
+  | "ecosystem"
   | "gateway"
   | "settings";
 
 const NAV_ITEMS: { view: View; icon: LucideIcon; labelKey: string }[] = [
   { view: "chat", icon: ChatBubble, labelKey: "navigation.chat" },
+  { view: "dashboard", icon: LayoutDashboard, labelKey: "navigation.dashboard" },
   { view: "sessions", icon: Clock, labelKey: "navigation.sessions" },
   { view: "agents", icon: Users, labelKey: "navigation.agents" },
   { view: "office", icon: Building, labelKey: "navigation.office" },
@@ -68,7 +80,10 @@ const NAV_ITEMS: { view: View; icon: LucideIcon; labelKey: string }[] = [
   { view: "soul", icon: Sparkles, labelKey: "navigation.soul" },
   { view: "memory", icon: Brain, labelKey: "navigation.memory" },
   { view: "tools", icon: Wrench, labelKey: "navigation.tools" },
+  { view: "mcp", icon: Network, labelKey: "navigation.mcp" },
   { view: "schedules", icon: Timer, labelKey: "navigation.schedules" },
+  { view: "swarm", icon: Globe, labelKey: "navigation.swarm" },
+  { view: "ecosystem", icon: Globe, labelKey: "navigation.ecosystem" },
   { view: "gateway", icon: Signal, labelKey: "navigation.gateway" },
   { view: "settings", icon: SettingsIcon, labelKey: "navigation.settings" },
 ];
@@ -312,6 +327,12 @@ function Layout({
           </div>
         )}
 
+        {visitedViews.has("dashboard") && (
+          <div style={paneStyle("dashboard")}>
+            <Dashboard profile={activeProfile} />
+          </div>
+        )}
+
         {visitedViews.has("office") && (
           <div style={paneStyle("office")}>
             <Office profile={activeProfile} visible={view === "office"} />
@@ -390,6 +411,24 @@ function Layout({
             ) : (
               <Kanban profile={activeProfile} visible={view === "kanban"} />
             )}
+          </div>
+        )}
+
+        {visitedViews.has("mcp") && (
+          <div style={paneStyle("mcp")}>
+            <MCP profile={activeProfile} />
+          </div>
+        )}
+
+        {visitedViews.has("swarm") && (
+          <div style={paneStyle("swarm")}>
+            <Swarm />
+          </div>
+        )}
+
+        {visitedViews.has("ecosystem") && (
+          <div style={paneStyle("ecosystem")}>
+            <Ecosystem profile={activeProfile} />
           </div>
         )}
 

--- a/src/renderer/src/screens/MCP/MCP.tsx
+++ b/src/renderer/src/screens/MCP/MCP.tsx
@@ -1,0 +1,48 @@
+import { useState, useEffect } from "react";
+
+function MCP({ profile }: { profile: string }): React.JSX.Element {
+  const [catalog, setCatalog] = useState<Array<{ name: string; description: string; installed: boolean }>>([]);
+  const [installed, setInstalled] = useState<Array<{ name: string; type: string; enabled: boolean; detail: string }>>([]);
+
+  useEffect(() => {
+    window.hermesAPI.listMcpCatalog().then(setCatalog);
+    window.hermesAPI.listMcpServers(profile).then(setInstalled);
+  }, [profile]);
+
+  return (
+    <div className="mcp-screen">
+      <header className="screen-header">
+        <h1 className="screen-title">MCP Hub</h1>
+        <p className="screen-subtitle">Model Context Protocol servers</p>
+      </header>
+      <section>
+        <h2>Installed</h2>
+        {installed.length === 0 ? (
+          <p className="empty-state">No MCP servers configured. Use <code>hermes mcp add</code> in terminal.</p>
+        ) : (
+          <ul className="mcp-list">
+            {installed.map((s) => (
+              <li key={s.name} className="card mcp-item">
+                <strong>{s.name}</strong> <span className="badge">{s.type}</span>
+                <p>{s.detail}</p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+      <section>
+        <h2>Catalog</h2>
+        <ul className="mcp-list">
+          {catalog.map((c) => (
+            <li key={c.name} className="card mcp-item">
+              <strong>{c.name}</strong> {c.installed && <span className="badge installed">Installed</span>}
+              <p>{c.description}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}
+
+export default MCP;

--- a/src/renderer/src/screens/Settings/Settings.tsx
+++ b/src/renderer/src/screens/Settings/Settings.tsx
@@ -61,7 +61,7 @@ function getCachedOpenClaw(): { found: boolean; path: string | null } | null {
 function Settings({ profile }: { profile?: string }): React.JSX.Element {
   const { t, locale, setLocale } = useI18n();
   const [hermesHome, setHermesHome] = useState("");
-  const { theme, setTheme } = useTheme();
+  const { theme, setTheme, colorTheme, setColorTheme } = useTheme();
 
   // Hermes engine info — initialize from localStorage cache for instant display
   const [hermesVersion, setHermesVersion] = useState<string | null>(
@@ -892,6 +892,48 @@ function Settings({ profile }: { profile?: string }): React.JSX.Element {
           </div>
           <div className="settings-field-hint">
             {t("settings.appearanceHint")}
+          </div>
+        </div>
+        <div className="settings-field">
+          <label className="settings-field-label">
+            Color theme
+          </label>
+          <div className="settings-theme-options">
+            {[
+              { value: "hermes", label: "Hermes" },
+              { value: "nous", label: "Nous" },
+              { value: "bronze", label: "Bronze" },
+              { value: "slate", label: "Slate" },
+              { value: "mono", label: "Mono" },
+            ].map((opt) => (
+              <button
+                key={opt.value}
+                className={`settings-theme-option ${colorTheme === opt.value ? "active" : ""}`}
+                onClick={() => setColorTheme(opt.value as "hermes" | "nous" | "bronze" | "slate" | "mono")}
+              >
+                <span
+                  className="color-swatch"
+                  style={{
+                    display: "inline-block",
+                    width: 12,
+                    height: 12,
+                    borderRadius: "50%",
+                    marginRight: 6,
+                    verticalAlign: "middle",
+                    background:
+                      opt.value === "hermes" ? "#003f7a" :
+                      opt.value === "nous" ? "#6366f1" :
+                      opt.value === "bronze" ? "#b45309" :
+                      opt.value === "slate" ? "#64748b" :
+                      "#a3a3a3",
+                  }}
+                />
+                {opt.label}
+              </button>
+            ))}
+          </div>
+          <div className="settings-field-hint">
+            Changes accent color for buttons, links, and highlights.
           </div>
         </div>
         <div className="settings-field">

--- a/src/renderer/src/screens/Swarm/Swarm.tsx
+++ b/src/renderer/src/screens/Swarm/Swarm.tsx
@@ -1,0 +1,169 @@
+import { useState, useEffect, useCallback } from "react";
+
+interface SwarmWorker {
+  name: string;
+  role: string;
+  status: "idle" | "running" | "error" | "offline";
+  profile: string;
+  taskCount: number;
+  lastActive: string | null;
+  pid: number | null;
+}
+
+const DEFAULT_WORKERS: SwarmWorker[] = [
+  { name: "builder", role: "Coding & Build", status: "offline", profile: "coding", taskCount: 0, lastActive: null, pid: null },
+  { name: "reviewer", role: "Code Review & QA", status: "offline", profile: "research", taskCount: 0, lastActive: null, pid: null },
+  { name: "researcher", role: "Deep Research", status: "offline", profile: "research", taskCount: 0, lastActive: null, pid: null },
+  { name: "ops", role: "Operations & Monitoring", status: "offline", profile: "ops", taskCount: 0, lastActive: null, pid: null },
+  { name: "triage", role: "Issue Triage", status: "offline", profile: "research", taskCount: 0, lastActive: null, pid: null },
+];
+
+const WORKER_LABELS: Record<string, string> = {
+  idle: "Idle",
+  running: "Running",
+  error: "Error",
+  offline: "Offline",
+};
+
+function Swarm(): React.JSX.Element {
+  const [workers, setWorkers] = useState<SwarmWorker[]>(DEFAULT_WORKERS);
+  const [conductorRunning, setConductorRunning] = useState(false);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [gatewayStatus, setGatewayStatus] = useState(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      const gw = await window.hermesAPI.gatewayStatus();
+      setGatewayStatus(gw);
+    } catch { /* ignore */ }
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+  useEffect(() => {
+    const id = setInterval(refresh, 15000);
+    return () => clearInterval(id);
+  }, [refresh]);
+
+  function toggleConductor(): void {
+    setConductorRunning((p) => !p);
+    if (!conductorRunning) {
+      setWorkers((prev) =>
+        prev.map((w) => ({
+          ...w,
+          status: "idle" as const,
+          pid: Math.floor(Math.random() * 90000) + 10000,
+          lastActive: new Date().toISOString(),
+        })),
+      );
+    } else {
+      setWorkers((prev) =>
+        prev.map((w) => ({ ...w, status: "offline" as const, pid: null })),
+      );
+    }
+  }
+
+  return (
+    <div className="swarm-screen">
+      <header className="screen-header">
+        <div>
+          <h1 className="screen-title">
+            <span style={{ marginRight: 8 }}>🐝</span> Swarm Mode
+          </h1>
+          <p className="screen-subtitle">
+            Multi-agent orchestration with persistent role-based workers
+          </p>
+        </div>
+        <div className="form-actions">
+          <button
+            className={`btn ${conductorRunning ? "btn-secondary" : "btn-primary"}`}
+            onClick={toggleConductor}
+            disabled={!gatewayStatus}
+          >
+            {conductorRunning ? "Stop Conductor" : "Start Conductor"}
+          </button>
+        </div>
+      </header>
+
+      {!gatewayStatus && (
+        <div className="card" style={{ padding: 16, marginBottom: 16, background: "var(--warning-bg)", color: "var(--warning)" }}>
+          Gateway is not running. Start the gateway from the Chat or Gateway tab before enabling swarm.
+        </div>
+      )}
+
+      <div className="dashboard-grid" style={{ gridTemplateColumns: "repeat(5, 1fr)", marginBottom: 24 }}>
+        <div className="dashboard-card card">
+          <h3>Workers</h3>
+          <p className="dashboard-stat">{workers.filter((w) => w.status !== "offline").length}/{workers.length}</p>
+        </div>
+        <div className="dashboard-card card">
+          <h3>Running</h3>
+          <p className="dashboard-stat">{workers.filter((w) => w.status === "running").length}</p>
+        </div>
+        <div className="dashboard-card card">
+          <h3>Tasks</h3>
+          <p className="dashboard-stat">{workers.reduce((s, w) => s + w.taskCount, 0)}</p>
+        </div>
+        <div className="dashboard-card card">
+          <h3>Errors</h3>
+          <p className="dashboard-stat">{workers.filter((w) => w.status === "error").length}</p>
+        </div>
+        <div className={`dashboard-card card attention`}>
+          <h3>Status</h3>
+          <p>{conductorRunning ? "Active" : "Stopped"}</p>
+        </div>
+      </div>
+
+      <div className="swarm-worker-grid">
+        {workers.map((worker) => (
+          <div key={worker.name} className={`card swarm-worker ${worker.status}`}>
+            <div className="swarm-worker-header" onClick={() => setExpanded(expanded === worker.name ? null : worker.name)}>
+              <div className="swarm-worker-left">
+                <span className={`swarm-status-dot ${worker.status}`} />
+                <div>
+                  <strong className="swarm-worker-name">{worker.name}</strong>
+                  <div className="swarm-worker-role">{worker.role}</div>
+                </div>
+              </div>
+              <div className="swarm-worker-meta">
+                <span className={`badge badge-${worker.status}`}>{WORKER_LABELS[worker.status]}</span>
+                {worker.pid && <span className="swarm-pid">PID {worker.pid}</span>}
+              </div>
+            </div>
+            {expanded === worker.name && (
+              <div className="swarm-worker-detail">
+                <div className="swarm-detail-row"><span>Profile</span><code>{worker.profile}</code></div>
+                <div className="swarm-detail-row"><span>Tasks completed</span><span>{worker.taskCount}</span></div>
+                <div className="swarm-detail-row"><span>Last active</span><span>{worker.lastActive ? new Date(worker.lastActive).toLocaleString() : "Never"}</span></div>
+                <div className="form-actions" style={{ marginTop: 12 }}>
+                  <button className="btn btn-secondary btn-sm" disabled={!conductorRunning}
+                    onClick={() => setWorkers((prev) => prev.map((w) => w.name === worker.name ? { ...w, status: "running" as const } : w))}
+                  >Start</button>
+                  <button className="btn btn-secondary btn-sm" disabled={!conductorRunning}
+                    onClick={() => setWorkers((prev) => prev.map((w) => w.name === worker.name ? { ...w, status: "idle" as const } : w))}
+                  >Stop</button>
+                </div>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <div className="card" style={{ marginTop: 24 }}>
+        <h3>About Swarm Mode</h3>
+        <p style={{ marginTop: 8, color: "var(--text-secondary)", lineHeight: 1.6 }}>
+          Swarm mode creates persistent Hermes Agent workers with role-based dispatch.
+          Each worker runs in its own tmux session and maintains context across tasks.
+          The Conductor orchestrates task distribution, routes work by role,
+          and collects checkpoints from each worker.
+        </p>
+        <p style={{ marginTop: 8, color: "var(--text-secondary)", lineHeight: 1.6 }}>
+          <strong>To get started:</strong> Start the gateway, then click "Start Conductor".
+          Workers automatically spawn based on your swarm configuration.
+          Use the Kanban board to dispatch tasks to specific workers.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default Swarm;

--- a/src/renderer/src/screens/Swarm/Swarm.tsx
+++ b/src/renderer/src/screens/Swarm/Swarm.tsx
@@ -157,7 +157,7 @@ function Swarm(): React.JSX.Element {
           and collects checkpoints from each worker.
         </p>
         <p style={{ marginTop: 8, color: "var(--text-secondary)", lineHeight: 1.6 }}>
-          <strong>To get started:</strong> Start the gateway, then click "Start Conductor".
+          <strong>To get started:</strong> Start the gateway, then click &quot;Start Conductor&quot;.
           Workers automatically spawn based on your swarm configuration.
           Use the Kanban board to dispatch tasks to specific workers.
         </p>

--- a/src/shared/i18n/locales/en/navigation.ts
+++ b/src/shared/i18n/locales/en/navigation.ts
@@ -2,6 +2,7 @@ export default {
   chat: "Chat",
   sessions: "Sessions",
   agents: "Profiles",
+  dashboard: "Dashboard",
   office: "Office",
   models: "Models",
   providers: "Providers",
@@ -11,6 +12,9 @@ export default {
   tools: "Tools",
   schedules: "Schedules",
   kanban: "Kanban",
+  mcp: "MCP Hub",
+  swarm: "Swarm",
+  ecosystem: "Ecosystem",
   gateway: "Gateway",
   settings: "Settings",
 } as const;

--- a/tests/ipc-handlers.test.ts
+++ b/tests/ipc-handlers.test.ts
@@ -4,6 +4,7 @@ import { join } from "path";
 
 const ROOT = join(__dirname, "..");
 const indexSrc = readFileSync(join(ROOT, "src/main/index.ts"), "utf-8");
+const dashboardSrc = readFileSync(join(ROOT, "src/main/dashboard.ts"), "utf-8");
 const preloadSrc = readFileSync(join(ROOT, "src/preload/index.ts"), "utf-8");
 
 /**
@@ -32,7 +33,10 @@ function extractPreloadInvokeChannels(src: string): string[] {
   return [...new Set(channels)];
 }
 
-const mainChannels = extractIpcHandleChannels(indexSrc);
+const mainChannels = [
+  ...extractIpcHandleChannels(indexSrc),
+  ...extractIpcHandleChannels(dashboardSrc),
+];
 const preloadChannels = extractPreloadInvokeChannels(preloadSrc);
 
 describe("IPC Handler ↔ Preload Consistency", () => {
@@ -65,6 +69,8 @@ describe("New IPC handlers from v0.8/v0.9 features", () => {
     "run-hermes-dump",
     "list-mcp-servers",
     "discover-memory-providers",
+    "dashboard-stats",
+    "mcp-catalog",
   ];
 
   for (const ch of newChannels) {

--- a/tests/preload-api-surface.test.ts
+++ b/tests/preload-api-surface.test.ts
@@ -92,6 +92,13 @@ describe("New APIs from v0.8/v0.9 features", () => {
     expect(preloadMethods).toContain("discoverMemoryProviders");
     expect(typeMethods).toContain("discoverMemoryProviders");
   });
+
+  it("has dashboard and MCP catalog APIs", () => {
+    expect(preloadMethods).toContain("getDashboardStats");
+    expect(typeMethods).toContain("getDashboardStats");
+    expect(preloadMethods).toContain("listMcpCatalog");
+    expect(typeMethods).toContain("listMcpCatalog");
+  });
 });
 
 // ─── Legacy APIs still present ──────────────────────────


### PR DESCRIPTION
## Summary

Adds the remaining navigation/UI shell screens from the #438 split:

- **Dashboard:** Live stats (sessions, model, gateway, cron jobs) via `dashboard-stats` IPC
- **MCP Hub:** Installed servers + static catalog via `mcp-catalog` IPC
- **Swarm:** Multi-agent worker grid prototype (UI-only conductor toggle)
- **Ecosystem:** Skills count, memory provider links, theme previews
- **ThemeProvider:** Accent color themes (Hermes/Nous/Bronze/Slate/Mono) with Settings picker

**Excluded** (deferred per split plan): `Chat/ToolCallCard.tsx`, `Chat/WorkspacePanel.tsx`, and other chat workspace changes.

Independent PR off `main`. Part of the split from #438.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test -- tests/ipc-handlers.test.ts tests/preload-api-surface.test.ts`
- [ ] `npm run build`
- [ ] Manual: open Dashboard, verify stats refresh
- [ ] Manual: MCP Hub shows installed servers and catalog
- [ ] Manual: change color theme in Settings, confirm accent updates
- [ ] Manual: Swarm/Ecosystem screens render without errors

## Merge order (full split)

1. #444 — Tester build tooling
2. #445 — Embedded terminal
3. #446 — Vault/credentials
4. #447 — Files browser
5. #448 — Profile wizard (depends on #446)
6. **This PR** — Dashboard/UI shell


Made with [Cursor](https://cursor.com)