### PR TITLE
Collapse live streaming chat output

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -2133,6 +2133,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 8px;
   padding: 4px 12px;
   background: var(--code-bg);
 }
@@ -2142,6 +2143,13 @@ body {
   color: var(--text-muted);
   font-weight: 600;
   text-transform: lowercase;
+}
+
+.chat-code-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
 }
 
 .chat-code-copy {
@@ -2158,8 +2166,58 @@ body {
   transition: color var(--transition);
 }
 
-.chat-code-copy:hover {
+.chat-code-toggle {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 3px 7px;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  transition:
+    background var(--transition),
+    border-color var(--transition),
+    color var(--transition);
+}
+
+.chat-code-copy:hover,
+.chat-code-toggle:hover {
   color: var(--text-primary);
+}
+
+.chat-code-toggle:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.chat-code-content {
+  position: relative;
+  overflow: auto;
+}
+
+.chat-code-block--collapsed .chat-code-content {
+  max-height: 320px;
+  overflow: hidden;
+}
+
+.chat-code-block--collapsible:not(.chat-code-block--collapsed)
+  .chat-code-content {
+  max-height: min(48vh, 520px);
+  overflow: auto;
+}
+
+.chat-code-fade {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 48px;
+  pointer-events: none;
+  background: linear-gradient(to bottom, rgba(40, 44, 52, 0), var(--code-bg));
 }
 
 .chat-code-block + * {
@@ -3184,6 +3242,7 @@ body {
 }
 
 .chat-tool-progress {
+  position: relative;
   font-size: 13px;
   color: var(--text-secondary);
   animation: fadeIn 0.2s ease;
@@ -3192,8 +3251,66 @@ body {
 .chat-tool-progress-inline {
   font-size: 12px;
   color: var(--text-muted);
-  padding: 2px 60px;
+  margin: 2px 60px;
   animation: fadeIn 0.2s ease;
+}
+
+.chat-tool-progress-live {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  width: fit-content;
+  max-width: min(100%, 980px);
+  max-height: 34px;
+  overflow: hidden;
+  padding: 6px 10px 6px 8px;
+  border: 1px solid var(--border, rgba(127, 127, 127, 0.18));
+  border-radius: 8px;
+  background: var(--bg-secondary);
+}
+
+.chat-tool-progress-live--expanded {
+  width: min(100%, 980px);
+  max-height: min(42vh, 480px);
+  overflow: auto;
+}
+
+.chat-tool-progress-content {
+  min-width: 0;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.chat-tool-progress-live:not(.chat-tool-progress-live--expanded)
+  .chat-tool-progress-content {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-tool-progress-toggle {
+  flex: 0 0 auto;
+  width: 18px;
+  height: 18px;
+  margin-top: 1px;
+  background: transparent;
+  border: 0;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 0;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background var(--transition),
+    color var(--transition);
+}
+
+.chat-tool-progress-toggle:hover {
+  background: rgba(127, 127, 127, 0.1);
+  color: var(--text-primary);
 }
 
 /* ── Chat history sub-rows (reasoning / tool_call / tool_result) ───────

--- a/src/renderer/src/components/AgentMarkdown.tsx
+++ b/src/renderer/src/components/AgentMarkdown.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, memo } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { Copy } from "lucide-react";
+import { ChevronDown, ChevronUp, Copy } from "lucide-react";
 import { useI18n } from "./useI18n";
 import { MediaImage, DownloadChip } from "./MediaImage";
 import { describeImageSrc } from "../screens/Chat/mediaUtils";
@@ -44,13 +44,26 @@ function DiffView({ code }: { code: string }): React.JSX.Element {
   );
 }
 
+const CODE_BLOCK_COLLAPSE_LINE_THRESHOLD = 16;
+const CODE_BLOCK_LONG_LINE_LENGTH = 240;
+
+function shouldCollapseCodeBlock(code: string): boolean {
+  const lines = code.split("\n");
+  return (
+    lines.length > CODE_BLOCK_COLLAPSE_LINE_THRESHOLD ||
+    lines.some((line) => line.length > CODE_BLOCK_LONG_LINE_LENGTH)
+  );
+}
+
 // Code block with syntax highlighting and copy button (lazy-loaded highlighter)
 function CodeBlock({
   className,
   children,
+  collapseLongBlocks,
 }: {
   className?: string;
   children?: React.ReactNode;
+  collapseLongBlocks?: boolean;
 }): React.JSX.Element {
   const { t } = useI18n();
   const [copied, setCopied] = useState(false);
@@ -61,6 +74,9 @@ function CodeBlock({
   const match = /language-(\w+)/.exec(className || "");
   const language = match ? match[1] : "";
   const isDiff = language === "diff";
+  const canCollapse = collapseLongBlocks && shouldCollapseCodeBlock(code);
+  const [expanded, setExpanded] = useState(false);
+  const isCollapsed = canCollapse && !expanded;
 
   // Trigger lazy load when code block mounts
   useEffect(() => {
@@ -92,35 +108,63 @@ function CodeBlock({
   );
 
   return (
-    <div className="chat-code-block">
+    <div
+      className={`chat-code-block${
+        canCollapse ? " chat-code-block--collapsible" : ""
+      }${isCollapsed ? " chat-code-block--collapsed" : ""}`}
+    >
       <div className="chat-code-header">
         <span className="chat-code-lang">
           {isDiff ? "diff" : language || "code"}
         </span>
-        <button className="chat-code-copy" onClick={handleCopy}>
-          {copied ? t("common.copied") : <Copy size={13} />}
-        </button>
+        <div className="chat-code-actions">
+          {canCollapse && (
+            <button
+              type="button"
+              className="chat-code-toggle"
+              onClick={() => setExpanded((value) => !value)}
+            >
+              {expanded ? (
+                <>
+                  <ChevronUp size={13} />
+                  {t("chat.codeShowLess")}
+                </>
+              ) : (
+                <>
+                  <ChevronDown size={13} />
+                  {t("chat.codeShowMore")}
+                </>
+              )}
+            </button>
+          )}
+          <button type="button" className="chat-code-copy" onClick={handleCopy}>
+            {copied ? t("common.copied") : <Copy size={13} />}
+          </button>
+        </div>
       </div>
-      {isDiff ? (
-        <DiffView code={code} />
-      ) : highlighterReady && _highlighterMod && _oneDark ? (
-        <_highlighterMod.Prism
-          style={_oneDark}
-          language={language || "text"}
-          PreTag="div"
-          customStyle={{
-            margin: 0,
-            borderRadius: 0,
-            fontSize: "13px",
-            padding: "12px",
-            background: "transparent",
-          }}
-        >
-          {code}
-        </_highlighterMod.Prism>
-      ) : (
-        fallbackPre
-      )}
+      <div className="chat-code-content">
+        {isDiff ? (
+          <DiffView code={code} />
+        ) : highlighterReady && _highlighterMod && _oneDark ? (
+          <_highlighterMod.Prism
+            style={_oneDark}
+            language={language || "text"}
+            PreTag="div"
+            customStyle={{
+              margin: 0,
+              borderRadius: 0,
+              fontSize: "13px",
+              padding: "12px",
+              background: "transparent",
+            }}
+          >
+            {code}
+          </_highlighterMod.Prism>
+        ) : (
+          fallbackPre
+        )}
+        {isCollapsed && <div className="chat-code-fade" aria-hidden="true" />}
+      </div>
     </div>
   );
 }
@@ -128,8 +172,10 @@ function CodeBlock({
 // Shared Markdown renderer that opens links externally
 const AgentMarkdown = memo(function AgentMarkdown({
   children,
+  collapseCodeBlocks = false,
 }: {
   children: string;
+  collapseCodeBlocks?: boolean;
 }): React.JSX.Element {
   return (
     <Markdown
@@ -179,7 +225,14 @@ const AgentMarkdown = memo(function AgentMarkdown({
               </code>
             );
           }
-          return <CodeBlock className={className}>{children}</CodeBlock>;
+          return (
+            <CodeBlock
+              className={className}
+              collapseLongBlocks={collapseCodeBlocks}
+            >
+              {children}
+            </CodeBlock>
+          );
         },
       }}
     >

--- a/src/renderer/src/screens/Chat/MessageList.test.tsx
+++ b/src/renderer/src/screens/Chat/MessageList.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import { MessageList } from "./MessageList";
+
+vi.mock("../../components/useI18n", () => ({
+  useI18n: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string) =>
+      ({
+        "chat.approve": "Approve",
+        "chat.deny": "Deny",
+        "chat.codeShowMore": "Show more",
+        "chat.codeShowLess": "Show less",
+      })[key] ?? key,
+  }),
+}));
+
+describe("MessageList live tool progress", () => {
+  it("collapses live inline tool progress while an agent answer is streaming", () => {
+    const toolProgress = Array.from(
+      { length: 30 },
+      (_, index) => `python line ${index + 1} with a long generated command`,
+    ).join("\n");
+
+    render(
+      <MessageList
+        messages={[
+          { id: "user-1", role: "user", content: "make an image" },
+          { id: "agent-1", role: "agent", content: "Working on it..." },
+        ]}
+        isLoading={true}
+        toolProgress={toolProgress}
+        onApprove={vi.fn()}
+        onDeny={vi.fn()}
+      />,
+    );
+
+    const progress = screen
+      .getByText(/python line 1/)
+      .closest(".chat-tool-progress-live");
+    expect(progress).toHaveClass("chat-tool-progress-inline");
+    expect(progress).not.toHaveClass("chat-tool-progress-live--expanded");
+    expect(screen.getByRole("button", { name: "Show more" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show more" }));
+
+    expect(progress).toHaveClass("chat-tool-progress-live--expanded");
+    expect(screen.getByRole("button", { name: "Show less" })).toBeInTheDocument();
+  });
+});

--- a/src/renderer/src/screens/Chat/MessageList.tsx
+++ b/src/renderer/src/screens/Chat/MessageList.tsx
@@ -1,6 +1,8 @@
-import { memo, useMemo } from "react";
+import { memo, useMemo, useState } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import { HermesAvatar, MessageRow } from "./MessageRow";
 import { ReasoningRow, ToolCallRow, ToolResultRow } from "./HistoryRow";
+import { useI18n } from "../../components/useI18n";
 import type { ChatMessage } from "./types";
 
 interface MessageListProps {
@@ -21,7 +23,7 @@ function TypingIndicator({
       <HermesAvatar />
       <div className="chat-bubble chat-bubble-agent">
         {toolProgress ? (
-          <div className="chat-tool-progress">{toolProgress}</div>
+          <LiveToolProgress text={toolProgress} className="chat-tool-progress" />
         ) : (
           <div className="chat-typing">
             <span className="chat-typing-dot" />
@@ -30,6 +32,36 @@ function TypingIndicator({
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+function LiveToolProgress({
+  text,
+  className,
+}: {
+  text: string;
+  className: string;
+}): React.JSX.Element {
+  const { t } = useI18n();
+  const [expanded, setExpanded] = useState(false);
+  const toggleLabel = expanded ? t("chat.codeShowLess") : t("chat.codeShowMore");
+  return (
+    <div
+      className={`${className} chat-tool-progress-live${
+        expanded ? " chat-tool-progress-live--expanded" : ""
+      }`}
+    >
+      <button
+        type="button"
+        className="chat-tool-progress-toggle"
+        aria-label={toggleLabel}
+        title={toggleLabel}
+        onClick={() => setExpanded((value) => !value)}
+      >
+        {expanded ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
+      </button>
+      <div className="chat-tool-progress-content">{text}</div>
     </div>
   );
 }
@@ -126,7 +158,10 @@ export const MessageList = memo(function MessageList({
       )}
 
       {isLoading && toolProgress && lastMessageIsAgent && (
-        <div className="chat-tool-progress-inline">{toolProgress}</div>
+        <LiveToolProgress
+          text={toolProgress}
+          className="chat-tool-progress-inline"
+        />
       )}
     </>
   );

--- a/src/renderer/src/screens/Chat/MessageRow.test.tsx
+++ b/src/renderer/src/screens/Chat/MessageRow.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import { MessageRow } from "./MessageRow";
+
+vi.mock("../../components/useI18n", () => ({
+  useI18n: () => ({
+    locale: "en",
+    setLocale: vi.fn(),
+    t: (key: string) =>
+      ({
+        "chat.approve": "Approve",
+        "chat.deny": "Deny",
+        "chat.codeShowMore": "Show more",
+        "chat.codeShowLess": "Show less",
+      })[key] ?? key,
+  }),
+}));
+
+function fencedCode(lines: string[]): string {
+  return ["```ts", ...lines, "```"].join("\n");
+}
+
+describe("MessageRow streaming code bounds", () => {
+  it("collapses long code blocks while the agent answer is streaming", () => {
+    const content = fencedCode(
+      Array.from(
+        { length: 32 },
+        (_, index) => `line ${index + 1} const value = compute(${index});`,
+      ),
+    );
+
+    render(
+      <MessageRow
+        msg={{ id: "agent-1", role: "agent", content }}
+        isLast={true}
+        isLoading={true}
+        onApprove={vi.fn()}
+        onDeny={vi.fn()}
+      />,
+    );
+
+    const codeBlock = screen
+      .getByText(/line 1 const value/)
+      .closest(".chat-code-block");
+    expect(codeBlock).toHaveClass("chat-code-block--collapsible");
+    expect(codeBlock).toHaveClass("chat-code-block--collapsed");
+    expect(screen.getByRole("button", { name: "Show more" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show more" }));
+
+    expect(codeBlock).toHaveClass("chat-code-block--collapsible");
+    expect(codeBlock).not.toHaveClass("chat-code-block--collapsed");
+    expect(screen.getByRole("button", { name: "Show less" })).toBeInTheDocument();
+  });
+
+  it("does not collapse short streaming code blocks", () => {
+    render(
+      <MessageRow
+        msg={{
+          id: "agent-1",
+          role: "agent",
+          content: fencedCode(["line 1", "line 2"]),
+        }}
+        isLast={true}
+        isLoading={true}
+        onApprove={vi.fn()}
+        onDeny={vi.fn()}
+      />,
+    );
+
+    const codeBlock = screen.getByText(/line 1/).closest(".chat-code-block");
+    expect(codeBlock).not.toHaveClass("chat-code-block--collapsible");
+    expect(codeBlock).not.toHaveClass("chat-code-block--collapsed");
+    expect(screen.queryByRole("button", { name: "Show more" })).toBeNull();
+  });
+});

--- a/src/renderer/src/screens/Chat/MessageRow.tsx
+++ b/src/renderer/src/screens/Chat/MessageRow.tsx
@@ -102,6 +102,8 @@ export const MessageRow = memo(function MessageRow({
     isLast &&
     APPROVAL_RE.test(msg.content);
   const hasAttachments = !!msg.attachments && msg.attachments.length > 0;
+  const shouldCollapseStreamingCodeBlocks =
+    msg.role === "agent" && isLoading && isLast;
 
   return (
     <div
@@ -138,7 +140,10 @@ export const MessageRow = memo(function MessageRow({
                     // every subsequent index, which would otherwise re-mount
                     // each downstream MediaSegmentView and re-fire its
                     // `mediaFileExists` probe.
-                    <AgentMarkdown key={`t-${segment.start}`}>
+                    <AgentMarkdown
+                      key={`t-${segment.start}`}
+                      collapseCodeBlocks={shouldCollapseStreamingCodeBlocks}
+                    >
                       {segment.value}
                     </AgentMarkdown>
                   ) : null

--- a/src/shared/i18n/locales/en/chat.ts
+++ b/src/shared/i18n/locales/en/chat.ts
@@ -27,6 +27,8 @@ export default {
   newChat: "New chat (Cmd+N)",
   clearChat: "Clear chat",
   clearChatConfirm: "Clear this conversation? This cannot be undone.",
+  codeShowMore: "Show more",
+  codeShowLess: "Show less",
   setContextFolder: "Set context folder",
   contextFolderChip: "Choose Folder",
   contextFolderActive: "Context folder: {{path}}",

--- a/src/shared/i18n/locales/es/chat.ts
+++ b/src/shared/i18n/locales/es/chat.ts
@@ -28,6 +28,8 @@ export default {
   newChat: "Nuevo chat (Cmd+N)",
   clearChat: "Borrar chat",
   clearChatConfirm: "¿Borrar esta conversación? Esta acción no se puede deshacer.",
+  codeShowMore: "Mostrar más",
+  codeShowLess: "Mostrar menos",
   setContextFolder: "Establecer carpeta de contexto",
   contextFolderChip: "Elegir carpeta",
   contextFolderActive: "Carpeta de contexto: {{path}}",

--- a/src/shared/i18n/locales/id/chat.ts
+++ b/src/shared/i18n/locales/id/chat.ts
@@ -23,6 +23,8 @@ export default {
   deny: "Tolak",
   newChat: "Chat baru (Cmd+N)",
   clearChat: "Bersihkan chat",
+  codeShowMore: "Tampilkan lainnya",
+  codeShowLess: "Tampilkan lebih sedikit",
   setContextFolder: "Atur folder konteks",
   contextFolderActive: "Folder konteks: {{path}}",
   removeContextFolder: "Hapus folder konteks",

--- a/src/shared/i18n/locales/ja/chat.ts
+++ b/src/shared/i18n/locales/ja/chat.ts
@@ -21,6 +21,8 @@ export default {
   deny: "拒否",
   newChat: "新規チャット (Cmd+N)",
   clearChat: "チャットをクリア",
+  codeShowMore: "もっと表示",
+  codeShowLess: "折りたたむ",
   setContextFolder: "コンテキストフォルダを設定",
   contextFolderActive: "コンテキストフォルダ: {{path}}",
   removeContextFolder: "コンテキストフォルダを削除",

--- a/src/shared/i18n/locales/pl/chat.ts
+++ b/src/shared/i18n/locales/pl/chat.ts
@@ -27,6 +27,8 @@ export default {
   newChat: "Nowy czat (Cmd+N)",
   clearChat: "Wyczyść czat",
   clearChatConfirm: "Wyczyścić tę rozmowę? Tego nie da się cofnąć.",
+  codeShowMore: "Pokaż więcej",
+  codeShowLess: "Pokaż mniej",
   setContextFolder: "Ustaw folder kontekstu",
   contextFolderActive: "Folder kontekstu: {{path}}",
   removeContextFolder: "Usuń folder kontekstu",

--- a/src/shared/i18n/locales/pt-BR/chat.ts
+++ b/src/shared/i18n/locales/pt-BR/chat.ts
@@ -23,6 +23,8 @@ export default {
   deny: "Negar",
   newChat: "Novo chat (Cmd+N)",
   clearChat: "Limpar chat",
+  codeShowMore: "Mostrar mais",
+  codeShowLess: "Mostrar menos",
   setContextFolder: "Definir pasta de contexto",
   contextFolderActive: "Pasta de contexto: {{path}}",
   removeContextFolder: "Remover pasta de contexto",

--- a/src/shared/i18n/locales/pt-PT/chat.ts
+++ b/src/shared/i18n/locales/pt-PT/chat.ts
@@ -23,6 +23,8 @@ export default {
   deny: "Negar",
   newChat: "Novo chat (Cmd+N)",
   clearChat: "Limpar chat",
+  codeShowMore: "Mostrar mais",
+  codeShowLess: "Mostrar menos",
   setContextFolder: "Definir pasta de contexto",
   contextFolderActive: "Pasta de contexto: {{path}}",
   removeContextFolder: "Remover pasta de contexto",

--- a/src/shared/i18n/locales/tr/chat.ts
+++ b/src/shared/i18n/locales/tr/chat.ts
@@ -27,6 +27,8 @@ export default {
   newChat: "Yeni sohbet (Cmd+N)",
   clearChat: "Sohbeti temizle",
   clearChatConfirm: "Bu konuşma temizlensin mi? Bu işlem geri alınamaz.",
+  codeShowMore: "Daha fazla göster",
+  codeShowLess: "Daha az göster",
   setContextFolder: "Bağlam klasörü belirle",
   contextFolderChip: "Klasör Seç",
   contextFolderActive: "Bağlam klasörü: {{path}}",

--- a/src/shared/i18n/locales/zh-CN/chat.ts
+++ b/src/shared/i18n/locales/zh-CN/chat.ts
@@ -21,6 +21,8 @@ export default {
   deny: "拒绝",
   newChat: "新聊天 (Cmd+N)",
   clearChat: "清空聊天",
+  codeShowMore: "显示更多",
+  codeShowLess: "收起",
   setContextFolder: "设置上下文文件夹",
   contextFolderActive: "上下文文件夹：{{path}}",
   removeContextFolder: "移除上下文文件夹",

--- a/src/shared/i18n/locales/zh-TW/chat.ts
+++ b/src/shared/i18n/locales/zh-TW/chat.ts
@@ -21,6 +21,8 @@ export default {
   deny: "拒絕",
   newChat: "新聊天 (Cmd+N)",
   clearChat: "清除聊天",
+  codeShowMore: "顯示更多",
+  codeShowLess: "收合",
   setContextFolder: "設定上下文資料夾",
   contextFolderActive: "上下文資料夾：{{path}}",
   removeContextFolder: "移除上下文資料夾",


### PR DESCRIPTION
## Summary
- collapse live tool/progress output while an answer is streaming, so large transient tool text cannot take over the chat viewport
- keep completed reasoning/tool history rows using the existing collapsed details UI
- add opt-in collapse support for long fenced code blocks that appear in the active streaming agent answer
- use compact chevron-only controls for live progress so action names like skill_view and terminal remain readable

Closes #525.

## Testing
- npm test -- --run src/renderer/src/screens/Chat/MessageList.test.tsx src/renderer/src/screens/Chat/MessageRow.test.tsx src/shared/i18n/index.test.ts
- npm run lint -- --quiet src/renderer/src/screens/Chat/MessageList.tsx src/renderer/src/screens/Chat/MessageList.test.tsx src/renderer/src/assets/main.css
- npm run typecheck
- npm run build
- CDP visual/style probe against a dev Electron instance on port 9396 confirmed live progress collapses to a compact row with chevron-only control and unobscured action text
- Manual visual testing confirmed collapse/expand behavior during AI Playground tool streaming