### PR TITLE
fix: stream OAuth login output without buffering

### DIFF
--- a/src/main/hermes-auth.ts
+++ b/src/main/hermes-auth.ts
@@ -120,6 +120,7 @@ export function runHermesAuthLogin(
           PATH: getEnhancedPath(),
           HOME: homedir(),
           HERMES_HOME,
+          PYTHONUNBUFFERED: "1",
           TERM: "dumb",
         },
         stdio: ["ignore", "pipe", "pipe"],

--- a/tests/hermes-auth.test.ts
+++ b/tests/hermes-auth.test.ts
@@ -182,6 +182,10 @@ describe("runHermesAuthLogin", () => {
       "--type",
       "oauth",
     ]);
+    const options = spawnSpy.mock.calls[0][2] as {
+      env?: Record<string, string | undefined>;
+    };
+    expect(options.env?.PYTHONUNBUFFERED).toBe("1");
 
     const proc = lastProc();
     proc.stdout.emit("data", Buffer.from("Opening browser for sign-in...\n"));


### PR DESCRIPTION
## Summary
- run OAuth login subprocesses with `PYTHONUNBUFFERED=1` so device-code prompts stream immediately when stdout is piped
- add focused coverage that the OAuth subprocess env includes the unbuffered flag

## Evidence
- Native Windows Desktop on current `main` already streams the Codex OAuth URL/code correctly.
- WSL Ubuntu 24.04 and Docker Linux reproduce the blank-output behavior with normal `python3` + piped stdout, then stream immediately with `python3 -u` or `PYTHONUNBUFFERED=1`
- macOS GitHub Actions probe confirms the same behavior on macOS 15.7.7 / `macos-15-arm64`: https://github.com/fathah/hermes-desktop/actions/runs/26720959374

## Tests
- `npm test -- --run tests/hermes-auth.test.ts`
- `npm run typecheck:node`