### PR TITLE
fix(chat): handle mixed RTL/LTR prompt text

### DIFF
--- a/lat.md/chat-direction.md
+++ b/lat.md/chat-direction.md
@@ -1,0 +1,5 @@
+# Chat Direction
+
+Chat text uses browser bidi detection so mixed RTL/LTR prompts and responses stay readable without forcing English-only content into RTL layout.
+
+The composer textarea and the rendered chat bubble both set `dir="auto"`, letting the browser choose direction from the first strong character in the text. Agent code blocks keep explicit LTR styling so source code remains readable inside RTL-adjacent responses.

--- a/lat.md/lat.md
+++ b/lat.md/lat.md
@@ -3,6 +3,7 @@ This directory defines the high-level concepts, business logic, and architecture
 > **Hermes One** is a community-maintained project. This desktop app is a wrapper around **Hermes Agent** — it is **not affiliated with, endorsed by, or supported by Nous Research**. "Hermes One" is the name of this community project; "Hermes"/"Hermes Agent" refer to the upstream agent it builds on.
 
 - [[chat-commands]] — how typed slash commands are routed through the gateway's `slash.exec`/`command.dispatch` pipeline instead of being sent as prompt text.
+- [[chat-direction]] — how mixed RTL/LTR prompts and chat bubbles use browser bidi detection while code blocks stay LTR.
 - [[chat-performance]] — how chat rendering stays responsive through contained transcript rows, batched textarea resizing, and fixed-row slash-command virtualization.
 - [[model-context]] — the per-model context-window override that drives the context gauge and the agent's auto-compaction.
 - [[model-selection]] — the session-scoped in-chat model override that switches the model (and provider) for one conversation without touching the global default.

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -3992,7 +3992,7 @@ body {
 .chat-bubble-actions {
   position: absolute;
   top: 6px;
-  right: 8px;
+  inset-inline-end: 8px;
   display: flex;
   gap: 4px;
   opacity: 0;

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -3955,6 +3955,7 @@ body {
   border-radius: var(--radius-lg);
   font-size: 14px;
   line-height: 1.65;
+  unicode-bidi: plaintext;
   white-space: pre-wrap;
   word-wrap: break-word;
   overflow-wrap: break-word;
@@ -4063,6 +4064,8 @@ body {
 .chat-bubble-agent pre,
 .chat-bubble-agent code {
   /* Restore preserved whitespace inside code blocks and inline code. */
+  direction: ltr;
+  unicode-bidi: isolate;
   white-space: pre-wrap;
 }
 
@@ -4638,6 +4641,7 @@ body {
   background: none;
   border: none;
   color: var(--text-primary);
+  unicode-bidi: plaintext;
   font-size: 14px;
   font-family: var(--font-sans);
   padding: 4px 6px;

--- a/src/renderer/src/screens/Chat/ChatInput.test.tsx
+++ b/src/renderer/src/screens/Chat/ChatInput.test.tsx
@@ -147,7 +147,7 @@ describe("chat bidirectional text rendering", () => {
     );
 
     expect(
-      screen.getByText("مرحبا Hermes (123)").closest(".chat-bubble"),
+      screen.getByText("مرحبا Hermes (123)", { selector: ".chat-bubble" }),
     ).toHaveAttribute("dir", "auto");
   });
 });

--- a/src/renderer/src/screens/Chat/ChatInput.test.tsx
+++ b/src/renderer/src/screens/Chat/ChatInput.test.tsx
@@ -13,6 +13,7 @@ vi.mock("../../components/useI18n", () => ({
 }));
 
 import { ChatInput } from "./ChatInput";
+import { MessageRow } from "./MessageRow";
 
 afterEach(cleanup);
 
@@ -119,5 +120,35 @@ describe("ChatInput — slash command palette", () => {
     fireEvent.keyDown(textarea, { key: "ArrowUp" });
     expect(screen.getByText("command-999")).toBeTruthy();
     expect(screen.queryByText("command-0")).toBeNull();
+  });
+});
+
+describe("chat bidirectional text rendering", () => {
+  // @lat: [[chat-direction]]
+  it("lets the prompt textarea pick direction from user text", () => {
+    const { textarea } = renderInput();
+
+    expect(textarea).toHaveAttribute("dir", "auto");
+  });
+
+  it("lets chat bubbles pick direction from message text", () => {
+    render(
+      <MessageRow
+        msg={{
+          id: "rtl-message",
+          kind: "user",
+          role: "user",
+          content: "مرحبا Hermes (123)",
+        }}
+        isLast={false}
+        isLoading={false}
+        onApprove={() => {}}
+        onDeny={() => {}}
+      />,
+    );
+
+    expect(
+      screen.getByText("مرحبا Hermes (123)").closest(".chat-bubble"),
+    ).toHaveAttribute("dir", "auto");
   });
 });

--- a/src/renderer/src/screens/Chat/ChatInput.test.tsx
+++ b/src/renderer/src/screens/Chat/ChatInput.test.tsx
@@ -124,7 +124,6 @@ describe("ChatInput — slash command palette", () => {
 });
 
 describe("chat bidirectional text rendering", () => {
-  // @lat: [[chat-direction]]
   it("lets the prompt textarea pick direction from user text", () => {
     const { textarea } = renderInput();
 

--- a/src/renderer/src/screens/Chat/ChatInput.tsx
+++ b/src/renderer/src/screens/Chat/ChatInput.tsx
@@ -657,9 +657,11 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
             style={{ display: "none" }}
             onChange={handleFileInputChange}
           />
+          {/* @lat: [[chat-direction]] */}
           <textarea
             ref={inputRef}
             className="chat-input"
+            dir="auto"
             placeholder={t("chat.typeMessage")}
             value={input}
             onChange={handleInputChange}

--- a/src/renderer/src/screens/Chat/ChatInput.tsx
+++ b/src/renderer/src/screens/Chat/ChatInput.tsx
@@ -657,7 +657,6 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
             style={{ display: "none" }}
             onChange={handleFileInputChange}
           />
-          {/* @lat: [[chat-direction]] */}
           <textarea
             ref={inputRef}
             className="chat-input"

--- a/src/renderer/src/screens/Chat/MessageRow.tsx
+++ b/src/renderer/src/screens/Chat/MessageRow.tsx
@@ -305,10 +305,12 @@ export const MessageRow = memo(function MessageRow({
       ) : (
         <HermesAvatar active={isLoading && isLast} />
       )}
+      {/* @lat: [[chat-direction]] */}
       <div
         className={`chat-bubble chat-bubble-${msg.role}${
           msg.error ? " chat-bubble-error" : ""
         }`}
+        dir="auto"
       >
         {msg.content && !isLoading && !msg.isSlashLoader && (
           <div className="chat-bubble-actions">

--- a/src/renderer/src/screens/Chat/MessageRow.tsx
+++ b/src/renderer/src/screens/Chat/MessageRow.tsx
@@ -305,7 +305,6 @@ export const MessageRow = memo(function MessageRow({
       ) : (
         <HermesAvatar active={isLoading && isLast} />
       )}
-      {/* @lat: [[chat-direction]] */}
       <div
         className={`chat-bubble chat-bubble-${msg.role}${
           msg.error ? " chat-bubble-error" : ""


### PR DESCRIPTION
## Summary
- set the chat prompt textarea and message bubbles to auto-detect text direction
- apply unicode-bidi: plaintext so mixed RTL/LTR paragraphs render in reading order
- keep code blocks isolated as LTR inside assistant markdown
- add renderer tests for the direction attributes

Fixes #452.

## Verification
- npm run typecheck
- npm run lint (0 errors; existing CRLF prettier warnings in the repo)
- npx vitest run src/renderer/src/screens/Chat/ChatInput.test.tsx (blocked locally by Node 18/Vitest ESM config error: ERR_REQUIRE_ESM)