### PR TITLE
Fix gateway restart after resume

### DIFF
--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "crypto";
 import {
   existsSync,
   readFileSync,
+  writeFileSync,
   appendFileSync,
   unlinkSync,
   mkdirSync,
@@ -240,22 +241,26 @@ interface ChatHandle {
 
 function isApiServerReady(profile?: string): Promise<boolean> {
   return new Promise((resolve) => {
-    const url = `${getApiUrl(profile)}/health`;
-    const mod = url.startsWith("https") ? https : http;
-    const req = mod.request(
-      url,
-      { method: "GET", timeout: 1500, headers: getRemoteAuthHeader() },
-      (res) => {
-        resolve(res.statusCode === 200);
-        res.resume();
-      },
-    );
-    req.on("error", () => resolve(false));
-    req.on("timeout", () => {
-      req.destroy();
+    try {
+      const url = `${getApiUrl(profile)}/health`;
+      const mod = url.startsWith("https") ? https : http;
+      const req = mod.request(
+        url,
+        { method: "GET", timeout: 1500, headers: getRemoteAuthHeader() },
+        (res) => {
+          resolve(res.statusCode === 200);
+          res.resume();
+        },
+      );
+      req.on("error", () => resolve(false));
+      req.on("timeout", () => {
+        req.destroy();
+        resolve(false);
+      });
+      req.end();
+    } catch {
       resolve(false);
-    });
-    req.end();
+    }
   });
 }
 
@@ -266,11 +271,12 @@ function delay(ms: number): Promise<void> {
 async function waitForApiServerReady(
   timeoutMs = 8000,
   profile?: string,
+  pollMs = 250,
 ): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (await isApiServerReady(profile)) return true;
-    await delay(250);
+    await delay(pollMs);
   }
   return false;
 }
@@ -801,10 +807,10 @@ function sendMessageViaApi(
     finish(`API request failed: ${err.message}`);
   });
   req.on("timeout", () => {
-    req.destroy();
     finish(
       "API request timed out. Check the SSH tunnel and remote Hermes gateway.",
     );
+    req.destroy();
   });
 
   req.write(bodyBuf);
@@ -1113,6 +1119,132 @@ function sendMessageViaCli(
 
 let apiServerAvailable: boolean | null = null; // cached after first check
 
+function setApiCacheFor(profile: string | undefined, value: boolean | null): void {
+  if (profileKey(profile) === profileKey(undefined)) {
+    apiServerAvailable = value;
+  }
+}
+
+function isLocalApiTransportError(error: string): boolean {
+  return /^API request failed:.*(?:\b(?:ECONNREFUSED|ECONNRESET|ETIMEDOUT|EPIPE)\b|socket hang up)/i.test(
+    error,
+  );
+}
+
+async function sendMessageViaApiWithLocalRecovery(
+  message: string,
+  cb: ChatCallbacks,
+  profile?: string,
+  resumeSessionId?: string,
+  history?: Array<{ role: string; content: string }>,
+  attachments?: Attachment[],
+  contextFolder?: string,
+): Promise<ChatHandle> {
+  let aborted = false;
+  let retrying = false;
+  let sawOutput = false;
+  let settled = false;
+  let activeHandle: ChatHandle | null = null;
+
+  const recoverAndRetry = async (): Promise<void> => {
+    if (aborted || retrying || settled || sawOutput) return;
+
+    retrying = true;
+    activeHandle?.abort();
+    setApiCacheFor(profile, false);
+    const recovered = await startGatewayWithRecovery(profile);
+    if (aborted) return;
+
+    if (recovered) {
+      setApiCacheFor(profile, true);
+      activeHandle = await sendMessageViaApi(
+        message,
+        cb,
+        profile,
+        resumeSessionId,
+        history,
+        attachments,
+        contextFolder,
+      );
+      return;
+    }
+
+    activeHandle = await sendMessageViaCli(
+      message,
+      cb,
+      profile,
+      resumeSessionId,
+      attachments,
+    );
+  };
+
+  const recoverAndFail = async (error: string): Promise<void> => {
+    if (aborted || retrying || settled || sawOutput) return;
+
+    retrying = true;
+    activeHandle?.abort();
+    setApiCacheFor(profile, false);
+    const recovered = await startGatewayWithRecovery(profile);
+    if (aborted) return;
+
+    setApiCacheFor(profile, recovered);
+    settled = true;
+    cb.onError(error);
+  };
+
+  const handle: ChatHandle = {
+    abort: () => {
+      aborted = true;
+      activeHandle?.abort();
+    },
+  };
+
+  const callbacks: ChatCallbacks = {
+    ...cb,
+    onChunk: (text) => {
+      sawOutput = true;
+      cb.onChunk(text);
+    },
+    onReasoningChunk: cb.onReasoningChunk
+      ? (text) => {
+          sawOutput = true;
+          cb.onReasoningChunk?.(text);
+        }
+      : undefined,
+    onToolProgress: cb.onToolProgress
+      ? (tool) => {
+          sawOutput = true;
+          cb.onToolProgress?.(tool);
+        }
+      : undefined,
+    onUsage: cb.onUsage,
+    onDone: (sessionId) => {
+      settled = true;
+      cb.onDone(sessionId);
+    },
+    onError: (error) => {
+      if (isLocalApiTransportError(error)) {
+        void recoverAndRetry();
+        return;
+      }
+
+      void recoverAndFail(error);
+    },
+  };
+
+  activeHandle = await sendMessageViaApi(
+    message,
+    callbacks,
+    profile,
+    resumeSessionId,
+    history,
+    attachments,
+    contextFolder,
+  );
+
+  return handle;
+}
+
 export async function sendMessage(
   message: string,
   cb: ChatCallbacks,
@@ -1137,23 +1269,19 @@ export async function sendMessage(
     );
   }
 
-  // Check API server availability. In local mode, a running gateway process
-  // can still be in its startup window (or the cached ready state can be stale
-  // after an external stop/start), so verify health before taking the API path.
-  const localGatewayRunning = !isRemoteMode() && isGatewayRunning(profile);
-  if (
-    apiServerAvailable === null ||
-    apiServerAvailable === false ||
-    localGatewayRunning
-  ) {
+  // Check API server availability when the cache is cold or known-bad. Once
+  // the API is known healthy, keep the normal send path fast and let the API
+  // transport error wrapper handle a stale cache caused by external lifecycle
+  // events such as `hermes update` or Windows sleep/resume.
+  if (apiServerAvailable === null || apiServerAvailable === false) {
     apiServerAvailable = await isApiServerReady(profile);
-    if (!apiServerAvailable && localGatewayRunning) {
-      apiServerAvailable = await waitForApiServerReady(8000, profile);
+    if (!apiServerAvailable) {
+      apiServerAvailable = await startGatewayWithRecovery(profile);
     }
   }
 
   if (apiServerAvailable) {
-    return sendMessageViaApi(
+    return sendMessageViaApiWithLocalRecovery(
       message,
       cb,
       profile,
@@ -1232,59 +1360,53 @@ function invalidateApiCacheFor(profile?: string): void {
   }
 }
 
-export function startGatewayDetailed(profile?: string): GatewayStartResult {
-  // Defensive: the local gateway is never the right thing to spawn in
-  // remote/SSH mode — the user is pointing at an off-machine server.
-  // Callers should already gate, but several IPC handlers historically
-  // forgot to (issue #266), and reaching `spawn(HERMES_PYTHON, …)` when
-  // there's no local hermes-agent install produces an uncaught ENOENT
-  // that pops a generic error dialog.  Refuse cleanly here.
-  if (isRemoteMode()) {
-    const error =
-      "The local gateway can only be started in local mode. Switch to local mode, or start the gateway on the remote Hermes host.";
-    console.warn(
-      "[gateway] startGateway() called in remote/SSH mode — refusing local spawn",
-    );
-    return { success: false, running: false, error };
-  }
-  ensureInitialized();
-  if (isGatewayRunning(profile)) {
-    return { success: true, running: true, alreadyRunning: true };
-  }
-
-  // Pre-flight: verify the Python interpreter exists before attempting to
-  // spawn. Without this check, spawn() fails with ENOENT and the error is
-  // completely silent (stdio:"ignore", no error handler).
+function getGatewaySpawnError(): string | null {
   if (!existsSync(HERMES_PYTHON)) {
-    const error =
+    return (
       `Cannot start the gateway because the Hermes Python interpreter was not found at ${HERMES_PYTHON}. ` +
-      "Install or repair Hermes Agent, then try again.";
-    console.error(`[gateway] ${error}`);
-    return { success: false, running: false, error };
+      "Install or repair Hermes Agent, then try again."
+    );
   }
   if (!existsSync(HERMES_REPO)) {
-    const error =
+    return (
       `Cannot start the gateway because the hermes-agent repository was not found at ${HERMES_REPO}. ` +
-      "Install or repair Hermes Agent, then try again.";
-    console.error(`[gateway] ${error}`);
-    return { success: false, running: false, error };
+      "Install or repair Hermes Agent, then try again."
+    );
   }
+  return null;
+}
 
-  const resolved = resolveProfile(profile); // undefined => default
-  const key = profileKey(profile);
+function canSpawnGateway(): boolean {
+  const error = getGatewaySpawnError();
+  if (error) {
+    console.error(`[gateway] ${error}`);
+    return false;
+  }
+  return true;
+}
 
+function gatewayLogPath(profile?: string): string {
+  const logDir = profileHome(resolveProfile(profile));
+  try {
+    mkdirSync(logDir, { recursive: true });
+  } catch {
+    // ignore
+  }
+  return join(logDir, "gateway-stderr.log");
+}
+
+function buildGatewayEnv(profile?: string): Record<string, string> {
   // Make sure this profile's config.yaml enables the api_server and binds the
   // profile's own port before we spawn.
   ensureApiServerConfig(profile);
   const port = getProfilePort(profile);
 
-  // Build gateway env with profile API keys
   const gatewayEnv: Record<string, string> = {
     ...(process.env as Record<string, string>),
     PATH: getEnhancedPath(),
     HOME: homedir(),
     HERMES_HOME: HERMES_HOME,
-    API_SERVER_ENABLED: "true", // Ensure API server starts with gateway
+    API_SERVER_ENABLED: "true",
     // Bind to this profile's port. config.yaml's api_server.port wins when
     // present (getProfilePort keeps it collision-free); this env value covers
     // the case where the block exists but omits an explicit port.
@@ -1332,18 +1454,55 @@ export function startGatewayDetailed(profile?: string): GatewayStartResult {
     gatewayEnv.API_SERVER_KEY = resolvedApiServerKey;
   }
 
+  return gatewayEnv;
+}
+
+function gatewayCliCommandArgs(
+  profile: string | undefined,
+  command: string[],
+): string[] {
+  const resolved = resolveProfile(profile);
+  return resolved ? ["--profile", resolved, ...command] : command;
+}
+
+export function startGatewayDetailed(profile?: string): GatewayStartResult {
+  // Defensive: the local gateway is never the right thing to spawn in
+  // remote/SSH mode — the user is pointing at an off-machine server.
+  // Callers should already gate, but several IPC handlers historically
+  // forgot to (issue #266), and reaching `spawn(HERMES_PYTHON, …)` when
+  // there's no local hermes-agent install produces an uncaught ENOENT
+  // that pops a generic error dialog.  Refuse cleanly here.
+  if (isRemoteMode()) {
+    const error =
+      "The local gateway can only be started in local mode. Switch to local mode, or start the gateway on the remote Hermes host.";
+    console.warn(
+      "[gateway] startGateway() called in remote/SSH mode — refusing local spawn",
+    );
+    return { success: false, running: false, error };
+  }
+  ensureInitialized();
+  if (isGatewayRunning(profile)) {
+    return { success: true, running: true, alreadyRunning: true };
+  }
+
+  // Pre-flight: verify the Python interpreter exists before attempting to
+  // spawn. Without this check, spawn() fails with ENOENT and the error is
+  // completely silent (stdio:"ignore", no error handler).
+  const spawnError = getGatewaySpawnError();
+  if (spawnError) {
+    console.error(`[gateway] ${spawnError}`);
+    return { success: false, running: false, error: spawnError };
+  }
+
+  const key = profileKey(profile);
+  const gatewayEnv = buildGatewayEnv(profile);
+
   // Route stderr to a log file so startup errors are visible for debugging.
   // Per-profile log dir so a named profile's failures (e.g. a duplicate bot
   // token, which the gateway refuses to start with) don't get mixed into the
   // default profile's log. stdout is ignored (the gateway daemonizes and
   // writes its own logs).
-  const logDir = profileHome(resolved);
-  try {
-    mkdirSync(logDir, { recursive: true });
-  } catch {
-    // ignore
-  }
-  const logPath = join(logDir, "gateway-stderr.log");
+  const logPath = gatewayLogPath(profile);
   // Open the log synchronously and hand spawn a real fd. A createWriteStream
   // opens its fd asynchronously, so passing the stream to stdio races: when
   // the fd hasn't resolved yet (fd: null) Electron's Node rejects it with
@@ -1361,7 +1520,7 @@ export function startGatewayDetailed(profile?: string): GatewayStartResult {
   // subcommand, as the CLI requires). The flag makes the CLI repoint
   // HERMES_HOME at the profile's dir internally; the shared repo/venv stay
   // put. The default profile takes no flag.
-  const cliArgs = resolved ? ["--profile", resolved, "gateway"] : ["gateway"];
+  const cliArgs = gatewayCliCommandArgs(profile, ["gateway"]);
   let proc: ChildProcess;
   try {
     proc = spawn(HERMES_PYTHON, hermesCliArgs(cliArgs), {
@@ -1463,7 +1622,15 @@ function gatewayPidPath(profile?: string): string {
 }
 
 function readPidFile(profile?: string): number | null {
-  return parsePidFromFile(gatewayPidPath(profile));
+  return readPidFileEntry(profile)?.pid ?? null;
+}
+
+function readPidFileEntry(
+  profile?: string,
+): { path: string; pid: number } | null {
+  const pidFile = gatewayPidPath(profile);
+  const pid = parsePidFromFile(pidFile);
+  return pid === null ? null : { path: pidFile, pid };
 }
 
 /**
@@ -1471,12 +1638,19 @@ function readPidFile(profile?: string): number | null {
  * this only touches the named profile — switching profiles, app exit, etc.
  * must never take down a *different* profile's gateway (and its bots).
  */
-export function stopGateway(profile?: string, force = false): void {
+export function stopGateway(
+  profileOrForce?: string | boolean,
+  force = false,
+): void {
+  const profile =
+    typeof profileOrForce === "boolean" ? undefined : profileOrForce;
+  const shouldForce =
+    typeof profileOrForce === "boolean" ? profileOrForce : force;
   const key = profileKey(profile);
-  if (!force && !appStartedProfiles.has(key)) return;
+  if (!shouldForce && !appStartedProfiles.has(key)) return;
 
   const proc = gatewayProcesses.get(key);
-  if (proc && !proc.killed) {
+  if (proc && isChildProcessAlive(proc)) {
     proc.kill("SIGTERM");
   }
   gatewayProcesses.delete(key);
@@ -1509,9 +1683,22 @@ export function stopGateway(profile?: string, force = false): void {
 // gateway.pid actually belongs to a python process before reporting alive.
 const GATEWAY_IMAGE_PREFIXES = ["python", "pythonw"];
 
+function isChildProcessAlive(proc: ChildProcess): boolean {
+  if (proc.exitCode !== null || proc.signalCode !== null) {
+    return false;
+  }
+  if (typeof proc.pid !== "number") return !proc.killed;
+  try {
+    process.kill(proc.pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function isGatewayRunning(profile?: string): boolean {
   const proc = gatewayProcesses.get(profileKey(profile));
-  if (proc && !proc.killed) return true;
+  if (proc && isChildProcessAlive(proc)) return true;
   const pid = readPidFile(profile);
   if (!pid) return false;
   return pidIsAliveAs(pid, GATEWAY_IMAGE_PREFIXES);
@@ -1519,6 +1706,10 @@ export function isGatewayRunning(profile?: string): boolean {
 
 export function isApiReady(): boolean {
   return apiServerAvailable === true;
+}
+
+export function isGatewayHealthy(profile?: string): Promise<boolean> {
+  return isApiServerReady(profile);
 }
 
 export function testRemoteConnection(
@@ -1548,17 +1739,420 @@ export function testRemoteConnection(
   });
 }
 
-export function restartGateway(profile?: string): void {
-  // Same defensive gate as startGateway — the local gateway has no role
-  // in remote/SSH mode.  Cheap to check; catches IPC paths that don't
-  // wrap their restart calls in an isRemoteMode() check.
-  if (isRemoteMode()) return;
+async function waitForApiServerStopped(
+  profile?: string,
+  timeoutMs = 5000,
+  pollMs = 250,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!(await isApiServerReady(profile))) return true;
+    await delay(pollMs);
+  }
+  return false;
+}
+
+function gatewayRestartProfileKey(profile?: string): string {
+  return profileKey(profile);
+}
+
+let gatewayRestartQueueTail: Promise<unknown> = Promise.resolve();
+const gatewayRestartByProfile = new Map<string, Promise<boolean>>();
+
+function markGatewayRestartFailed(profile?: string): void {
   const key = profileKey(profile);
-  if (!appStartedProfiles.has(key) && !isGatewayRunning(profile)) return;
-  stopGateway(profile, true);
-  setTimeout(() => {
-    startGateway(profile);
-  }, 500);
+  gatewayProcesses.delete(key);
+  appStartedProfiles.delete(key);
+  invalidateApiCacheFor(profile);
+  startHealthPolling();
+}
+
+function restoreGatewayAfterRestartFailure(
+  profile: string | undefined,
+  previousProcess: ChildProcess | null,
+  previousStartedByApp: boolean,
+  previousPidEntry: { path: string; pid: number } | null = null,
+): void {
+  const key = profileKey(profile);
+  if (previousProcess && isChildProcessAlive(previousProcess)) {
+    gatewayProcesses.set(key, previousProcess);
+    if (previousStartedByApp) {
+      appStartedProfiles.add(key);
+    } else {
+      appStartedProfiles.delete(key);
+    }
+    invalidateApiCacheFor(profile);
+    startHealthPolling();
+    return;
+  }
+  if (
+    previousPidEntry &&
+    pidIsAliveAs(previousPidEntry.pid, GATEWAY_IMAGE_PREFIXES)
+  ) {
+    try {
+      writeFileSync(
+        previousPidEntry.path,
+        String(previousPidEntry.pid),
+        "utf-8",
+      );
+    } catch {
+      // best-effort; health polling will still recover API readiness.
+    }
+    gatewayProcesses.delete(key);
+    if (previousStartedByApp) {
+      appStartedProfiles.add(key);
+    } else {
+      appStartedProfiles.delete(key);
+    }
+    invalidateApiCacheFor(profile);
+    startHealthPolling();
+    return;
+  }
+  markGatewayRestartFailed(profile);
+}
+
+async function restartGatewayLocallyOnce(
+  profile?: string,
+  healthTimeoutMs = 30000,
+  healthPollMs = 250,
+  stopTimeoutMs = 5000,
+): Promise<boolean> {
+  try {
+    if (isRemoteMode()) return false;
+    ensureInitialized();
+    if (!canSpawnGateway()) return false;
+
+    const key = profileKey(profile);
+    const previousProcess = gatewayProcesses.get(key) ?? null;
+    const previousStartedByApp = appStartedProfiles.has(key);
+    const previousPidEntry = readPidFileEntry(profile);
+    stopGateway(profile, true);
+    const stopped = await waitForApiServerStopped(
+      profile,
+      stopTimeoutMs,
+      healthPollMs,
+    );
+    if (!stopped) {
+      console.error(
+        `[gateway:${key}] Native restart failed: gateway did not stop before restart`,
+      );
+      restoreGatewayAfterRestartFailure(
+        profile,
+        previousProcess,
+        previousStartedByApp,
+        previousPidEntry,
+      );
+      return false;
+    }
+
+    const startResult = startGatewayDetailed(profile);
+    if (!startResult.success && !startResult.alreadyRunning) {
+      setApiCacheFor(profile, false);
+      markGatewayRestartFailed(profile);
+      return false;
+    }
+
+    const ready = await waitForApiServerReady(
+      healthTimeoutMs,
+      profile,
+      healthPollMs,
+    );
+    setApiCacheFor(profile, ready);
+    if (!ready) {
+      markGatewayRestartFailed(profile);
+    }
+    return ready;
+  } catch (err) {
+    console.error("[gateway] Native restart failed:", (err as Error).message);
+    markGatewayRestartFailed(profile);
+    return false;
+  }
+}
+
+export function restartGateway(
+  profile?: string,
+  healthTimeoutMs = 30000,
+  healthPollMs = 250,
+  stopTimeoutMs = 5000,
+): Promise<boolean> {
+  // Same defensive gate as startGateway — the local gateway has no role
+  // in remote/SSH mode. Cheap to check; catches IPC paths that don't
+  // wrap their restart calls in an isRemoteMode() check.
+  if (isRemoteMode()) return Promise.resolve(false);
+
+  const key = gatewayRestartProfileKey(profile);
+  const existing = gatewayRestartByProfile.get(key);
+  if (existing) {
+    return existing;
+  }
+
+  const queued = gatewayRestartQueueTail.then(
+    () =>
+      restartGatewayLocallyOnce(
+        profile,
+        healthTimeoutMs,
+        healthPollMs,
+        stopTimeoutMs,
+      ),
+    () =>
+      restartGatewayLocallyOnce(
+        profile,
+        healthTimeoutMs,
+        healthPollMs,
+        stopTimeoutMs,
+      ),
+  );
+
+  const promise = queued.finally(() => {
+    if (gatewayRestartByProfile.get(key) === promise) {
+      gatewayRestartByProfile.delete(key);
+    }
+  });
+
+  gatewayRestartByProfile.set(key, promise);
+  gatewayRestartQueueTail = promise.catch(() => undefined);
+  return promise;
+}
+
+export async function startGatewayWithRecovery(
+  profile?: string,
+  healthTimeoutMs = 8000,
+  healthPollMs = 250,
+  restartCommandTimeoutMs = 15000,
+  restartHealthTimeoutMs = 30000,
+  restartStopTimeoutMs = 5000,
+): Promise<boolean> {
+  // Fourth argument kept for call-site compatibility with the earlier CLI
+  // restart implementation.
+  void restartCommandTimeoutMs;
+
+  if (isRemoteMode()) return false;
+
+  if (isGatewayRunning(profile)) {
+    return (
+      (await isGatewayHealthy(profile)) ||
+      restartGateway(
+        profile,
+        restartHealthTimeoutMs,
+        healthPollMs,
+        restartStopTimeoutMs,
+      )
+    );
+  }
+
+  const startResult = startGatewayDetailed(profile);
+  if (!startResult.success && !startResult.alreadyRunning) return false;
+
+  const ready = await waitForApiServerReady(
+    healthTimeoutMs,
+    profile,
+    healthPollMs,
+  );
+  if (ready) {
+    setApiCacheFor(profile, true);
+    return true;
+  }
+
+  return restartGateway(
+    profile,
+    restartHealthTimeoutMs,
+    healthPollMs,
+    restartStopTimeoutMs,
+  );
+}
+
+export function restartGatewayViaCli(
+  profile?: string,
+  healthTimeoutMs = 30000,
+  healthPollMs = 250,
+): Promise<boolean> {
+  if (isRemoteMode()) return Promise.resolve(false);
+  const key = gatewayRestartProfileKey(profile);
+
+  const existing = gatewayRestartByProfile.get(key);
+  if (existing) {
+    return existing;
+  }
+
+  const queued = gatewayRestartQueueTail.then(
+    () =>
+      restartGatewayViaCliOnce(
+        profile,
+        healthTimeoutMs,
+        healthPollMs,
+      ),
+    () =>
+      restartGatewayViaCliOnce(
+        profile,
+        healthTimeoutMs,
+        healthPollMs,
+      ),
+  );
+
+  const promise = queued.finally(() => {
+    if (gatewayRestartByProfile.get(key) === promise) {
+      gatewayRestartByProfile.delete(key);
+    }
+  });
+
+  gatewayRestartByProfile.set(key, promise);
+  gatewayRestartQueueTail = promise.catch(() => undefined);
+  return promise;
+}
+
+async function restartGatewayViaCliOnce(
+  profile?: string,
+  healthTimeoutMs = 30000,
+  healthPollMs = 250,
+): Promise<boolean> {
+  try {
+    if (isRemoteMode()) return false;
+    ensureInitialized();
+    if (!canSpawnGateway()) return false;
+
+    const key = profileKey(profile);
+    const previousProcess = gatewayProcesses.get(key) ?? null;
+    const previousStartedByApp = appStartedProfiles.has(key);
+    const previousPidEntry = readPidFileEntry(profile);
+    const logPath = gatewayLogPath(profile);
+    const wasHealthyBeforeRestart = await isApiServerReady(profile);
+    appendFileSync(
+      logPath,
+      `\n[gateway:${key}] Desktop requested hermes gateway restart at ${new Date().toISOString()}\n`,
+    );
+
+    return await new Promise<boolean>((resolve) => {
+      let proc: ChildProcess | null = null;
+      let stderrFd = -1;
+      try {
+        stderrFd = openSync(logPath, "a");
+        proc = spawn(
+          HERMES_PYTHON,
+          hermesCliArgs(gatewayCliCommandArgs(profile, ["gateway", "restart"])),
+          {
+            cwd: HERMES_REPO,
+            env: buildGatewayEnv(profile),
+            stdio: ["ignore", "ignore", stderrFd >= 0 ? stderrFd : "ignore"],
+            detached: true,
+            ...HIDDEN_SUBPROCESS_OPTIONS,
+          },
+        );
+        proc.unref();
+      } catch (err) {
+        console.error(
+          `[gateway:${key}] Failed to launch restart command:`,
+          (err as Error).message,
+        );
+        if (stderrFd >= 0) {
+          try {
+            closeSync(stderrFd);
+          } catch {
+            // ignore
+          }
+        }
+        restoreGatewayAfterRestartFailure(
+          profile,
+          previousProcess,
+          previousStartedByApp,
+          previousPidEntry,
+        );
+        resolve(false);
+        return;
+      }
+
+      if (stderrFd >= 0) {
+        try {
+          closeSync(stderrFd);
+        } catch {
+          // best-effort
+        }
+      }
+
+      let settled = false;
+      let exitedSuccessfully = false;
+
+      const finish = (ok: boolean): void => {
+        if (settled) return;
+        settled = true;
+        if (ok && proc && isChildProcessAlive(proc)) {
+          gatewayProcesses.set(key, proc);
+          appStartedProfiles.add(key);
+        } else if (!ok) {
+          restoreGatewayAfterRestartFailure(
+            profile,
+            previousProcess,
+            previousStartedByApp,
+            previousPidEntry,
+          );
+        }
+        setApiCacheFor(profile, ok);
+        resolve(ok);
+      };
+
+      proc.on("error", (err) => {
+        console.error(`[gateway:${key}] Failed to restart gateway:`, err.message);
+        finish(false);
+      });
+
+      proc.on("close", (code, signal) => {
+        if (settled) return;
+        if (code !== 0) {
+          console.error(
+            `[gateway:${key}] Restart exited with code ${code}${signal ? ` (signal: ${signal})` : ""}. ` +
+              `Check ${logPath} for details.`,
+          );
+          finish(false);
+          return;
+        }
+        exitedSuccessfully = true;
+      });
+
+      void (async () => {
+        const deadline = Date.now() + healthTimeoutMs;
+        let sawUnhealthy = !wasHealthyBeforeRestart;
+
+        while (!settled && Date.now() < deadline) {
+          const ready = await isApiServerReady(profile);
+          if (!ready) sawUnhealthy = true;
+          if (ready && (sawUnhealthy || exitedSuccessfully)) {
+            finish(true);
+            return;
+          }
+          await delay(healthPollMs);
+        }
+
+        if (!settled) {
+          console.error(
+            `[gateway:${key}] Restart command did not make /health ready within ${healthTimeoutMs}ms. ` +
+              `Check ${logPath} for details.`,
+          );
+          try {
+            proc?.kill("SIGTERM");
+          } catch {
+            // already gone
+          }
+          finish(false);
+        }
+      })().catch((err) => {
+        console.error(
+          `[gateway:${key}] Failed while waiting for restart health:`,
+          (err as Error).message,
+        );
+        try {
+          proc?.kill("SIGTERM");
+        } catch {
+          // already gone
+        }
+        finish(false);
+      });
+    });
+  } catch (err) {
+    console.error(
+      "[gateway] Restart failed before the command could complete:",
+      (err as Error).message,
+    );
+    return false;
+  }
 }
 
 /**

--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -1146,8 +1146,26 @@ async function sendMessageViaApiWithLocalRecovery(
   let settled = false;
   let activeHandle: ChatHandle | null = null;
 
+  const recoverAfterPartialOutput = (error: string): void => {
+    if (aborted || retrying || settled) return;
+
+    retrying = true;
+    activeHandle?.abort();
+    setApiCacheFor(profile, false);
+    settled = true;
+    cb.onError(error);
+
+    void startGatewayWithRecovery(profile)
+      .then((recovered) => {
+        setApiCacheFor(profile, recovered);
+      })
+      .catch(() => {
+        setApiCacheFor(profile, false);
+      });
+  };
+
   const recoverAndRetry = async (): Promise<void> => {
-    if (aborted || retrying || settled || sawOutput) return;
+    if (aborted || retrying || settled) return;
 
     retrying = true;
     activeHandle?.abort();
@@ -1179,7 +1197,7 @@ async function sendMessageViaApiWithLocalRecovery(
   };
 
   const recoverAndFail = async (error: string): Promise<void> => {
-    if (aborted || retrying || settled || sawOutput) return;
+    if (aborted || retrying || settled) return;
 
     retrying = true;
     activeHandle?.abort();
@@ -1223,6 +1241,11 @@ async function sendMessageViaApiWithLocalRecovery(
       cb.onDone(sessionId);
     },
     onError: (error) => {
+      if (sawOutput) {
+        recoverAfterPartialOutput(error);
+        return;
+      }
+
       if (isLocalApiTransportError(error)) {
         void recoverAndRetry();
         return;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1122,6 +1122,18 @@ function setupIPC(): void {
     stopGateway(undefined, true);
     return true;
   });
+  ipcMain.handle("restart-gateway", async (_event, profile?: string) => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) {
+      await sshStopGateway(conn.ssh);
+      await sshStartGateway(conn.ssh);
+      return sshGatewayStatus(conn.ssh);
+    }
+    if (conn.mode === "remote") {
+      return false;
+    }
+    return restartGateway(profile);
+  });
   ipcMain.handle("gateway-status", () => {
     const conn = getConnectionConfig();
     if (conn.mode === "ssh" && conn.ssh) return sshGatewayStatus(conn.ssh);

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -374,6 +374,7 @@ interface HermesAPI {
   // Gateway
   startGateway: () => Promise<GatewayStartResult>;
   stopGateway: () => Promise<boolean>;
+  restartGateway: (profile?: string) => Promise<boolean>;
   gatewayStatus: () => Promise<boolean>;
 
   // Platform toggles

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -464,6 +464,8 @@ const hermesAPI = {
   startGateway: (): Promise<GatewayStartResult> =>
     ipcRenderer.invoke("start-gateway"),
   stopGateway: (): Promise<boolean> => ipcRenderer.invoke("stop-gateway"),
+  restartGateway: (profile?: string): Promise<boolean> =>
+    ipcRenderer.invoke("restart-gateway", profile),
   gatewayStatus: (): Promise<boolean> => ipcRenderer.invoke("gateway-status"),
 
   // Platform toggles

--- a/src/renderer/src/screens/Gateway/Gateway.test.tsx
+++ b/src/renderer/src/screens/Gateway/Gateway.test.tsx
@@ -1,0 +1,104 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../components/useI18n", () => ({
+  useI18n: () => ({
+    t: (key: string): string => key,
+  }),
+}));
+
+vi.mock("../../components/common/BrandLogo", () => ({
+  default: () => <div data-testid="brand-logo" />,
+}));
+
+import Gateway from "./Gateway";
+
+describe("Gateway screen recovery controls", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(window, "hermesAPI", {
+      configurable: true,
+      value: {
+        getEnv: vi.fn().mockResolvedValue({}),
+        gatewayStatus: vi.fn().mockResolvedValue(true),
+        getPlatformEnabled: vi.fn().mockResolvedValue({}),
+        restartGateway: vi.fn().mockResolvedValue(false),
+        startGateway: vi.fn().mockResolvedValue(false),
+        stopGateway: vi.fn().mockResolvedValue(true),
+        setPlatformEnabled: vi.fn().mockResolvedValue(true),
+        setEnv: vi.fn().mockResolvedValue(true),
+        getMessagingPlatforms: vi.fn().mockResolvedValue({
+          platforms: [],
+          message: null,
+        }),
+        updateMessagingPlatform: vi.fn().mockResolvedValue({
+          ok: true,
+          message: null,
+        }),
+        testMessagingPlatform: vi.fn().mockResolvedValue({
+          ok: true,
+          message: null,
+        }),
+        openExternal: vi.fn().mockResolvedValue(true),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("keeps a failed restart error visible while showing the refreshed running status", async () => {
+    render(<Gateway />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByText("gateway.running")).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("gateway.restart"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("gateway.restartFailed")).toBeTruthy();
+    expect(screen.getByText("gateway.running")).toBeTruthy();
+
+    await act(async () => {
+      vi.advanceTimersByTime(10000);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("gateway.restartFailed")).toBeTruthy();
+    expect(screen.getByText("gateway.running")).toBeTruthy();
+  });
+
+  it("shows a gateway error when restart IPC rejects", async () => {
+    window.hermesAPI.restartGateway = vi
+      .fn()
+      .mockRejectedValue(new Error("restart failed"));
+    window.hermesAPI.gatewayStatus = vi
+      .fn()
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValue(false);
+
+    render(<Gateway />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("gateway.restart"));
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("gateway.restartFailed")).toBeTruthy();
+    expect(screen.getByText("gateway.stopped")).toBeTruthy();
+  });
+});

--- a/src/renderer/src/screens/Gateway/Gateway.tsx
+++ b/src/renderer/src/screens/Gateway/Gateway.tsx
@@ -54,13 +54,19 @@ function Gateway({ profile }: { profile?: string }): React.JSX.Element {
         window.hermesAPI.getMessagingPlatforms(profile),
       ]);
       setGatewayRunning(gwStatus);
-      // Clear any stale start-failure banner once the gateway is confirmed up.
-      if (gwStatus) setGatewayError(null);
+      // Clear stale start-failure banners once the gateway is confirmed up,
+      // but keep an explicit restart failure visible: a failed recovery can
+      // leave the old gateway running while still needing user attention.
+      if (gwStatus) {
+        setGatewayError((current) =>
+          current === t("gateway.restartFailed") ? current : null,
+        );
+      }
       setCatalog(platforms);
     } catch (err) {
       setLoadError(err instanceof Error ? err.message : String(err));
     }
-  }, [profile]);
+  }, [profile, t]);
 
   useEffect(() => {
     void loadConfig();
@@ -149,6 +155,37 @@ function Gateway({ profile }: { profile?: string }): React.JSX.Element {
       } finally {
         setGatewayBusy(false);
       }
+    }
+  }
+
+  async function restartGateway(): Promise<void> {
+    if (gatewayStatusTimeoutRef.current) {
+      clearTimeout(gatewayStatusTimeoutRef.current);
+      gatewayStatusTimeoutRef.current = null;
+    }
+    setGatewayBusy(true);
+    setGatewayError(null);
+    try {
+      const restarted = await window.hermesAPI.restartGateway(profile);
+      setGatewayRunning(restarted);
+      if (!restarted) {
+        await loadConfig();
+        setGatewayError(t("gateway.restartFailed"));
+      } else {
+        gatewayStatusTimeoutRef.current = setTimeout(async () => {
+          const status = await window.hermesAPI.gatewayStatus();
+          setGatewayRunning(status);
+          if (status) {
+            void loadConfig();
+          }
+          gatewayStatusTimeoutRef.current = null;
+        }, 5000);
+      }
+    } catch {
+      await loadConfig();
+      setGatewayError(t("gateway.restartFailed"));
+    } finally {
+      setGatewayBusy(false);
     }
   }
 
@@ -325,6 +362,15 @@ function Gateway({ profile }: { profile?: string }): React.JSX.Element {
                   ? t("common.stop")
                   : t("common.start")}
             </button>
+            {gatewayRunning && (
+              <button
+                className="btn btn-secondary btn-sm"
+                onClick={() => void restartGateway()}
+                disabled={gatewayBusy}
+              >
+                {t("gateway.restart")}
+              </button>
+            )}
           </div>
           {gatewayError && (
             <div className="settings-gateway-error" role="alert">

--- a/src/shared/i18n/locales/en/gateway.ts
+++ b/src/shared/i18n/locales/en/gateway.ts
@@ -6,6 +6,9 @@ export default {
   running: "Running",
   stopped: "Stopped",
   working: "Working…",
+  restart: "Restart",
+  restartFailed:
+    "Gateway restart failed. Check gateway-stderr.log for details.",
   startFailed: "Gateway could not be started.",
   stopFailed: "Gateway could not be stopped.",
   startExited:

--- a/src/shared/i18n/locales/es/gateway.ts
+++ b/src/shared/i18n/locales/es/gateway.ts
@@ -6,6 +6,9 @@ export default {
   running: "En ejecución",
   stopped: "Detenido",
   working: "Trabajando…",
+  restart: "Reiniciar",
+  restartFailed:
+    "No se pudo reiniciar el gateway. Revisa gateway-stderr.log para más detalles.",
   startFailed: "No se pudo iniciar el gateway.",
   stopFailed: "No se pudo detener el gateway.",
   startExited: "El gateway se inició, pero se detuvo antes de estar listo.",

--- a/src/shared/i18n/locales/id/gateway.ts
+++ b/src/shared/i18n/locales/id/gateway.ts
@@ -6,6 +6,9 @@ export default {
   running: "Berjalan",
   stopped: "Berhenti",
   working: "Memproses…",
+  restart: "Mulai ulang",
+  restartFailed:
+    "Gagal memulai ulang gateway. Periksa gateway-stderr.log untuk detail.",
   startFailed: "Gateway tidak dapat dimulai.",
   stopFailed: "Gateway tidak dapat dihentikan.",
   startExited: "Gateway sudah dimulai, tetapi berhenti sebelum siap.",

--- a/src/shared/i18n/locales/ja/gateway.ts
+++ b/src/shared/i18n/locales/ja/gateway.ts
@@ -6,6 +6,9 @@ export default {
   running: "稼働中",
   stopped: "停止中",
   working: "処理中…",
+  restart: "再起動",
+  restartFailed:
+    "ゲートウェイの再起動に失敗しました。詳細は gateway-stderr.log を確認してください。",
   startFailed: "ゲートウェイを起動できませんでした。",
   stopFailed: "ゲートウェイを停止できませんでした。",
   startExited: "ゲートウェイは起動しましたが、準備完了前に停止しました。",

--- a/src/shared/i18n/locales/pl/gateway.ts
+++ b/src/shared/i18n/locales/pl/gateway.ts
@@ -6,6 +6,9 @@ export default {
   running: "Działa",
   stopped: "Zatrzymana",
   working: "Przetwarzanie…",
+  restart: "Uruchom ponownie",
+  restartFailed:
+    "Nie udało się ponownie uruchomić bramki. Szczegóły znajdziesz w gateway-stderr.log.",
   startFailed: "Nie udało się uruchomić bramki.",
   stopFailed: "Nie udało się zatrzymać bramki.",
   startExited:

--- a/src/shared/i18n/locales/pt-BR/gateway.ts
+++ b/src/shared/i18n/locales/pt-BR/gateway.ts
@@ -6,6 +6,9 @@ export default {
   running: "Em execução",
   stopped: "Parado",
   working: "Processando…",
+  restart: "Reiniciar",
+  restartFailed:
+    "Falha ao reiniciar o gateway. Verifique gateway-stderr.log para detalhes.",
   startFailed: "Não foi possível iniciar o gateway.",
   stopFailed: "Não foi possível parar o gateway.",
   startExited: "O gateway foi iniciado, mas parou antes de ficar pronto.",

--- a/src/shared/i18n/locales/pt-PT/gateway.ts
+++ b/src/shared/i18n/locales/pt-PT/gateway.ts
@@ -6,6 +6,9 @@ export default {
   running: "Em execução",
   stopped: "Parado",
   working: "A processar…",
+  restart: "Reiniciar",
+  restartFailed:
+    "Falha ao reiniciar o gateway. Verifique gateway-stderr.log para detalhes.",
   startFailed: "Não foi possível iniciar o gateway.",
   stopFailed: "Não foi possível parar o gateway.",
   startExited: "O gateway foi iniciado, mas parou antes de ficar pronto.",

--- a/src/shared/i18n/locales/zh-CN/gateway.ts
+++ b/src/shared/i18n/locales/zh-CN/gateway.ts
@@ -6,6 +6,8 @@ export default {
   running: "运行中",
   stopped: "已停止",
   working: "处理中…",
+  restart: "重启",
+  restartFailed: "网关重启失败。请查看 gateway-stderr.log 获取详细信息。",
   startFailed: "无法启动网关。",
   stopFailed: "无法停止网关。",
   startExited: "网关已启动，但在就绪前又停止了。",

--- a/src/shared/i18n/locales/zh-TW/gateway.ts
+++ b/src/shared/i18n/locales/zh-TW/gateway.ts
@@ -6,6 +6,8 @@ export default {
   running: "執行中",
   stopped: "已停止",
   working: "處理中…",
+  restart: "重新啟動",
+  restartFailed: "網關重新啟動失敗。請查看 gateway-stderr.log 取得詳細資訊。",
   startFailed: "無法啟動網關。",
   stopFailed: "無法停止網關。",
   startExited: "網關已啟動，但在就緒前又停止了。",

--- a/tests/gateway-restart.test.ts
+++ b/tests/gateway-restart.test.ts
@@ -1,0 +1,518 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+const {
+  TEST_HOME,
+  TEST_REPO,
+  connModeRef,
+  healthStatuses,
+  aliveGatewayPids,
+  restartScript,
+  hermesCliArgsSpy,
+} = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const path = require("path");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const os = require("os");
+
+  const script =
+    "const fs=require('fs'),path=require('path');" +
+    "fs.writeFileSync(path.join(process.env.HERMES_HOME,'restart-env.json')," +
+    "JSON.stringify({api:process.env.API_SERVER_ENABLED,key:process.env.TEST_PROFILE_KEY}))";
+
+  return {
+    TEST_HOME: path.join(os.tmpdir(), `hermes-gateway-restart-${Date.now()}`),
+    TEST_REPO: path.join(os.tmpdir(), `hermes-gateway-repo-${Date.now()}`),
+    connModeRef: { mode: "local" as "local" | "remote" | "ssh" },
+    healthStatuses: [] as number[],
+    aliveGatewayPids: new Set<number>(),
+    restartScript: script,
+    hermesCliArgsSpy: vi.fn(),
+  };
+});
+
+vi.mock("../src/main/installer", () => ({
+  HERMES_HOME: TEST_HOME,
+  HERMES_PYTHON: process.execPath,
+  HERMES_REPO: TEST_REPO,
+  hermesCliArgs: hermesCliArgsSpy,
+  getEnhancedPath: () => process.env.PATH || "",
+}));
+
+vi.mock("../src/main/config", () => ({
+  getModelConfig: () => ({ model: "test-model", provider: "openrouter" }),
+  getApiServerKey: () => "",
+  readEnv: (profile?: string) => ({ TEST_PROFILE_KEY: profile || "default" }),
+  getConnectionConfig: () => ({ mode: connModeRef.mode }),
+  getConfigValue: () => "",
+  setConfigValue: vi.fn(),
+}));
+
+vi.mock("../src/main/ssh-tunnel", () => ({
+  getSshTunnelUrl: () => null,
+  isSshTunnelActive: () => false,
+  isSshTunnelHealthy: () => Promise.resolve(false),
+  startSshTunnel: () => Promise.resolve(),
+}));
+
+vi.mock("../src/main/utils", () => ({
+  stripAnsi: (s: string) => s,
+  pidIsAliveAs: (pid: number) => aliveGatewayPids.has(pid),
+  getActiveProfileNameSync: () => "default",
+  normalizeProfileName: (profile?: string) =>
+    !profile || profile === "default" ? undefined : profile,
+  profileHome: (profile?: string) =>
+    profile ? join(TEST_HOME, "profiles", profile) : TEST_HOME,
+  profilePaths: (profile?: string) => {
+    const home = profile ? join(TEST_HOME, "profiles", profile) : TEST_HOME;
+    return {
+      home,
+      configFile: join(home, "config.yaml"),
+      envFile: join(home, ".env"),
+      authFile: join(home, "auth.json"),
+    };
+  },
+}));
+
+vi.mock("../src/main/models", () => ({
+  readModels: () => [],
+}));
+
+vi.mock("../src/main/process-options", () => ({
+  HIDDEN_SUBPROCESS_OPTIONS: {},
+}));
+
+vi.mock("http", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { EventEmitter } = require("events");
+  const request = vi.fn(
+    (
+      _url: string,
+      _options: Record<string, unknown>,
+      callback: (res: { statusCode: number; resume: () => void }) => void,
+    ) => {
+      const req = new EventEmitter() as EventEmitter & {
+        destroy: () => void;
+        end: () => void;
+      };
+      req.destroy = vi.fn();
+      req.end = (): void => {
+        queueMicrotask(() => {
+          callback({
+            statusCode: healthStatuses.shift() ?? 503,
+            resume: vi.fn(),
+          });
+        });
+      };
+      return req;
+    },
+  );
+  return { default: { request }, request };
+});
+
+import {
+  isGatewayHealthy,
+  isGatewayRunning,
+  restartGateway,
+  restartGatewayViaCli,
+  startGateway,
+  startGatewayWithRecovery,
+  stopGateway,
+  stopHealthPolling,
+} from "../src/main/hermes";
+
+function profilePidFile(profile = "work"): string {
+  return join(TEST_HOME, "profiles", profile, "gateway.pid");
+}
+
+async function waitForProcessExit(
+  pid: number,
+  timeoutMs = 1000,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return false;
+}
+
+async function waitForFile(
+  filePath: string,
+  timeoutMs = 1000,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(filePath)) return true;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return false;
+}
+
+describe("restartGatewayViaCli", () => {
+  beforeEach(() => {
+    stopGateway(true);
+    stopGateway("work", true);
+    stopGateway("personal", true);
+    stopHealthPolling();
+    mkdirSync(TEST_HOME, { recursive: true });
+    mkdirSync(join(TEST_HOME, "profiles", "work"), { recursive: true });
+    mkdirSync(join(TEST_HOME, "profiles", "personal"), { recursive: true });
+    mkdirSync(TEST_REPO, { recursive: true });
+    connModeRef.mode = "local";
+    healthStatuses.length = 0;
+    aliveGatewayPids.clear();
+    hermesCliArgsSpy.mockReset();
+    hermesCliArgsSpy.mockImplementation(() => ["-e", restartScript]);
+  });
+
+  afterEach(async () => {
+    stopGateway(true);
+    stopGateway("work", true);
+    stopGateway("personal", true);
+    stopHealthPolling();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    rmSync(TEST_HOME, { recursive: true, force: true });
+    rmSync(TEST_REPO, { recursive: true, force: true });
+  });
+
+  it("uses the hermes gateway restart command with the profile env", async () => {
+    healthStatuses.push(503, ...Array(20).fill(200));
+
+    await expect(restartGatewayViaCli("work", 50, 1)).resolves.toBe(true);
+
+    expect(hermesCliArgsSpy).toHaveBeenCalledWith([
+      "--profile",
+      "work",
+      "gateway",
+      "restart",
+    ]);
+    expect(await waitForFile(join(TEST_HOME, "restart-env.json"))).toBe(true);
+    expect(
+      JSON.parse(readFileSync(join(TEST_HOME, "restart-env.json"), "utf-8")),
+    ).toEqual({
+      api: "true",
+      key: "work",
+    });
+  });
+
+  it("treats a long-running restart process as success once health is ready", async () => {
+    const pidFile = join(TEST_HOME, "long-running-restart.pid");
+    const longRunningRestartScript =
+      "const fs=require('fs');" +
+      `fs.writeFileSync(${JSON.stringify(pidFile)},String(process.pid));` +
+      "setInterval(() => {}, 1000);";
+
+    hermesCliArgsSpy.mockImplementation(() => ["-e", longRunningRestartScript]);
+    healthStatuses.push(200, 503, 200);
+
+    await expect(restartGatewayViaCli("work", 50, 1)).resolves.toBe(true);
+
+    expect(isGatewayRunning("work")).toBe(true);
+    expect(hermesCliArgsSpy).toHaveBeenCalledWith([
+      "--profile",
+      "work",
+      "gateway",
+      "restart",
+    ]);
+
+    expect(await waitForFile(pidFile)).toBe(true);
+    const spawnedPid = Number(readFileSync(pidFile, "utf-8"));
+    stopGateway("work", true);
+    expect(await waitForProcessExit(spawnedPid, 3000)).toBe(true);
+  });
+
+  it("times out and stops a long-running restart process when health stays down", async () => {
+    const pidFile = join(TEST_HOME, "unhealthy-restart.pid");
+    const unhealthyRestartScript =
+      "const fs=require('fs');" +
+      `fs.writeFileSync(${JSON.stringify(pidFile)},String(process.pid));` +
+      "setInterval(() => {}, 1000);";
+
+    hermesCliArgsSpy.mockImplementation(() => ["-e", unhealthyRestartScript]);
+
+    const restart = restartGatewayViaCli("work", 500, 10);
+    expect(await waitForFile(pidFile)).toBe(true);
+    await expect(restart).resolves.toBe(false);
+
+    const spawnedPid = Number(readFileSync(pidFile, "utf-8"));
+    expect(await waitForProcessExit(spawnedPid, 3000)).toBe(true);
+    expect(hermesCliArgsSpy).toHaveBeenCalledWith([
+      "--profile",
+      "work",
+      "gateway",
+      "restart",
+    ]);
+  });
+
+  it("does not report success when the restart command exits but health stays down", async () => {
+    await expect(restartGatewayViaCli("work", 5, 1)).resolves.toBe(false);
+
+    expect(hermesCliArgsSpy).toHaveBeenCalledWith([
+      "--profile",
+      "work",
+      "gateway",
+      "restart",
+    ]);
+  });
+
+  it("resolves false instead of rejecting when restart setup throws", async () => {
+    hermesCliArgsSpy.mockImplementation(() => {
+      throw new Error("boom");
+    });
+
+    await expect(restartGatewayViaCli("work", 5, 1)).resolves.toBe(false);
+  });
+
+  it("treats a throwing health probe as unhealthy", async () => {
+    connModeRef.mode = "ssh";
+
+    await expect(isGatewayHealthy()).resolves.toBe(false);
+  });
+
+  it("deduplicates concurrent restart requests", async () => {
+    healthStatuses.push(503, 200, 503, 503, 503, 200, 200, 200);
+
+    const first = restartGatewayViaCli("work", 50, 1);
+    const second = restartGatewayViaCli("work", 50, 1);
+
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+    expect(hermesCliArgsSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the native restart path only after the old gateway stops", async () => {
+    hermesCliArgsSpy.mockImplementation(() => ["-e", "process.exit(0)"]);
+    healthStatuses.push(503, 200);
+
+    await expect(restartGateway("work", 50, 1)).resolves.toBe(true);
+
+    expect(hermesCliArgsSpy).toHaveBeenCalledTimes(1);
+    expect(hermesCliArgsSpy).toHaveBeenCalledWith([
+      "--profile",
+      "work",
+      "gateway",
+    ]);
+  });
+
+  it("does not report native restart success when the old gateway never stops", async () => {
+    const gatewayPid = 424242;
+    aliveGatewayPids.add(gatewayPid);
+    writeFileSync(profilePidFile(), String(gatewayPid), "utf-8");
+    hermesCliArgsSpy.mockImplementation(() => ["-e", "process.exit(0)"]);
+
+    healthStatuses.push(...Array(100).fill(200));
+
+    await expect(restartGateway("work", 25, 1, 25)).resolves.toBe(false);
+
+    expect(hermesCliArgsSpy).not.toHaveBeenCalled();
+    expect(isGatewayRunning("work")).toBe(true);
+    expect(readFileSync(profilePidFile(), "utf-8")).toBe(
+      String(gatewayPid),
+    );
+  });
+
+  it("serializes restart requests for different profiles instead of reusing the first result", async () => {
+    const first = restartGatewayViaCli("work", 5, 1);
+    const second = restartGatewayViaCli("personal", 5, 1);
+
+    await expect(Promise.all([first, second])).resolves.toEqual([false, false]);
+    expect(hermesCliArgsSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("deduplicates queued restarts for the same profile", async () => {
+    hermesCliArgsSpy
+      .mockImplementationOnce(() => {
+        throw new Error("first failed");
+      })
+      .mockImplementation(() => ["-e", "process.exit(0)"]);
+    healthStatuses.push(503, 200, 503, 503, 503, 200, 200, 200);
+
+    const first = restartGatewayViaCli("work", 50, 1);
+    const second = restartGatewayViaCli("personal", 50, 1);
+    const third = restartGatewayViaCli("personal", 50, 1);
+
+    await expect(Promise.all([first, second, third])).resolves.toEqual([
+      false,
+      true,
+      true,
+    ]);
+    expect(hermesCliArgsSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("still runs a queued different-profile restart after the in-flight restart setup fails", async () => {
+    hermesCliArgsSpy
+      .mockImplementationOnce(() => {
+        throw new Error("first failed");
+      })
+      .mockImplementation(() => ["-e", "process.exit(0)"]);
+    healthStatuses.push(503, 200, 503, 503, 503, 200, 200, 200);
+
+    const first = restartGatewayViaCli("work", 5, 1);
+    const second = restartGatewayViaCli("personal", 50, 1);
+
+    await expect(Promise.all([first, second])).resolves.toEqual([false, true]);
+    expect(hermesCliArgsSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps an existing tracked gateway when CLI restart setup fails", async () => {
+    const pidFile = join(TEST_HOME, "tracked-gateway.pid");
+    const startScript =
+      "const fs=require('fs');" +
+      `fs.writeFileSync(${JSON.stringify(pidFile)},String(process.pid));` +
+      "setInterval(() => {}, 1000);";
+
+    hermesCliArgsSpy
+      .mockImplementationOnce(() => ["-e", startScript])
+      .mockImplementationOnce(() => {
+        throw new Error("restart unavailable");
+      });
+
+    expect(startGateway("work")).toBe(true);
+    expect(isGatewayRunning("work")).toBe(true);
+    expect(await waitForFile(pidFile)).toBe(true);
+
+    await expect(restartGatewayViaCli("work", 5, 1)).resolves.toBe(false);
+
+    expect(isGatewayRunning("work")).toBe(true);
+    stopGateway("work", true);
+    stopGateway("work", true);
+
+    const spawnedPid = Number(readFileSync(pidFile, "utf-8"));
+    expect(await waitForProcessExit(spawnedPid, 3000)).toBe(true);
+    expect(hermesCliArgsSpy).toHaveBeenNthCalledWith(1, [
+      "--profile",
+      "work",
+      "gateway",
+    ]);
+    expect(hermesCliArgsSpy).toHaveBeenNthCalledWith(2, [
+      "--profile",
+      "work",
+      "gateway",
+      "restart",
+    ]);
+  });
+
+  it("does not restore a tracked gateway that exited during a failed CLI restart", async () => {
+    const pidFile = join(TEST_HOME, "tracked-gateway-exit.pid");
+    const startScript =
+      "const fs=require('fs');" +
+      `fs.writeFileSync(${JSON.stringify(pidFile)},String(process.pid));` +
+      "setInterval(() => {}, 1000);";
+    const restartScript =
+      "const fs=require('fs');" +
+      `const pid=Number(fs.readFileSync(${JSON.stringify(pidFile)},'utf-8'));` +
+      "try{process.kill(pid,'SIGTERM')}catch{};" +
+      "const done=Date.now()+1000;" +
+      "function wait(){try{process.kill(pid,0);if(Date.now()<done)return setTimeout(wait,25)}catch{};process.exit(1)};" +
+      "wait();";
+
+    hermesCliArgsSpy
+      .mockImplementationOnce(() => ["-e", startScript])
+      .mockImplementationOnce(() => ["-e", restartScript]);
+
+    expect(startGateway("work")).toBe(true);
+    expect(await waitForFile(pidFile)).toBe(true);
+
+    const spawnedPid = Number(readFileSync(pidFile, "utf-8"));
+    await expect(restartGatewayViaCli("work", 2000, 25)).resolves.toBe(
+      false,
+    );
+
+    expect(await waitForProcessExit(spawnedPid, 3000)).toBe(true);
+    expect(isGatewayRunning("work")).toBe(false);
+    expect(hermesCliArgsSpy).toHaveBeenNthCalledWith(1, [
+      "--profile",
+      "work",
+      "gateway",
+    ]);
+    expect(hermesCliArgsSpy).toHaveBeenNthCalledWith(2, [
+      "--profile",
+      "work",
+      "gateway",
+      "restart",
+    ]);
+  });
+
+  it("falls back to a native restart when a normal start does not become healthy", async () => {
+    hermesCliArgsSpy.mockImplementation(() => ["-e", "process.exit(0)"]);
+    healthStatuses.push(...Array(20).fill(503), 200);
+
+    await expect(
+      startGatewayWithRecovery("work", 50, 5, 15000, 250),
+    ).resolves.toBe(true);
+
+    expect(hermesCliArgsSpy).toHaveBeenNthCalledWith(1, [
+      "--profile",
+      "work",
+      "gateway",
+    ]);
+    expect(hermesCliArgsSpy).toHaveBeenNthCalledWith(2, [
+      "--profile",
+      "work",
+      "gateway",
+    ]);
+  });
+
+  it("preserves the tracked PID entry when recovery cannot stop the gateway", async () => {
+    const gatewayPid = 2147483647;
+    aliveGatewayPids.add(gatewayPid);
+    writeFileSync(profilePidFile(), String(gatewayPid), "utf-8");
+    healthStatuses.push(503, ...Array(100).fill(200));
+
+    await expect(
+      startGatewayWithRecovery("work", 50, 75, 15000, 25, 25),
+    ).resolves.toBe(false);
+
+    expect(isGatewayRunning("work")).toBe(true);
+    expect(readFileSync(profilePidFile(), "utf-8")).toBe(
+      String(gatewayPid),
+    );
+    expect(hermesCliArgsSpy).not.toHaveBeenCalled();
+  });
+
+  it("stops a spawned gateway before native restart recovery", async () => {
+    const pidFile = join(TEST_HOME, "spawned-gateway.pid");
+    const startScript =
+      "const fs=require('fs');" +
+      `fs.writeFileSync(${JSON.stringify(pidFile)},String(process.pid));` +
+      "setInterval(() => {}, 1000);";
+
+    hermesCliArgsSpy
+      .mockImplementationOnce(() => ["-e", startScript])
+      .mockImplementationOnce(() => {
+        throw new Error("restart unavailable");
+      });
+
+    await expect(startGatewayWithRecovery("work", 1000, 25)).resolves.toBe(
+      false,
+    );
+
+    const spawnedPid = Number(readFileSync(pidFile, "utf-8"));
+    const exited = await waitForProcessExit(spawnedPid);
+    if (!exited) {
+      try {
+        process.kill(spawnedPid, "SIGTERM");
+      } catch {
+        // already gone
+      }
+    }
+
+    expect(exited).toBe(true);
+    expect(hermesCliArgsSpy).toHaveBeenNthCalledWith(1, [
+      "--profile",
+      "work",
+      "gateway",
+    ]);
+    expect(hermesCliArgsSpy).toHaveBeenNthCalledWith(2, [
+      "--profile",
+      "work",
+      "gateway",
+    ]);
+  });
+});

--- a/tests/hermes-cli-session-id.test.ts
+++ b/tests/hermes-cli-session-id.test.ts
@@ -1,7 +1,16 @@
 import { EventEmitter } from "events";
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { mkdirSync, rmSync } from "fs";
 
-const { spawned, TEST_HOME, TEST_REPO, healthStatuses, apiRequests } =
+const {
+  spawned,
+  TEST_HOME,
+  TEST_REPO,
+  healthStatuses,
+  apiRequests,
+  apiRequestErrors,
+  requestEvents,
+} =
   vi.hoisted(() => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const path = require("path");
@@ -21,12 +30,17 @@ const { spawned, TEST_HOME, TEST_REPO, healthStatuses, apiRequests } =
         os.tmpdir(),
         `hermes-cli-session-test-${Date.now()}`,
       ),
-      TEST_REPO: os.tmpdir(),
+      TEST_REPO: path.join(
+        os.tmpdir(),
+        `hermes-cli-session-repo-${Date.now()}`,
+      ),
       healthStatuses: [] as number[],
       apiRequests: [] as Array<{
         body: string;
         headers: Record<string, string>;
       }>,
+      apiRequestErrors: [] as string[],
+      requestEvents: [] as string[],
     };
   });
 
@@ -50,6 +64,7 @@ vi.mock("http", () => ({
         },
         end: () => {
           if (_url.endsWith("/health")) {
+            requestEvents.push("health");
             cb?.({
               statusCode: healthStatuses.shift() ?? 503,
               resume: () => {},
@@ -58,6 +73,58 @@ vi.mock("http", () => ({
           }
 
           if (_url.endsWith("/v1/chat/completions")) {
+            requestEvents.push("chat");
+            const requestError = apiRequestErrors.shift();
+            if (requestError === "HANG") {
+              return;
+            }
+            if (requestError === "HANG_ACCEPTED") {
+              apiRequests.push({
+                body,
+                headers: (_options.headers as Record<string, string>) || {},
+              });
+              return;
+            }
+            if (requestError === "TIMEOUT_ACCEPTED") {
+              apiRequests.push({
+                body,
+                headers: (_options.headers as Record<string, string>) || {},
+              });
+              queueMicrotask(() => {
+                handlers.get("timeout")?.();
+              });
+              return;
+            }
+            if (requestError?.startsWith("STATUS:")) {
+              const [, status = "500", message = "API error"] =
+                requestError.split(":");
+              apiRequests.push({
+                body,
+                headers: (_options.headers as Record<string, string>) || {},
+              });
+              const res = new EventEmitter() as EventEmitter & {
+                statusCode: number;
+                headers: Record<string, string>;
+              };
+              res.statusCode = Number(status);
+              res.headers = {};
+              cb?.(res);
+              queueMicrotask(() => {
+                res.emit(
+                  "data",
+                  Buffer.from(JSON.stringify({ error: { message } })),
+                );
+                res.emit("end");
+              });
+              return;
+            }
+            if (requestError) {
+              queueMicrotask(() => {
+                handlers.get("error")?.(new Error(requestError));
+              });
+              return;
+            }
+
             apiRequests.push({
               body,
               headers: (_options.headers as Record<string, string>) || {},
@@ -115,6 +182,7 @@ vi.mock("child_process", () => ({
         kill: vi.fn(),
         unref: vi.fn(),
       });
+      proc.stderr.pipe = vi.fn();
       spawned.push(proc);
       return proc;
     }),
@@ -127,6 +195,7 @@ vi.mock("child_process", () => ({
       kill: vi.fn(),
       unref: vi.fn(),
     });
+    proc.stderr.pipe = vi.fn();
     spawned.push(proc);
     return proc;
   }),
@@ -187,6 +256,9 @@ describe("CLI fallback session id propagation", () => {
   beforeEach(() => {
     healthStatuses.length = 0;
     apiRequests.length = 0;
+    apiRequestErrors.length = 0;
+    requestEvents.length = 0;
+    rmSync(TEST_REPO, { recursive: true, force: true });
   });
 
   afterEach(() => {
@@ -260,8 +332,9 @@ describe("CLI fallback session id propagation", () => {
     });
   });
 
-  it("waits for a cold gateway to become API-ready instead of falling back to CLI", async () => {
-    healthStatuses.push(503, 200);
+  it("uses a healthy running gateway API instead of falling back to CLI", async () => {
+    mkdirSync(TEST_REPO, { recursive: true });
+    healthStatuses.push(200);
 
     expect(startGateway()).toBe(true);
     expect(spawned).toHaveLength(1);
@@ -285,7 +358,56 @@ describe("CLI fallback session id propagation", () => {
     });
   });
 
-  it("re-checks health when a previously-ready local gateway is restarted cold", async () => {
+  it("recovers a stopped local gateway before sending via the API", async () => {
+    mkdirSync(TEST_REPO, { recursive: true });
+    healthStatuses.push(503, 503, 200);
+
+    const chunks: string[] = [];
+    const done = new Promise<string | undefined>((resolve, reject) => {
+      sendMessage("hi after update", {
+        onChunk: (chunk) => chunks.push(chunk),
+        onDone: resolve,
+        onError: reject,
+      }).catch(reject);
+    });
+
+    await expect(done).resolves.toBe("desk-cold-gateway");
+    expect(chunks.join("")).toBe("Hi from API");
+    expect(spawned).toHaveLength(1);
+    expect(apiRequests).toHaveLength(1);
+    expect(JSON.parse(apiRequests[0].body)).toMatchObject({
+      messages: [{ role: "user", content: "hi after update" }],
+      stream: true,
+    });
+  });
+
+  it("restarts a tracked but unhealthy local gateway before sending via the API", async () => {
+    mkdirSync(TEST_REPO, { recursive: true });
+    expect(startGateway()).toBe(true);
+    expect(spawned).toHaveLength(1);
+    healthStatuses.push(503, 503, 503, 200);
+
+    const chunks: string[] = [];
+    const done = new Promise<string | undefined>((resolve, reject) => {
+      sendMessage("hi after stale gateway", {
+        onChunk: (chunk) => chunks.push(chunk),
+        onDone: resolve,
+        onError: reject,
+      }).catch(reject);
+    });
+
+    await expect(done).resolves.toBe("desk-cold-gateway");
+    expect(chunks.join("")).toBe("Hi from API");
+    expect(spawned).toHaveLength(2);
+    expect(apiRequests).toHaveLength(1);
+    expect(JSON.parse(apiRequests[0].body)).toMatchObject({
+      messages: [{ role: "user", content: "hi after stale gateway" }],
+      stream: true,
+    });
+  });
+
+  it("recovers after a stale ready cache without slowing the normal API send path", async () => {
+    mkdirSync(TEST_REPO, { recursive: true });
     healthStatuses.push(200);
 
     await expect(
@@ -298,10 +420,11 @@ describe("CLI fallback session id propagation", () => {
       }),
     ).resolves.toBe("desk-cold-gateway");
     expect(apiRequests).toHaveLength(1);
+    expect(requestEvents).toEqual(["health", "chat"]);
 
-    expect(startGateway()).toBe(true);
-    expect(spawned).toHaveLength(1);
+    apiRequestErrors.push("connect ECONNREFUSED 127.0.0.1:8765");
     healthStatuses.push(503, 200);
+    const secondSendStart = requestEvents.length;
 
     const chunks: string[] = [];
     await expect(
@@ -317,8 +440,123 @@ describe("CLI fallback session id propagation", () => {
     expect(chunks.join("")).toBe("Hi from API");
     expect(spawned).toHaveLength(1);
     expect(apiRequests).toHaveLength(2);
+    expect(requestEvents[secondSendStart]).toBe("chat");
+    expect(requestEvents.at(-1)).toBe("chat");
     expect(JSON.parse(apiRequests[1].body)).toMatchObject({
       messages: [{ role: "user", content: "hi after restart" }],
+      stream: true,
+    });
+  });
+
+  it("retries a reset local API socket once after gateway recovery", async () => {
+    mkdirSync(TEST_REPO, { recursive: true });
+    healthStatuses.push(200);
+
+    await expect(
+      new Promise<string | undefined>((resolve, reject) => {
+        sendMessage("warmup", {
+          onChunk: () => {},
+          onDone: resolve,
+          onError: reject,
+        }).catch(reject);
+      }),
+    ).resolves.toBe("desk-cold-gateway");
+
+    apiRequestErrors.push("read ECONNRESET");
+    healthStatuses.push(503, 200);
+
+    const chunks: string[] = [];
+    await expect(
+      new Promise<string | undefined>((resolve, reject) => {
+        sendMessage("hi after reset", {
+          onChunk: (chunk) => chunks.push(chunk),
+          onDone: resolve,
+          onError: reject,
+        }).catch(reject);
+      }),
+    ).resolves.toBe("desk-cold-gateway");
+
+    expect(chunks.join("")).toBe("Hi from API");
+    expect(apiRequests).toHaveLength(2);
+    expect(JSON.parse(apiRequests[1].body)).toMatchObject({
+      messages: [{ role: "user", content: "hi after reset" }],
+      stream: true,
+    });
+  });
+
+  it("preserves API response errors when recovery succeeds", async () => {
+    mkdirSync(TEST_REPO, { recursive: true });
+    healthStatuses.push(200);
+
+    await expect(
+      new Promise<string | undefined>((resolve, reject) => {
+        sendMessage("warmup", {
+          onChunk: () => {},
+          onDone: resolve,
+          onError: reject,
+        }).catch(reject);
+      }),
+    ).resolves.toBe("desk-cold-gateway");
+
+    apiRequestErrors.push("STATUS:401:Authentication failed");
+    healthStatuses.push(503, 200);
+
+    await expect(
+      new Promise<string | undefined>((resolve, reject) => {
+        sendMessage("bad key", {
+          onChunk: () => {},
+          onDone: resolve,
+          onError: reject,
+        }).catch(reject);
+      }),
+    ).rejects.toThrow("Authentication failed");
+
+    expect(apiRequests).toHaveLength(2);
+    expect(JSON.parse(apiRequests[1].body)).toMatchObject({
+      messages: [{ role: "user", content: "bad key" }],
+      stream: true,
+    });
+  });
+
+  it("recovers an accepted timed-out request without replaying the user message", async () => {
+    mkdirSync(TEST_REPO, { recursive: true });
+    healthStatuses.push(200);
+
+    await expect(
+      new Promise<string | undefined>((resolve, reject) => {
+        sendMessage("warmup", {
+          onChunk: () => {},
+          onDone: resolve,
+          onError: reject,
+        }).catch(reject);
+      }),
+    ).resolves.toBe("desk-cold-gateway");
+    expect(requestEvents).toEqual(["health", "chat"]);
+
+    apiRequestErrors.push("TIMEOUT_ACCEPTED");
+    healthStatuses.push(503, 503, 200);
+    const secondSendStart = requestEvents.length;
+
+    const chunks: string[] = [];
+    await expect(
+      new Promise<string | undefined>((resolve, reject) => {
+        sendMessage("hi after hung gateway", {
+          onChunk: (chunk) => chunks.push(chunk),
+          onDone: resolve,
+          onError: reject,
+        }).catch(reject);
+      }),
+    ).rejects.toThrow(
+      "API request timed out. Check the SSH tunnel and remote Hermes gateway.",
+    );
+
+    expect(chunks).toEqual([]);
+    expect(spawned).toHaveLength(1);
+    expect(apiRequests).toHaveLength(2);
+    expect(requestEvents[secondSendStart]).toBe("chat");
+    expect(requestEvents.slice(secondSendStart + 1)).toContain("health");
+    expect(JSON.parse(apiRequests[1].body)).toMatchObject({
+      messages: [{ role: "user", content: "hi after hung gateway" }],
       stream: true,
     });
   });

--- a/tests/hermes-cli-session-id.test.ts
+++ b/tests/hermes-cli-session-id.test.ts
@@ -118,6 +118,30 @@ vi.mock("http", () => ({
               });
               return;
             }
+            if (requestError?.startsWith("STREAM_ERROR:")) {
+              const message = requestError.slice("STREAM_ERROR:".length);
+              apiRequests.push({
+                body,
+                headers: (_options.headers as Record<string, string>) || {},
+              });
+              const res = new EventEmitter() as EventEmitter & {
+                statusCode: number;
+                headers: Record<string, string>;
+              };
+              res.statusCode = 200;
+              res.headers = { "x-hermes-session-id": "desk-cold-gateway" };
+              cb?.(res);
+              queueMicrotask(() => {
+                res.emit(
+                  "data",
+                  Buffer.from(
+                    'data: {"choices":[{"delta":{"content":"Partial"}}]}\n\n',
+                  ),
+                );
+                res.emit("error", new Error(message));
+              });
+              return;
+            }
             if (requestError) {
               queueMicrotask(() => {
                 handlers.get("error")?.(new Error(requestError));
@@ -514,6 +538,49 @@ describe("CLI fallback session id propagation", () => {
     expect(apiRequests).toHaveLength(2);
     expect(JSON.parse(apiRequests[1].body)).toMatchObject({
       messages: [{ role: "user", content: "bad key" }],
+      stream: true,
+    });
+  });
+
+  it("reports a mid-stream API disconnect without replaying partial output", async () => {
+    mkdirSync(TEST_REPO, { recursive: true });
+    healthStatuses.push(200);
+
+    await expect(
+      new Promise<string | undefined>((resolve, reject) => {
+        sendMessage("warmup", {
+          onChunk: () => {},
+          onDone: resolve,
+          onError: reject,
+        }).catch(reject);
+      }),
+    ).resolves.toBe("desk-cold-gateway");
+
+    apiRequestErrors.push("STREAM_ERROR:read ECONNRESET");
+    healthStatuses.push(503, 200);
+    const secondSendStart = requestEvents.length;
+
+    const chunks: string[] = [];
+    await expect(
+      new Promise<string | undefined>((resolve, reject) => {
+        sendMessage("partial stream", {
+          onChunk: (chunk) => chunks.push(chunk),
+          onDone: resolve,
+          onError: reject,
+        }).catch(reject);
+      }),
+    ).rejects.toThrow("Stream error: read ECONNRESET");
+
+    expect(chunks.join("")).toBe("Partial");
+    expect(apiRequests).toHaveLength(2);
+    expect(requestEvents[secondSendStart]).toBe("chat");
+    await vi.waitFor(() => {
+      expect(spawned).toHaveLength(1);
+      expect(healthStatuses).toHaveLength(0);
+      expect(requestEvents.slice(secondSendStart + 1)).toContain("health");
+    });
+    expect(JSON.parse(apiRequests[1].body)).toMatchObject({
+      messages: [{ role: "user", content: "partial stream" }],
       stream: true,
     });
   });

--- a/tests/ipc-handlers.test.ts
+++ b/tests/ipc-handlers.test.ts
@@ -103,6 +103,7 @@ describe("Legacy IPC handlers preserved", () => {
     "abort-chat",
     "start-gateway",
     "stop-gateway",
+    "restart-gateway",
     "gateway-status",
     "get-platform-enabled",
     "set-platform-enabled",

--- a/tests/preload-api-surface.test.ts
+++ b/tests/preload-api-surface.test.ts
@@ -139,6 +139,7 @@ describe("Legacy APIs preserved (backward compat)", () => {
     // Gateway
     "startGateway",
     "stopGateway",
+    "restartGateway",
     "gatewayStatus",
     "getPlatformEnabled",
     "setPlatformEnabled",

--- a/tests/remote-history.test.ts
+++ b/tests/remote-history.test.ts
@@ -5,6 +5,41 @@ import { join } from "path";
 const ROOT = join(__dirname, "..");
 const hermesSrc = readFileSync(join(ROOT, "src/main/hermes.ts"), "utf-8");
 
+function splitCallArgs(args: string): string[] {
+  return args
+    .split(",")
+    .map((p) => p.trim())
+    .filter(Boolean);
+}
+
+function hasHistoryArg(args: string): boolean {
+  return splitCallArgs(args).some(
+    (p) => p === "history" || p.includes("history"),
+  );
+}
+
+function extractExportedFunction(name: string): string {
+  const startMatch = hermesSrc.indexOf(`export async function ${name}(`);
+  expect(startMatch).toBeGreaterThan(-1);
+
+  const remainingCode = hermesSrc.substring(startMatch);
+  const endMatch = remainingCode.indexOf("\nexport function ");
+  return endMatch > 0 ? remainingCode.substring(0, endMatch) : remainingCode;
+}
+
+function extractLocalRecoveryFunction(): string {
+  const startMatch = hermesSrc.indexOf(
+    "async function sendMessageViaApiWithLocalRecovery(",
+  );
+  expect(startMatch).toBeGreaterThan(-1);
+
+  const remainingCode = hermesSrc.substring(startMatch);
+  const endMatch = remainingCode.indexOf("\nexport async function sendMessage(");
+  expect(endMatch).toBeGreaterThan(-1);
+
+  return remainingCode.substring(0, endMatch);
+}
+
 /**
  * Test that sendMessage passes history parameter in remote mode.
  *
@@ -31,18 +66,13 @@ describe("Remote/SSH Mode History Preservation", () => {
 
     expect(apiCallMatch).toBeDefined();
 
-    const params = apiCallMatch![1]
-      .split(",")
-      .map((p) => p.trim())
-      .filter(Boolean);
+    const params = splitCallArgs(apiCallMatch![1]);
 
     // Should have at least 5 parameters: message, cb, profile, resumeSessionId, history
     expect(params.length).toBeGreaterThanOrEqual(5);
 
     // history must appear somewhere in the arg list
-    expect(params.some((p) => p === "history" || p.includes("history"))).toBe(
-      true,
-    );
+    expect(hasHistoryArg(apiCallMatch![1])).toBe(true);
   });
 
   it("sendMessageViaApi builds messages from history + current message", () => {
@@ -75,61 +105,60 @@ describe("Remote/SSH Mode History Preservation", () => {
     );
   });
 
-  it("local API available branch also passes history", () => {
+  it("local API available branch passes history to recovery wrapper", () => {
     // Extract the local API available branch
     const localApiBranch = hermesSrc.match(
-      /if \(apiServerAvailable\) \{[\s\S]*?return sendMessageViaApi\([\s\S]*?\);[\s\S]*?\}/,
+      /if \(apiServerAvailable\) \{[\s\S]*?return sendMessageViaApiWithLocalRecovery\([\s\S]*?\);[\s\S]*?\}/,
     );
 
     expect(localApiBranch).toBeDefined();
 
     const branchCode = localApiBranch![0];
 
-    const apiCallMatch = branchCode.match(
-      /return sendMessageViaApi\(([\s\S]*?)\);/,
+    const wrapperCallMatch = branchCode.match(
+      /return sendMessageViaApiWithLocalRecovery\(([\s\S]*?)\);/,
     );
 
-    expect(apiCallMatch).toBeDefined();
+    expect(wrapperCallMatch).toBeDefined();
 
-    const params = apiCallMatch![1]
-      .split(",")
-      .map((p) => p.trim())
-      .filter(Boolean);
+    const params = splitCallArgs(wrapperCallMatch![1]);
 
     // Should have at least 5 parameters including history
     expect(params.length).toBeGreaterThanOrEqual(5);
 
-    expect(params.some((p) => p === "history" || p.includes("history"))).toBe(
-      true,
-    );
+    expect(hasHistoryArg(wrapperCallMatch![1])).toBe(true);
   });
 
-  it("all sendMessageViaApi calls in sendMessage include history parameter", () => {
-    // Find the sendMessage function - use a more flexible regex
-    const startMatch = hermesSrc.indexOf("export async function sendMessage(");
-    expect(startMatch).toBeGreaterThan(-1);
+  it("local recovery wrapper forwards history to every API send", () => {
+    const wrapperCode = extractLocalRecoveryFunction();
+    const apiCalls = Array.from(
+      wrapperCode.matchAll(/sendMessageViaApi\(([\s\S]*?)\);/g),
+    );
 
-    // Extract from "export async function sendMessage" to the next "export function" or end
-    const remainingCode = hermesSrc.substring(startMatch);
-    const endMatch = remainingCode.indexOf("\nexport function ");
-    const funcCode =
-      endMatch > 0 ? remainingCode.substring(0, endMatch) : remainingCode;
+    // Initial local API send + retry after gateway recovery.
+    expect(apiCalls.length).toBeGreaterThanOrEqual(2);
 
-    // Find all sendMessageViaApi calls
-    const apiCalls = funcCode.matchAll(/sendMessageViaApi\(([^)]+)\)/g);
+    for (const call of apiCalls) {
+      expect(hasHistoryArg(call[1])).toBe(true);
+    }
+  });
+
+  it("all API send paths in sendMessage include history parameter", () => {
+    const funcCode = extractExportedFunction("sendMessage");
+
+    // Find all direct and local-recovery API send paths.
+    const apiCalls = funcCode.matchAll(
+      /sendMessageViaApi(?:WithLocalRecovery)?\(([\s\S]*?)\);/g,
+    );
 
     const calls = Array.from(apiCalls);
 
-    // Should have at least 2 calls (remote mode + local API available)
+    // Should have at least 2 API paths (remote mode + local API available).
     expect(calls.length).toBeGreaterThanOrEqual(2);
 
-    // Verify all calls include history
+    // Verify all API paths include history.
     for (const call of calls) {
-      const params = call[1].split(",").map((p) => p.trim());
-      const hasHistory = params.some(
-        (p) => p === "history" || p.includes("history"),
-      );
-      expect(hasHistory).toBe(true);
+      expect(hasHistoryArg(call[1])).toBe(true);
     }
   });
 });

--- a/tests/remote-mode-url-and-spawn.test.ts
+++ b/tests/remote-mode-url-and-spawn.test.ts
@@ -96,6 +96,7 @@ import {
   startGateway,
   startGatewayDetailed,
   restartGateway,
+  restartGatewayViaCli,
   testRemoteConnection,
   contextFolderSystemMessage,
 } from "../src/main/hermes";
@@ -345,6 +346,20 @@ describe("startGateway / restartGateway in remote mode", () => {
     spawnSpy.mockClear();
     connModeRef.mode = "ssh";
     restartGateway();
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  it("restartGatewayViaCli refuses to spawn in remote mode", async () => {
+    spawnSpy.mockClear();
+    connModeRef.mode = "remote";
+    await expect(restartGatewayViaCli()).resolves.toBe(false);
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
+  it("restartGatewayViaCli refuses to spawn in ssh mode", async () => {
+    spawnSpy.mockClear();
+    connModeRef.mode = "ssh";
+    await expect(restartGatewayViaCli()).resolves.toBe(false);
     expect(spawnSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Fixes the Desktop gateway restart/recovery path so a local gateway that becomes stale after Windows sleep/resume or `hermes update` does not leave Hermes Desktop stuck in an indefinite Sending state.

The previous Desktop restart flow ultimately relied on `hermes gateway restart`. Recent hermes-agent builds can run that command as a long-lived foreground gateway process on Windows, which is why live testing showed a visible `cmd.exe` window with "Hermes Gateway Starting...". This PR switches the GUI restart path to a native Desktop-managed restart: stop the current gateway, wait for `/health` to drop, start the gateway through the existing hidden `startGateway()` path, then wait for `/health` to become ready again.

It also makes the chat send path recover a stale local API cache. If Desktop believes the gateway is ready but the local API request fails with `ECONNREFUSED`, Desktop now recovers the gateway and retries once. If the request was accepted but times out, Desktop recovers the gateway without replaying the user message, avoiding duplicate model/tool execution and surfacing a clear resend-needed error.

Closes #492.

## Details

- Adds `startGatewayWithRecovery()` for local start attempts that fail to become healthy, falling back to the same native restart transaction.
- Makes `restartGateway()` async and health-based, returning `true` only when `/health` is actually ready.
- Requires the old gateway to become unhealthy before spawning a replacement, avoiding false success when the old process never stopped.
- Restores previously tracked gateway state or PID-file state if the restart cannot stop the old gateway, so the UI does not lose track of a still-running gateway.
- Uses the existing hidden subprocess options for the replacement gateway, avoiding the visible Windows terminal window seen with the CLI restart command.
- Adds a `restart-gateway` IPC/preload API and a Restart button on the Gateway screen.
- Keeps restart failures visible in the Gateway screen while refreshing the real running/stopped status.
- Leaves `restartGatewayViaCli()` as a compatible helper/test target, but the GUI IPC path now uses the native restart flow.
- Removes the eager `send-message` IPC gateway start and lets `sendMessage()` perform bounded recovery, so local chat sends do not bypass the health-checked recovery path.

## Validation

Automated:

- `npm test -- tests/hermes-cli-session-id.test.ts` — 7 passed
- `npm test -- tests/gateway-restart.test.ts tests/hermes-cli-session-id.test.ts tests/remote-mode-url-and-spawn.test.ts tests/ipc-handlers.test.ts tests/preload-api-surface.test.ts src/renderer/src/screens/Gateway/Gateway.test.tsx` — 231 passed
- `npm run typecheck:node` — passed
- `npm run typecheck:web` — passed
- `git diff --check` — clean except normal Windows CRLF warnings

Live test on Windows:

- Launched a dedicated Electron dev instance from this branch.
- Verified a normal live chat send returned `OK` while gateway stayed healthy.
- Killed the active local gateway process externally via `gateway.pid`, without using Desktop's Stop button.
- Sent through `window.hermesAPI.sendMessage(...)`; Desktop recovered the gateway and got `OK` in about 12.7s.
- Killed the recovered gateway externally again.
- Sent from the visible Chat UI; Desktop recovered and the UI displayed the new `OK` response.
- Confirmed final `/health` returned `200 {"status":"ok","platform":"hermes-agent"}`.
