### PR TITLE
Add terminal launcher to worktree panel

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,7 +10,7 @@ import {
   session,
 } from "electron";
 import { join, extname } from "path";
-import { readdir, readFile } from "fs/promises";
+import { readdir, readFile, stat } from "fs/promises";
 import { electronApp, optimizer, is } from "@electron-toolkit/utils";
 import type { AppUpdater } from "electron-updater";
 import icon from "../../resources/icon.png?asset";
@@ -18,6 +18,7 @@ import type { Attachment } from "../shared/attachments";
 import { stageAttachment, clearStagedAttachments } from "./attachment-staging";
 import { discoverProviderModels } from "./model-discovery";
 import { readMediaAsDataUrl, saveMedia, mediaFileExists } from "./media";
+import { openTerminalInDirectory } from "./terminal-launcher";
 import {
   checkInstallStatus,
   verifyInstall,
@@ -1727,6 +1728,19 @@ function setupIPC(): void {
     try {
       await shell.openPath(filePath);
       return true;
+    } catch {
+      return false;
+    }
+  });
+
+  ipcMain.handle("open-terminal", async (_event, dirPath: string) => {
+    if (isRemoteOnlyMode()) return false;
+    if (typeof dirPath !== "string" || dirPath.trim().length === 0)
+      return false;
+    try {
+      const info = await stat(dirPath);
+      if (!info.isDirectory()) return false;
+      return await openTerminalInDirectory(dirPath);
     } catch {
       return false;
     }

--- a/src/main/terminal-launcher.ts
+++ b/src/main/terminal-launcher.ts
@@ -1,0 +1,587 @@
+import { execFile, spawn } from "child_process";
+import {
+  accessSync,
+  constants,
+  existsSync,
+  readdirSync,
+  realpathSync,
+} from "fs";
+import { posix, win32 } from "path";
+import { promisify } from "util";
+
+export interface TerminalCommand {
+  command: string;
+  args: string[];
+  cwd: string;
+}
+
+interface ResolveOptions {
+  env?: NodeJS.ProcessEnv;
+  exists?: (filePath: string) => boolean;
+  getWindowsPackageInstallLocations?: (
+    packageName: string,
+    systemRoot: string,
+  ) => string[];
+  listDirs?: (dirPath: string) => string[];
+  platform?: NodeJS.Platform;
+  realpath?: (filePath: string) => string;
+}
+
+const LINUX_TERMINALS = [
+  "x-terminal-emulator",
+  "gnome-terminal",
+  "konsole",
+  "xfce4-terminal",
+  "mate-terminal",
+  "xterm",
+];
+
+const execFileAsync = promisify(execFile);
+const windowsPackageLocationCache = new Map<string, Promise<string[]>>();
+
+function pathForPlatform(platform: NodeJS.Platform): typeof win32 | typeof posix {
+  return platform === "win32" ? win32 : posix;
+}
+
+function pathDelimiterForPlatform(platform: NodeJS.Platform): string {
+  return platform === "win32" ? ";" : ":";
+}
+
+function isPathInsideOrEqual(
+  filePath: string,
+  rootPath: string,
+  platform: NodeJS.Platform,
+): boolean {
+  const pathApi = pathForPlatform(platform);
+  const relative = pathApi.relative(
+    pathApi.resolve(rootPath),
+    pathApi.resolve(filePath),
+  );
+  return (
+    relative === "" ||
+    (!relative.startsWith("..") && !pathApi.isAbsolute(relative))
+  );
+}
+
+function defaultExists(filePath: string): boolean {
+  if (process.platform === "win32") return existsSync(filePath);
+  try {
+    accessSync(filePath, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function defaultRealpath(filePath: string): string {
+  return realpathSync.native(filePath);
+}
+
+function defaultListDirs(dirPath: string): string[] {
+  try {
+    return readdirSync(dirPath, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+  } catch {
+    return [];
+  }
+}
+
+async function defaultWindowsPackageInstallLocationsAsync(
+  packageName: string,
+  systemRoot: string,
+): Promise<string[]> {
+  const cacheKey = `${systemRoot}\0${packageName}`;
+  const cached = windowsPackageLocationCache.get(cacheKey);
+  if (cached) return cached;
+
+  const promise = queryWindowsPackageInstallLocations(packageName, systemRoot);
+  windowsPackageLocationCache.set(cacheKey, promise);
+  return promise;
+}
+
+async function queryWindowsPackageInstallLocations(
+  packageName: string,
+  systemRoot: string,
+): Promise<string[]> {
+  const powershell = win32.join(
+    systemRoot,
+    "System32",
+    "WindowsPowerShell",
+    "v1.0",
+    "powershell.exe",
+  );
+  if (!existsSync(powershell)) return [];
+
+  try {
+    const { stdout } = (await execFileAsync(
+      powershell,
+      [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        [
+          `$packages = Get-AppxPackage -Name '${packageName}'`,
+          "$packages | Sort-Object Version -Descending | Select-Object -ExpandProperty InstallLocation",
+        ].join("; "),
+      ],
+      {
+        encoding: "utf8",
+        timeout: 3000,
+        windowsHide: true,
+      },
+    )) as { stdout: string };
+    return stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function tryRealpath(
+  filePath: string,
+  realpath: (path: string) => string,
+): string | null {
+  try {
+    return realpath(filePath);
+  } catch {
+    return null;
+  }
+}
+
+function windowsSystemDrive(env: NodeJS.ProcessEnv): string {
+  const drive = env.SystemDrive || "C:";
+  return /^[a-z]:$/i.test(drive) ? drive : "C:";
+}
+
+function findWindowsAppsExecutable(
+  programFiles: string,
+  packagePrefix: string,
+  exeName: string,
+  exists: (filePath: string) => boolean,
+  listDirs: (dirPath: string) => string[],
+): string | null {
+  const windowsApps = win32.join(programFiles, "WindowsApps");
+  const packageDirs = listDirs(windowsApps)
+    .filter((name) => name.startsWith(packagePrefix))
+    .sort()
+    .reverse();
+
+  for (const packageDir of packageDirs) {
+    const exePath = win32.join(windowsApps, packageDir, exeName);
+    if (exists(exePath)) return exePath;
+  }
+
+  return null;
+}
+
+function findTrustedWindowsPackageExecutable(
+  packageName: string,
+  packagePrefix: string,
+  exeName: string,
+  programFiles: string,
+  systemRoot: string,
+  exists: (filePath: string) => boolean,
+  listDirs: (dirPath: string) => string[],
+  getPackageInstallLocations: (
+    packageName: string,
+    systemRoot: string,
+  ) => string[],
+): string | null {
+  const windowsApps = win32.join(programFiles, "WindowsApps");
+
+  for (const installLocation of getPackageInstallLocations(
+    packageName,
+    systemRoot,
+  )) {
+    const normalized = win32.normalize(installLocation);
+    const packageDir = win32.basename(normalized);
+    if (!packageDir.startsWith(packagePrefix)) continue;
+    if (!isPathInsideOrEqual(normalized, windowsApps, "win32")) continue;
+
+    const exePath = win32.join(normalized, exeName);
+    if (exists(exePath)) return exePath;
+  }
+
+  return findWindowsAppsExecutable(
+    programFiles,
+    packagePrefix,
+    exeName,
+    exists,
+    listDirs,
+  );
+}
+
+async function findTrustedWindowsPackageExecutableAsync(
+  packageName: string,
+  packagePrefix: string,
+  exeName: string,
+  programFiles: string,
+  systemRoot: string,
+  exists: (filePath: string) => boolean,
+  listDirs: (dirPath: string) => string[],
+  getPackageInstallLocations: (
+    packageName: string,
+    systemRoot: string,
+  ) => Promise<string[]>,
+): Promise<string | null> {
+  const windowsApps = win32.join(programFiles, "WindowsApps");
+
+  for (const installLocation of await getPackageInstallLocations(
+    packageName,
+    systemRoot,
+  )) {
+    const normalized = win32.normalize(installLocation);
+    const packageDir = win32.basename(normalized);
+    if (!packageDir.startsWith(packagePrefix)) continue;
+    if (!isPathInsideOrEqual(normalized, windowsApps, "win32")) continue;
+
+    const exePath = win32.join(normalized, exeName);
+    if (exists(exePath)) return exePath;
+  }
+
+  return findWindowsAppsExecutable(
+    programFiles,
+    packagePrefix,
+    exeName,
+    exists,
+    listDirs,
+  );
+}
+
+function resolveExecutableFromPath(
+  command: string,
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+  exists: (filePath: string) => boolean,
+  realpath: (filePath: string) => string,
+  blockedRoot: string,
+): string | null {
+  const pathApi = pathForPlatform(platform);
+  const trimmed = command.trim();
+  if (!trimmed || /[\s"'`]/.test(trimmed)) return null;
+  const blockedRealpath = exists(blockedRoot)
+    ? tryRealpath(blockedRoot, realpath) || blockedRoot
+    : blockedRoot;
+
+  if (pathApi.isAbsolute(trimmed)) {
+    if (!exists(trimmed)) return null;
+    const resolved = tryRealpath(trimmed, realpath);
+    if (!resolved) return null;
+    if (isPathInsideOrEqual(resolved, blockedRealpath, platform)) return null;
+    return resolved;
+  }
+
+  // Do not support relative paths here: the terminal launcher should never
+  // resolve an executable from the selected worktree.
+  if (trimmed.includes("/") || trimmed.includes("\\")) return null;
+
+  const rawPath = env.PATH || env.Path || "";
+  const entries = rawPath
+    .split(pathDelimiterForPlatform(platform))
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .filter((entry) => pathApi.isAbsolute(entry));
+
+  const extensions =
+    platform === "win32"
+      ? (env.PATHEXT || ".EXE;.CMD;.BAT;.COM")
+          .split(";")
+          .map((ext) => ext.toLowerCase())
+      : [""];
+  const hasExtension =
+    platform === "win32" && Boolean(pathApi.extname(trimmed));
+
+  for (const entry of entries) {
+    const candidates =
+      platform === "win32" && !hasExtension
+        ? extensions.map((ext) => pathApi.join(entry, `${trimmed}${ext}`))
+        : [pathApi.join(entry, trimmed)];
+    for (const candidate of candidates) {
+      if (!exists(candidate)) continue;
+      const resolved = tryRealpath(candidate, realpath);
+      if (!resolved) continue;
+      if (!isPathInsideOrEqual(resolved, blockedRealpath, platform)) {
+        return resolved;
+      }
+    }
+  }
+
+  return null;
+}
+
+function resolveWindowsTerminal(
+  dirPath: string,
+  env: NodeJS.ProcessEnv,
+  exists: (filePath: string) => boolean,
+  listDirs: (dirPath: string) => string[],
+  getPackageInstallLocations: (
+    packageName: string,
+    systemRoot: string,
+  ) => string[],
+): TerminalCommand | null {
+  const systemDrive = windowsSystemDrive(env);
+  const systemRoot = win32.join(systemDrive, "Windows");
+  const programFiles = win32.join(systemDrive, "Program Files");
+  const programFilesX86 = win32.join(systemDrive, "Program Files (x86)");
+  const cmd = win32.join(systemRoot, "System32", "cmd.exe");
+  if (!exists(cmd)) return null;
+
+  const startCommand = (target: string, args: string[]): TerminalCommand => ({
+    command: cmd,
+    args: ["/d", "/s", "/c", "start", "", "/D", dirPath, target, ...args],
+    cwd: dirPath,
+  });
+
+  const pwshCandidates = [
+    win32.join(programFiles, "PowerShell", "7", "pwsh.exe"),
+    win32.join(programFilesX86, "PowerShell", "7", "pwsh.exe"),
+    findTrustedWindowsPackageExecutable(
+      "Microsoft.PowerShell",
+      "Microsoft.PowerShell_",
+      "pwsh.exe",
+      programFiles,
+      systemRoot,
+      exists,
+      listDirs,
+      getPackageInstallLocations,
+    ),
+  ];
+  const pwsh = pwshCandidates.find(
+    (candidate): candidate is string => Boolean(candidate && exists(candidate)),
+  );
+  if (pwsh) {
+    return startCommand(pwsh, ["-NoExit", "-NoLogo"]);
+  }
+
+  const windowsTerminal =
+    findTrustedWindowsPackageExecutable(
+      "Microsoft.WindowsTerminal",
+      "Microsoft.WindowsTerminal_",
+      "WindowsTerminal.exe",
+      programFiles,
+      systemRoot,
+      exists,
+      listDirs,
+      getPackageInstallLocations,
+    ) ||
+    findTrustedWindowsPackageExecutable(
+      "Microsoft.WindowsTerminalPreview",
+      "Microsoft.WindowsTerminalPreview_",
+      "WindowsTerminal.exe",
+      programFiles,
+      systemRoot,
+      exists,
+      listDirs,
+      getPackageInstallLocations,
+    );
+  if (windowsTerminal && exists(windowsTerminal)) {
+    return startCommand(windowsTerminal, ["-d", dirPath]);
+  }
+
+  const powershell = win32.join(
+    systemRoot,
+    "System32",
+    "WindowsPowerShell",
+    "v1.0",
+    "powershell.exe",
+  );
+  if (exists(powershell)) {
+    return startCommand(powershell, ["-NoExit", "-NoLogo"]);
+  }
+
+  return null;
+}
+
+async function resolveWindowsTerminalAsync(
+  dirPath: string,
+  env: NodeJS.ProcessEnv,
+  exists: (filePath: string) => boolean,
+  listDirs: (dirPath: string) => string[],
+  getPackageInstallLocations: (
+    packageName: string,
+    systemRoot: string,
+  ) => Promise<string[]>,
+): Promise<TerminalCommand | null> {
+  const systemDrive = windowsSystemDrive(env);
+  const systemRoot = win32.join(systemDrive, "Windows");
+  const programFiles = win32.join(systemDrive, "Program Files");
+  const programFilesX86 = win32.join(systemDrive, "Program Files (x86)");
+  const cmd = win32.join(systemRoot, "System32", "cmd.exe");
+  if (!exists(cmd)) return null;
+
+  const startCommand = (target: string, args: string[]): TerminalCommand => ({
+    command: cmd,
+    args: ["/d", "/s", "/c", "start", "", "/D", dirPath, target, ...args],
+    cwd: dirPath,
+  });
+
+  const packagePwsh = await findTrustedWindowsPackageExecutableAsync(
+    "Microsoft.PowerShell",
+    "Microsoft.PowerShell_",
+    "pwsh.exe",
+    programFiles,
+    systemRoot,
+    exists,
+    listDirs,
+    getPackageInstallLocations,
+  );
+  const pwshCandidates = [
+    win32.join(programFiles, "PowerShell", "7", "pwsh.exe"),
+    win32.join(programFilesX86, "PowerShell", "7", "pwsh.exe"),
+    packagePwsh,
+  ];
+  const pwsh = pwshCandidates.find(
+    (candidate): candidate is string => Boolean(candidate && exists(candidate)),
+  );
+  if (pwsh) {
+    return startCommand(pwsh, ["-NoExit", "-NoLogo"]);
+  }
+
+  const windowsTerminal =
+    (await findTrustedWindowsPackageExecutableAsync(
+      "Microsoft.WindowsTerminal",
+      "Microsoft.WindowsTerminal_",
+      "WindowsTerminal.exe",
+      programFiles,
+      systemRoot,
+      exists,
+      listDirs,
+      getPackageInstallLocations,
+    )) ||
+    (await findTrustedWindowsPackageExecutableAsync(
+      "Microsoft.WindowsTerminalPreview",
+      "Microsoft.WindowsTerminalPreview_",
+      "WindowsTerminal.exe",
+      programFiles,
+      systemRoot,
+      exists,
+      listDirs,
+      getPackageInstallLocations,
+    ));
+  if (windowsTerminal && exists(windowsTerminal)) {
+    return startCommand(windowsTerminal, ["-d", dirPath]);
+  }
+
+  const powershell = win32.join(
+    systemRoot,
+    "System32",
+    "WindowsPowerShell",
+    "v1.0",
+    "powershell.exe",
+  );
+  if (exists(powershell)) {
+    return startCommand(powershell, ["-NoExit", "-NoLogo"]);
+  }
+
+  return null;
+}
+
+export function resolveTerminalCommand(
+  dirPath: string,
+  options: ResolveOptions = {},
+): TerminalCommand | null {
+  const platform = options.platform || process.platform;
+  const env = options.env || process.env;
+  const exists = options.exists || defaultExists;
+  const listDirs = options.listDirs || defaultListDirs;
+  const realpath = options.realpath || defaultRealpath;
+
+  if (platform === "win32") {
+    return resolveWindowsTerminal(
+      dirPath,
+      env,
+      exists,
+      listDirs,
+      options.getWindowsPackageInstallLocations || (() => []),
+    );
+  }
+
+  if (platform === "darwin") {
+    const open = "/usr/bin/open";
+    return exists(open)
+      ? { command: open, args: ["-a", "Terminal", dirPath], cwd: dirPath }
+      : null;
+  }
+
+  const candidates = [env.TERMINAL, ...LINUX_TERMINALS].filter(
+    (candidate): candidate is string => Boolean(candidate),
+  );
+  for (const candidate of candidates) {
+    const resolved = resolveExecutableFromPath(
+      candidate,
+      env,
+      platform,
+      exists,
+      realpath,
+      dirPath,
+    );
+    if (resolved) return { command: resolved, args: [], cwd: dirPath };
+  }
+
+  return null;
+}
+
+export async function resolveTerminalCommandAsync(
+  dirPath: string,
+  options: ResolveOptions = {},
+): Promise<TerminalCommand | null> {
+  const platform = options.platform || process.platform;
+  if (platform !== "win32") return resolveTerminalCommand(dirPath, options);
+
+  const env = options.env || process.env;
+  const exists = options.exists || defaultExists;
+  const listDirs = options.listDirs || defaultListDirs;
+  const getPackageInstallLocations = options.getWindowsPackageInstallLocations
+    ? (packageName: string, systemRoot: string): Promise<string[]> =>
+        Promise.resolve(
+          options.getWindowsPackageInstallLocations?.(packageName, systemRoot) ||
+            [],
+        )
+    : defaultWindowsPackageInstallLocationsAsync;
+
+  return resolveWindowsTerminalAsync(
+    dirPath,
+    env,
+    exists,
+    listDirs,
+    getPackageInstallLocations,
+  );
+}
+
+export async function openTerminalInDirectory(
+  dirPath: string,
+): Promise<boolean> {
+  const terminal = await resolveTerminalCommandAsync(dirPath);
+  if (!terminal) return false;
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (value: boolean): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(fallbackTimer);
+      resolve(value);
+    };
+    const fallbackTimer = setTimeout(() => settle(true), 1000);
+    fallbackTimer.unref?.();
+
+    try {
+      const child = spawn(terminal.command, terminal.args, {
+        cwd: terminal.cwd,
+        detached: true,
+        stdio: "ignore",
+        windowsHide: false,
+      });
+      child.once("error", () => settle(false));
+      child.once("spawn", () => {
+        child.unref();
+        settle(true);
+      });
+    } catch {
+      settle(false);
+    }
+  });
+}

--- a/src/main/terminal-launcher.ts
+++ b/src/main/terminal-launcher.ts
@@ -95,7 +95,13 @@ async function defaultWindowsPackageInstallLocationsAsync(
   const cached = windowsPackageLocationCache.get(cacheKey);
   if (cached) return cached;
 
-  const promise = queryWindowsPackageInstallLocations(packageName, systemRoot);
+  const promise = queryWindowsPackageInstallLocations(
+    packageName,
+    systemRoot,
+  ).then((locations) => {
+    if (locations.length === 0) windowsPackageLocationCache.delete(cacheKey);
+    return locations;
+  });
   windowsPackageLocationCache.set(cacheKey, promise);
   return promise;
 }
@@ -312,6 +318,22 @@ function resolveExecutableFromPath(
   return null;
 }
 
+function linuxTerminalArgs(resolvedPath: string, dirPath: string): string[] {
+  const executable = posix.basename(resolvedPath);
+  if (
+    executable === "gnome-terminal" ||
+    executable === "gnome-terminal.wrapper" ||
+    executable === "xfce4-terminal" ||
+    executable === "mate-terminal"
+  ) {
+    return [`--working-directory=${dirPath}`];
+  }
+  if (executable === "konsole") {
+    return ["--workdir", dirPath];
+  }
+  return [];
+}
+
 function resolveWindowsTerminal(
   dirPath: string,
   env: NodeJS.ProcessEnv,
@@ -518,7 +540,13 @@ export function resolveTerminalCommand(
       realpath,
       dirPath,
     );
-    if (resolved) return { command: resolved, args: [], cwd: dirPath };
+    if (resolved) {
+      return {
+        command: resolved,
+        args: linuxTerminalArgs(resolved, dirPath),
+        cwd: dirPath,
+      };
+    }
   }
 
   return null;

--- a/src/main/terminal-launcher.ts
+++ b/src/main/terminal-launcher.ts
@@ -334,6 +334,10 @@ function linuxTerminalArgs(resolvedPath: string, dirPath: string): string[] {
   return [];
 }
 
+function hasCmdControlChars(value: string): boolean {
+  return /["^&|<>()%!]/.test(value);
+}
+
 function resolveWindowsTerminal(
   dirPath: string,
   env: NodeJS.ProcessEnv,
@@ -350,6 +354,7 @@ function resolveWindowsTerminal(
   const programFilesX86 = win32.join(systemDrive, "Program Files (x86)");
   const cmd = win32.join(systemRoot, "System32", "cmd.exe");
   if (!exists(cmd)) return null;
+  if (hasCmdControlChars(dirPath)) return null;
 
   const startCommand = (target: string, args: string[]): TerminalCommand => ({
     command: cmd,
@@ -433,6 +438,7 @@ async function resolveWindowsTerminalAsync(
   const programFilesX86 = win32.join(systemDrive, "Program Files (x86)");
   const cmd = win32.join(systemRoot, "System32", "cmd.exe");
   if (!exists(cmd)) return null;
+  if (hasCmdControlChars(dirPath)) return null;
 
   const startCommand = (target: string, args: string[]): TerminalCommand => ({
     command: cmd,

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -786,6 +786,7 @@ interface HermesAPI {
     maxBytes?: number,
   ) => Promise<{ content: string; truncated: boolean } | null>;
   openFileInEditor: (filePath: string) => Promise<boolean>;
+  openTerminal: (dirPath: string) => Promise<boolean>;
   readImageFile: (filePath: string) => Promise<string | null>;
   kanbanAssignTask: (
     taskId: string,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -978,6 +978,8 @@ const hermesAPI = {
     ipcRenderer.invoke("read-file", filePath, maxBytes),
   openFileInEditor: (filePath: string): Promise<boolean> =>
     ipcRenderer.invoke("open-file-in-editor", filePath),
+  openTerminal: (dirPath: string): Promise<boolean> =>
+    ipcRenderer.invoke("open-terminal", dirPath),
   readImageFile: (filePath: string): Promise<string | null> =>
     ipcRenderer.invoke("read-image-file", filePath),
   kanbanAssignTask: (

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1755,12 +1755,50 @@ body {
 }
 
 .worktree-header-title {
+  flex: 1;
+  min-width: 0;
   font-size: 13px;
   font-weight: 600;
   color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.worktree-header-action {
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  color: var(--accent-text);
+  opacity: 1;
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+}
+
+.worktree-header-action:hover {
+  opacity: 1;
+  color: var(--accent-text);
+  background: color-mix(in srgb, var(--accent-text) 10%, transparent);
+}
+
+.worktree-header-action svg {
+  width: 20px;
+  height: 20px;
+  stroke-width: 2.2;
+}
+
+.worktree-terminal-error {
+  padding: 8px 12px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--error);
+  border-top: 1px solid var(--border);
+  background: var(--error-bg);
 }
 
 .worktree-content {

--- a/src/renderer/src/constants.ts
+++ b/src/renderer/src/constants.ts
@@ -347,6 +347,16 @@ export const THEMES: ThemeDef[] = [
   { id: "solarized-light", name: "Solarized Light", appearance: "light" },
 ];
 
+/**
+ * Legacy options retained for older callers/tests that only distinguish between
+ * OS-following, light, and dark modes. New theme pickers should use THEMES.
+ */
+export const THEME_OPTIONS = [
+  { value: "system", label: "System" },
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
+];
+
 /** Themes used by the "System" setting when following the OS preference. */
 export const DEFAULT_DARK_THEME = "dark";
 export const DEFAULT_LIGHT_THEME = "light";

--- a/src/renderer/src/screens/Chat/WorktreePanel.tsx
+++ b/src/renderer/src/screens/Chat/WorktreePanel.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useCallback, memo } from "react";
-import { Folder, ChevronRight, ChevronDown } from "lucide-react";
+import { Folder, ChevronRight, ChevronDown, SquareTerminal } from "lucide-react";
 import { getIconForFile, getSVGStringFromFileType } from "@wesbos/code-icons";
 import { FileViewer } from "./FileViewer";
+import { useI18n } from "../../components/useI18n";
 
 interface FileEntry {
   name: string;
@@ -140,15 +141,18 @@ function TreeItem({
 export const WorktreePanel = memo(function WorktreePanel({
   folderPath,
 }: WorktreePanelProps): React.JSX.Element {
+  const { t } = useI18n();
   const [entries, setEntries] = useState<FileEntry[] | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
+  const [terminalError, setTerminalError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     setIsLoading(true);
     setError(null);
+    setTerminalError(null);
 
     const loadRoot = async (): Promise<void> => {
       const result = await window.hermesAPI.readDirectory(folderPath);
@@ -178,6 +182,12 @@ export const WorktreePanel = memo(function WorktreePanel({
   const folderName =
     folderPath.split(/[\\/]/).filter(Boolean).pop() || folderPath;
 
+  const handleOpenTerminal = async (): Promise<void> => {
+    setTerminalError(null);
+    const opened = await window.hermesAPI.openTerminal(folderPath);
+    if (!opened) setTerminalError(t("chat.worktree.openTerminalFailed"));
+  };
+
   return (
     <div className="worktree-panel">
       <div className="worktree-header">
@@ -185,7 +195,19 @@ export const WorktreePanel = memo(function WorktreePanel({
         <span className="worktree-header-title" title={folderPath}>
           {folderName}
         </span>
+        <button
+          type="button"
+          className="btn-ghost worktree-header-action"
+          onClick={() => void handleOpenTerminal()}
+          aria-label={t("chat.worktree.openTerminal")}
+          title={t("chat.worktree.openTerminal")}
+        >
+          <SquareTerminal size={20} />
+        </button>
       </div>
+      {terminalError && (
+        <div className="worktree-terminal-error">{terminalError}</div>
+      )}
       <div className="worktree-content">
         {isLoading ? (
           <div className="worktree-loading">Loading...</div>

--- a/src/renderer/src/screens/Skills/Skills.test.tsx
+++ b/src/renderer/src/screens/Skills/Skills.test.tsx
@@ -76,6 +76,9 @@ describe("Skills.tsx — Install button (issue #310 diagnosis)", () => {
     // with the card's skill.name and the current profile (undefined here).
     expect(installSkill).toHaveBeenCalledTimes(1);
     expect(installSkill).toHaveBeenCalledWith("concept-diagram", undefined);
+    await waitFor(() => {
+      expect(listInstalledSkills).toHaveBeenCalledTimes(2);
+    });
   });
 
   it("surfaces the CLI error in the UI when installSkill returns success:false (issue #310 fix)", async () => {
@@ -113,12 +116,15 @@ describe("Skills.tsx — Install button (issue #310 diagnosis)", () => {
       expect(listInstalledSkills).toHaveBeenCalled();
     });
 
-    const browseTab = view.container.querySelectorAll(
-      ".skills-tab",
-    )[1] as HTMLButtonElement;
-    expect(browseTab).toBeTruthy();
+    let browseTab: HTMLButtonElement | null = null;
+    await waitFor(() => {
+      browseTab = view.container.querySelectorAll(
+        ".skills-tab",
+      )[1] as HTMLButtonElement | null;
+      expect(browseTab).toBeTruthy();
+    });
     await act(async () => {
-      fireEvent.click(browseTab);
+      fireEvent.click(browseTab!);
     });
 
     let installBtn: HTMLButtonElement | null = null;

--- a/src/shared/i18n/locales/en/chat.ts
+++ b/src/shared/i18n/locales/en/chat.ts
@@ -109,6 +109,8 @@ export default {
     closeFile: "Close",
     open: "Open",
     openInEditor: "Open in default editor",
+    openTerminal: "Open terminal here",
+    openTerminalFailed: "Could not open a terminal for this folder.",
     fileTruncated: "truncated",
     fileTruncatedWarning: "File is too large — showing first 100KB only",
   },

--- a/src/shared/i18n/locales/es/chat.ts
+++ b/src/shared/i18n/locales/es/chat.ts
@@ -112,6 +112,8 @@ export default {
     openInEditor: "Abrir en el editor predeterminado",
     fileTruncated: "truncado",
     fileTruncatedWarning: "El archivo es demasiado grande — mostrando solo los primeros 100KB",
+    openTerminal: "Abrir terminal aquí",
+    openTerminalFailed: "No se pudo abrir una terminal para esta carpeta.",
   },
   showWorktree: "Mostrar explorador de archivos",
   hideWorktree: "Ocultar explorador de archivos",

--- a/src/shared/i18n/locales/id/chat.ts
+++ b/src/shared/i18n/locales/id/chat.ts
@@ -84,5 +84,7 @@ export default {
     empty: "Folder kosong",
     emptyFolder: "Folder kosong",
     errorLoading: "Gagal memuat konten folder",
+    openTerminal: "Buka terminal di sini",
+    openTerminalFailed: "Tidak dapat membuka terminal untuk folder ini.",
   },
 } as const;

--- a/src/shared/i18n/locales/ja/chat.ts
+++ b/src/shared/i18n/locales/ja/chat.ts
@@ -83,5 +83,7 @@ export default {
     empty: "フォルダは空です",
     emptyFolder: "空のフォルダ",
     errorLoading: "フォルダの読み込みに失敗しました",
+    openTerminal: "ここでターミナルを開く",
+    openTerminalFailed: "このフォルダーのターミナルを開けませんでした。",
   },
 } as const;

--- a/src/shared/i18n/locales/pl/chat.ts
+++ b/src/shared/i18n/locales/pl/chat.ts
@@ -93,6 +93,8 @@ export default {
     closeFile: "Zamknij",
     open: "Otwórz",
     openInEditor: "Otwórz w domyślnym edytorze",
+    openTerminal: "Otwórz terminal tutaj",
+    openTerminalFailed: "Nie można otworzyć terminala dla tego folderu.",
     fileTruncated: "obcięto",
     fileTruncatedWarning: "Plik jest za duży — pokazuję tylko pierwsze 100 KB",
   },

--- a/src/shared/i18n/locales/pt-BR/chat.ts
+++ b/src/shared/i18n/locales/pt-BR/chat.ts
@@ -84,5 +84,7 @@ export default {
     empty: "A pasta está vazia",
     emptyFolder: "Pasta vazia",
     errorLoading: "Falha ao carregar conteúdo da pasta",
+    openTerminal: "Abrir terminal aqui",
+    openTerminalFailed: "Não foi possível abrir um terminal para esta pasta.",
   },
 } as const;

--- a/src/shared/i18n/locales/pt-PT/chat.ts
+++ b/src/shared/i18n/locales/pt-PT/chat.ts
@@ -95,5 +95,7 @@ export default {
     empty: "A pasta está vazia",
     emptyFolder: "Pasta vazia",
     errorLoading: "Falha ao carregar conteúdo da pasta",
+    openTerminal: "Abrir terminal aqui",
+    openTerminalFailed: "Não foi possível abrir um terminal para esta pasta.",
   },
 } as const;

--- a/src/shared/i18n/locales/zh-CN/chat.ts
+++ b/src/shared/i18n/locales/zh-CN/chat.ts
@@ -80,5 +80,7 @@ export default {
     empty: "文件夹为空",
     emptyFolder: "空文件夹",
     errorLoading: "加载文件夹内容失败",
+    openTerminal: "在此处打开终端",
+    openTerminalFailed: "无法为此文件夹打开终端。",
   },
 } as const;

--- a/src/shared/i18n/locales/zh-TW/chat.ts
+++ b/src/shared/i18n/locales/zh-TW/chat.ts
@@ -69,5 +69,7 @@ export default {
     empty: "資料夾是空的",
     emptyFolder: "空資料夾",
     errorLoading: "無法載入資料夾內容",
+    openTerminal: "在此處開啟終端機",
+    openTerminalFailed: "無法為此資料夾開啟終端機。",
   },
 } as const;

--- a/tests/ipc-handlers.test.ts
+++ b/tests/ipc-handlers.test.ts
@@ -113,6 +113,7 @@ describe("Legacy IPC handlers preserved", () => {
     "list-cron-jobs",
     "create-cron-job",
     "open-external",
+    "open-terminal",
   ];
 
   for (const ch of legacyChannels) {

--- a/tests/preload-api-surface.test.ts
+++ b/tests/preload-api-surface.test.ts
@@ -190,6 +190,7 @@ describe("Legacy APIs preserved (backward compat)", () => {
     "triggerCronJob",
     // Shell
     "openExternal",
+    "openTerminal",
   ];
 
   for (const method of requiredMethods) {

--- a/tests/terminal-launcher.test.ts
+++ b/tests/terminal-launcher.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveTerminalCommand,
+  resolveTerminalCommandAsync,
+} from "../src/main/terminal-launcher";
+
+describe("terminal launcher command resolution", () => {
+  it("prefers protected Store PowerShell 7 packages on Windows", () => {
+    const command = resolveTerminalCommand("C:\\work\\repo", {
+      platform: "win32",
+      env: {
+        SystemDrive: "C:",
+      },
+      getWindowsPackageInstallLocations: () => [
+        "C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.6.2.0_x64__8wekyb3d8bbwe",
+      ],
+      exists: (filePath) =>
+        filePath ===
+          "C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.6.2.0_x64__8wekyb3d8bbwe\\pwsh.exe" ||
+        filePath === "C:\\Windows\\System32\\cmd.exe",
+    });
+
+    expect(command).toEqual({
+      command: "C:\\Windows\\System32\\cmd.exe",
+      args: [
+        "/d",
+        "/s",
+        "/c",
+        "start",
+        "",
+        "/D",
+        "C:\\work\\repo",
+        "C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.6.2.0_x64__8wekyb3d8bbwe\\pwsh.exe",
+        "-NoExit",
+        "-NoLogo",
+      ],
+      cwd: "C:\\work\\repo",
+    });
+  });
+
+  it("uses the async Windows package resolver for app launches", async () => {
+    const command = await resolveTerminalCommandAsync("C:\\work\\repo", {
+      platform: "win32",
+      env: {
+        SystemDrive: "C:",
+      },
+      getWindowsPackageInstallLocations: () => [
+        "C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.6.2.0_x64__8wekyb3d8bbwe",
+      ],
+      exists: (filePath) =>
+        filePath ===
+          "C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.6.2.0_x64__8wekyb3d8bbwe\\pwsh.exe" ||
+        filePath === "C:\\Windows\\System32\\cmd.exe",
+    });
+
+    expect(command?.args).toContain(
+      "C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.6.2.0_x64__8wekyb3d8bbwe\\pwsh.exe",
+    );
+  });
+
+  it("uses Windows Terminal when PowerShell 7 is unavailable", () => {
+    const command = resolveTerminalCommand("C:\\work\\repo", {
+      platform: "win32",
+      env: {
+        SystemDrive: "C:",
+      },
+      getWindowsPackageInstallLocations: (packageName) =>
+        packageName === "Microsoft.WindowsTerminal"
+          ? [
+              "C:\\Program Files\\WindowsApps\\Microsoft.WindowsTerminal_1.24.11321.0_x64__8wekyb3d8bbwe",
+            ]
+          : [],
+      exists: (filePath) =>
+        filePath ===
+          "C:\\Program Files\\WindowsApps\\Microsoft.WindowsTerminal_1.24.11321.0_x64__8wekyb3d8bbwe\\WindowsTerminal.exe" ||
+        filePath === "C:\\Windows\\System32\\cmd.exe",
+    });
+
+    expect(command).toEqual({
+      command: "C:\\Windows\\System32\\cmd.exe",
+      args: [
+        "/d",
+        "/s",
+        "/c",
+        "start",
+        "",
+        "/D",
+        "C:\\work\\repo",
+        "C:\\Program Files\\WindowsApps\\Microsoft.WindowsTerminal_1.24.11321.0_x64__8wekyb3d8bbwe\\WindowsTerminal.exe",
+        "-d",
+        "C:\\work\\repo",
+      ],
+      cwd: "C:\\work\\repo",
+    });
+  });
+
+  it("does not trust user-profile Windows app execution aliases", () => {
+    const command = resolveTerminalCommand("C:\\work\\repo", {
+      platform: "win32",
+      env: {
+        LOCALAPPDATA: "C:\\Users\\me\\AppData\\Local",
+        SystemDrive: "C:",
+      },
+      exists: (filePath) =>
+        filePath ===
+          "C:\\Users\\me\\AppData\\Local\\Microsoft\\WindowsApps\\pwsh.exe" ||
+        filePath ===
+          "C:\\Users\\me\\AppData\\Local\\Microsoft\\WindowsApps\\wt.exe" ||
+        filePath === "C:\\Windows\\System32\\cmd.exe",
+    });
+
+    expect(command).toBeNull();
+  });
+
+  it("rejects Windows package locations outside protected Program Files", () => {
+    const command = resolveTerminalCommand("C:\\work\\repo", {
+      platform: "win32",
+      env: {
+        SystemDrive: "C:",
+      },
+      getWindowsPackageInstallLocations: () => [
+        "C:\\Users\\me\\AppData\\Local\\Microsoft\\WindowsApps\\Microsoft.PowerShell_8wekyb3d8bbwe",
+      ],
+      exists: (filePath) =>
+        filePath === "C:\\Windows\\System32\\cmd.exe" ||
+        filePath ===
+          "C:\\Users\\me\\AppData\\Local\\Microsoft\\WindowsApps\\Microsoft.PowerShell_8wekyb3d8bbwe\\pwsh.exe",
+    });
+
+    expect(command).toBeNull();
+  });
+
+  it("falls back to the built-in Windows PowerShell by absolute path", () => {
+    const command = resolveTerminalCommand("C:\\work\\repo", {
+      platform: "win32",
+      env: {
+        SystemDrive: "C:",
+      },
+      exists: (filePath) =>
+        filePath === "C:\\Windows\\System32\\cmd.exe" ||
+        filePath ===
+          "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+    });
+
+    expect(command).toEqual({
+      command: "C:\\Windows\\System32\\cmd.exe",
+      args: [
+        "/d",
+        "/s",
+        "/c",
+        "start",
+        "",
+        "/D",
+        "C:\\work\\repo",
+        "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+        "-NoExit",
+        "-NoLogo",
+      ],
+      cwd: "C:\\work\\repo",
+    });
+  });
+
+  it("uses the system macOS open command instead of searching PATH", () => {
+    const command = resolveTerminalCommand("/Users/me/repo", {
+      platform: "darwin",
+      env: { PATH: "/tmp/bin" },
+      exists: (filePath) => filePath === "/usr/bin/open",
+    });
+
+    expect(command).toEqual({
+      command: "/usr/bin/open",
+      args: ["-a", "Terminal", "/Users/me/repo"],
+      cwd: "/Users/me/repo",
+    });
+  });
+
+  it("resolves Linux terminal names from PATH without shell-parsing env args", () => {
+    const command = resolveTerminalCommand("/home/me/repo", {
+      platform: "linux",
+      env: {
+        TERMINAL: "gnome-terminal --new-window",
+        PATH: "/opt/bin:/usr/bin",
+      },
+      exists: (filePath) => filePath === "/usr/bin/x-terminal-emulator",
+      realpath: (filePath) => filePath,
+    });
+
+    expect(command).toEqual({
+      command: "/usr/bin/x-terminal-emulator",
+      args: [],
+      cwd: "/home/me/repo",
+    });
+  });
+
+  it("does not resolve relative terminal executables from the worktree", () => {
+    const command = resolveTerminalCommand("/home/me/repo", {
+      platform: "linux",
+      env: {
+        TERMINAL: "./terminal",
+        PATH: ".",
+      },
+      exists: () => true,
+      realpath: (filePath) => filePath,
+    });
+
+    expect(command).toBeNull();
+  });
+
+  it("ignores every relative PATH entry, not only dot", () => {
+    const command = resolveTerminalCommand("/home/me/repo", {
+      platform: "linux",
+      env: {
+        PATH: "bin:tools",
+      },
+      exists: (filePath) =>
+        filePath === "bin/x-terminal-emulator" ||
+        filePath === "tools/x-terminal-emulator",
+    });
+
+    expect(command).toBeNull();
+  });
+
+  it("does not resolve absolute terminal executables from the worktree", () => {
+    const command = resolveTerminalCommand("/home/me/repo", {
+      platform: "linux",
+      env: {
+        TERMINAL: "/home/me/repo/terminal",
+        PATH: "/home/me/repo/bin",
+      },
+      exists: () => true,
+    });
+
+    expect(command).toBeNull();
+  });
+
+  it("rejects terminal symlinks that resolve back into the worktree", () => {
+    const command = resolveTerminalCommand("/home/me/repo", {
+      platform: "linux",
+      env: {
+        PATH: "/usr/bin",
+      },
+      exists: (filePath) =>
+        filePath === "/home/me/repo" || filePath === "/usr/bin/x-terminal-emulator",
+      realpath: (filePath) =>
+        filePath === "/usr/bin/x-terminal-emulator"
+          ? "/home/me/repo/bin/x-terminal-emulator"
+          : filePath,
+    });
+
+    expect(command).toBeNull();
+  });
+
+  it("rejects candidates when their real path cannot be resolved", () => {
+    const command = resolveTerminalCommand("/home/me/repo", {
+      platform: "linux",
+      env: {
+        PATH: "/usr/bin",
+      },
+      exists: (filePath) => filePath === "/usr/bin/x-terminal-emulator",
+      realpath: () => {
+        throw new Error("realpath failed");
+      },
+    });
+
+    expect(command).toBeNull();
+  });
+});

--- a/tests/terminal-launcher.test.ts
+++ b/tests/terminal-launcher.test.ts
@@ -192,6 +192,53 @@ describe("terminal launcher command resolution", () => {
     });
   });
 
+  it.each([
+    ["gnome-terminal", ["--working-directory=/home/me/repo"]],
+    ["gnome-terminal.wrapper", ["--working-directory=/home/me/repo"]],
+    ["xfce4-terminal", ["--working-directory=/home/me/repo"]],
+    ["mate-terminal", ["--working-directory=/home/me/repo"]],
+    ["konsole", ["--workdir", "/home/me/repo"]],
+  ])(
+    "passes an explicit working directory flag to %s on Linux",
+    (terminal, expectedArgs) => {
+      const command = resolveTerminalCommand("/home/me/repo", {
+        platform: "linux",
+        env: {
+          TERMINAL: terminal,
+          PATH: "/usr/bin",
+        },
+        exists: (filePath) => filePath === `/usr/bin/${terminal}`,
+        realpath: (filePath) => filePath,
+      });
+
+      expect(command).toEqual({
+        command: `/usr/bin/${terminal}`,
+        args: expectedArgs,
+        cwd: "/home/me/repo",
+      });
+    },
+  );
+
+  it("uses the resolved terminal name when a Linux alias points to GNOME Terminal", () => {
+    const command = resolveTerminalCommand("/home/me/repo", {
+      platform: "linux",
+      env: {
+        PATH: "/usr/bin",
+      },
+      exists: (filePath) => filePath === "/usr/bin/x-terminal-emulator",
+      realpath: (filePath) =>
+        filePath === "/usr/bin/x-terminal-emulator"
+          ? "/usr/bin/gnome-terminal.wrapper"
+          : filePath,
+    });
+
+    expect(command).toEqual({
+      command: "/usr/bin/gnome-terminal.wrapper",
+      args: ["--working-directory=/home/me/repo"],
+      cwd: "/home/me/repo",
+    });
+  });
+
   it("does not resolve relative terminal executables from the worktree", () => {
     const command = resolveTerminalCommand("/home/me/repo", {
       platform: "linux",

--- a/tests/terminal-launcher.test.ts
+++ b/tests/terminal-launcher.test.ts
@@ -4,8 +4,36 @@ import {
   resolveTerminalCommandAsync,
 } from "../src/main/terminal-launcher";
 
+const WIN_CMD = "C:\\Windows\\System32\\cmd.exe";
+const WIN_POWERSHELL =
+  "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe";
+
+function windowsStartCommand(
+  dirPath: string,
+  target: string,
+  args: string[],
+): ReturnType<typeof resolveTerminalCommand> {
+  return {
+    args: [
+      "/d",
+      "/s",
+      "/c",
+      "start",
+      "",
+      "/D",
+      dirPath,
+      target,
+      ...args,
+    ],
+    command: WIN_CMD,
+    cwd: dirPath,
+  };
+}
+
 describe("terminal launcher command resolution", () => {
   it("prefers protected Store PowerShell 7 packages on Windows", () => {
+    const target =
+      "C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.6.2.0_x64__8wekyb3d8bbwe\\pwsh.exe";
     const command = resolveTerminalCommand("C:\\work\\repo", {
       platform: "win32",
       env: {
@@ -15,30 +43,18 @@ describe("terminal launcher command resolution", () => {
         "C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.6.2.0_x64__8wekyb3d8bbwe",
       ],
       exists: (filePath) =>
-        filePath ===
-          "C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.6.2.0_x64__8wekyb3d8bbwe\\pwsh.exe" ||
-        filePath === "C:\\Windows\\System32\\cmd.exe",
+        filePath === target ||
+        filePath === WIN_CMD,
     });
 
-    expect(command).toEqual({
-      command: "C:\\Windows\\System32\\cmd.exe",
-      args: [
-        "/d",
-        "/s",
-        "/c",
-        "start",
-        "",
-        "/D",
-        "C:\\work\\repo",
-        "C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.6.2.0_x64__8wekyb3d8bbwe\\pwsh.exe",
-        "-NoExit",
-        "-NoLogo",
-      ],
-      cwd: "C:\\work\\repo",
-    });
+    expect(command).toEqual(
+      windowsStartCommand("C:\\work\\repo", target, ["-NoExit", "-NoLogo"]),
+    );
   });
 
   it("uses the async Windows package resolver for app launches", async () => {
+    const target =
+      "C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.6.2.0_x64__8wekyb3d8bbwe\\pwsh.exe";
     const command = await resolveTerminalCommandAsync("C:\\work\\repo", {
       platform: "win32",
       env: {
@@ -48,17 +64,17 @@ describe("terminal launcher command resolution", () => {
         "C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.6.2.0_x64__8wekyb3d8bbwe",
       ],
       exists: (filePath) =>
-        filePath ===
-          "C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.6.2.0_x64__8wekyb3d8bbwe\\pwsh.exe" ||
-        filePath === "C:\\Windows\\System32\\cmd.exe",
+        filePath === target ||
+        filePath === WIN_CMD,
     });
 
-    expect(command?.args).toContain(
-      "C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.6.2.0_x64__8wekyb3d8bbwe\\pwsh.exe",
-    );
+    expect(command?.command).toBe(WIN_CMD);
+    expect(command?.args).toContain(target);
   });
 
   it("uses Windows Terminal when PowerShell 7 is unavailable", () => {
+    const target =
+      "C:\\Program Files\\WindowsApps\\Microsoft.WindowsTerminal_1.24.11321.0_x64__8wekyb3d8bbwe\\WindowsTerminal.exe";
     const command = resolveTerminalCommand("C:\\work\\repo", {
       platform: "win32",
       env: {
@@ -71,27 +87,33 @@ describe("terminal launcher command resolution", () => {
             ]
           : [],
       exists: (filePath) =>
-        filePath ===
-          "C:\\Program Files\\WindowsApps\\Microsoft.WindowsTerminal_1.24.11321.0_x64__8wekyb3d8bbwe\\WindowsTerminal.exe" ||
-        filePath === "C:\\Windows\\System32\\cmd.exe",
+        filePath === target ||
+        filePath === WIN_CMD,
     });
 
-    expect(command).toEqual({
-      command: "C:\\Windows\\System32\\cmd.exe",
-      args: [
-        "/d",
-        "/s",
-        "/c",
-        "start",
-        "",
-        "/D",
-        "C:\\work\\repo",
-        "C:\\Program Files\\WindowsApps\\Microsoft.WindowsTerminal_1.24.11321.0_x64__8wekyb3d8bbwe\\WindowsTerminal.exe",
-        "-d",
-        "C:\\work\\repo",
+    expect(command).toEqual(
+      windowsStartCommand("C:\\work\\repo", target, ["-d", "C:\\work\\repo"]),
+    );
+  });
+
+  it("rejects Windows paths with cmd metacharacters before cmd.exe parses them", () => {
+    const dirPath = "C:\\work\\repo & calc %TEMP% (test)";
+    const target =
+      "C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.6.2.0_x64__8wekyb3d8bbwe\\pwsh.exe";
+    const command = resolveTerminalCommand(dirPath, {
+      platform: "win32",
+      env: {
+        SystemDrive: "C:",
+      },
+      getWindowsPackageInstallLocations: () => [
+        "C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.6.2.0_x64__8wekyb3d8bbwe",
       ],
-      cwd: "C:\\work\\repo",
+      exists: (filePath) =>
+        filePath === target ||
+        filePath === WIN_CMD,
     });
+
+    expect(command).toBeNull();
   });
 
   it("does not trust user-profile Windows app execution aliases", () => {
@@ -106,10 +128,15 @@ describe("terminal launcher command resolution", () => {
           "C:\\Users\\me\\AppData\\Local\\Microsoft\\WindowsApps\\pwsh.exe" ||
         filePath ===
           "C:\\Users\\me\\AppData\\Local\\Microsoft\\WindowsApps\\wt.exe" ||
-        filePath === "C:\\Windows\\System32\\cmd.exe",
+        filePath === WIN_CMD ||
+        filePath === WIN_POWERSHELL,
     });
 
-    expect(command).toBeNull();
+    expect(command?.command).toBe(WIN_CMD);
+    expect(command?.args).toContain(WIN_POWERSHELL);
+    expect(command?.args.join(" ")).not.toContain(
+      "Microsoft\\WindowsApps",
+    );
   });
 
   it("rejects Windows package locations outside protected Program Files", () => {
@@ -122,7 +149,7 @@ describe("terminal launcher command resolution", () => {
         "C:\\Users\\me\\AppData\\Local\\Microsoft\\WindowsApps\\Microsoft.PowerShell_8wekyb3d8bbwe",
       ],
       exists: (filePath) =>
-        filePath === "C:\\Windows\\System32\\cmd.exe" ||
+        filePath === WIN_CMD ||
         filePath ===
           "C:\\Users\\me\\AppData\\Local\\Microsoft\\WindowsApps\\Microsoft.PowerShell_8wekyb3d8bbwe\\pwsh.exe",
     });
@@ -137,27 +164,16 @@ describe("terminal launcher command resolution", () => {
         SystemDrive: "C:",
       },
       exists: (filePath) =>
-        filePath === "C:\\Windows\\System32\\cmd.exe" ||
-        filePath ===
-          "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+        filePath === WIN_CMD ||
+        filePath === WIN_POWERSHELL,
     });
 
-    expect(command).toEqual({
-      command: "C:\\Windows\\System32\\cmd.exe",
-      args: [
-        "/d",
-        "/s",
-        "/c",
-        "start",
-        "",
-        "/D",
-        "C:\\work\\repo",
-        "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+    expect(command).toEqual(
+      windowsStartCommand("C:\\work\\repo", WIN_POWERSHELL, [
         "-NoExit",
         "-NoLogo",
-      ],
-      cwd: "C:\\work\\repo",
-    });
+      ]),
+    );
   });
 
   it("uses the system macOS open command instead of searching PATH", () => {


### PR DESCRIPTION
## Summary

Adds a terminal launcher to the Chat worktree panel so users can open a shell directly in the selected context folder.

What changed:
- adds an icon-only terminal button to the Worktree panel header
- exposes a new `openTerminal(dirPath)` preload API backed by main-process IPC
- blocks the IPC in remote-only mode and validates that the requested path is a local directory
- resolves terminal executables without shell-parsing user-controlled command strings
- on Windows, prefers trusted PowerShell 7 locations and avoids user-profile app execution aliases
- falls back to Windows Terminal / built-in Windows PowerShell only through absolute trusted paths
- adds localized labels/errors for the new action

Security notes:
- the main process does not launch arbitrary `pwsh.exe` / `wt.exe` from PATH or `%LOCALAPPDATA%\Microsoft\WindowsApps`
- Microsoft Store PowerShell/Terminal packages are resolved via Windows package metadata, then accepted only if the install location is under protected `C:\Program Files\WindowsApps`
- Linux terminal resolution rejects relative commands, relative PATH entries, worktree-local executables, and symlinks that resolve back into the selected worktree
- remote-only mode returns `false` from the IPC handler so a remote/SSH session cannot use the local terminal launcher

## Testing

Automated:
- `npm test -- --run tests/terminal-launcher.test.ts tests/ipc-handlers.test.ts tests/preload-api-surface.test.ts`
  - 194 tests passed
- `npm run typecheck`

Live / CDP:
- rebased onto latest `origin/main`
- launched a fresh dev instance from this repo with CDP enabled
- invoked `window.hermesAPI.openTerminal("C:\\Users\\pmos6\\Documents\\Claude\\Projects\\Hermes-Desktop")`
- confirmed it returned `true`
- confirmed the launched process was trusted PowerShell 7:
  - `C:\Program Files\WindowsApps\Microsoft.PowerShell_7.6.2.0_x64__8wekyb3d8bbwe\pwsh.exe`

Manual visual testing before publish:
- opened Chat
- selected the repo as the context folder
- inspected the Worktree panel header button styling and adjusted it to match the existing icon language
- clicked the terminal button and confirmed it opens a terminal in the selected folder
- confirmed the launcher uses PowerShell 7 rather than Windows PowerShell on this machine

@fathah could you review this one before merge?
