### PR TITLE
fix(test): stub missing utils exports in hermes-cli-session-id mock

### DIFF
--- a/tests/hermes-cli-session-id.test.ts
+++ b/tests/hermes-cli-session-id.test.ts
@@ -152,6 +152,11 @@ vi.mock("../src/main/ssh-tunnel", () => ({
 vi.mock("../src/main/utils", () => ({
   stripAnsi: (s: string) => s,
   pidIsAliveAs: () => false,
+  getActiveProfileNameSync: () => "default",
+  profileHome: (profile?: unknown) =>
+    profile && profile !== "default"
+      ? `${TEST_HOME}/profiles/${profile}`
+      : TEST_HOME,
 }));
 
 vi.mock("../src/main/models", () => ({


### PR DESCRIPTION
## What

The `vi.mock("../src/main/utils", …)` factory in `tests/hermes-cli-session-id.test.ts` only stubbed `stripAnsi` and `pidIsAliveAs`, but `src/main/hermes.ts` also imports `profileHome` and `getActiveProfileNameSync`. Because a `vi.mock` factory replaces the *entire* module, the un-stubbed exports are `undefined`. When `gatewayPidPaths()` calls `getActiveProfileNameSync()`, Vitest throws *"No 'getActiveProfileNameSync' export is defined on the mock"*, failing all 4 tests in the file.

## Why it matters

This is currently breaking **CI on `main`** — the latest run (Node 22) fails with this exact error. This file is the only one that exercises the gateway-PID path, which is why the sibling `utils` mocks (which stub only `stripAnsi`) don't hit it.

## Change

Add the two missing exports to the mock, mirroring the real module's behavior (`getActiveProfileNameSync` → `"default"`; `profileHome` builds a `profiles/<name>` path for named profiles, so a future named-profile test resolves distinct PID paths). Test-only — no production code touched.

## Verification

- `npm run typecheck` ✅
- `npm test` ✅ — 60 files, 690 passed / 3 skipped (previously 4 failed in this file)
