### PR TITLE
Fix Windows gateway start stderr fd

### DIFF
--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -6,7 +6,8 @@ import {
   appendFileSync,
   unlinkSync,
   mkdirSync,
-  createWriteStream,
+  openSync,
+  closeSync,
 } from "fs";
 import { join } from "path";
 import { homedir } from "os";
@@ -1163,17 +1164,32 @@ export function startGateway(profile?: string): boolean {
     // ignore
   }
   const logPath = join(logDir, "gateway-stderr.log");
-  const stderrStream = createWriteStream(logPath, { flags: "a" });
+  // Pass an already-open fd to child_process.spawn. On Windows/Electron,
+  // createWriteStream(...).fd can still be null at spawn time, which makes
+  // Node reject stdio with "The argument 'stdio' is invalid" and leaves the
+  // Gateway Start button unable to launch the process.
+  let stderrFd: number | null = openSync(logPath, "a");
 
   gatewayProcess = spawn(HERMES_PYTHON, hermesCliArgs(["gateway"]), {
     cwd: HERMES_REPO,
     env: gatewayEnv,
-    stdio: ["ignore", "ignore", stderrStream],
+    stdio: ["ignore", "ignore", stderrFd],
     detached: true,
     ...HIDDEN_SUBPROCESS_OPTIONS,
   });
 
+  const closeGatewayStderrFd = (): void => {
+    if (stderrFd === null) return;
+    try {
+      closeSync(stderrFd);
+    } catch {
+      // best-effort cleanup
+    }
+    stderrFd = null;
+  };
+
   gatewayProcess.on("error", (err) => {
+    closeGatewayStderrFd();
     console.error("[gateway] Failed to spawn gateway process:", err.message);
     gatewayProcess = null;
     gatewayStartedByApp = false;
@@ -1181,6 +1197,7 @@ export function startGateway(profile?: string): boolean {
   });
 
   gatewayProcess.on("close", (code, signal) => {
+    closeGatewayStderrFd();
     if (code !== null && code !== 0) {
       console.error(
         `[gateway] Process exited with code ${code}${signal ? ` (signal: ${signal})` : ""}. ` +

--- a/tests/hermes-cli-session-id.test.ts
+++ b/tests/hermes-cli-session-id.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from "events";
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 
-const { spawned, TEST_HOME, TEST_REPO, healthStatuses, apiRequests } = vi.hoisted(() => {
+const { spawned, spawnCalls, TEST_HOME, TEST_REPO, healthStatuses, apiRequests } = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const path = require("path");
   // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -16,6 +16,7 @@ const { spawned, TEST_HOME, TEST_REPO, healthStatuses, apiRequests } = vi.hoiste
         unref: ReturnType<typeof vi.fn>;
       }
     >,
+    spawnCalls: [] as Array<{ command: string; args?: string[]; options?: unknown }>,
     TEST_HOME: path.join(os.tmpdir(), `hermes-cli-session-test-${Date.now()}`),
     TEST_REPO: os.tmpdir(),
     healthStatuses: [] as number[],
@@ -101,21 +102,14 @@ vi.mock("https", () => ({
   },
 }));
 
-vi.mock("child_process", () => ({
-  default: {
-    spawn: vi.fn(() => {
-      const proc = Object.assign(new EventEmitter(), {
-        stdout: new EventEmitter(),
-        stderr: new EventEmitter(),
-        killed: false,
-        kill: vi.fn(),
-        unref: vi.fn(),
-      });
-      spawned.push(proc);
-      return proc;
-    }),
-  },
-  spawn: vi.fn(() => {
+vi.mock("child_process", () => {
+  const makeProc = (): EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    killed: boolean;
+    kill: ReturnType<typeof vi.fn>;
+    unref: ReturnType<typeof vi.fn>;
+  } => {
     const proc = Object.assign(new EventEmitter(), {
       stdout: new EventEmitter(),
       stderr: new EventEmitter(),
@@ -125,8 +119,18 @@ vi.mock("child_process", () => ({
     });
     spawned.push(proc);
     return proc;
-  }),
-}));
+  };
+  const mockSpawn = vi.fn((command: string, args?: string[], options?: unknown) => {
+    spawnCalls.push({ command, args, options });
+    return makeProc();
+  });
+  return {
+    default: {
+      spawn: mockSpawn,
+    },
+    spawn: mockSpawn,
+  };
+});
 
 vi.mock("../src/main/installer", () => ({
   HERMES_HOME: TEST_HOME,
@@ -181,6 +185,7 @@ describe("CLI fallback session id propagation", () => {
     stopGateway(true);
     stopHealthPolling();
     spawned.length = 0;
+    spawnCalls.length = 0;
   });
 
   it("captures the quiet CLI session id from stderr so the next desktop turn can resume it", async () => {
@@ -268,6 +273,17 @@ describe("CLI fallback session id propagation", () => {
       messages: [{ role: "user", content: "hi" }],
       stream: true,
     });
+  });
+
+  it("passes an opened stderr file descriptor to gateway spawn", () => {
+    expect(startGateway()).toBe(true);
+
+    expect(spawnCalls).toHaveLength(1);
+    const options = spawnCalls[0].options as {
+      stdio?: unknown[];
+    };
+    expect(Array.isArray(options.stdio)).toBe(true);
+    expect(typeof options.stdio?.[2]).toBe("number");
   });
 
   it("re-checks health when a previously-ready local gateway is restarted cold", async () => {


### PR DESCRIPTION
## Summary

Fix the Messaging Gateway Start action failing on Windows/Electron when stderr is routed to a log file.

`startGateway()` was passing an `fs.createWriteStream(...)` object directly to `child_process.spawn({ stdio })`. In Electron/Node on Windows, the stream's `.fd` can still be `null` at spawn time, so `spawn()` rejects the stdio entry and the desktop Start button cannot launch the gateway. Starting the gateway manually from a terminal still works, which matches the report in #466.

This PR opens `gateway-stderr.log` synchronously with `openSync()` and passes the numeric file descriptor to `spawn()`, then closes the parent fd on process error/close.

## Tests

- `npm test -- tests/hermes-cli-session-id.test.ts`
- `npm run typecheck`
- `npm run build`
- Targeted ESLint error check: `npx eslint src/main/hermes.ts tests/hermes-cli-session-id.test.ts -f json` → `eslint_errors=0`

Note: full `npm run lint` currently emits many pre-existing Prettier CRLF warnings in the checkout; the targeted files have no ESLint errors.

Fixes the Windows stderr fd gateway-start failure reported in #466