### PR TITLE
Fix local session continuation when API_SERVER_KEY is missing

### DIFF
--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -94,6 +94,14 @@ export function getRemoteAuthHeader(): Record<string, string> {
   return {};
 }
 
+function resolveResumedSessionId(
+  resumeSessionId: string | undefined,
+  hasAuth: boolean,
+): string {
+  if (!resumeSessionId) return "";
+  return hasAuth ? resumeSessionId : "";
+}
+
 function resolveRemoteApiKey(url: string, apiKey?: string): string {
   if (apiKey !== undefined) return apiKey;
 
@@ -445,8 +453,9 @@ function sendMessageViaApi(
   // local install degrades to the pre-fix (fingerprint) behaviour
   // rather than 403-looping.
   const hasAuth = "Authorization" in headers;
+  const resumedSessionId = resolveResumedSessionId(_resumeSessionId, hasAuth);
   let sessionId =
-    _resumeSessionId || (hasAuth ? `desk-${Date.now()}-${randomUUID()}` : "");
+    resumedSessionId || (hasAuth ? `desk-${Date.now()}-${randomUUID()}` : "");
   if (sessionId) {
     headers["X-Hermes-Session-Id"] = sessionId;
   }
@@ -1200,3 +1209,5 @@ export function restartGateway(profile?: string): void {
     startGateway(profile);
   }, 500);
 }
+
+export { resolveResumedSessionId };

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -231,6 +231,31 @@ process.on("unhandledRejection", (reason) => {
 let mainWindow: BrowserWindow | null = null;
 let currentChatAbort: (() => void) | null = null;
 
+async function ensureLocalApiServerKey(profile?: string): Promise<string> {
+  if (isRemoteMode()) return "";
+
+  const existing = getApiServerKey(profile);
+  if (existing) return existing;
+
+  const { randomUUID } = await import("crypto");
+  const key = `desk-${randomUUID()}`;
+
+  // Keep the active profile and default profile aligned so the desktop
+  // and local gateway resolve the same API_SERVER_KEY consistently.
+  setEnvValue("API_SERVER_KEY", key, profile);
+  if (profile && profile !== "default") {
+    setEnvValue("API_SERVER_KEY", key);
+  }
+
+  if (isGatewayRunning()) {
+    stopGateway();
+    await new Promise<void>((r) => setTimeout(r, 800));
+    startGateway(profile);
+  }
+
+  return key;
+}
+
 function openExternalUrl(rawUrl: unknown): void {
   if (!isAllowedExternalUrl(rawUrl)) {
     console.warn("[SECURITY] Blocked unsafe external URL");
@@ -638,21 +663,7 @@ function setupIPC(): void {
   ipcMain.handle(
     "generate-api-server-key",
     async (_event, profile?: string) => {
-      const { randomUUID } = await import("crypto");
-      const key = `desk-${randomUUID()}`;
-      // Write to both the active profile .env and the default .env so the
-      // gateway (which reads the profile .env) and the desktop (which reads
-      // the default .env as fallback) both see the same key.
-      setEnvValue("API_SERVER_KEY", key, profile);
-      if (profile && profile !== "default") {
-        setEnvValue("API_SERVER_KEY", key);
-      }
-      // Restart gateway so it picks up the new key immediately.
-      if (isGatewayRunning()) {
-        stopGateway();
-        await new Promise<void>((r) => setTimeout(r, 800));
-        startGateway(profile);
-      }
+      const key = await ensureLocalApiServerKey(profile);
       return { key };
     },
   );
@@ -765,6 +776,7 @@ function setupIPC(): void {
       attachments?: Attachment[],
       contextFolder?: string,
     ) => {
+      await ensureLocalApiServerKey(profile);
       if (!isRemoteMode() && !isGatewayRunning()) {
         startGateway(profile);
       }

--- a/tests/hermes-api.test.ts
+++ b/tests/hermes-api.test.ts
@@ -113,6 +113,7 @@ vi.mock("../src/main/process-options", () => ({
 import {
   sendMessage,
   stopHealthPolling as realStopHealthPolling,
+  resolveResumedSessionId,
 } from "../src/main/hermes";
 
 describe("sendMessageViaApi forwards resumeSessionId", () => {
@@ -273,5 +274,17 @@ describe("sendMessageViaApi forwards resumeSessionId", () => {
     expect(ids[0]).toBeTruthy();
     expect(ids[1]).toBeTruthy();
     expect(ids[0]).not.toBe(ids[1]);
+  });
+});
+
+describe("resolveResumedSessionId", () => {
+  it("drops resumeSessionId when there is no auth header", () => {
+    expect(resolveResumedSessionId("session-abc-123", false)).toBe("");
+  });
+
+  it("keeps resumeSessionId when auth is present", () => {
+    expect(resolveResumedSessionId("session-abc-123", true)).toBe(
+      "session-abc-123",
+    );
   });
 });


### PR DESCRIPTION
## Summary

Fixes a local-mode session continuation failure where the first message succeeds but the second message fails with:

> Session continuation requires API key authentication. Configure API_SERVER_KEY to enable this feature.

## Root cause

In local mode, Hermes Desktop could attempt session continuation without a configured `API_SERVER_KEY`.

That created two failure modes:

1. The local Hermes gateway had no auth key configured, so continuation requests were rejected.
2. The desktop could still send a resume session id even when no auth header was present, which triggered the gateway-side continuation error.

## Changes

- Automatically ensure a local `API_SERVER_KEY` exists before sending a local chat message
- Reuse the same generation/write path as the manual "Generate & save a key for me" flow
- Restart the local gateway after generating a missing key so the new value is picked up immediately
- Drop `resumeSessionId` when no auth header is available, so local chat degrades safely instead of forcing a continuation error
- Add regression coverage for the no-auth resume path

## Why this helps

This fixes the confusing "first message works, second message fails" behavior for local installs that do not already have `API_SERVER_KEY` configured.

## Tests

- `npm test -- --run tests/hermes-api.test.ts tests/api-server-key-resolution.test.ts`
