### PR TITLE
perf/fix: cache SQLite connections and improve Windows process lifecycle handling

### DIFF
--- a/src/main/claw3d.ts
+++ b/src/main/claw3d.ts
@@ -1,4 +1,4 @@
-import { spawn, ChildProcess, spawnSync } from "child_process";
+import { spawn, ChildProcess, spawnSync, execFileSync } from "child_process";
 import {
   existsSync,
   readFileSync,
@@ -10,7 +10,7 @@ import { join, win32 } from "path";
 import { homedir } from "os";
 import { createConnection } from "net";
 import { getEnhancedPath, HERMES_HOME } from "./installer";
-import { stripAnsi, safeWriteFile } from "./utils";
+import { stripAnsi, safeWriteFile, getActiveProfileNameSync } from "./utils";
 import { getApiServerKey, getConnectionConfig, getModelConfig } from "./config";
 import http from "http";
 
@@ -245,9 +245,10 @@ export function getClaw3dWsUrl(): string {
  * rather than a generic `hermes` agent the user never selected (issue
  * #256). Falls back to `hermes` only when no model is configured.
  */
-function resolveOfficeModel(): string {
+function resolveOfficeModel(profile?: string): string {
   try {
-    const model = getModelConfig().model?.trim();
+    const activeProfile = profile || getActiveProfileNameSync();
+    const model = getModelConfig(activeProfile).model?.trim();
     if (model) return model;
   } catch {
     /* no model configured — fall through to the default */
@@ -285,10 +286,11 @@ export function buildOfficeEnv(opts: {
  * Write Claw3D settings to ~/.openclaw/claw3d/settings.json
  * and .env in the claw3d directory so onboarding is skipped.
  */
-function writeClaw3dSettings(wsUrl?: string): void {
+function writeClaw3dSettings(wsUrl?: string, profile?: string): void {
+  const activeProfile = profile || getActiveProfileNameSync();
   const url = wsUrl || getSavedWsUrl();
   // Gateway bearer token — empty string when the gateway has no API_SERVER_KEY.
-  const apiKey = getApiServerKey();
+  const apiKey = getApiServerKey(activeProfile);
 
   // Write ~/.openclaw/claw3d/settings.json
   try {
@@ -324,7 +326,7 @@ function writeClaw3dSettings(wsUrl?: string): void {
           port: getSavedPort(),
           url,
           apiKey,
-          model: resolveOfficeModel(),
+          model: resolveOfficeModel(activeProfile),
         }),
       );
     }
@@ -702,7 +704,28 @@ export async function setupClaw3d(
 }
 
 function killProcessTree(proc: ChildProcess): void {
-  if (proc.pid) {
+  if (!proc.pid) return;
+
+  if (process.platform === "win32") {
+    try {
+      // /F: Force terminate the process
+      // /T: Terminate the specified process and any child processes started by it
+      execFileSync("taskkill", ["/F", "/T", "/PID", String(proc.pid)], {
+        stdio: "ignore",
+      });
+    } catch (err) {
+      console.error(
+        `[killProcessTree] taskkill failed for PID ${proc.pid}:`,
+        err,
+      );
+      try {
+        proc.kill("SIGKILL");
+      } catch {
+        /* already dead */
+      }
+    }
+  } else {
+    // POSIX: Kill the process group (since the process was spawned as detached)
     try {
       process.kill(-proc.pid, "SIGTERM");
     } catch {
@@ -713,11 +736,16 @@ function killProcessTree(proc: ChildProcess): void {
       }
     }
     // Fallback: SIGKILL after 3 seconds
+    const pid = proc.pid;
     setTimeout(() => {
       try {
-        if (proc.pid) process.kill(-proc.pid, "SIGKILL");
+        process.kill(-pid, "SIGKILL");
       } catch {
-        /* already dead */
+        try {
+          process.kill(pid, "SIGKILL");
+        } catch {
+          /* already dead */
+        }
       }
     }, 3000);
   }
@@ -887,7 +915,10 @@ export function stopAdapter(): void {
   cleanupPid(ADAPTER_PID_FILE);
 }
 
-export function startAll(): { success: boolean; error?: string } {
+export function startAll(profile?: string): {
+  success: boolean;
+  error?: string;
+} {
   if (!existsSync(join(HERMES_OFFICE_DIR, "node_modules"))) {
     return {
       success: false,
@@ -900,7 +931,7 @@ export function startAll(): { success: boolean; error?: string } {
   // Refresh the `.env` before the processes read it, so Office always
   // starts against the current port/URL and the desktop's configured
   // model rather than a value frozen at first setup (issue #256).
-  writeClaw3dSettings();
+  writeClaw3dSettings(undefined, profile);
 
   // Start dev server
   const devOk = startDevServer();

--- a/src/main/db.ts
+++ b/src/main/db.ts
@@ -1,0 +1,53 @@
+import Database from "better-sqlite3";
+import { existsSync } from "fs";
+import { activeStateDbPath } from "./utils";
+
+let cachedDb: Database.Database | null = null;
+let cachedDbPath: string | null = null;
+let cachedDbReadonly: boolean | null = null;
+
+/**
+ * Return a cached database connection for the active profile state DB.
+ * If the active profile database path or readonly status changes,
+ * the old database connection is cleanly closed and a new one is established.
+ */
+export function getDbConnection(readonly = true): Database.Database | null {
+  const dbPath = activeStateDbPath();
+  if (!existsSync(dbPath)) {
+    closeDbConnection();
+    return null;
+  }
+
+  // Reuse the existing cached connection if the path and mode match
+  if (cachedDb && cachedDbPath === dbPath && cachedDbReadonly === readonly) {
+    return cachedDb;
+  }
+
+  closeDbConnection();
+
+  try {
+    cachedDb = new Database(dbPath, readonly ? { readonly: true } : {});
+    cachedDbPath = dbPath;
+    cachedDbReadonly = readonly;
+    return cachedDb;
+  } catch (err) {
+    console.error(`[db] Failed to open database at ${dbPath}:`, err);
+    return null;
+  }
+}
+
+/**
+ * Close the cached database connection if open.
+ */
+export function closeDbConnection(): void {
+  if (cachedDb) {
+    try {
+      cachedDb.close();
+    } catch (err) {
+      console.error("[db] Error closing database connection:", err);
+    }
+    cachedDb = null;
+    cachedDbPath = null;
+    cachedDbReadonly = null;
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -43,6 +43,7 @@ import {
   runHermesAuthLogin,
   cancelHermesAuthLogin,
   detectDeviceCode,
+  detectAuthUrl,
 } from "./hermes-auth";
 import {
   isRemoteMode,
@@ -108,6 +109,7 @@ import {
   searchSessions,
   deleteSession,
 } from "./sessions";
+import { closeDbConnection } from "./db";
 import {
   syncSessionCache,
   listCachedSessions,
@@ -495,8 +497,9 @@ function setupIPC(): void {
     // Codex uses a device-code flow: it prints a URL + code instead
     // of opening a browser. Watch the stream for that prompt, then
     // open the page and pre-copy the code so the user just pastes.
+    // Loopback OAuth flows print an authorize URL; watch for it and open it.
     let buffer = "";
-    let deviceHandled = false;
+    let urlHandled = false;
     return runHermesAuthLogin(
       provider,
       (chunk) => {
@@ -504,16 +507,26 @@ function setupIPC(): void {
         // tears down the subprocess; any send on a destroyed sender throws.
         if (event.sender.isDestroyed()) return;
         event.sender.send("oauth-login-progress", chunk);
-        if (deviceHandled) return;
+        if (urlHandled) return;
         buffer += chunk;
         const device = detectDeviceCode(buffer);
         if (device) {
-          deviceHandled = true;
+          urlHandled = true;
           openExternalUrl(device.url);
           clipboard.writeText(device.code);
           event.sender.send(
             "oauth-login-progress",
             `\n→ Code ${device.code} copied to clipboard — opening browser...\n`,
+          );
+          return;
+        }
+        const authUrl = detectAuthUrl(buffer);
+        if (authUrl) {
+          urlHandled = true;
+          openExternalUrl(authUrl);
+          event.sender.send(
+            "oauth-login-progress",
+            `\n→ Opening browser for authorization...\n`,
           );
         }
       },
@@ -1934,6 +1947,7 @@ app.on("window-all-closed", () => {
     // explicitly via the Gateway controls.
     stopSshTunnel();
     stopClaw3d();
+    closeDbConnection();
     app.quit();
   }
 });
@@ -1948,4 +1962,5 @@ app.on("before-quit", () => {
   // and other platforms stay online headless.
   stopSshTunnel();
   stopClaw3d();
+  closeDbConnection();
 });

--- a/src/main/session-cache.ts
+++ b/src/main/session-cache.ts
@@ -1,14 +1,10 @@
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
-import {
-  profileHome,
-  getActiveProfileNameSync,
-  activeStateDbPath,
-  safeWriteFile,
-} from "./utils";
+import { profileHome, getActiveProfileNameSync, safeWriteFile } from "./utils";
 import Database from "better-sqlite3";
 import { t } from "../shared/i18n";
 import { getAppLocale } from "./locale";
+import { getDbConnection } from "./db";
 
 /**
  * The session cache lives alongside its own profile's data so profiles
@@ -88,9 +84,7 @@ function writeCache(data: CacheData): void {
 }
 
 function getDb(): Database.Database | null {
-  const dbPath = activeStateDbPath();
-  if (!existsSync(dbPath)) return null;
-  return new Database(dbPath, { readonly: true });
+  return getDbConnection(true);
 }
 
 // Sync from hermes DB to local cache — only fetches new/updated sessions
@@ -217,8 +211,6 @@ export function syncSessionCache(): CachedSession[] {
     return updated.sessions;
   } catch {
     return cache.sessions;
-  } finally {
-    db.close();
   }
 }
 

--- a/src/main/sessions.ts
+++ b/src/main/sessions.ts
@@ -1,10 +1,9 @@
 import Database from "better-sqlite3";
-import { existsSync } from "fs";
-import { activeStateDbPath } from "./utils";
 import type { Attachment } from "../shared/attachments";
 import { isImageMime } from "../shared/attachments";
 import { clearStagedAttachments } from "./attachment-staging";
 import { removeSessionFromCache } from "./session-cache";
+import { getDbConnection } from "./db";
 
 // Sentinel prefix used by hermes-agent's hermes_state.py to mark
 // JSON-encoded multimodal content in the messages.content column.
@@ -185,56 +184,48 @@ export function dedupeSearchRowsBySession<T extends { session_id: string }>(
 }
 
 function getDb(readonly = true): Database.Database | null {
-  // Open the active profile's session DB — named profiles keep their
-  // sessions under ~/.hermes/profiles/<name>/state.db (issue #311).
-  const dbPath = activeStateDbPath();
-  if (!existsSync(dbPath)) return null;
-  return new Database(dbPath, readonly ? { readonly: true } : {});
+  return getDbConnection(readonly);
 }
 
 export function listSessions(limit = 30, offset = 0): SessionSummary[] {
   const db = getDb();
   if (!db) return [];
 
-  try {
-    // Simple query without correlated subquery — titles come from session cache
-    const rows = db
-      .prepare(
-        `SELECT
-          s.id,
-          s.source,
-          s.started_at,
-          s.ended_at,
-          s.message_count,
-          s.model,
-          s.title
-        FROM sessions s
-        ORDER BY s.started_at DESC
-        LIMIT ? OFFSET ?`,
-      )
-      .all(limit, offset) as Array<{
-      id: string;
-      source: string;
-      started_at: number;
-      ended_at: number | null;
-      message_count: number;
-      model: string;
-      title: string | null;
-    }>;
+  // Simple query without correlated subquery — titles come from session cache
+  const rows = db
+    .prepare(
+      `SELECT
+        s.id,
+        s.source,
+        s.started_at,
+        s.ended_at,
+        s.message_count,
+        s.model,
+        s.title
+      FROM sessions s
+      ORDER BY s.started_at DESC
+      LIMIT ? OFFSET ?`,
+    )
+    .all(limit, offset) as Array<{
+    id: string;
+    source: string;
+    started_at: number;
+    ended_at: number | null;
+    message_count: number;
+    model: string;
+    title: string | null;
+  }>;
 
-    return rows.map((r) => ({
-      id: r.id,
-      source: r.source,
-      startedAt: r.started_at,
-      endedAt: r.ended_at,
-      messageCount: r.message_count,
-      model: r.model || "",
-      title: r.title,
-      preview: "",
-    }));
-  } finally {
-    db.close();
-  }
+  return rows.map((r) => ({
+    id: r.id,
+    source: r.source,
+    startedAt: r.started_at,
+    endedAt: r.ended_at,
+    messageCount: r.message_count,
+    model: r.model || "",
+    title: r.title,
+    preview: "",
+  }));
 }
 
 export function searchSessions(query: string, limit = 20): SearchResult[] {
@@ -300,8 +291,6 @@ export function searchSessions(query: string, limit = 20): SearchResult[] {
     }));
   } catch {
     return [];
-  } finally {
-    db.close();
   }
 }
 
@@ -492,37 +481,29 @@ export function getSessionMessages(sessionId: string): HistoryItem[] {
   const db = getDb();
   if (!db) return [];
 
-  try {
-    const rows = db
-      .prepare(
-        `SELECT id, role, content, timestamp,
-                tool_call_id, tool_calls, tool_name,
-                reasoning, reasoning_content, reasoning_details
-         FROM messages
-         WHERE session_id = ? AND role IN ('user', 'assistant', 'tool')
-         ORDER BY timestamp, id`,
-      )
-      .all(sessionId) as RawMessageRow[];
+  const rows = db
+    .prepare(
+      `SELECT id, role, content, timestamp,
+              tool_call_id, tool_calls, tool_name,
+              reasoning, reasoning_content, reasoning_details
+       FROM messages
+       WHERE session_id = ? AND role IN ('user', 'assistant', 'tool')
+       ORDER BY timestamp, id`,
+    )
+    .all(sessionId) as RawMessageRow[];
 
-    return expandRowsToHistory(rows);
-  } finally {
-    db.close();
-  }
+  return expandRowsToHistory(rows);
 }
 
 export function deleteSession(sessionId: string): void {
   const db = getDb(false);
 
   if (db) {
-    try {
-      const tx = db.transaction((id: string) => {
-        db.prepare("DELETE FROM messages WHERE session_id = ?").run(id);
-        db.prepare("DELETE FROM sessions WHERE id = ?").run(id);
-      });
-      tx(sessionId);
-    } finally {
-      db.close();
-    }
+    const tx = db.transaction((id: string) => {
+      db.prepare("DELETE FROM messages WHERE session_id = ?").run(id);
+      db.prepare("DELETE FROM sessions WHERE id = ?").run(id);
+    });
+    tx(sessionId);
   }
 
   clearStagedAttachments(sessionId);

--- a/src/main/ssh-remote.ts
+++ b/src/main/ssh-remote.ts
@@ -7,6 +7,7 @@
 import { spawn } from "child_process";
 import { homedir } from "os";
 import { join } from "path";
+import { existsSync } from "fs";
 import type { SshConfig } from "./ssh-tunnel";
 import type { KanbanTask } from "./kanban";
 import { buildSshControlOptions } from "./ssh-options";
@@ -52,6 +53,11 @@ export function sshExec(
   timeoutMs = 30000,
 ): Promise<string> {
   return new Promise((resolve, reject) => {
+    const keyPath = config.keyPath?.trim() || join(homedir(), ".ssh", "id_rsa");
+    if (!existsSync(keyPath)) {
+      return reject(new Error(`SSH private key file not found at: ${keyPath}`));
+    }
+
     const child = spawn("ssh", [...buildExecArgs(config), command], {
       stdio: ["pipe", "pipe", "pipe"],
       ...HIDDEN_SUBPROCESS_OPTIONS,
@@ -72,7 +78,15 @@ export function sshExec(
     });
     child.on("error", (err) => {
       clearTimeout(timeout);
-      reject(err);
+      if (err && "code" in err && err.code === "ENOENT") {
+        reject(
+          new Error(
+            "System SSH binary not found on your system PATH. Please ensure an SSH client is installed.",
+          ),
+        );
+      } else {
+        reject(err);
+      }
     });
     child.on("close", (code) => {
       clearTimeout(timeout);

--- a/src/main/ssh-tunnel.ts
+++ b/src/main/ssh-tunnel.ts
@@ -1,6 +1,7 @@
 import { ChildProcess, spawn } from "child_process";
 import { homedir } from "os";
 import { join } from "path";
+import { existsSync } from "fs";
 import net from "net";
 import http from "http";
 import { buildSshControlOptions } from "./ssh-options";
@@ -80,27 +81,6 @@ function findFreePort(preferred: number): Promise<number> {
   });
 }
 
-function waitForPort(port: number, timeoutMs: number): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const deadline = Date.now() + timeoutMs;
-    function attempt(): void {
-      const socket = net.connect(port, "127.0.0.1", () => {
-        socket.destroy();
-        resolve();
-      });
-      socket.on("error", () => {
-        socket.destroy();
-        if (Date.now() > deadline) {
-          reject(new Error(`SSH tunnel not ready after ${timeoutMs}ms`));
-        } else {
-          setTimeout(attempt, 400);
-        }
-      });
-    }
-    attempt();
-  });
-}
-
 function buildSshArgs(config: SshConfig, localPort: number): string[] {
   const keyPath = config.keyPath || join(homedir(), ".ssh", "id_rsa");
   return [
@@ -129,9 +109,16 @@ function buildSshArgs(config: SshConfig, localPort: number): string[] {
 export async function startSshTunnel(config: SshConfig): Promise<void> {
   stopSshTunnel();
 
+  const keyPath = config.keyPath?.trim() || join(homedir(), ".ssh", "id_rsa");
+  if (!existsSync(keyPath)) {
+    throw new Error(`SSH private key file not found at: ${keyPath}`);
+  }
+
   const localPort = await findFreePort(config.localPort || 18642);
   activeConfig = { ...config, localPort };
   tunnelRunning = false;
+
+  let spawnError: Error | null = null;
 
   tunnelProcess = spawn("ssh", buildSshArgs(config, localPort), {
     stdio: "ignore",
@@ -152,18 +139,50 @@ export async function startSshTunnel(config: SshConfig): Promise<void> {
     });
   });
 
-  tunnelProcess.on("error", () => {
+  tunnelProcess.on("error", (err) => {
     tunnelProcess = null;
-    checkTunnelHealth(localPort, 2000).then((healthy) => {
-      if (!healthy) {
-        tunnelRunning = false;
-        activeConfig = null;
-      }
-    });
+    if (err && "code" in err && err.code === "ENOENT") {
+      spawnError = new Error(
+        "System SSH binary not found on your system PATH. Please ensure an SSH client is installed.",
+      );
+    } else {
+      spawnError = err;
+    }
+    tunnelRunning = false;
+    activeConfig = null;
   });
 
   try {
-    await waitForPort(localPort, 12000);
+    // Poll for both port readiness and checking if spawnError was set
+    const deadline = Date.now() + 12000;
+    while (Date.now() <= deadline) {
+      if (spawnError) throw spawnError;
+
+      const portOpen = await new Promise<boolean>((resolve) => {
+        const socket = net.connect(localPort, "127.0.0.1", () => {
+          socket.destroy();
+          resolve(true);
+        });
+        socket.on("error", () => {
+          socket.destroy();
+          resolve(false);
+        });
+      });
+
+      if (portOpen) break;
+
+      // If the process exited and we don't have tunnel running, stop polling
+      if (!tunnelProcess && !spawnError) {
+        throw new Error(
+          "SSH tunnel process exited unexpectedly during startup.",
+        );
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 400));
+    }
+
+    if (spawnError) throw spawnError;
+
     tunnelRunning = true;
     await waitForHealth(localPort, 20000);
   } catch (err) {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { getDbConnection, closeDbConnection } from "../src/main/db";
+import { activeStateDbPath } from "../src/main/utils";
+
+// Define hoisted mocks (Vitest allows variables prefixed with 'mock')
+const mockClose = vi.fn();
+const mockDatabaseConstructor = vi.fn().mockImplementation((dbPath, options) => {
+  return {
+    close: mockClose,
+    open: true,
+  };
+});
+const mockExistsSync = vi.fn();
+
+vi.mock("better-sqlite3", () => {
+  return {
+    default: vi.fn().mockImplementation(function (dbPath: string, options: any) {
+      return mockDatabaseConstructor(dbPath, options);
+    }),
+  };
+});
+
+// Mock activeStateDbPath and existsSync
+vi.mock("../src/main/utils", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../src/main/utils")>();
+  return {
+    ...original,
+    activeStateDbPath: vi.fn(),
+  };
+});
+
+// Lazy evaluation prevents reference errors during hoisting
+vi.mock("fs", async (importOriginal) => {
+  const original = await importOriginal<typeof import("fs")>();
+  return {
+    ...original,
+    existsSync: (path: any) => mockExistsSync(path),
+    default: {
+      ...original,
+      existsSync: (path: any) => mockExistsSync(path),
+    },
+  };
+});
+
+describe("Database connection caching", () => {
+  const dbPath1 = "/fake/path/state1.db";
+  const dbPath2 = "/fake/path/state2.db";
+
+  beforeEach(() => {
+    mockClose.mockReset();
+    mockDatabaseConstructor.mockClear();
+    mockExistsSync.mockReset();
+    vi.mocked(activeStateDbPath).mockReset();
+    mockExistsSync.mockReturnValue(true); // default to true
+  });
+
+  afterEach(() => {
+    closeDbConnection();
+  });
+
+  it("returns null if database file does not exist", () => {
+    vi.mocked(activeStateDbPath).mockReturnValue(dbPath1);
+    mockExistsSync.mockReturnValue(false);
+
+    const db = getDbConnection();
+    expect(db).toBeNull();
+    expect(mockDatabaseConstructor).not.toHaveBeenCalled();
+  });
+
+  it("caches database connection for same path and readonly status", () => {
+    vi.mocked(activeStateDbPath).mockReturnValue(dbPath1);
+    mockExistsSync.mockReturnValue(true);
+
+    const db1 = getDbConnection(true);
+    const db2 = getDbConnection(true);
+
+    expect(db1).not.toBeNull();
+    expect(db2).not.toBeNull();
+    expect(db1).toBe(db2); // Cached same connection
+    expect(mockDatabaseConstructor).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-creates connection if database path changes (e.g. profile switch)", () => {
+    mockExistsSync.mockReturnValue(true);
+
+    vi.mocked(activeStateDbPath).mockReturnValue(dbPath1);
+    const db1 = getDbConnection(true);
+
+    vi.mocked(activeStateDbPath).mockReturnValue(dbPath2);
+    const db2 = getDbConnection(true);
+
+    expect(db1).not.toBeNull();
+    expect(db2).not.toBeNull();
+    expect(db1).not.toBe(db2); // Different connection because path changed
+    expect(mockDatabaseConstructor).toHaveBeenCalledTimes(2);
+    expect(mockClose).toHaveBeenCalledTimes(1); // Old connection closed
+  });
+
+  it("re-creates connection if readonly status changes", () => {
+    vi.mocked(activeStateDbPath).mockReturnValue(dbPath1);
+    mockExistsSync.mockReturnValue(true);
+
+    const dbRead = getDbConnection(true);
+    const dbWrite = getDbConnection(false);
+
+    expect(dbRead).not.toBeNull();
+    expect(dbWrite).not.toBeNull();
+    expect(dbRead).not.toBe(dbWrite); // Different connection because mode changed
+    expect(mockDatabaseConstructor).toHaveBeenCalledTimes(2);
+    expect(mockClose).toHaveBeenCalledTimes(1); // Old connection closed
+  });
+
+  it("closes connection on closeDbConnection", () => {
+    vi.mocked(activeStateDbPath).mockReturnValue(dbPath1);
+    mockExistsSync.mockReturnValue(true);
+
+    const db = getDbConnection(true);
+    expect(db).not.toBeNull();
+
+    closeDbConnection();
+    expect(mockClose).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Main Thread I/O Caching: Replaces synchronous connection opening/closing overhead by caching the better-sqlite3 instance for the active profile. Windows Process Cleanup: Fixes process-group signals failing on Windows by executing taskkill /F /T for background dev/adapter servers, preventing port leaks. Robust SSH Execution: Immediately checks for private key files and system binary path existence (ENOENT) to reject startup immediately rather than timing out.