### PR TITLE
Add bulk session deletion

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -106,6 +106,7 @@ import {
   getSessionMessages,
   searchSessions,
   deleteSession,
+  deleteSessions,
 } from "./sessions";
 import {
   syncSessionCache,
@@ -1099,6 +1100,10 @@ function setupIPC(): void {
 
   ipcMain.handle("delete-session", (_event, sessionId: string) => {
     return deleteSession(sessionId);
+  });
+
+  ipcMain.handle("delete-sessions", (_event, sessionIds: string[]) => {
+    return deleteSessions(Array.isArray(sessionIds) ? sessionIds : []);
   });
 
   // Profiles

--- a/src/main/session-cache.ts
+++ b/src/main/session-cache.ts
@@ -193,6 +193,9 @@ export function syncSessionCache(): CachedSession[] {
           .all(...chunk) as Array<{ id: string; message_count: number }>;
         for (const r of refreshed) countsById.set(r.id, r.message_count);
       }
+      cache.sessions = cache.sessions.filter(
+        (s) => refreshedIds.has(s.id) || countsById.has(s.id),
+      );
       for (const s of cache.sessions) {
         const fresh = countsById.get(s.id);
         if (fresh !== undefined && fresh !== s.messageCount) {

--- a/src/main/sessions.ts
+++ b/src/main/sessions.ts
@@ -184,6 +184,48 @@ export function dedupeSearchRowsBySession<T extends { session_id: string }>(
   return uniqueRows;
 }
 
+function escapeLikePattern(query: string): string {
+  return query.replace(/[\\%_]/g, (match) => `\\${match}`);
+}
+
+function highlightTextMatch(text: string, query: string): string {
+  if (!text) return "";
+
+  const terms = [query.trim(), ...query.trim().split(/\s+/)]
+    .filter(Boolean)
+    .sort((a, b) => b.length - a.length);
+
+  for (const term of terms) {
+    const index = text.toLocaleLowerCase().indexOf(term.toLocaleLowerCase());
+    if (index >= 0) {
+      return `${text.slice(0, index)}<<${text.slice(
+        index,
+        index + term.length,
+      )}>>${text.slice(index + term.length)}`;
+    }
+  }
+
+  return text;
+}
+
+function fallbackSessionTitle(sessionId: string): string {
+  return `Sessions ${sessionId.slice(-6)}`;
+}
+
+function highlightSessionMatch(
+  title: string | null,
+  sessionId: string,
+  query: string,
+): string {
+  const text = title || "";
+  const highlightedTitle = highlightTextMatch(text, query);
+  if (highlightedTitle && highlightedTitle.includes("<<")) {
+    return highlightedTitle;
+  }
+
+  return highlightTextMatch(fallbackSessionTitle(sessionId), query);
+}
+
 function getDb(readonly = true): Database.Database | null {
   // Open the active profile's session DB — named profiles keep their
   // sessions under ~/.hermes/profiles/<name>/state.db (issue #311).
@@ -242,6 +284,42 @@ export function searchSessions(query: string, limit = 20): SearchResult[] {
   if (!db) return [];
 
   try {
+    const trimmedQuery = query.trim();
+    if (!trimmedQuery) return [];
+
+    const titleRows = db
+      .prepare(
+        `SELECT
+          s.id as session_id,
+          s.title,
+          s.started_at,
+          s.source,
+          s.message_count,
+          s.model
+        FROM sessions s
+        WHERE LOWER(COALESCE(s.title, '')) LIKE ? ESCAPE '\\'
+          OR LOWER(s.id) LIKE ? ESCAPE '\\'
+        ORDER BY s.started_at DESC
+        LIMIT ?`,
+      )
+      .all(
+        `%${escapeLikePattern(trimmedQuery.toLocaleLowerCase())}%`,
+        `%${escapeLikePattern(trimmedQuery.toLocaleLowerCase())}%`,
+        limit,
+      ) as Array<{
+      session_id: string;
+      title: string | null;
+      started_at: number;
+      source: string;
+      message_count: number;
+      model: string;
+    }>;
+
+    const titleMatches = titleRows.map((r) => ({
+      ...r,
+      snippet: highlightSessionMatch(r.title, r.session_id, trimmedQuery),
+    }));
+
     // Check if FTS table exists
     const tableCheck = db
       .prepare(
@@ -249,46 +327,47 @@ export function searchSessions(query: string, limit = 20): SearchResult[] {
       )
       .get() as { name: string } | undefined;
 
-    if (!tableCheck) return [];
-
     // Sanitize query for FTS5: wrap each word with quotes for safety, add * for prefix
-    const sanitized = query
+    const sanitized = trimmedQuery
       .trim()
       .split(/\s+/)
       .filter((w) => w.length > 0)
       .map((w) => `"${w.replace(/"/g, "")}"*`)
       .join(" ");
 
-    if (!sanitized) return [];
+    const ftsRows = tableCheck
+      ? (db
+          .prepare(
+            `SELECT DISTINCT
+              m.session_id,
+              s.title,
+              s.started_at,
+              s.source,
+              s.message_count,
+              s.model,
+              snippet(messages_fts, 0, '<<', '>>', '...', 40) as snippet
+            FROM messages_fts
+            JOIN messages m ON m.id = messages_fts.rowid
+            JOIN sessions s ON s.id = m.session_id
+            WHERE messages_fts MATCH ?
+            ORDER BY rank
+            LIMIT ?`,
+          )
+          .all(sanitized, Math.max(limit * 5, limit)) as Array<{
+          session_id: string;
+          title: string | null;
+          started_at: number;
+          source: string;
+          message_count: number;
+          model: string;
+          snippet: string;
+        }>)
+      : [];
 
-    const rows = db
-      .prepare(
-        `SELECT DISTINCT
-          m.session_id,
-          s.title,
-          s.started_at,
-          s.source,
-          s.message_count,
-          s.model,
-          snippet(messages_fts, 0, '<<', '>>', '...', 40) as snippet
-        FROM messages_fts
-        JOIN messages m ON m.id = messages_fts.rowid
-        JOIN sessions s ON s.id = m.session_id
-        WHERE messages_fts MATCH ?
-        ORDER BY rank
-        LIMIT ?`,
-      )
-      .all(sanitized, Math.max(limit * 5, limit)) as Array<{
-      session_id: string;
-      title: string | null;
-      started_at: number;
-      source: string;
-      message_count: number;
-      model: string;
-      snippet: string;
-    }>;
-
-    const uniqueRows = dedupeSearchRowsBySession(rows, limit);
+    const uniqueRows = dedupeSearchRowsBySession(
+      [...titleMatches, ...ftsRows],
+      limit,
+    );
     return uniqueRows.map((r) => ({
       sessionId: r.session_id,
       title: r.title,
@@ -510,21 +589,60 @@ export function getSessionMessages(sessionId: string): HistoryItem[] {
   }
 }
 
-export function deleteSession(sessionId: string): void {
+export interface DeleteSessionsResult {
+  requested: number;
+  deleted: number;
+}
+
+function normalizeSessionIds(sessionIds: string[]): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const id of sessionIds) {
+    if (typeof id !== "string") continue;
+    const trimmed = id.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  }
+  return normalized;
+}
+
+export function deleteSessions(sessionIds: string[]): DeleteSessionsResult {
+  const ids = normalizeSessionIds(sessionIds);
+  let deleted = 0;
+
   const db = getDb(false);
 
   if (db) {
     try {
-      const tx = db.transaction((id: string) => {
-        db.prepare("DELETE FROM messages WHERE session_id = ?").run(id);
-        db.prepare("DELETE FROM sessions WHERE id = ?").run(id);
+      const tx = db.transaction((idsToDelete: string[]) => {
+        const deleteMessages = db.prepare(
+          "DELETE FROM messages WHERE session_id = ?",
+        );
+        const deleteSessionRow = db.prepare(
+          "DELETE FROM sessions WHERE id = ?",
+        );
+
+        for (const id of idsToDelete) {
+          deleteMessages.run(id);
+          const result = deleteSessionRow.run(id);
+          if (result.changes > 0) deleted += result.changes;
+        }
       });
-      tx(sessionId);
+      tx(ids);
     } finally {
       db.close();
     }
   }
 
-  clearStagedAttachments(sessionId);
-  removeSessionFromCache(sessionId);
+  for (const id of ids) {
+    clearStagedAttachments(id);
+    removeSessionFromCache(id);
+  }
+
+  return { requested: ids.length, deleted };
+}
+
+export function deleteSession(sessionId: string): void {
+  deleteSessions([sessionId]);
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -530,6 +530,9 @@ interface HermesAPI {
   >;
   updateSessionTitle: (sessionId: string, title: string) => Promise<void>;
   deleteSession: (sessionId: string) => Promise<void>;
+  deleteSessions: (
+    sessionIds: string[],
+  ) => Promise<{ requested: number; deleted: number }>;
 
   // Session search
   searchSessions: (

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -605,6 +605,10 @@ const hermesAPI = {
     ipcRenderer.invoke("update-session-title", sessionId, title),
   deleteSession: (sessionId: string): Promise<void> =>
     ipcRenderer.invoke("delete-session", sessionId),
+  deleteSessions: (
+    sessionIds: string[],
+  ): Promise<{ requested: number; deleted: number }> =>
+    ipcRenderer.invoke("delete-sessions", sessionIds),
 
   // Session search
   searchSessions: (

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -4034,6 +4034,34 @@ body {
   color: var(--text-primary);
 }
 
+.sessions-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sessions-select-mode {
+  min-width: 78px;
+}
+
+.sessions-selection-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
+}
+
+.sessions-selection-count {
+  flex: 1;
+  min-width: 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+}
+
 /* Search bar — integrated into header */
 .sessions-searchbar {
   display: flex;
@@ -4161,11 +4189,34 @@ body {
   border-color: var(--border-focus);
 }
 
+.sessions-card--selected {
+  border-color: var(--border-focus);
+  box-shadow: inset 3px 0 0 var(--accent);
+}
+
 .sessions-card-main {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
   gap: 16px;
+}
+
+.sessions-card-select {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+}
+
+.sessions-card-select input {
+  width: 15px;
+  height: 15px;
+  margin: 0;
+  accent-color: var(--accent);
+  cursor: pointer;
 }
 
 .sessions-card-title {
@@ -4320,6 +4371,13 @@ body {
 }
 
 .sessions-result-snippet mark {
+  background: rgba(245, 158, 11, 0.3);
+  color: var(--text-primary);
+  padding: 0 2px;
+  border-radius: 2px;
+}
+
+.sessions-card-title mark {
   background: rgba(245, 158, 11, 0.3);
   color: var(--text-primary);
   padding: 0 2px;

--- a/src/renderer/src/screens/Sessions/Sessions.test.tsx
+++ b/src/renderer/src/screens/Sessions/Sessions.test.tsx
@@ -30,12 +30,14 @@ function installHermesAPI(initialSessions: unknown[] = []): {
   syncSessionCache: ReturnType<typeof vi.fn>;
   searchSessions: ReturnType<typeof vi.fn>;
   deleteSession: ReturnType<typeof vi.fn>;
+  deleteSessions: ReturnType<typeof vi.fn>;
 } {
   const api = {
     listCachedSessions: vi.fn().mockResolvedValue(initialSessions),
     syncSessionCache: vi.fn().mockResolvedValue(initialSessions),
     searchSessions: vi.fn().mockResolvedValue([]),
     deleteSession: vi.fn().mockResolvedValue(undefined),
+    deleteSessions: vi.fn().mockResolvedValue({ requested: 0, deleted: 0 }),
   };
   Object.defineProperty(window, "hermesAPI", {
     configurable: true,
@@ -44,9 +46,13 @@ function installHermesAPI(initialSessions: unknown[] = []): {
   return api;
 }
 
-function sessionSearchResult(title: string, snippet: string): {
+function sessionSearchResult(
+  title: string | null,
+  snippet: string,
+  sessionId?: string,
+): {
   sessionId: string;
-  title: string;
+  title: string | null;
   startedAt: number;
   source: string;
   messageCount: number;
@@ -54,7 +60,13 @@ function sessionSearchResult(title: string, snippet: string): {
   snippet: string;
 } {
   return {
-    sessionId: title.toLowerCase().replace(/\s+/g, "-"),
+    sessionId:
+      sessionId ??
+      (title ?? snippet)
+        .replace(/<</g, "")
+        .replace(/>>/g, "")
+        .toLowerCase()
+        .replace(/\s+/g, "-"),
     title,
     startedAt: Math.floor(Date.now() / 1000),
     source: "desktop",
@@ -200,6 +212,29 @@ describe("Sessions tab live refresh (#322)", () => {
     expect(screen.queryByText("Broad h match")).toBeNull();
   });
 
+  it("uses matched text as the visible title for untitled search results", async () => {
+    vi.useRealTimers();
+    const api = installHermesAPI();
+    api.searchSessions.mockResolvedValue([
+      sessionSearchResult(
+        null,
+        "<<Live PR499>> smoke test. Reply exactly: OK",
+        "session-722999",
+      ),
+    ]);
+
+    render(<Sessions {...baseProps} visible={true} />);
+    await act(async () => {});
+
+    const search = screen.getByPlaceholderText("sessions.searchPlaceholder");
+    fireEvent.change(search, { target: { value: "Live PR499" } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/smoke test\. Reply exactly: OK/)).toBeTruthy();
+    });
+    expect(screen.queryByText("sessions.title 722999")).toBeNull();
+  });
+
   it("does not repopulate search results after clearing the input", async () => {
     const api = installHermesAPI();
     let resolveSearch:
@@ -339,5 +374,178 @@ describe("Sessions tab — delete affordance (#408)", () => {
 
     expect(onResume).not.toHaveBeenCalled();
     expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+});
+
+describe("Sessions tab — bulk delete selection (#490)", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("deletes the selected sessions after confirmation", async () => {
+    const sessions = [
+      {
+        id: "sess-one",
+        title: "First chat",
+        startedAt: Math.floor(Date.now() / 1000),
+        source: "api_server",
+        messageCount: 3,
+        model: "gpt-4",
+      },
+      {
+        id: "sess-two",
+        title: "Second chat",
+        startedAt: Math.floor(Date.now() / 1000),
+        source: "api_server",
+        messageCount: 1,
+        model: "gpt-4",
+      },
+      {
+        id: "sess-three",
+        title: "Third chat",
+        startedAt: Math.floor(Date.now() / 1000),
+        source: "api_server",
+        messageCount: 2,
+        model: "gpt-4",
+      },
+    ];
+    const api = installHermesAPI(sessions);
+
+    render(<Sessions {...baseProps} visible={true} />);
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "sessions.selectMode" }),
+      );
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("First chat"));
+      fireEvent.click(screen.getByText("Second chat"));
+    });
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "sessions.deleteSelected" }),
+      );
+    });
+
+    expect(screen.getByRole("dialog")).toHaveTextContent(
+      "sessions.deleteSelectedConfirm",
+    );
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: "sessions.deleteConfirmAction",
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(api.deleteSessions).toHaveBeenCalledWith([
+        "sess-one",
+        "sess-two",
+      ]);
+    });
+    expect(api.deleteSession).not.toHaveBeenCalled();
+  });
+
+  it("selects only visible search results", async () => {
+    const api = installHermesAPI([
+      {
+        id: "main-session",
+        title: "Main chat",
+        startedAt: Math.floor(Date.now() / 1000),
+        source: "api_server",
+        messageCount: 1,
+        model: "gpt-4",
+      },
+    ]);
+    api.searchSessions.mockResolvedValue([
+      sessionSearchResult("Search one", "<<bulk>> one"),
+      sessionSearchResult("Search two", "<<bulk>> two"),
+    ]);
+
+    render(<Sessions {...baseProps} visible={true} />);
+    await act(async () => {});
+
+    const search = screen.getByPlaceholderText("sessions.searchPlaceholder");
+    fireEvent.change(search, { target: { value: "bulk" } });
+    await waitFor(() => {
+      expect(screen.getByText("Search one")).toBeTruthy();
+    });
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "sessions.selectMode" }),
+      );
+    });
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "sessions.selectVisible" }),
+      );
+    });
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "sessions.deleteSelected" }),
+      );
+    });
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: "sessions.deleteConfirmAction",
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(api.deleteSessions).toHaveBeenCalledWith([
+        "search-one",
+        "search-two",
+      ]);
+    });
+    expect(api.deleteSessions).not.toHaveBeenCalledWith(["main-session"]);
+  });
+
+  it("does not delete selected sessions when the bulk confirm is cancelled", async () => {
+    const sessions = [
+      {
+        id: "sess-one",
+        title: "First chat",
+        startedAt: Math.floor(Date.now() / 1000),
+        source: "api_server",
+        messageCount: 3,
+        model: "gpt-4",
+      },
+    ];
+    const api = installHermesAPI(sessions);
+
+    render(<Sessions {...baseProps} visible={true} />);
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "sessions.selectMode" }),
+      );
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("First chat"));
+    });
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "sessions.deleteSelected" }),
+      );
+    });
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "sessions.deleteCancel" }),
+      );
+    });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(api.deleteSessions).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/src/screens/Sessions/Sessions.tsx
+++ b/src/renderer/src/screens/Sessions/Sessions.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useState, useRef, useCallback, memo } from "react";
+import {
+  useEffect,
+  useState,
+  useRef,
+  useCallback,
+  useMemo,
+  memo,
+} from "react";
 import { Plus, Search, X, ChatBubble, Trash } from "../../assets/icons";
 import { useI18n } from "../../components/useI18n";
 
@@ -98,6 +105,19 @@ function highlightSnippet(snippet: string): React.JSX.Element {
   );
 }
 
+function cleanSearchSnippet(snippet: string, preserveMarkers = false): string {
+  let text = snippet
+    .replace(/\\r\\n|\\n|\\r|\r\n|\n|\r/g, " ")
+    .replace(/^\s*(?:\.{3}|…)+\s*/, "")
+    .replace(/\s*(?:\.{3}|…)+\s*$/, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!preserveMarkers) {
+    text = text.replace(/<</g, "").replace(/>>/g, "");
+  }
+  return text;
+}
+
 function formatModel(model: string): string {
   const name = model.split("/").pop() || model;
   // Shorten common patterns: "gpt-oss-20b:free" → "gpt-oss-20b"
@@ -112,6 +132,10 @@ const SessionCard = memo(function SessionCard({
   onClick,
   onDelete,
   deleteTitle,
+  selectionMode = false,
+  selected = false,
+  onToggleSelected,
+  selectTitle,
 }: {
   session: CachedSession;
   isActive: boolean;
@@ -120,7 +144,19 @@ const SessionCard = memo(function SessionCard({
   // When provided, renders a trash icon button on the card. Closes #408.
   onDelete?: (id: string) => void;
   deleteTitle?: string;
+  selectionMode?: boolean;
+  selected?: boolean;
+  onToggleSelected?: (id: string) => void;
+  selectTitle?: string;
 }) {
+  const activate = (): void => {
+    if (selectionMode) {
+      onToggleSelected?.(session.id);
+      return;
+    }
+    onClick();
+  };
+
   // `div` instead of `button` because nesting a button-inside-button is
   // invalid HTML and many a11y / interaction layers (focus trap, keyboard
   // navigation) break on it. Click + Enter/Space behavior matches the
@@ -129,16 +165,31 @@ const SessionCard = memo(function SessionCard({
     <div
       role="button"
       tabIndex={0}
-      className={`sessions-card ${isActive ? "sessions-card--active" : ""}`}
-      onClick={onClick}
+      className={`sessions-card ${isActive ? "sessions-card--active" : ""} ${
+        selected ? "sessions-card--selected" : ""
+      }`}
+      onClick={activate}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
-          onClick();
+          activate();
         }
       }}
     >
       <div className="sessions-card-main">
+        {selectionMode && (
+          <label
+            className="sessions-card-select"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <input
+              type="checkbox"
+              checked={selected}
+              onChange={() => onToggleSelected?.(session.id)}
+              aria-label={selectTitle}
+            />
+          </label>
+        )}
         <span className="sessions-card-title">
           {session.title || "New conversation"}
         </span>
@@ -160,7 +211,7 @@ const SessionCard = memo(function SessionCard({
             {formatModel(session.model)}
           </span>
         )}
-        {onDelete && (
+        {!selectionMode && onDelete && (
           <button
             type="button"
             className="sessions-card-delete"
@@ -208,6 +259,14 @@ function Sessions({
   const [deletingSessionId, setDeletingSessionId] = useState<string | null>(
     null,
   );
+  const [isSelectionMode, setIsSelectionMode] = useState(false);
+  const [selectedSessionIds, setSelectedSessionIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [pendingBulkDeleteIds, setPendingBulkDeleteIds] = useState<
+    string[] | null
+  >(null);
+  const [deletingBulk, setDeletingBulk] = useState(false);
   const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const searchRequestId = useRef(0);
   const searchRef = useRef<HTMLInputElement>(null);
@@ -276,16 +335,83 @@ function Sessions({
     [refreshSessions],
   );
 
+  const toggleSelectionMode = useCallback((): void => {
+    setIsSelectionMode((active) => {
+      if (active) {
+        setSelectedSessionIds(new Set());
+      }
+      return !active;
+    });
+  }, []);
+
+  const toggleSessionSelected = useCallback((sessionId: string): void => {
+    setSelectedSessionIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(sessionId)) {
+        next.delete(sessionId);
+      } else {
+        next.add(sessionId);
+      }
+      return next;
+    });
+  }, []);
+
+  const cancelBulkDelete = useCallback((): void => {
+    if (deletingBulk) return;
+    setPendingBulkDeleteIds(null);
+  }, [deletingBulk]);
+
+  const confirmBulkDelete = useCallback(
+    async (sessionIds: string[]): Promise<void> => {
+      const ids = Array.from(new Set(sessionIds.map((id) => id.trim()))).filter(
+        Boolean,
+      );
+      if (ids.length === 0) {
+        setPendingBulkDeleteIds(null);
+        return;
+      }
+
+      const idSet = new Set(ids);
+      setDeletingBulk(true);
+      setSessions((prev) => prev.filter((s) => !idSet.has(s.id)));
+      setSearchResults((prev) => prev.filter((r) => !idSet.has(r.sessionId)));
+      try {
+        await window.hermesAPI.deleteSessions(ids);
+      } catch (err) {
+        console.error("Failed to delete selected sessions", ids, err);
+      } finally {
+        await refreshSessions();
+        setDeletingBulk(false);
+        setPendingBulkDeleteIds(null);
+        setSelectedSessionIds(new Set());
+        setIsSelectionMode(false);
+      }
+    },
+    [refreshSessions],
+  );
+
   useEffect(() => {
-    if (!pendingDeleteSessionId || deletingSessionId) return;
+    if (
+      (!pendingDeleteSessionId && !pendingBulkDeleteIds) ||
+      deletingSessionId ||
+      deletingBulk
+    ) {
+      return;
+    }
     const onKeyDown = (event: KeyboardEvent): void => {
       if (event.key === "Escape") {
         setPendingDeleteSessionId(null);
+        setPendingBulkDeleteIds(null);
       }
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [deletingSessionId, pendingDeleteSessionId]);
+  }, [
+    deletingBulk,
+    deletingSessionId,
+    pendingBulkDeleteIds,
+    pendingDeleteSessionId,
+  ]);
 
   // Refresh sessions whenever the Sessions view becomes visible.
   // This ensures new sessions created in the Chat view (via "+")
@@ -347,6 +473,40 @@ function Sessions({
 
   const isShowingSearch = searchQuery.trim().length > 0;
   const grouped = groupSessions(sessions);
+  const visibleSessionIds = useMemo(() => {
+    const ids = isShowingSearch
+      ? searchResults.map((result) => result.sessionId)
+      : sessions.map((session) => session.id);
+    return Array.from(new Set(ids));
+  }, [isShowingSearch, searchResults, sessions]);
+  const visibleSessionIdKey = visibleSessionIds.join("\u0000");
+  const selectedCount = selectedSessionIds.size;
+  const allVisibleSelected =
+    visibleSessionIds.length > 0 &&
+    visibleSessionIds.every((id) => selectedSessionIds.has(id));
+
+  const toggleVisibleSelection = useCallback((): void => {
+    setSelectedSessionIds((prev) => {
+      const next = new Set(prev);
+      if (allVisibleSelected) {
+        for (const id of visibleSessionIds) next.delete(id);
+      } else {
+        for (const id of visibleSessionIds) next.add(id);
+      }
+      return next;
+    });
+  }, [allVisibleSelected, visibleSessionIds]);
+
+  useEffect(() => {
+    if (!isSelectionMode) return;
+    const visibleIds = new Set(visibleSessionIds);
+    setSelectedSessionIds((prev) => {
+      const next = new Set(
+        Array.from(prev).filter((id) => visibleIds.has(id)),
+      );
+      return next.size === prev.size ? prev : next;
+    });
+  }, [isSelectionMode, visibleSessionIdKey]);
 
   return (
     <div className="sessions-container">
@@ -354,10 +514,22 @@ function Sessions({
       <div className="sessions-header">
         <div className="sessions-header-top">
           <h2 className="sessions-title">{t("sessions.title")}</h2>
-          <button className="btn btn-primary " onClick={onNewChat}>
-            <Plus size={14} />
-            {t("sessions.newChat")}
-          </button>
+          <div className="sessions-header-actions">
+            <button
+              type="button"
+              className="btn btn-secondary sessions-select-mode"
+              onClick={toggleSelectionMode}
+              disabled={loading || visibleSessionIds.length === 0}
+            >
+              {isSelectionMode
+                ? t("sessions.cancelSelect")
+                : t("sessions.selectMode")}
+            </button>
+            <button className="btn btn-primary" onClick={onNewChat}>
+              <Plus size={14} />
+              {t("sessions.newChat")}
+            </button>
+          </div>
         </div>
         <div className="sessions-searchbar">
           <Search size={14} className="sessions-searchbar-icon" />
@@ -381,6 +553,33 @@ function Sessions({
             </button>
           )}
         </div>
+        {isSelectionMode && (
+          <div className="sessions-selection-toolbar">
+            <span className="sessions-selection-count">
+              {t("sessions.selectedCount", { count: selectedCount })}
+            </span>
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={toggleVisibleSelection}
+              disabled={visibleSessionIds.length === 0}
+            >
+              {allVisibleSelected
+                ? t("sessions.clearVisible")
+                : t("sessions.selectVisible")}
+            </button>
+            <button
+              type="button"
+              className="btn btn-danger"
+              onClick={() =>
+                setPendingBulkDeleteIds(Array.from(selectedSessionIds))
+              }
+              disabled={selectedCount === 0}
+            >
+              {t("sessions.deleteSelected")}
+            </button>
+          </div>
+        )}
       </div>
 
       {/* Content */}
@@ -401,30 +600,73 @@ function Sessions({
           </div>
         ) : (
           <div className="sessions-list">
-            {searchResults.map((r, index) => (
-              <div
+            {searchResults.map((r, index) => {
+              const snippetTitle =
+                !r.title && r.snippet
+                  ? cleanSearchSnippet(r.snippet, true)
+                  : "";
+              const fallbackTitle =
+                (r.snippet && cleanSearchSnippet(r.snippet)) ||
+                `${t("sessions.title")} ${r.sessionId.slice(-6)}`;
+              const shouldShowSnippet = Boolean(r.title && r.snippet);
+
+              return (
+                <div
                 key={`${r.sessionId}-${index}`}
                 role="button"
                 tabIndex={0}
-                className={`sessions-card ${currentSessionId === r.sessionId ? "sessions-card--active" : ""}`}
-                onClick={() => onResumeSession(r.sessionId)}
+                className={`sessions-card ${
+                  currentSessionId === r.sessionId
+                    ? "sessions-card--active"
+                    : ""
+                } ${
+                  selectedSessionIds.has(r.sessionId)
+                    ? "sessions-card--selected"
+                    : ""
+                }`}
+                onClick={() => {
+                  if (isSelectionMode) {
+                    toggleSessionSelected(r.sessionId);
+                  } else {
+                    onResumeSession(r.sessionId);
+                  }
+                }}
                 onKeyDown={(e) => {
                   if (e.key === "Enter" || e.key === " ") {
                     e.preventDefault();
-                    onResumeSession(r.sessionId);
+                    if (isSelectionMode) {
+                      toggleSessionSelected(r.sessionId);
+                    } else {
+                      onResumeSession(r.sessionId);
+                    }
                   }
                 }}
               >
                 <div className="sessions-card-main">
+                  {isSelectionMode && (
+                    <label
+                      className="sessions-card-select"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selectedSessionIds.has(r.sessionId)}
+                        onChange={() => toggleSessionSelected(r.sessionId)}
+                        aria-label={t("sessions.selectSession")}
+                      />
+                    </label>
+                  )}
                   <span className="sessions-card-title">
                     {r.title ||
-                      `${t("sessions.title")} ${r.sessionId.slice(-6)}`}
+                      (snippetTitle
+                        ? highlightSnippet(snippetTitle)
+                        : fallbackTitle)}
                   </span>
                   <span className="sessions-card-time">
                     {formatFullDate(r.startedAt)}
                   </span>
                 </div>
-                {r.snippet && (
+                {shouldShowSnippet && (
                   <div className="sessions-result-snippet">
                     {highlightSnippet(r.snippet)}
                   </div>
@@ -444,22 +686,25 @@ function Sessions({
                       {formatModel(r.model)}
                     </span>
                   )}
-                  <button
-                    type="button"
-                    className="sessions-card-delete"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleDelete(r.sessionId);
-                    }}
-                    onKeyDown={(e) => e.stopPropagation()}
-                    title={t("sessions.delete")}
-                    aria-label={t("sessions.delete")}
-                  >
-                    <Trash size={14} />
-                  </button>
+                  {!isSelectionMode && (
+                    <button
+                      type="button"
+                      className="sessions-card-delete"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleDelete(r.sessionId);
+                      }}
+                      onKeyDown={(e) => e.stopPropagation()}
+                      title={t("sessions.delete")}
+                      aria-label={t("sessions.delete")}
+                    >
+                      <Trash size={14} />
+                    </button>
+                  )}
                 </div>
               </div>
-            ))}
+              );
+            })}
           </div>
         )
       ) : sessions.length === 0 ? (
@@ -486,6 +731,10 @@ function Sessions({
                   onClick={() => onResumeSession(s.id)}
                   onDelete={handleDelete}
                   deleteTitle={t("sessions.delete")}
+                  selectionMode={isSelectionMode}
+                  selected={selectedSessionIds.has(s.id)}
+                  onToggleSelected={toggleSessionSelected}
+                  selectTitle={t("sessions.selectSession")}
                 />
               ))}
             </div>
@@ -538,6 +787,63 @@ function Sessions({
                 disabled={!!deletingSessionId}
               >
                 {deletingSessionId
+                  ? t("sessions.deleteDeleting")
+                  : t("sessions.deleteConfirmAction")}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      {pendingBulkDeleteIds && (
+        <div
+          className="sessions-confirm-overlay"
+          onClick={cancelBulkDelete}
+          role="presentation"
+        >
+          <div
+            className="sessions-confirm-modal"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="sessions-bulk-delete-confirm-title"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="sessions-confirm-header">
+              <h3 id="sessions-bulk-delete-confirm-title">
+                {t("sessions.deleteSelectedConfirmTitle")}
+              </h3>
+              <button
+                type="button"
+                className="btn-ghost sessions-confirm-close"
+                onClick={cancelBulkDelete}
+                disabled={deletingBulk}
+                aria-label={t("sessions.deleteSelectedClose")}
+              >
+                <X size={16} />
+              </button>
+            </div>
+            <div className="sessions-confirm-body">
+              <p>
+                {t("sessions.deleteSelectedConfirm", {
+                  count: pendingBulkDeleteIds.length,
+                })}
+              </p>
+            </div>
+            <div className="sessions-confirm-footer">
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={cancelBulkDelete}
+                disabled={deletingBulk}
+              >
+                {t("sessions.deleteCancel")}
+              </button>
+              <button
+                type="button"
+                className="btn btn-danger"
+                onClick={() => void confirmBulkDelete(pendingBulkDeleteIds)}
+                disabled={deletingBulk}
+              >
+                {deletingBulk
                   ? t("sessions.deleteDeleting")
                   : t("sessions.deleteConfirmAction")}
               </button>

--- a/src/shared/i18n/locales/en/sessions.ts
+++ b/src/shared/i18n/locales/en/sessions.ts
@@ -21,4 +21,15 @@ export default {
   deleteCancel: "Cancel",
   deleteConfirmAction: "Delete",
   deleteDeleting: "Deleting...",
+  selectMode: "Select",
+  cancelSelect: "Cancel",
+  selectedCount: "{{count}} selected",
+  selectVisible: "Select visible",
+  clearVisible: "Clear visible",
+  deleteSelected: "Delete selected",
+  selectSession: "Select session",
+  deleteSelectedConfirmTitle: "Delete selected sessions",
+  deleteSelectedConfirm:
+    "Delete {{count}} selected sessions? This cannot be undone — messages and session records will be permanently removed.",
+  deleteSelectedClose: "Close bulk delete confirmation",
 } as const;

--- a/tests/preload-api-surface.test.ts
+++ b/tests/preload-api-surface.test.ts
@@ -133,6 +133,7 @@ describe("Legacy APIs preserved (backward compat)", () => {
     // Sessions
     "listSessions",
     "getSessionMessages",
+    "deleteSessions",
     // Profiles
     "listProfiles",
     "createProfile",

--- a/tests/session-cache-sync.test.ts
+++ b/tests/session-cache-sync.test.ts
@@ -429,6 +429,50 @@ describe("syncSessionCache", () => {
     expect(second[0].title).toContain("first");
   });
 
+  it("prunes cached sessions that no longer exist in state.db", () => {
+    const oldStart = Math.floor(Date.now() / 1000) - 86400 * 14;
+    seedDb([
+      {
+        id: "still-present",
+        started_at: oldStart,
+        message_count: 3,
+        firstUserMessage: "keep me",
+      },
+    ]);
+
+    mkdirSync(join(TEST_HOME, "desktop"), { recursive: true });
+    writeFileSync(
+      CACHE_FILE,
+      JSON.stringify({
+        sessions: [
+          {
+            id: "already-deleted",
+            title: "Already deleted",
+            startedAt: oldStart,
+            source: "api_server",
+            messageCount: 1,
+            model: "gpt-5.5",
+          },
+          {
+            id: "still-present",
+            title: "Keep me",
+            startedAt: oldStart,
+            source: "api_server",
+            messageCount: 1,
+            model: "gpt-5.5",
+          },
+        ],
+        lastSync: Math.floor(Date.now() / 1000),
+      }),
+      "utf-8",
+    );
+
+    const result = syncSessionCache();
+
+    expect(result.map((s) => s.id)).toEqual(["still-present"]);
+    expect(result[0].messageCount).toBe(3);
+  });
+
   it("refreshes some old, leaves others untouched, all in one sync", () => {
     // Mix: one session inside the lastSync window (handled by Phase 1)
     // and two outside it (handled by Phase 2). All three counts grow

--- a/tests/sessions-delete-session.test.ts
+++ b/tests/sessions-delete-session.test.ts
@@ -105,7 +105,7 @@ vi.mock("better-sqlite3", () => {
         this.sql.includes("INSERT OR REPLACE INTO sessions") ||
         this.sql.includes("INSERT INTO sessions")
       ) {
-        const [id, source, startedAt, , messageCount, model, title] = args;
+        const [id, source, startedAt, messageCount, model, title] = args;
         this.store.sessions.set(String(id), {
           id: String(id),
           source: String(source),
@@ -149,7 +149,39 @@ vi.mock("better-sqlite3", () => {
       throw new Error(`Unhandled fake run SQL: ${this.sql}`);
     }
 
-    all(...args: unknown[]): SessionRow[] | MessageRow[] {
+    all(...args: unknown[]): unknown[] {
+      if (
+        this.sql.includes("FROM sessions s") &&
+        this.sql.includes("LOWER(COALESCE")
+      ) {
+        const titlePattern = String(args[0])
+          .replace(/^%/, "")
+          .replace(/%$/, "")
+          .replace(/\\/g, "")
+          .toLowerCase();
+        const idPattern = String(args[1])
+          .replace(/^%/, "")
+          .replace(/%$/, "")
+          .replace(/\\/g, "")
+          .toLowerCase();
+        const limit = Number(args[2]);
+        return Array.from(this.store.sessions.values())
+          .filter((session) =>
+            (session.title || "").toLowerCase().includes(titlePattern) ||
+            session.id.toLowerCase().includes(idPattern),
+          )
+          .sort((a, b) => b.started_at - a.started_at)
+          .slice(0, limit)
+          .map((session) => ({
+            session_id: session.id,
+            title: session.title,
+            started_at: session.started_at,
+            source: session.source,
+            message_count: session.message_count,
+            model: session.model,
+          }));
+      }
+
       if (this.sql.includes("FROM sessions s")) {
         const [limit, offset] = args.map(Number);
         return Array.from(this.store.sessions.values())
@@ -174,6 +206,10 @@ vi.mock("better-sqlite3", () => {
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     get(..._args: unknown[]): unknown {
+      if (this.sql.includes("sqlite_master") && this.sql.includes("messages_fts")) {
+        return undefined;
+      }
+
       throw new Error(`Unhandled fake get SQL: ${this.sql}`);
     }
   }
@@ -214,8 +250,10 @@ vi.mock("better-sqlite3", () => {
 import Database from "better-sqlite3";
 import {
   deleteSession,
+  deleteSessions,
   listSessions,
   getSessionMessages,
+  searchSessions,
 } from "../src/main/sessions";
 
 function seedDb(
@@ -390,5 +428,141 @@ describe("deleteSession", () => {
   it("returns early when the database file does not exist", () => {
     // No DB seeded — HERMES_HOME/state.db doesn't exist
     expect(() => deleteSession("any-session")).not.toThrow();
+  });
+});
+
+describe("searchSessions", () => {
+  it("finds title-only matches when the message body does not contain the query", () => {
+    const now = Math.floor(Date.now() / 1000);
+    seedDb([
+      {
+        id: "title-only-match",
+        title: "Manual bulk delete search target 1780363992423",
+        started_at: now,
+        message_count: 1,
+        messages: [
+          {
+            role: "user",
+            content: "temporary manual bulk delete test row",
+            timestamp: now,
+          },
+        ],
+      },
+    ]);
+
+    const results = searchSessions("1780363992423");
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      sessionId: "title-only-match",
+      title: "Manual bulk delete search target 1780363992423",
+    });
+    expect(results[0].snippet).toContain("<<1780363992423>>");
+  });
+
+  it("finds sessions by id suffix when the UI displays a fallback title", () => {
+    const now = Math.floor(Date.now() / 1000);
+    seedDb([
+      {
+        id: "desk-old-session-295d8a",
+        title: null,
+        started_at: now,
+        message_count: 1,
+        messages: [
+          {
+            role: "user",
+            content: "body does not include the id suffix",
+            timestamp: now,
+          },
+        ],
+      },
+    ]);
+
+    const results = searchSessions("295d");
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      sessionId: "desk-old-session-295d8a",
+      title: null,
+    });
+    expect(results[0].snippet).toContain("Sessions <<295d>>8a");
+  });
+});
+
+describe("deleteSessions", () => {
+  it("deletes multiple sessions and all of their messages", () => {
+    const now = Math.floor(Date.now() / 1000);
+    seedDb([
+      {
+        id: "bulk-delete-a",
+        started_at: now,
+        message_count: 1,
+        messages: [{ role: "user", content: "delete a", timestamp: now }],
+      },
+      {
+        id: "bulk-delete-b",
+        started_at: now + 1,
+        message_count: 1,
+        messages: [
+          { role: "assistant", content: "delete b", timestamp: now + 1 },
+        ],
+      },
+      {
+        id: "bulk-keep",
+        started_at: now + 2,
+        message_count: 1,
+        messages: [{ role: "user", content: "keep", timestamp: now + 2 }],
+      },
+    ]);
+
+    const result = deleteSessions(["bulk-delete-a", "bulk-delete-b"]);
+
+    expect(result).toEqual({ requested: 2, deleted: 2 });
+    expect(listSessions().map((s) => s.id)).toEqual(["bulk-keep"]);
+    expect(getSessionMessages("bulk-delete-a")).toHaveLength(0);
+    expect(getSessionMessages("bulk-delete-b")).toHaveLength(0);
+    expect(getSessionMessages("bulk-keep")).toHaveLength(1);
+  });
+
+  it("dedupes and ignores blank session ids", () => {
+    const now = Math.floor(Date.now() / 1000);
+    seedDb([
+      {
+        id: "dedupe-me",
+        started_at: now,
+        message_count: 1,
+        messages: [{ role: "user", content: "delete", timestamp: now }],
+      },
+    ]);
+
+    const result = deleteSessions([
+      "",
+      " ",
+      "dedupe-me",
+      "dedupe-me",
+      " missing ",
+    ]);
+
+    expect(result).toEqual({ requested: 2, deleted: 1 });
+    expect(listSessions()).toHaveLength(0);
+  });
+
+  it("clears staged attachment files for every deleted id", () => {
+    const now = Math.floor(Date.now() / 1000);
+    seedDb([
+      { id: "bulk-staged-a", started_at: now },
+      { id: "bulk-staged-b", started_at: now + 1 },
+    ]);
+    const stagingA = join(TEST_HOME, "desktop-staging", "bulk-staged-a");
+    const stagingB = join(TEST_HOME, "desktop-staging", "bulk-staged-b");
+    mkdirSync(stagingA, { recursive: true });
+    mkdirSync(stagingB, { recursive: true });
+    writeFileSync(join(stagingA, "a.txt"), "a");
+    writeFileSync(join(stagingB, "b.txt"), "b");
+
+    deleteSessions(["bulk-staged-a", "bulk-staged-b"]);
+
+    expect(existsSync(stagingA)).toBe(false);
+    expect(existsSync(stagingB)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #490.

This adds bulk deletion support to the Sessions screen and tightens the related session list/search refresh paths that surfaced during live testing.

Changes included:

- adds a main-process `deleteSessions()` path that deletes multiple sessions in one operation
- exposes `window.hermesAPI.deleteSessions()` through preload
- adds Sessions UI selection mode with `Select visible` and `Delete selected`
- keeps direct single-session delete behavior working through the same backend path
- clears staged attachments for deleted sessions
- removes deleted sessions from the desktop session cache immediately
- prunes cached sessions that no longer exist in `state.db` during cache sync, so deleted sessions do not reappear after clearing search
- improves Sessions search so title-only, message, and id/fallback-title matches are findable
- improves title-less search result rendering so useful matched text is shown instead of opaque `Sessions <id>` fallback labels

## Why this shape

Bulk delete needs to be more than a renderer-only loop over single deletes. The main process now normalizes/dedupes IDs and performs the DB/cache cleanup centrally, which keeps direct delete and bulk delete consistent and gives tests a single behavior surface to assert.

During live testing, deleted rows could still appear from the fast `sessions.json` cache after clearing a search. That was a stale-cache problem, so this also prunes cache rows that no longer exist in `state.db` when syncing.

Search also had two confusing edge cases discovered while testing:

- sessions whose match was only in the title were not found reliably
- sessions with no saved title but useful matched content rendered as `Sessions <id>`, which made results look unrelated to the query

Both are covered here.

## Testing

Automated:

- `npm test -- tests/session-cache-sync.test.ts tests/sessions-delete-session.test.ts src/renderer/src/screens/Sessions/Sessions.test.tsx tests/preload-api-surface.test.ts`
  - 172 passed
- `npm test -- --testTimeout=60000`
  - 819 passed, 3 skipped
- `npm run build`
  - passed

Live / visual:

- launched the dev instance from this repo with the real local config
- used the CDP/Playwright harness against the Electron window
- verified searching `Live PR499` returns the two expected rows
- verified those rows now display meaningful matched titles (`Live PR499 smoke...`, `Live PR499 UI recovery...`) instead of `Sessions 722999` / `Sessions 44a55e`
- verified stale `Bulk live...` rows were absent after cache sync and after clearing search

Manual live testing by Pedro:

- exercised search mode and clear-search behavior
- bulk-deleted filtered/visible sessions
- confirmed deleted sessions disappeared from matching search results
- found the stale-cache reappearance case after clearing search, which this PR now fixes
- checked the improved search result presentation after the title-less result fix

@fathah, could you review this before merge? Pedro mentioned he will not merge his own PRs without your review.
