### PR TITLE
Fix gateway stderr spawn

### DIFF
--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -1183,16 +1183,30 @@ export function startGateway(profile?: string): boolean {
   }
   const logPath = join(logDir, "gateway-stderr.log");
   const stderrStream = createWriteStream(logPath, { flags: "a" });
+  let stderrStreamClosed = false;
+  const closeStderrStream = (): void => {
+    if (stderrStreamClosed) return;
+    stderrStreamClosed = true;
+    stderrStream.end();
+  };
 
-  gatewayProcess = spawn(HERMES_PYTHON, hermesCliArgs(["gateway"]), {
-    cwd: HERMES_REPO,
-    env: gatewayEnv,
-    stdio: ["ignore", "ignore", stderrStream],
-    detached: true,
-    ...HIDDEN_SUBPROCESS_OPTIONS,
-  });
+  try {
+    gatewayProcess = spawn(HERMES_PYTHON, hermesCliArgs(["gateway"]), {
+      cwd: HERMES_REPO,
+      env: gatewayEnv,
+      stdio: ["ignore", "ignore", "pipe"],
+      detached: true,
+      ...HIDDEN_SUBPROCESS_OPTIONS,
+    });
+  } catch (err) {
+    closeStderrStream();
+    throw err;
+  }
+
+  gatewayProcess.stderr?.pipe(stderrStream);
 
   gatewayProcess.on("error", (err) => {
+    closeStderrStream();
     console.error("[gateway] Failed to spawn gateway process:", err.message);
     gatewayProcess = null;
     gatewayStartedByApp = false;
@@ -1200,6 +1214,7 @@ export function startGateway(profile?: string): boolean {
   });
 
   gatewayProcess.on("close", (code, signal) => {
+    closeStderrStream();
     if (code !== null && code !== 0) {
       console.error(
         `[gateway] Process exited with code ${code}${signal ? ` (signal: ${signal})` : ""}. ` +

--- a/tests/hermes-cli-session-id.test.ts
+++ b/tests/hermes-cli-session-id.test.ts
@@ -1,8 +1,14 @@
 import { EventEmitter } from "events";
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 
-const { spawned, TEST_HOME, TEST_REPO, healthStatuses, apiRequests } =
-  vi.hoisted(() => {
+const {
+  spawned,
+  TEST_HOME,
+  TEST_REPO,
+  healthStatuses,
+  apiRequests,
+  spawnCalls,
+} = vi.hoisted(() => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const path = require("path");
     // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -11,12 +17,17 @@ const { spawned, TEST_HOME, TEST_REPO, healthStatuses, apiRequests } =
       spawned: [] as Array<
         EventEmitter & {
           stdout: EventEmitter;
-          stderr: EventEmitter;
+          stderr: EventEmitter & { pipe: ReturnType<typeof vi.fn> };
           killed: boolean;
           kill: ReturnType<typeof vi.fn>;
           unref: ReturnType<typeof vi.fn>;
         }
       >,
+      spawnCalls: [] as Array<{
+        command: string;
+        args?: string[];
+        options?: Record<string, unknown>;
+      }>,
       TEST_HOME: path.join(
         os.tmpdir(),
         `hermes-cli-session-test-${Date.now()}`,
@@ -107,29 +118,35 @@ vi.mock("https", () => ({
 
 vi.mock("child_process", () => ({
   default: {
-    spawn: vi.fn(() => {
+    spawn: vi.fn(
+      (command: string, args?: string[], options?: Record<string, unknown>) => {
+        spawnCalls.push({ command, args, options });
+        const proc = Object.assign(new EventEmitter(), {
+          stdout: new EventEmitter(),
+          stderr: Object.assign(new EventEmitter(), { pipe: vi.fn() }),
+          killed: false,
+          kill: vi.fn(),
+          unref: vi.fn(),
+        });
+        spawned.push(proc);
+        return proc;
+      },
+    ),
+  },
+  spawn: vi.fn(
+    (command: string, args?: string[], options?: Record<string, unknown>) => {
+      spawnCalls.push({ command, args, options });
       const proc = Object.assign(new EventEmitter(), {
         stdout: new EventEmitter(),
-        stderr: new EventEmitter(),
+        stderr: Object.assign(new EventEmitter(), { pipe: vi.fn() }),
         killed: false,
         kill: vi.fn(),
         unref: vi.fn(),
       });
       spawned.push(proc);
       return proc;
-    }),
-  },
-  spawn: vi.fn(() => {
-    const proc = Object.assign(new EventEmitter(), {
-      stdout: new EventEmitter(),
-      stderr: new EventEmitter(),
-      killed: false,
-      kill: vi.fn(),
-      unref: vi.fn(),
-    });
-    spawned.push(proc);
-    return proc;
-  }),
+    },
+  ),
 }));
 
 vi.mock("../src/main/installer", () => ({
@@ -179,12 +196,23 @@ describe("CLI fallback session id propagation", () => {
   beforeEach(() => {
     healthStatuses.length = 0;
     apiRequests.length = 0;
+    spawnCalls.length = 0;
   });
 
   afterEach(() => {
     stopGateway(true);
     stopHealthPolling();
     spawned.length = 0;
+    spawnCalls.length = 0;
+  });
+
+  it("spawns the gateway with piped stderr before writing it to the log file", () => {
+    expect(startGateway()).toBe(true);
+    expect(spawned).toHaveLength(1);
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0].options?.stdio).toEqual(["ignore", "ignore", "pipe"]);
+    expect(spawned[0].stderr.pipe).toHaveBeenCalledTimes(1);
+    spawned[0].emit("close", 0);
   });
 
   it("captures the quiet CLI session id from stderr so the next desktop turn can resume it", async () => {


### PR DESCRIPTION
## Summary

This fixes the desktop gateway startup path on Windows by avoiding a direct `WriteStream` in `spawn(..., { stdio })`.

## Changes

- spawn the gateway with `stdio: ["ignore", "ignore", "pipe"]`
- pipe `gatewayProcess.stderr` to `gateway-stderr.log` after spawn
- close the log stream on spawn failure, process error, and process exit
- add a regression test that verifies the gateway is spawned with piped stderr

## Verification

- `npm run typecheck`
- `npm exec -- vitest run tests/hermes-cli-session-id.test.ts`

## Notes

`npm run lint` still reports existing repo-wide CRLF/Prettier warnings unrelated to this change.