### PR TITLE
fix(memory): read character limits from profile config

### DIFF
--- a/src/main/memory-limits.ts
+++ b/src/main/memory-limits.ts
@@ -1,0 +1,27 @@
+import { getYamlPath } from "./yaml-path";
+
+export const DEFAULT_MEMORY_CHAR_LIMIT = 2200;
+export const DEFAULT_USER_CHAR_LIMIT = 1375;
+
+export interface MemoryLimits {
+  memoryCharLimit: number;
+  userCharLimit: number;
+}
+
+function parsePositiveInteger(raw: string | null): number | null {
+  if (!raw) return null;
+  const value = Number(raw.trim());
+  if (!Number.isSafeInteger(value) || value <= 0) return null;
+  return value;
+}
+
+export function parseMemoryLimitsConfig(content: string): MemoryLimits {
+  return {
+    memoryCharLimit:
+      parsePositiveInteger(getYamlPath(content, "memory.memory_char_limit")) ??
+      DEFAULT_MEMORY_CHAR_LIMIT,
+    userCharLimit:
+      parsePositiveInteger(getYamlPath(content, "memory.user_char_limit")) ??
+      DEFAULT_USER_CHAR_LIMIT,
+  };
+}

--- a/src/main/memory.ts
+++ b/src/main/memory.ts
@@ -2,10 +2,9 @@ import { existsSync, readFileSync, statSync } from "fs";
 import { join } from "path";
 import Database from "better-sqlite3";
 import { profileHome, safeWriteFile } from "./utils";
+import { parseMemoryLimitsConfig, type MemoryLimits } from "./memory-limits";
 
 const ENTRY_DELIMITER = "\n§\n";
-const MEMORY_CHAR_LIMIT = 2200;
-const USER_CHAR_LIMIT = 1375;
 
 export interface MemoryEntry {
   index: number;
@@ -37,6 +36,20 @@ function memoryPath(profile?: string): string {
 
 function userPath(profile?: string): string {
   return join(profileHome(profile), "memories", "USER.md");
+}
+
+function configPath(profile?: string): string {
+  return join(profileHome(profile), "config.yaml");
+}
+
+function readMemoryLimits(profile?: string): MemoryLimits {
+  try {
+    const filePath = configPath(profile);
+    if (!existsSync(filePath)) return parseMemoryLimitsConfig("");
+    return parseMemoryLimitsConfig(readFileSync(filePath, "utf-8"));
+  } catch {
+    return parseMemoryLimitsConfig("");
+  }
 }
 
 function readFileSafe(filePath: string): {
@@ -110,18 +123,19 @@ function getSessionStats(profile?: string): {
 export function readMemory(profile?: string): MemoryInfo {
   const memFile = readFileSafe(memoryPath(profile));
   const userFile = readFileSafe(userPath(profile));
+  const limits = readMemoryLimits(profile);
 
   return {
     memory: {
       ...memFile,
       entries: parseMemoryEntries(memFile.content),
       charCount: memFile.content.length,
-      charLimit: MEMORY_CHAR_LIMIT,
+      charLimit: limits.memoryCharLimit,
     },
     user: {
       ...userFile,
       charCount: userFile.content.length,
-      charLimit: USER_CHAR_LIMIT,
+      charLimit: limits.userCharLimit,
     },
     stats: getSessionStats(profile),
   };
@@ -140,11 +154,12 @@ export function addMemoryEntry(
     ...entries,
     { index: entries.length, content: content.trim() },
   ]);
+  const limits = readMemoryLimits(profile);
 
-  if (newContent.length > MEMORY_CHAR_LIMIT) {
+  if (newContent.length > limits.memoryCharLimit) {
     return {
       success: false,
-      error: `Would exceed memory limit (${newContent.length}/${MEMORY_CHAR_LIMIT} chars)`,
+      error: `Would exceed memory limit (${newContent.length}/${limits.memoryCharLimit} chars)`,
     };
   }
 
@@ -167,11 +182,12 @@ export function updateMemoryEntry(
 
   entries[index] = { ...entries[index], content: content.trim() };
   const newContent = serializeEntries(entries);
+  const limits = readMemoryLimits(profile);
 
-  if (newContent.length > MEMORY_CHAR_LIMIT) {
+  if (newContent.length > limits.memoryCharLimit) {
     return {
       success: false,
-      error: `Would exceed memory limit (${newContent.length}/${MEMORY_CHAR_LIMIT} chars)`,
+      error: `Would exceed memory limit (${newContent.length}/${limits.memoryCharLimit} chars)`,
     };
   }
 
@@ -195,10 +211,11 @@ export function writeUserProfile(
   content: string,
   profile?: string,
 ): { success: boolean; error?: string } {
-  if (content.length > USER_CHAR_LIMIT) {
+  const limits = readMemoryLimits(profile);
+  if (content.length > limits.userCharLimit) {
     return {
       success: false,
-      error: `Exceeds limit (${content.length}/${USER_CHAR_LIMIT} chars)`,
+      error: `Exceeds limit (${content.length}/${limits.userCharLimit} chars)`,
     };
   }
   writeFileSafe(userPath(profile), content);

--- a/src/main/ssh-remote.ts
+++ b/src/main/ssh-remote.ts
@@ -21,6 +21,7 @@ import type { CachedSession } from "./session-cache";
 import type { ToolsetInfo } from "./tools";
 import type { SavedModel } from "./models";
 import type { MemoryProviderInfo } from "./installer";
+import { parseMemoryLimitsConfig, type MemoryLimits } from "./memory-limits";
 import { t } from "../shared/i18n";
 import { getAppLocale } from "./locale";
 import { HIDDEN_SUBPROCESS_OPTIONS } from "./process-options";
@@ -302,8 +303,6 @@ export async function sshListBundledSkills(
 // ── Memory ───────────────────────────────────────────────────────────────────
 
 const ENTRY_DELIMITER = "\n§\n";
-const MEMORY_CHAR_LIMIT = 2200;
-const USER_CHAR_LIMIT = 1375;
 
 function parseMemoryEntries(
   content: string,
@@ -333,6 +332,14 @@ function remoteUserPath(profile?: string): string {
     return `~/.hermes/profiles/${profile}/memories/USER.md`;
   }
   return "~/.hermes/memories/USER.md";
+}
+
+async function sshReadMemoryLimits(
+  config: SshConfig,
+  profile?: string,
+): Promise<MemoryLimits> {
+  const content = await sshReadFile(config, remoteConfigPath(profile));
+  return parseMemoryLimitsConfig(content);
 }
 
 async function sshGetSessionStats(
@@ -369,9 +376,12 @@ export async function sshReadMemory(
   config: SshConfig,
   profile?: string,
 ): Promise<MemoryInfo> {
-  const memContent = await sshReadFile(config, remoteMemoryPath(profile));
-  const userContent = await sshReadFile(config, remoteUserPath(profile));
-  const stats = await sshGetSessionStats(config, profile);
+  const [memContent, userContent, stats, limits] = await Promise.all([
+    sshReadFile(config, remoteMemoryPath(profile)),
+    sshReadFile(config, remoteUserPath(profile)),
+    sshGetSessionStats(config, profile),
+    sshReadMemoryLimits(config, profile),
+  ]);
 
   return {
     memory: {
@@ -380,14 +390,14 @@ export async function sshReadMemory(
       lastModified: null,
       entries: parseMemoryEntries(memContent),
       charCount: memContent.length,
-      charLimit: MEMORY_CHAR_LIMIT,
+      charLimit: limits.memoryCharLimit,
     },
     user: {
       content: userContent,
       exists: userContent.length > 0,
       lastModified: null,
       charCount: userContent.length,
-      charLimit: USER_CHAR_LIMIT,
+      charLimit: limits.userCharLimit,
     },
     stats,
   };
@@ -398,16 +408,19 @@ export async function sshAddMemoryEntry(
   content: string,
   profile?: string,
 ): Promise<{ success: boolean; error?: string }> {
-  const current = await sshReadFile(config, remoteMemoryPath(profile));
+  const [current, limits] = await Promise.all([
+    sshReadFile(config, remoteMemoryPath(profile)),
+    sshReadMemoryLimits(config, profile),
+  ]);
   const entries = parseMemoryEntries(current);
   const newContent = serializeEntries([
     ...entries,
     { index: entries.length, content: content.trim() },
   ]);
-  if (newContent.length > MEMORY_CHAR_LIMIT) {
+  if (newContent.length > limits.memoryCharLimit) {
     return {
       success: false,
-      error: `Would exceed memory limit (${newContent.length}/${MEMORY_CHAR_LIMIT} chars)`,
+      error: `Would exceed memory limit (${newContent.length}/${limits.memoryCharLimit} chars)`,
     };
   }
   await sshWriteFile(config, remoteMemoryPath(profile), newContent);
@@ -420,16 +433,19 @@ export async function sshUpdateMemoryEntry(
   content: string,
   profile?: string,
 ): Promise<{ success: boolean; error?: string }> {
-  const current = await sshReadFile(config, remoteMemoryPath(profile));
+  const [current, limits] = await Promise.all([
+    sshReadFile(config, remoteMemoryPath(profile)),
+    sshReadMemoryLimits(config, profile),
+  ]);
   const entries = parseMemoryEntries(current);
   if (index < 0 || index >= entries.length)
     return { success: false, error: "Entry not found" };
   entries[index] = { ...entries[index], content: content.trim() };
   const newContent = serializeEntries(entries);
-  if (newContent.length > MEMORY_CHAR_LIMIT) {
+  if (newContent.length > limits.memoryCharLimit) {
     return {
       success: false,
-      error: `Would exceed memory limit (${newContent.length}/${MEMORY_CHAR_LIMIT} chars)`,
+      error: `Would exceed memory limit (${newContent.length}/${limits.memoryCharLimit} chars)`,
     };
   }
   await sshWriteFile(config, remoteMemoryPath(profile), newContent);
@@ -458,10 +474,11 @@ export async function sshWriteUserProfile(
   content: string,
   profile?: string,
 ): Promise<{ success: boolean; error?: string }> {
-  if (content.length > USER_CHAR_LIMIT) {
+  const limits = await sshReadMemoryLimits(config, profile);
+  if (content.length > limits.userCharLimit) {
     return {
       success: false,
-      error: `Exceeds limit (${content.length}/${USER_CHAR_LIMIT} chars)`,
+      error: `Exceeds limit (${content.length}/${limits.userCharLimit} chars)`,
     };
   }
   await sshWriteFile(config, remoteUserPath(profile), content);

--- a/tests/memory-limits.test.ts
+++ b/tests/memory-limits.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+
+const { TEST_HOME } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const path = require("path");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const os = require("os");
+  return {
+    TEST_HOME: path.join(
+      os.tmpdir(),
+      `hermes-memory-limits-test-${Date.now()}`,
+    ),
+  };
+});
+
+vi.mock("../src/main/installer", () => ({
+  HERMES_HOME: TEST_HOME,
+}));
+
+vi.mock("better-sqlite3", () => ({
+  default: vi.fn(),
+}));
+
+import {
+  DEFAULT_MEMORY_CHAR_LIMIT,
+  DEFAULT_USER_CHAR_LIMIT,
+  parseMemoryLimitsConfig,
+} from "../src/main/memory-limits";
+import {
+  addMemoryEntry,
+  readMemory,
+  updateMemoryEntry,
+  writeUserProfile,
+} from "../src/main/memory";
+
+function profileDir(profile?: string): string {
+  return profile ? join(TEST_HOME, "profiles", profile) : TEST_HOME;
+}
+
+function writeConfig(content: string, profile?: string): void {
+  const dir = profileDir(profile);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "config.yaml"), content, "utf-8");
+}
+
+function writeMemoryFile(content: string, profile?: string): void {
+  const dir = join(profileDir(profile), "memories");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "MEMORY.md"), content, "utf-8");
+}
+
+beforeEach(() => {
+  rmSync(TEST_HOME, { recursive: true, force: true });
+  mkdirSync(TEST_HOME, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(TEST_HOME, { recursive: true, force: true });
+});
+
+describe("parseMemoryLimitsConfig", () => {
+  it("reads both memory limits from the memory block", () => {
+    expect(
+      parseMemoryLimitsConfig(
+        [
+          "memory:",
+          "  memory_char_limit: 3200",
+          "  user_char_limit: '2000'",
+          "",
+        ].join("\n"),
+      ),
+    ).toEqual({ memoryCharLimit: 3200, userCharLimit: 2000 });
+  });
+
+  it("falls back when configured limits are missing or invalid", () => {
+    expect(
+      parseMemoryLimitsConfig(
+        [
+          "memory:",
+          "  memory_char_limit: not-a-number",
+          "  user_char_limit: 0",
+          "",
+        ].join("\n"),
+      ),
+    ).toEqual({
+      memoryCharLimit: DEFAULT_MEMORY_CHAR_LIMIT,
+      userCharLimit: DEFAULT_USER_CHAR_LIMIT,
+    });
+  });
+});
+
+describe("memory limits from active profile config.yaml", () => {
+  it("returns configured local memory limits in readMemory", () => {
+    writeConfig(
+      [
+        "memory:",
+        "  memory_char_limit: 3200",
+        "  user_char_limit: 2000",
+        "",
+      ].join("\n"),
+    );
+    writeMemoryFile("remember this");
+
+    const info = readMemory();
+
+    expect(info.memory.charLimit).toBe(3200);
+    expect(info.user.charLimit).toBe(2000);
+  });
+
+  it("uses a named profile's config.yaml instead of default constants", () => {
+    writeConfig(
+      [
+        "memory:",
+        "  memory_char_limit: 4096",
+        "  user_char_limit: 2048",
+        "",
+      ].join("\n"),
+      "work",
+    );
+    writeMemoryFile("profile-scoped memory", "work");
+
+    const info = readMemory("work");
+
+    expect(info.memory.charLimit).toBe(4096);
+    expect(info.user.charLimit).toBe(2048);
+  });
+
+  it("allows memory and user writes up to the configured limits", () => {
+    writeConfig(
+      [
+        "memory:",
+        "  memory_char_limit: 3200",
+        "  user_char_limit: 2000",
+        "",
+      ].join("\n"),
+    );
+
+    expect(addMemoryEntry("x".repeat(2600))).toEqual({ success: true });
+    expect(writeUserProfile("u".repeat(1800))).toEqual({ success: true });
+
+    expect(
+      readFileSync(join(TEST_HOME, "memories", "MEMORY.md"), "utf-8").length,
+    ).toBe(2600);
+    expect(
+      readFileSync(join(TEST_HOME, "memories", "USER.md"), "utf-8").length,
+    ).toBe(1800);
+  });
+
+  it("uses profile limits when validating memory entry updates", () => {
+    writeConfig(
+      [
+        "memory:",
+        "  memory_char_limit: 2600",
+        "  user_char_limit: 1375",
+        "",
+      ].join("\n"),
+      "work",
+    );
+    writeMemoryFile("short", "work");
+
+    expect(updateMemoryEntry(0, "x".repeat(2300), "work")).toEqual({
+      success: true,
+    });
+  });
+
+  it("falls back to defaults for invalid config values", () => {
+    writeConfig(
+      [
+        "memory:",
+        "  memory_char_limit: nope",
+        "  user_char_limit: -1",
+        "",
+      ].join("\n"),
+    );
+
+    const result = addMemoryEntry("x".repeat(DEFAULT_MEMORY_CHAR_LIMIT + 1));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain(`/${DEFAULT_MEMORY_CHAR_LIMIT} chars`);
+  });
+});


### PR DESCRIPTION
## Summary
- read `memory.memory_char_limit` and `memory.user_char_limit` from the active profile's `config.yaml`, with the existing 2200 / 1375 defaults as fallback
- use the resolved limits for Memory page payloads and for local add/update/user-profile write validation
- apply the same config-based limits in SSH mode so remote profiles are consistent with local profiles

Fixes #483

## Tests
- `npm test` (clean worktree: 64 files, 716 passed, 3 skipped)
- `npm run typecheck`
- `npx eslint src/main/memory-limits.ts src/main/memory.ts src/main/ssh-remote.ts tests/memory-limits.test.ts`