### PR TITLE
Add collapsible sidebar

### DIFF
--- a/src/renderer/src/assets/icons/index.tsx
+++ b/src/renderer/src/assets/icons/index.tsx
@@ -15,6 +15,8 @@ export {
   Layers,
   Monitor,
   Moon,
+  PanelLeftClose,
+  PanelLeftOpen,
   Plus,
   Puzzle,
   Search,

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -912,16 +912,22 @@ body {
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
-
+  transition:
+    width var(--transition),
+    padding var(--transition);
   border-radius: 16px;
+}
+
+.sidebar-collapsed .sidebar {
+  width: 64px;
 }
 
 .sidebar-brand {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
   gap: 10px;
-  padding: 20px 10px;
+  padding: 20px 14px 20px 20px;
   margin-top: 25px;
 }
 
@@ -935,6 +941,36 @@ body {
   -webkit-mask-repeat: no-repeat;
   -webkit-mask-position: center;
   -webkit-mask-size: contain;
+}
+
+.sidebar-collapse-toggle {
+  width: 30px;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.sidebar-collapse-toggle:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.sidebar-collapsed .sidebar-brand {
+  justify-content: center;
+  padding: 18px 10px;
+  margin-top: 18px;
+}
+
+.sidebar-collapsed .sidebar-logo {
+  display: none;
 }
 
 .sidebar-brand-icon {
@@ -971,6 +1007,11 @@ body {
   overflow-y: auto;
 }
 
+.sidebar-collapsed .sidebar-nav {
+  padding: 0 10px;
+  align-items: center;
+}
+
 .sidebar-nav-item {
   display: flex;
   align-items: center;
@@ -989,6 +1030,12 @@ body {
   font-family: var(--font-sans);
 }
 
+.sidebar-nav-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .sidebar-nav-item:hover {
   background: var(--bg-tertiary);
   color: var(--text-primary);
@@ -1003,6 +1050,18 @@ body {
   flex-shrink: 0;
 }
 
+.sidebar-collapsed .sidebar-nav-item {
+  width: 40px;
+  height: 40px;
+  justify-content: center;
+  gap: 0;
+  padding: 0;
+}
+
+.sidebar-collapsed .sidebar-nav-label {
+  display: none;
+}
+
 /* Sidebar footer with theme switcher */
 .sidebar-footer {
   padding: 12px;
@@ -1012,9 +1071,19 @@ body {
   gap: 8px;
 }
 
+.sidebar-collapsed .sidebar-footer {
+  align-items: center;
+  padding: 10px;
+}
+
 /* ── Profile switcher (sidebar footer) ──────────────────── */
 .profile-switcher {
   position: relative;
+  width: 100%;
+}
+
+.profile-switcher.compact {
+  width: 40px;
 }
 
 .profile-switcher-trigger {
@@ -1033,6 +1102,14 @@ body {
   cursor: pointer;
   text-align: left;
   transition: all var(--transition);
+}
+
+.profile-switcher.compact .profile-switcher-trigger {
+  width: 40px;
+  height: 40px;
+  justify-content: center;
+  gap: 0;
+  padding: 0;
 }
 
 .profile-switcher-trigger:hover,
@@ -1082,6 +1159,12 @@ body {
   padding: 6px;
   z-index: 200;
   animation: profileMenuIn 0.12s ease;
+}
+
+.profile-switcher.compact .profile-menu {
+  left: calc(100% + 8px);
+  right: auto;
+  bottom: 0;
 }
 
 @keyframes profileMenuIn {
@@ -1210,6 +1293,18 @@ body {
   font-weight: 600;
   cursor: pointer;
   transition: background var(--transition);
+}
+
+.sidebar-collapsed .sidebar-update-btn {
+  width: 40px;
+  height: 40px;
+  justify-content: center;
+  padding: 0;
+  margin-bottom: 0;
+}
+
+.sidebar-collapsed .sidebar-update-btn span {
+  display: none;
 }
 
 .sidebar-update-btn:hover {

--- a/src/renderer/src/screens/Layout/Layout.tsx
+++ b/src/renderer/src/screens/Layout/Layout.tsx
@@ -35,6 +35,8 @@ import {
   Timer,
   Kanban as KanbanIcon,
   Download,
+  PanelLeftClose,
+  PanelLeftOpen,
 } from "../../assets/icons";
 import type { LucideIcon } from "lucide-react";
 import { useI18n } from "../../components/useI18n";
@@ -74,6 +76,8 @@ const NAV_ITEMS: { view: View; icon: LucideIcon; labelKey: string }[] = [
   { view: "settings", icon: SettingsIcon, labelKey: "navigation.settings" },
 ];
 
+const SIDEBAR_COLLAPSED_KEY = "hermes.sidebar.collapsed";
+
 interface LayoutProps {
   verifyWarning?: boolean;
   onReinstall?: () => void;
@@ -90,6 +94,13 @@ function Layout({
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [currentSessionId, setCurrentSessionId] = useState<string | null>(null);
   const [activeProfile, setActiveProfile] = useState("default");
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
+    try {
+      return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === "true";
+    } catch {
+      return false;
+    }
+  });
   // Tabs lazy-mount on first visit, then stay mounted (display:none toggle).
   // Keeps IPC refetch / DOM rebuild off the tab-switch hot path.
   const [visitedViews, setVisitedViews] = useState<Set<View>>(
@@ -189,6 +200,18 @@ function Layout({
     }
   }
 
+  const updateButtonTitle =
+    updateError ??
+    (updateState === "available"
+      ? t("common.updateAvailable", { version: updateVersion })
+      : updateState === "downloading"
+        ? t("common.downloading", { percent: downloadPercent })
+        : updateState === "ready"
+          ? t("common.restartToUpdate")
+          : updateState === "error"
+            ? t("common.updateFailed")
+            : undefined);
+
   const handleNewChat = useCallback(() => {
     // Abort any in-flight chat before clearing
     window.hermesAPI.abortChat();
@@ -229,8 +252,24 @@ function Layout({
     [goTo],
   );
 
+  const toggleSidebar = useCallback(() => {
+    setSidebarCollapsed((collapsed) => {
+      const next = !collapsed;
+      try {
+        localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(next));
+      } catch {
+        /* ignore persistence failures */
+      }
+      return next;
+    });
+  }, []);
+
+  const sidebarToggleLabel = sidebarCollapsed
+    ? t("navigation.expandSidebar")
+    : t("navigation.collapseSidebar");
+
   return (
-    <div className="layout">
+    <div className={`layout ${sidebarCollapsed ? "sidebar-collapsed" : ""}`}>
       <aside className="sidebar">
         <div className="sidebar-brand">
           <span
@@ -242,6 +281,20 @@ function Layout({
               WebkitMaskImage: `url(${hermeslogo})`,
             }}
           />
+          <button
+            className="sidebar-collapse-toggle"
+            type="button"
+            onClick={toggleSidebar}
+            title={sidebarToggleLabel}
+            aria-label={sidebarToggleLabel}
+            aria-expanded={!sidebarCollapsed}
+          >
+            {sidebarCollapsed ? (
+              <PanelLeftOpen size={16} />
+            ) : (
+              <PanelLeftClose size={16} />
+            )}
+          </button>
         </div>
 
         <nav className="sidebar-nav">
@@ -250,9 +303,11 @@ function Layout({
               key={v}
               className={`sidebar-nav-item ${view === v ? "active" : ""}`}
               onClick={() => goTo(v)}
+              title={t(labelKey)}
+              aria-label={t(labelKey)}
             >
               <Icon size={16} />
-              {t(labelKey)}
+              <span className="sidebar-nav-label">{t(labelKey)}</span>
             </button>
           ))}
         </nav>
@@ -265,7 +320,8 @@ function Layout({
               }`}
               onClick={handleUpdate}
               disabled={updateState === "downloading"}
-              title={updateError ?? undefined}
+              title={updateButtonTitle}
+              aria-label={updateButtonTitle}
             >
               <Download size={13} />
               {updateState === "available" && (
@@ -290,6 +346,7 @@ function Layout({
             activeProfile={activeProfile}
             onSwitch={handleSelectProfile}
             onManage={() => goTo("agents")}
+            compact={sidebarCollapsed}
           />
         </div>
       </aside>

--- a/src/renderer/src/screens/Layout/ProfileSwitcher.tsx
+++ b/src/renderer/src/screens/Layout/ProfileSwitcher.tsx
@@ -18,6 +18,8 @@ interface ProfileSwitcherProps {
   onSwitch: (name: string) => void;
   /** Open the full Profiles management screen. */
   onManage: () => void;
+  /** Render as an icon-only sidebar footer affordance. */
+  compact?: boolean;
 }
 
 /**
@@ -28,6 +30,7 @@ export default function ProfileSwitcher({
   activeProfile,
   onSwitch,
   onManage,
+  compact = false,
 }: ProfileSwitcherProps): React.JSX.Element {
   const { t } = useI18n();
   const [open, setOpen] = useState(false);
@@ -86,7 +89,10 @@ export default function ProfileSwitcher({
   }
 
   return (
-    <div className="profile-switcher" ref={rootRef}>
+    <div
+      className={`profile-switcher ${compact ? "compact" : ""}`}
+      ref={rootRef}
+    >
       {open && (
         <div className="profile-menu" role="menu">
           <div className="profile-menu-list">
@@ -146,7 +152,7 @@ export default function ProfileSwitcher({
       <button
         className={`profile-switcher-trigger ${open ? "open" : ""}`}
         onClick={() => setOpen((o) => !o)}
-        title={t("agents.switchProfile")}
+        title={`${t("agents.switchProfile")}: ${label}`}
         aria-haspopup="menu"
         aria-expanded={open}
       >
@@ -155,8 +161,10 @@ export default function ProfileSwitcher({
           className={`profile-icon ${activeRunning ? "running" : ""}`}
           aria-hidden
         />
-        <span className="profile-switcher-name">{label}</span>
-        <ChevronDown size={14} className="profile-switcher-chevron" />
+        {!compact && <span className="profile-switcher-name">{label}</span>}
+        {!compact && (
+          <ChevronDown size={14} className="profile-switcher-chevron" />
+        )}
       </button>
     </div>
   );

--- a/src/shared/i18n/locales/en/navigation.ts
+++ b/src/shared/i18n/locales/en/navigation.ts
@@ -14,4 +14,6 @@ export default {
   kanban: "Kanban",
   gateway: "Gateway",
   settings: "Settings",
+  collapseSidebar: "Collapse sidebar",
+  expandSidebar: "Expand sidebar",
 } as const;

--- a/src/shared/i18n/locales/es/navigation.ts
+++ b/src/shared/i18n/locales/es/navigation.ts
@@ -13,4 +13,6 @@ export default {
   kanban: "Kanban",
   gateway: "Gateway",
   settings: "Configuración",
+  collapseSidebar: "Contraer barra lateral",
+  expandSidebar: "Expandir barra lateral",
 } as const;

--- a/src/shared/i18n/locales/id/navigation.ts
+++ b/src/shared/i18n/locales/id/navigation.ts
@@ -13,4 +13,6 @@ export default {
   kanban: "Kanban",
   gateway: "Gateway",
   settings: "Pengaturan",
+  collapseSidebar: "Ciutkan sidebar",
+  expandSidebar: "Perluas sidebar",
 } as const;

--- a/src/shared/i18n/locales/ja/navigation.ts
+++ b/src/shared/i18n/locales/ja/navigation.ts
@@ -13,4 +13,6 @@ export default {
   kanban: "カンバン",
   gateway: "ゲートウェイ",
   settings: "設定",
+  collapseSidebar: "サイドバーを折りたたむ",
+  expandSidebar: "サイドバーを展開",
 } as const;

--- a/src/shared/i18n/locales/pl/navigation.ts
+++ b/src/shared/i18n/locales/pl/navigation.ts
@@ -13,4 +13,6 @@ export default {
   kanban: "Kanban",
   gateway: "Bramka",
   settings: "Ustawienia",
+  collapseSidebar: "Zwin pasek boczny",
+  expandSidebar: "Rozwiń pasek boczny",
 } as const;

--- a/src/shared/i18n/locales/pt-BR/navigation.ts
+++ b/src/shared/i18n/locales/pt-BR/navigation.ts
@@ -13,4 +13,6 @@ export default {
   kanban: "Kanban",
   gateway: "Gateway",
   settings: "Configurações",
+  collapseSidebar: "Recolher barra lateral",
+  expandSidebar: "Expandir barra lateral",
 } as const;

--- a/src/shared/i18n/locales/pt-PT/navigation.ts
+++ b/src/shared/i18n/locales/pt-PT/navigation.ts
@@ -13,4 +13,6 @@ export default {
   kanban: "Kanban",
   gateway: "Gateway",
   settings: "Definições",
+  collapseSidebar: "Recolher barra lateral",
+  expandSidebar: "Expandir barra lateral",
 } as const;

--- a/src/shared/i18n/locales/tr/navigation.ts
+++ b/src/shared/i18n/locales/tr/navigation.ts
@@ -13,4 +13,6 @@ export default {
   kanban: "Kanban",
   gateway: "Gateway",
   settings: "Ayarlar",
+  collapseSidebar: "Collapse sidebar",
+  expandSidebar: "Expand sidebar",
 } as const;

--- a/src/shared/i18n/locales/zh-CN/navigation.ts
+++ b/src/shared/i18n/locales/zh-CN/navigation.ts
@@ -13,4 +13,6 @@ export default {
   kanban: "看板",
   gateway: "网关",
   settings: "设置",
+  collapseSidebar: "折叠侧边栏",
+  expandSidebar: "展开侧边栏",
 } as const;

--- a/src/shared/i18n/locales/zh-TW/navigation.ts
+++ b/src/shared/i18n/locales/zh-TW/navigation.ts
@@ -13,4 +13,6 @@ export default {
   kanban: "看板",
   gateway: "網關",
   settings: "設定",
+  collapseSidebar: "收合側邊欄",
+  expandSidebar: "展開側邊欄",
 } as const;


### PR DESCRIPTION
## Summary

Adds a Claude/Codex-style collapsible left sidebar for Desktop.

- Adds a collapse/expand button in the sidebar brand area
- Collapses the sidebar to a 64px icon rail
- Keeps nav items accessible with `aria-label`/`title` while labels are hidden
- Persists the user preference in `localStorage`
- Makes the profile switcher compact in collapsed mode and opens its menu beside the rail
- Makes the update button icon-only in collapsed mode
- Adds translated collapse/expand labels to the existing navigation locale files

## Testing

- `npm test -- src/renderer/src/components/I18nProvider.test.tsx`
- `npm run typecheck`
- `npm run build`
- CDP/live test against the dev app:
  - expanded sidebar width: 230px
  - collapsed sidebar width: 64px
  - collapsed nav button target: 40px
  - nav labels hidden while collapsed
  - navigation still works while collapsed
  - collapsed/expanded state persists in `localStorage`

## Manual visual check

Visually checked the running dev instance and screenshots for:

- expanded sidebar keeps the existing look
- collapsed sidebar is icon-only and aligned
- active nav state remains visible
- profile switcher remains usable in compact mode
- expanding restores the logo and labels

@fathah Please review when you can. As discussed, I will not merge my own PRs without your review.
