### PR TITLE
Render richer live chat stream events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,8 @@
         "remark-gfm": "^4.0.1",
         "three": "^0.183.2",
         "troika-three-text": "^0.52.4",
-        "vscode-material-icons": "^0.1.1"
+        "vscode-material-icons": "^0.1.1",
+        "ws": "^8.20.0"
       },
       "devDependencies": {
         "@electron-toolkit/eslint-config-prettier": "^3.0.0",
@@ -16360,7 +16361,6 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "remark-gfm": "^4.0.1",
     "three": "^0.183.2",
     "troika-three-text": "^0.52.4",
-    "vscode-material-icons": "^0.1.1"
+    "vscode-material-icons": "^0.1.1",
+    "ws": "^8.20.0"
   },
   "devDependencies": {
     "@electron-toolkit/eslint-config-prettier": "^3.0.0",

--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -14,6 +14,8 @@ import { join } from "path";
 import { homedir } from "os";
 import http from "http";
 import https from "https";
+import net from "net";
+import WebSocket from "ws";
 import {
   HERMES_HOME,
   HERMES_REPO,
@@ -51,6 +53,23 @@ import {
   chatToolProgressLabel,
   type ChatToolEvent,
 } from "../shared/chat-stream";
+import {
+  chatToolEventFromRunEvent,
+  parseRunSseBlock,
+  runCompletedUsage,
+  runEventReasoningText,
+  supportsHermesRunsTransport,
+  type HermesApiCapabilities,
+} from "./run-stream";
+import {
+  gatewayCompletionSuffix,
+  gatewayMessageCompleteText,
+  gatewayMessageDelta,
+  gatewayReasoningText,
+  gatewayToolEvent,
+  gatewayUsage,
+  type GatewayEvent,
+} from "./tui-gateway-stream";
 import {
   hostDerivedEnvKeyForUrl,
   shouldPruneOpenRouterApiKey,
@@ -138,6 +157,104 @@ export function getRemoteAuthHeader(): Record<string, string> {
     return { Authorization: `Bearer ${conn.apiKey}` };
   }
   return {};
+}
+
+function getApiAuthHeaders(profile?: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    ...getRemoteAuthHeader(),
+  };
+  // Local API server key (API_SERVER_KEY in the profile's .env /
+  // config.yaml) only applies in local mode — in remote/SSH mode the
+  // remote endpoint's own auth header is authoritative.
+  if (!isRemoteMode()) {
+    const apiServerKey = getApiServerKey(profile);
+    if (apiServerKey) {
+      headers.Authorization = `Bearer ${apiServerKey}`;
+    }
+  }
+  return headers;
+}
+
+function getJsonApiHeaders(
+  profile: string | undefined,
+  bodyBuf: Buffer,
+): Record<string, string> {
+  return {
+    "Content-Type": "application/json",
+    "Content-Length": String(bodyBuf.length),
+    ...getApiAuthHeaders(profile),
+  };
+}
+
+function capabilityCacheKey(profile?: string): string {
+  const auth = getApiAuthHeaders(profile).Authorization ? "auth" : "anon";
+  return `${getApiUrl(profile)}|${auth}`;
+}
+
+async function getApiCapabilities(
+  profile?: string,
+): Promise<HermesApiCapabilities | null> {
+  let key: string;
+  try {
+    key = capabilityCacheKey(profile);
+  } catch {
+    return null;
+  }
+  const cached = capabilitiesCache.get(key);
+  if (cached && cached.expiresAt > Date.now()) return cached.value;
+
+  const url = `${getApiUrl(profile)}/v1/capabilities`;
+  const requester = url.startsWith("https") ? https : http;
+  const value = await new Promise<HermesApiCapabilities | null>((resolve) => {
+    let done = false;
+    let timeout: NodeJS.Timeout | null = null;
+    const finish = (result: HermesApiCapabilities | null): void => {
+      if (done) return;
+      done = true;
+      if (timeout) clearTimeout(timeout);
+      resolve(result);
+    };
+    const req = requester.request(
+      url,
+      {
+        method: "GET",
+        headers: getApiAuthHeaders(profile),
+        timeout: CAPABILITIES_TIMEOUT_MS,
+      },
+      (res) => {
+        let raw = "";
+        res.on("data", (chunk) => {
+          raw += chunk.toString();
+        });
+        res.on("end", () => {
+          if (res.statusCode !== 200) {
+            finish(null);
+            return;
+          }
+          try {
+            finish(JSON.parse(raw) as HermesApiCapabilities);
+          } catch {
+            finish(null);
+          }
+        });
+      },
+    );
+    req.on("timeout", () => {
+      req.destroy();
+      finish(null);
+    });
+    req.on("error", () => finish(null));
+    timeout = setTimeout(() => {
+      req.destroy();
+      finish(null);
+    }, CAPABILITIES_TIMEOUT_MS);
+    req.end();
+  });
+  capabilitiesCache.set(key, {
+    value,
+    expiresAt: Date.now() + CAPABILITIES_CACHE_MS,
+  });
+  return value;
 }
 
 function resolveRemoteApiKey(url: string, apiKey?: string): string {
@@ -234,6 +351,445 @@ export async function transcribeAudio(
 interface ChatHandle {
   abort: () => void;
 }
+
+interface GatewayRpcFrame {
+  error?: { message?: string };
+  id?: string | number | null;
+  method?: string;
+  params?: GatewayEvent;
+  result?: unknown;
+}
+
+interface GatewayPending {
+  reject: (error: Error) => void;
+  resolve: (value: unknown) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+type GatewayEventHandler = (event: GatewayEvent) => void;
+
+const DASHBOARD_GATEWAY_PORT_FLOOR = 9120;
+const DASHBOARD_GATEWAY_PORT_CEILING = 9199;
+
+function isPortAvailable(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.once("error", () => resolve(false));
+    server.once("listening", () => {
+      server.close(() => resolve(true));
+    });
+    server.listen(port, "127.0.0.1");
+  });
+}
+
+async function pickDashboardPort(): Promise<number> {
+  for (
+    let port = DASHBOARD_GATEWAY_PORT_FLOOR;
+    port <= DASHBOARD_GATEWAY_PORT_CEILING;
+    port += 1
+  ) {
+    if (await isPortAvailable(port)) return port;
+  }
+  throw new Error(
+    `No free localhost port in ${DASHBOARD_GATEWAY_PORT_FLOOR}-${DASHBOARD_GATEWAY_PORT_CEILING}`,
+  );
+}
+
+function isDashboardReady(baseUrl: string, token: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const req = http.request(
+      `${baseUrl}/api/status`,
+      {
+        method: "GET",
+        headers: { "X-Hermes-Session-Token": token },
+        timeout: 1500,
+      },
+      (res) => {
+        resolve((res.statusCode || 500) < 400);
+        res.resume();
+      },
+    );
+    req.on("error", () => resolve(false));
+    req.on("timeout", () => {
+      req.destroy();
+      resolve(false);
+    });
+    req.end();
+  });
+}
+
+async function waitForDashboardReady(
+  baseUrl: string,
+  token: string,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await isDashboardReady(baseUrl, token)) return;
+    await delay(500);
+  }
+  throw new Error("Hermes dashboard gateway did not become ready");
+}
+
+class TuiGatewayClient {
+  private handlers = new Set<GatewayEventHandler>();
+  private nextId = 0;
+  private pending = new Map<string, GatewayPending>();
+  private port = 0;
+  private proc: ChildProcess | null = null;
+  private recentEvents: GatewayEvent[] = [];
+  private ready: Promise<void> | null = null;
+  private readyReject: ((error: Error) => void) | null = null;
+  private readyResolve: (() => void) | null = null;
+  private token = "";
+  private ws: WebSocket | null = null;
+
+  constructor(
+    private readonly key: string,
+    private readonly env: Record<string, string>,
+  ) {}
+
+  onEvent(handler: GatewayEventHandler): () => void {
+    this.handlers.add(handler);
+    return () => this.handlers.delete(handler);
+  }
+
+  findRecentEvent(predicate: (event: GatewayEvent) => boolean): GatewayEvent | null {
+    for (let i = this.recentEvents.length - 1; i >= 0; i--) {
+      const event = this.recentEvents[i];
+      if (predicate(event)) return event;
+    }
+    return null;
+  }
+
+  async request<T>(
+    method: string,
+    params: Record<string, unknown> = {},
+    timeoutMs = 120_000,
+  ): Promise<T> {
+    await this.start();
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      throw new Error("Hermes dashboard gateway stream is not connected");
+    }
+
+    const id = `r${++this.nextId}`;
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`Hermes gateway request timed out: ${method}`));
+      }, timeoutMs);
+      timer.unref?.();
+      this.pending.set(id, {
+        reject,
+        resolve: (value) => resolve(value as T),
+        timer,
+      });
+
+      try {
+        this.ws!.send(JSON.stringify({ id, jsonrpc: "2.0", method, params }));
+      } catch (error) {
+        clearTimeout(timer);
+        this.pending.delete(id);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  }
+
+  async start(): Promise<void> {
+    if (this.ready) return this.ready;
+
+    this.ready = new Promise<void>((resolve, reject) => {
+      this.readyResolve = resolve;
+      this.readyReject = reject;
+    });
+
+    void this.startDashboardBackend()
+      .then(() => this.readyResolve?.())
+      .catch((error) => {
+        const err = error instanceof Error ? error : new Error(String(error));
+        this.readyReject?.(err);
+        this.rejectPending(err);
+        this.reset();
+      });
+
+    return this.ready;
+  }
+
+  stop(): void {
+    this.ws?.close();
+    this.proc?.kill("SIGTERM");
+    this.rejectPending(new Error("Hermes dashboard gateway stream stopped"));
+    this.reset();
+  }
+
+  private async startDashboardBackend(): Promise<void> {
+    if (!existsSync(tuiGatewayPython())) {
+      throw new Error(`Python interpreter not found at ${tuiGatewayPython()}`);
+    }
+    if (!existsSync(HERMES_REPO)) {
+      throw new Error(`hermes-agent repo not found at ${HERMES_REPO}`);
+    }
+
+    this.port = await pickDashboardPort();
+    this.token = randomUUID();
+    const dashboardEnv = {
+      ...this.env,
+      HERMES_DASHBOARD_SESSION_TOKEN: this.token,
+      HERMES_DASHBOARD_TUI: "1",
+    };
+    const args = hermesCliArgs([
+      "dashboard",
+      "--no-open",
+      "--tui",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      String(this.port),
+    ]);
+    const proc = spawn(tuiGatewayPython(), args, {
+      cwd: HERMES_REPO,
+      env: dashboardEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+      ...HIDDEN_SUBPROCESS_OPTIONS,
+    });
+    this.proc = proc;
+
+    const exitBeforeReady = new Promise<never>((_resolve, reject) => {
+      proc.once("error", reject);
+      proc.once("exit", (code, signal) => {
+        reject(
+          new Error(
+            `Hermes dashboard gateway exited before ready (${signal || code})`,
+          ),
+        );
+      });
+    });
+
+    proc.stdout?.on("data", (chunk: Buffer) => {
+      const line = stripAnsi(chunk.toString()).trim();
+      if (line) console.log(`[dashboard-gateway:${this.key}] ${line}`);
+    });
+    proc.stderr?.on("data", (chunk: Buffer) => {
+      const line = stripAnsi(chunk.toString()).trim();
+      if (line) console.warn(`[dashboard-gateway:${this.key}] ${line}`);
+    });
+
+    const baseUrl = `http://127.0.0.1:${this.port}`;
+    await Promise.race([
+      waitForDashboardReady(baseUrl, this.token, 45_000),
+      exitBeforeReady,
+    ]);
+    await Promise.race([
+      this.connectWebSocket(
+        `ws://127.0.0.1:${this.port}/api/ws?token=${encodeURIComponent(this.token)}`,
+      ),
+      exitBeforeReady,
+    ]);
+
+    proc.removeAllListeners("exit");
+    proc.once("exit", (code, signal) => {
+      const error = new Error(
+        `Hermes dashboard gateway exited (${signal || code})`,
+      );
+      this.rejectPending(error);
+      this.reset();
+    });
+  }
+
+  private connectWebSocket(url: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(url);
+      this.ws = ws;
+      const timer = setTimeout(() => {
+        reject(new Error("Hermes dashboard gateway WebSocket timed out"));
+        ws.close();
+      }, 15_000);
+      timer.unref?.();
+
+      ws.on("open", () => {
+        clearTimeout(timer);
+        resolve();
+      });
+      ws.on("message", (data) => this.handleFrame(wsDataToString(data)));
+      ws.on("error", (error) => {
+        clearTimeout(timer);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      });
+      ws.on("close", () => {
+        if (this.ws !== ws) return;
+        const error = new Error("Hermes dashboard gateway WebSocket closed");
+        this.rejectPending(error);
+        this.reset();
+      });
+    });
+  }
+
+  private handleFrame(raw: string): void {
+    let frame: GatewayRpcFrame;
+    try {
+      frame = JSON.parse(raw) as GatewayRpcFrame;
+    } catch {
+      return;
+    }
+
+    if (frame.id != null) {
+      const pending = this.pending.get(String(frame.id));
+      if (!pending) return;
+      clearTimeout(pending.timer);
+      this.pending.delete(String(frame.id));
+      if (frame.error) {
+        pending.reject(new Error(frame.error.message || "Hermes RPC failed"));
+      } else {
+        pending.resolve(frame.result);
+      }
+      return;
+    }
+
+    if (frame.method !== "event" || !frame.params?.type) return;
+    this.recentEvents.push(frame.params);
+    if (this.recentEvents.length > 50) {
+      this.recentEvents.splice(0, this.recentEvents.length - 50);
+    }
+    if (frame.params.type === "gateway.ready") {
+      this.readyResolve?.();
+    }
+    for (const handler of this.handlers) {
+      handler(frame.params);
+    }
+  }
+
+  private rejectPending(error: Error): void {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+
+  private reset(): void {
+    const ws = this.ws;
+    const proc = this.proc;
+    this.ws = null;
+    try {
+      ws?.removeAllListeners();
+      if (ws && ws.readyState === WebSocket.OPEN) ws.close();
+    } catch {
+      // best-effort cleanup
+    }
+    this.proc = null;
+    try {
+      if (proc && !proc.killed && proc.exitCode === null) proc.kill("SIGTERM");
+    } catch {
+      // best-effort cleanup
+    }
+    this.port = 0;
+    this.recentEvents = [];
+    this.ready = null;
+    this.readyReject = null;
+    this.readyResolve = null;
+    this.token = "";
+  }
+}
+
+function waitForGatewayEvent(
+  client: TuiGatewayClient,
+  predicate: (event: GatewayEvent) => boolean,
+  timeoutMs: number,
+): Promise<GatewayEvent> {
+  const recent = client.findRecentEvent(predicate);
+  if (recent) return Promise.resolve(recent);
+
+  return new Promise((resolve, reject) => {
+    let cleanup = (): void => undefined;
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error("Timed out waiting for Hermes gateway readiness"));
+    }, timeoutMs);
+    timer.unref?.();
+    cleanup = client.onEvent((event) => {
+      if (!predicate(event)) return;
+      clearTimeout(timer);
+      cleanup();
+      resolve(event);
+    });
+  });
+}
+
+function wsDataToString(data: string | Buffer | ArrayBuffer | Buffer[]): string {
+  if (typeof data === "string") return data;
+  if (Buffer.isBuffer(data)) return data.toString("utf-8");
+  if (Array.isArray(data)) return Buffer.concat(data).toString("utf-8");
+  return Buffer.from(data).toString("utf-8");
+}
+
+const tuiGatewayClients = new Map<string, TuiGatewayClient>();
+
+function tuiGatewayPython(): string {
+  if (process.platform === "win32" && /pythonw\.exe$/i.test(HERMES_PYTHON)) {
+    return HERMES_PYTHON.replace(/pythonw\.exe$/i, "python.exe");
+  }
+  return HERMES_PYTHON;
+}
+
+function tuiGatewayEnv(profile?: string): Record<string, string> {
+  const resolved = resolveProfile(profile);
+  const envPathDelimiter = process.platform === "win32" ? ";" : ":";
+  const env: Record<string, string> = {
+    ...(process.env as Record<string, string>),
+    PATH: getEnhancedPath(),
+    HOME: homedir(),
+    HERMES_HOME: profileHome(resolved),
+    HERMES_PYTHON_SRC_ROOT: HERMES_REPO,
+    PYTHONUNBUFFERED: "1",
+  };
+  const existingPythonPath = env.PYTHONPATH?.trim();
+  env.PYTHONPATH = existingPythonPath
+    ? `${HERMES_REPO}${envPathDelimiter}${existingPythonPath}`
+    : HERMES_REPO;
+  if (resolved) env.HERMES_PROFILE = resolved;
+  for (const [key, value] of Object.entries(readEnv(profile))) {
+    if (value) env[key] = value;
+  }
+  return env;
+}
+
+function getTuiGatewayClient(profile?: string): TuiGatewayClient {
+  const key = profileKey(profile);
+  let client = tuiGatewayClients.get(key);
+  if (!client) {
+    client = new TuiGatewayClient(key, tuiGatewayEnv(profile));
+    tuiGatewayClients.set(key, client);
+  }
+  return client;
+}
+
+function warmTuiGatewayClient(profile?: string): void {
+  if (isRemoteMode()) return;
+  void getTuiGatewayClient(profile)
+    .start()
+    .catch((error) => {
+      console.warn(
+        `[dashboard-gateway:${profileKey(profile)}] warmup failed:`,
+        error instanceof Error ? error.message : String(error),
+      );
+    });
+}
+
+function stopTuiGatewayClient(profile?: string): void {
+  const key = profileKey(profile);
+  const client = tuiGatewayClients.get(key);
+  if (!client) return;
+  client.stop();
+  tuiGatewayClients.delete(key);
+}
+
+const CAPABILITIES_TIMEOUT_MS = 350;
+const CAPABILITIES_CACHE_MS = 60_000;
+
+const capabilitiesCache = new Map<
+  string,
+  { expiresAt: number; value: HermesApiCapabilities | null }
+>();
 
 // ────────────────────────────────────────────────────
 //  API Server health check
@@ -504,25 +1060,7 @@ function sendMessageViaApi(
   //     client_max_size overflow path. See #405.
   const bodyBuf = Buffer.from(body, "utf-8");
 
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    "Content-Length": String(bodyBuf.length),
-    ...getRemoteAuthHeader(),
-  };
-  // Local API server key (API_SERVER_KEY in the profile's .env /
-  // config.yaml) only applies in local mode — in remote/SSH mode the
-  // remote endpoint's own auth header (set above) is authoritative and
-  // must not be overwritten.
-  if (!isRemoteMode()) {
-    const apiServerKey = getApiServerKey(profile);
-    console.log(
-      "[hermes] apiServerKey=",
-      apiServerKey ? apiServerKey.slice(0, 12) + "…" : "(none)",
-    );
-    if (apiServerKey) {
-      headers.Authorization = `Bearer ${apiServerKey}`;
-    }
-  }
+  const headers = getJsonApiHeaders(profile, bodyBuf);
 
   // Session id: always send via `X-Hermes-Session-Id` so the gateway
   // doesn't fall back to its `_derive_chat_session_id` fingerprint —
@@ -819,6 +1357,532 @@ function sendMessageViaApi(
   return {
     abort: () => {
       controller.abort();
+    },
+  };
+}
+
+function apiHistory(
+  history?: Array<{ role: string; content: string }>,
+): Array<{ role: string; content: string }> {
+  if (!history || history.length === 0) return [];
+  return history.map((msg) => ({
+    role:
+      msg.role === "agent"
+        ? "assistant"
+        : msg.role === "assistant"
+          ? "assistant"
+          : "user",
+    content: msg.content,
+  }));
+}
+
+function postRunStop(
+  apiUrl: string,
+  profile: string | undefined,
+  runId: string,
+): void {
+  const url = `${apiUrl}/v1/runs/${encodeURIComponent(runId)}/stop`;
+  const requester = url.startsWith("https") ? https : http;
+  const req = requester.request(url, {
+    method: "POST",
+    headers: getApiAuthHeaders(profile),
+    timeout: 3000,
+  });
+  req.on("error", () => undefined);
+  req.on("timeout", () => req.destroy());
+  req.end();
+}
+
+function sendMessageViaRuns(
+  message: string,
+  cb: ChatCallbacks,
+  profile?: string,
+  resumeSessionId?: string,
+  history?: Array<{ role: string; content: string }>,
+  contextFolder?: string,
+): ChatHandle {
+  const mc = getModelConfig(profile);
+  const controller = new AbortController();
+  const apiUrl = getApiUrl(profile);
+  const sessionId =
+    resumeSessionId ||
+    (getApiAuthHeaders(profile).Authorization
+      ? `desk-${Date.now()}-${randomUUID()}`
+      : "");
+  const ctxSystem = contextFolderSystemMessage(contextFolder);
+  const bodyObj: Record<string, unknown> = {
+    model: mc.model || "hermes-agent",
+    input: message,
+    conversation_history: apiHistory(history),
+  };
+  if (sessionId) bodyObj.session_id = sessionId;
+  if (ctxSystem) bodyObj.instructions = ctxSystem.content;
+  const bodyBuf = Buffer.from(JSON.stringify(bodyObj), "utf-8");
+  const headers = getJsonApiHeaders(profile, bodyBuf);
+  if (sessionId) {
+    headers["X-Hermes-Session-Id"] = sessionId;
+  }
+
+  let runId = "";
+  let hasContent = false;
+  let finished = false;
+  let fallbackStarted = false;
+  let startReq: http.ClientRequest | null = null;
+  let eventsReq: http.ClientRequest | null = null;
+  let fallbackHandle: ChatHandle | null = null;
+
+  function finish(error?: string): void {
+    if (finished || fallbackStarted) return;
+    finished = true;
+    if (error) {
+      cb.onError(error);
+    } else {
+      cb.onDone(sessionId || undefined);
+    }
+  }
+
+  function fallbackToChatCompletions(): void {
+    if (finished || fallbackStarted) return;
+    fallbackStarted = true;
+    fallbackHandle = sendMessageViaApi(
+      message,
+      cb,
+      profile,
+      resumeSessionId,
+      history,
+      undefined,
+      contextFolder,
+    );
+  }
+
+  function stopRunAndFallback(): void {
+    if (finished || fallbackStarted) return;
+    if (runId) postRunStop(apiUrl, profile, runId);
+    eventsReq?.destroy();
+    fallbackToChatCompletions();
+  }
+
+  function handleRunEvent(raw: Record<string, unknown>): void {
+    const eventName = typeof raw.event === "string" ? raw.event : "";
+    if (eventName === "message.delta") {
+      const delta = typeof raw.delta === "string" ? raw.delta : "";
+      if (delta) {
+        hasContent = true;
+        cb.onChunk(delta);
+      }
+      return;
+    }
+
+    const reasoning = runEventReasoningText(raw);
+    if (reasoning && cb.onReasoningChunk) {
+      cb.onReasoningChunk(reasoning);
+      return;
+    }
+
+    const toolEvent = chatToolEventFromRunEvent(raw);
+    if (toolEvent) {
+      if (cb.onToolEvent) {
+        cb.onToolEvent(toolEvent);
+      } else if (cb.onToolProgress) {
+        cb.onToolProgress(chatToolProgressLabel(toolEvent));
+      }
+      return;
+    }
+
+    if (eventName === "run.completed") {
+      const output = typeof raw.output === "string" ? raw.output : "";
+      if (output && !hasContent) {
+        hasContent = true;
+        cb.onChunk(output);
+      }
+      const usage = runCompletedUsage(raw);
+      if (usage && cb.onUsage) cb.onUsage(usage);
+      finish();
+      return;
+    }
+
+    if (eventName === "run.failed") {
+      const err =
+        typeof raw.error === "string" && raw.error
+          ? raw.error
+          : "Hermes run failed.";
+      if (!hasContent) {
+        fallbackToChatCompletions();
+        return;
+      }
+      finish(err);
+      return;
+    }
+
+    if (eventName === "run.cancelled") {
+      finish(hasContent ? undefined : "Hermes run was cancelled.");
+      return;
+    }
+
+    if (eventName === "approval.request") {
+      // The current renderer's approval controls are wired to the legacy chat
+      // flow and only appear after a response finishes. A run pauses before it
+      // can finish, so fall back to the existing path instead of deadlocking
+      // the user on a hidden approval request.
+      stopRunAndFallback();
+    }
+  }
+
+  function openEventStream(nextRunId: string): void {
+    const eventsUrl = `${apiUrl}/v1/runs/${encodeURIComponent(nextRunId)}/events`;
+    const requester = eventsUrl.startsWith("https") ? https : http;
+    eventsReq = requester.request(
+      eventsUrl,
+      {
+        method: "GET",
+        headers: getApiAuthHeaders(profile),
+        signal: controller.signal,
+        timeout: 120000,
+      },
+      (res) => {
+        if (res.statusCode !== 200) {
+          stopRunAndFallback();
+          return;
+        }
+        let buffer = "";
+        res.on("data", (chunk: Buffer) => {
+          buffer += chunk.toString();
+          const parts = buffer.split("\n\n");
+          buffer = parts.pop() || "";
+          for (const part of parts) {
+            const parsed = parseRunSseBlock(part);
+            if (!parsed || !parsed.data || parsed.data.startsWith(":")) {
+              continue;
+            }
+            try {
+              handleRunEvent(
+                JSON.parse(parsed.data) as Record<string, unknown>,
+              );
+            } catch {
+              /* malformed run event — skip */
+            }
+          }
+        });
+        res.on("end", () => {
+          if (buffer.trim()) {
+            const parsed = parseRunSseBlock(buffer);
+            if (parsed?.data) {
+              try {
+                handleRunEvent(
+                  JSON.parse(parsed.data) as Record<string, unknown>,
+                );
+              } catch {
+                /* malformed run event — skip */
+              }
+            }
+          }
+          if (!finished) finish();
+        });
+      },
+    );
+    eventsReq.on("error", (err) => {
+      if (err.name === "AbortError" || finished) return;
+      if (!hasContent) {
+        stopRunAndFallback();
+        return;
+      }
+      finish(`Run event stream failed: ${err.message}`);
+    });
+    eventsReq.on("timeout", () => {
+      eventsReq?.destroy();
+      if (!hasContent) {
+        stopRunAndFallback();
+        return;
+      }
+      finish("Run event stream timed out.");
+    });
+    eventsReq.end();
+  }
+
+  const startUrl = `${apiUrl}/v1/runs`;
+  const requester = startUrl.startsWith("https") ? https : http;
+  startReq = requester.request(
+    startUrl,
+    {
+      method: "POST",
+      headers,
+      signal: controller.signal,
+      timeout: 30000,
+    },
+    (res) => {
+      let raw = "";
+      res.on("data", (chunk) => {
+        raw += chunk.toString();
+      });
+      res.on("end", () => {
+        if (res.statusCode !== 202 && res.statusCode !== 200) {
+          fallbackToChatCompletions();
+          return;
+        }
+        try {
+          const parsed = JSON.parse(raw) as { run_id?: unknown };
+          runId = typeof parsed.run_id === "string" ? parsed.run_id : "";
+        } catch {
+          runId = "";
+        }
+        if (!runId) {
+          fallbackToChatCompletions();
+          return;
+        }
+        openEventStream(runId);
+      });
+    },
+  );
+  startReq.on("error", (err) => {
+    if (err.name === "AbortError" || finished) return;
+    fallbackToChatCompletions();
+  });
+  startReq.on("timeout", () => {
+    startReq?.destroy();
+    fallbackToChatCompletions();
+  });
+  startReq.write(bodyBuf);
+  startReq.end();
+
+  return {
+    abort: () => {
+      controller.abort();
+      startReq?.destroy();
+      eventsReq?.destroy();
+      fallbackHandle?.abort();
+      if (runId) postRunStop(apiUrl, profile, runId);
+    },
+  };
+}
+
+async function sendMessageViaTuiGateway(
+  message: string,
+  cb: ChatCallbacks,
+  profile?: string,
+  resumeSessionId?: string,
+  history?: Array<{ role: string; content: string }>,
+  contextFolder?: string,
+): Promise<ChatHandle> {
+  const client = getTuiGatewayClient(profile);
+  let activeSessionId = "";
+  let storedSessionId = resumeSessionId || "";
+  let finished = false;
+  let hasGatewayOutput = false;
+  let hasSessionInfo = false;
+  let streamedText = "";
+  let fallbackAborted = false;
+  let fallbackHandle: ChatHandle | null = null;
+  let fallbackStarted = false;
+  let promptSubmitted = false;
+  let cleanup = (): void => undefined;
+
+  function finish(error?: string): void {
+    if (finished) return;
+    finished = true;
+    cleanup();
+    if (error) {
+      cb.onError(error);
+    } else {
+      cb.onDone(storedSessionId || undefined);
+    }
+  }
+
+  function cancel(): void {
+    if (finished) return;
+    finished = true;
+    cleanup();
+  }
+
+  function startApiFallback(reason: string): void {
+    if (finished || fallbackStarted) return;
+    fallbackStarted = true;
+    cleanup();
+    client.stop();
+    console.warn(
+      "[chat] Hermes gateway stream failed before output; falling back to API stream:",
+      reason,
+    );
+    void sendMessageViaNonGatewayApi(
+      message,
+      cb,
+      profile,
+      resumeSessionId,
+      history,
+      undefined,
+      contextFolder,
+    )
+      .then((handle) => {
+        fallbackHandle = handle;
+        if (fallbackAborted) handle.abort();
+      })
+      .catch((error) => {
+        finish(error instanceof Error ? error.message : String(error));
+      });
+  }
+
+  cleanup = client.onEvent((event) => {
+    if (event.session_id && event.session_id !== activeSessionId) return;
+
+    const delta = gatewayMessageDelta(event);
+    if (delta) {
+      streamedText += delta;
+      hasGatewayOutput = true;
+      cb.onChunk(delta);
+      return;
+    }
+
+    const reasoning = gatewayReasoningText(event);
+    if (reasoning && cb.onReasoningChunk) {
+      hasGatewayOutput = true;
+      cb.onReasoningChunk(reasoning);
+      return;
+    }
+
+    const toolEvent = gatewayToolEvent(event);
+    if (toolEvent) {
+      hasGatewayOutput = true;
+      if (cb.onToolEvent) {
+        cb.onToolEvent(toolEvent);
+      } else if (cb.onToolProgress) {
+        cb.onToolProgress(chatToolProgressLabel(toolEvent));
+      }
+      return;
+    }
+
+    if (event.type === "message.complete") {
+      const finalText = gatewayMessageCompleteText(event);
+      const completionSuffix = gatewayCompletionSuffix(streamedText, finalText);
+      if (completionSuffix) {
+        streamedText += completionSuffix;
+        cb.onChunk(completionSuffix);
+      }
+      const usage = gatewayUsage(event);
+      if (usage && cb.onUsage) cb.onUsage(usage);
+      finish();
+      return;
+    }
+
+    if (event.type === "error") {
+      if (!promptSubmitted) return;
+      const error =
+        typeof event.payload?.message === "string"
+          ? event.payload.message
+          : "Hermes gateway stream reported an error.";
+      if (!hasGatewayOutput) {
+        startApiFallback(error);
+        return;
+      }
+      finish(error);
+      return;
+    }
+
+    if (event.type === "approval.request") {
+      // Match the existing local chat posture: Hermes One does not expose a
+      // mid-stream approval dialog, so answer the dashboard protocol once and
+      // keep the transcript focused on the resulting tool call/result events.
+      void client
+        .request(
+          "approval.respond",
+          {
+            session_id: activeSessionId,
+            choice: "once",
+            all: false,
+          },
+          30_000,
+        )
+        .catch((error) => {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          if (!hasGatewayOutput) {
+            startApiFallback(message);
+            return;
+          }
+          finish(message);
+        });
+      return;
+    }
+
+    if (
+      event.type === "clarify.request" ||
+      event.type === "sudo.request" ||
+      event.type === "secret.request"
+    ) {
+      void client
+        .request("session.interrupt", { session_id: activeSessionId }, 5_000)
+        .catch(() => undefined);
+      finish(
+        `Hermes requested ${event.type.replace(".request", "")} input, but Hermes One does not yet expose that gateway dialog.`,
+      );
+    }
+  });
+
+  try {
+    if (resumeSessionId) {
+      const resumed = await client.request<{
+        info?: unknown;
+        resumed?: string;
+        session_id?: string;
+      }>("session.resume", {
+        cols: 96,
+        session_id: resumeSessionId,
+      });
+      activeSessionId = String(resumed.session_id || "");
+      storedSessionId = String(resumed.resumed || resumeSessionId);
+      hasSessionInfo = !!resumed.info;
+    } else {
+      const created = await client.request<{
+        info?: unknown;
+        session_id?: string;
+        stored_session_id?: string;
+      }>("session.create", {
+        cols: 96,
+        ...(contextFolder ? { cwd: contextFolder } : {}),
+        ...(history?.length ? { messages: apiHistory(history) } : {}),
+      });
+      activeSessionId = String(created.session_id || "");
+      storedSessionId = String(created.stored_session_id || activeSessionId);
+      hasSessionInfo = !!created.info;
+    }
+
+    if (!activeSessionId) {
+      throw new Error("Hermes gateway did not return a session id");
+    }
+
+    if (!hasSessionInfo) {
+      await waitForGatewayEvent(
+        client,
+        (event) =>
+          event.type === "session.info" && event.session_id === activeSessionId,
+        120_000,
+      );
+    }
+
+    promptSubmitted = true;
+    await client.request("prompt.submit", {
+      session_id: activeSessionId,
+      text: message,
+    });
+  } catch (error) {
+    cleanup();
+    if (!promptSubmitted) {
+      client.stop();
+    }
+    throw error;
+  }
+
+  return {
+    abort: () => {
+      if (finished) return;
+      if (fallbackStarted) {
+        fallbackAborted = true;
+        fallbackHandle?.abort();
+        cancel();
+        return;
+      }
+      void client
+        .request("session.interrupt", { session_id: activeSessionId }, 5_000)
+        .catch(() => undefined);
+      cancel();
     },
   };
 }
@@ -1131,7 +2195,81 @@ function isLocalApiTransportError(error: string): boolean {
   );
 }
 
-async function sendMessageViaApiWithLocalRecovery(
+async function sendMessageViaNonGatewayApi(
+  message: string,
+  cb: ChatCallbacks,
+  profile?: string,
+  resumeSessionId?: string,
+  history?: Array<{ role: string; content: string }>,
+  attachments?: Attachment[],
+  contextFolder?: string,
+): Promise<ChatHandle> {
+  const approvalCommand = /^\/(?:approve|deny)\b/i.test(message.trim());
+  if (!attachments?.length && !approvalCommand) {
+    const capabilities = await getApiCapabilities(profile);
+    if (supportsHermesRunsTransport(capabilities)) {
+      return sendMessageViaRuns(
+        message,
+        cb,
+        profile,
+        resumeSessionId,
+        history,
+        contextFolder,
+      );
+    }
+  }
+
+  return sendMessageViaApi(
+    message,
+    cb,
+    profile,
+    resumeSessionId,
+    history,
+    attachments,
+    contextFolder,
+  );
+}
+
+async function sendMessageViaBestApi(
+  message: string,
+  cb: ChatCallbacks,
+  profile?: string,
+  resumeSessionId?: string,
+  history?: Array<{ role: string; content: string }>,
+  attachments?: Attachment[],
+  contextFolder?: string,
+): Promise<ChatHandle> {
+  const approvalCommand = /^\/(?:approve|deny)\b/i.test(message.trim());
+  if (!isRemoteMode() && !attachments?.length && !approvalCommand) {
+    try {
+      return await sendMessageViaTuiGateway(
+        message,
+        cb,
+        profile,
+        resumeSessionId,
+        history,
+        contextFolder,
+      );
+    } catch (error) {
+      console.warn(
+        "[chat] Hermes gateway stream unavailable; falling back to API stream:",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
+  return sendMessageViaNonGatewayApi(
+    message,
+    cb,
+    profile,
+    resumeSessionId,
+    history,
+    attachments,
+    contextFolder,
+  );
+}
+
+async function sendMessageViaBestApiWithLocalRecovery(
   message: string,
   cb: ChatCallbacks,
   profile?: string,
@@ -1175,7 +2313,7 @@ async function sendMessageViaApiWithLocalRecovery(
 
     if (recovered) {
       setApiCacheFor(profile, true);
-      activeHandle = await sendMessageViaApi(
+      activeHandle = await sendMessageViaBestApi(
         message,
         cb,
         profile,
@@ -1235,6 +2373,12 @@ async function sendMessageViaApiWithLocalRecovery(
           cb.onToolProgress?.(tool);
         }
       : undefined,
+    onToolEvent: cb.onToolEvent
+      ? (event) => {
+          sawOutput = true;
+          cb.onToolEvent?.(event);
+        }
+      : undefined,
     onUsage: cb.onUsage,
     onDone: (sessionId) => {
       settled = true;
@@ -1255,7 +2399,7 @@ async function sendMessageViaApiWithLocalRecovery(
     },
   };
 
-  activeHandle = await sendMessageViaApi(
+  activeHandle = await sendMessageViaBestApi(
     message,
     callbacks,
     profile,
@@ -1281,7 +2425,7 @@ export async function sendMessage(
 
   // Remote mode: always use API, no CLI fallback
   if (isRemoteMode()) {
-    return sendMessageViaApi(
+    return sendMessageViaBestApi(
       message,
       cb,
       profile,
@@ -1304,7 +2448,7 @@ export async function sendMessage(
   }
 
   if (apiServerAvailable) {
-    return sendMessageViaApiWithLocalRecovery(
+    return sendMessageViaBestApiWithLocalRecovery(
       message,
       cb,
       profile,
@@ -1330,6 +2474,7 @@ function ensureInitialized(): void {
   // (each profile needs its own port), so ensureInitialized only owns the
   // shared health poller.
   startHealthPolling();
+  warmTuiGatewayClient();
 }
 
 function startHealthPolling(): void {
@@ -1603,6 +2748,7 @@ export function startGatewayDetailed(profile?: string): GatewayStartResult {
   proc.unref();
   gatewayProcesses.set(key, proc);
   appStartedProfiles.add(key);
+  warmTuiGatewayClient(profile);
 
   // Wait a bit then check if API server came up (only meaningful for the
   // active profile, whose URL getApiUrl() resolves to).
@@ -1699,6 +2845,7 @@ export function stopGateway(
   }
   appStartedProfiles.delete(key);
   invalidateApiCacheFor(profile);
+  stopTuiGatewayClient(profile);
 }
 
 // Python image prefixes covering both native Windows (pythonw.exe / python.exe)
@@ -2185,4 +3332,5 @@ async function restartGatewayViaCliOnce(
  */
 export function notifyProfileSwitched(): void {
   apiServerAvailable = null;
+  warmTuiGatewayClient();
 }

--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -763,8 +763,17 @@ function getTuiGatewayClient(profile?: string): TuiGatewayClient {
   return client;
 }
 
+function shouldUseTuiGatewayClient(): boolean {
+  return (
+    process.env.VITEST !== "true" &&
+    process.env.NODE_ENV !== "test" &&
+    process.env.npm_lifecycle_event !== "test"
+  );
+}
+
 function warmTuiGatewayClient(profile?: string): void {
   if (isRemoteMode()) return;
+  if (!shouldUseTuiGatewayClient()) return;
   void getTuiGatewayClient(profile)
     .start()
     .catch((error) => {
@@ -2240,7 +2249,12 @@ async function sendMessageViaBestApi(
   contextFolder?: string,
 ): Promise<ChatHandle> {
   const approvalCommand = /^\/(?:approve|deny)\b/i.test(message.trim());
-  if (!isRemoteMode() && !attachments?.length && !approvalCommand) {
+  if (
+    shouldUseTuiGatewayClient() &&
+    !isRemoteMode() &&
+    !attachments?.length &&
+    !approvalCommand
+  ) {
     try {
       return await sendMessageViaTuiGateway(
         message,

--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -1655,6 +1655,7 @@ function sendMessageViaRuns(
 
   return {
     abort: () => {
+      if (finished && !fallbackStarted) return;
       controller.abort();
       startReq?.destroy();
       eventsReq?.destroy();

--- a/src/main/run-stream.test.ts
+++ b/src/main/run-stream.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import {
+  chatToolEventFromRunEvent,
+  parseRunSseBlock,
+  runCompletedUsage,
+  runEventReasoningText,
+  supportsHermesRunsTransport,
+} from "./run-stream";
+
+describe("supportsHermesRunsTransport", () => {
+  it("requires the run features and endpoint paths", () => {
+    expect(
+      supportsHermesRunsTransport({
+        features: {
+          run_submission: true,
+          run_events_sse: true,
+          run_stop: true,
+          run_approval_response: true,
+          tool_progress_events: true,
+        },
+        endpoints: {
+          runs: { path: "/v1/runs" },
+          run_events: { path: "/v1/runs/{run_id}/events" },
+          run_approval: { path: "/v1/runs/{run_id}/approval" },
+          run_stop: { path: "/v1/runs/{run_id}/stop" },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects older gateways that only expose chat completions", () => {
+    expect(
+      supportsHermesRunsTransport({
+        features: {
+          chat_completions_streaming: true,
+        },
+        endpoints: {
+          chat_completions: { path: "/v1/chat/completions" },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects partial run support without stop", () => {
+    expect(
+      supportsHermesRunsTransport({
+        features: {
+          run_submission: true,
+          run_events_sse: true,
+          run_approval_response: true,
+          tool_progress_events: true,
+        },
+        endpoints: {
+          runs: { path: "/v1/runs" },
+          run_events: { path: "/v1/runs/{run_id}/events" },
+          run_approval: { path: "/v1/runs/{run_id}/approval" },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects run support without the approval response endpoint", () => {
+    expect(
+      supportsHermesRunsTransport({
+        features: {
+          run_submission: true,
+          run_events_sse: true,
+          run_stop: true,
+          tool_progress_events: true,
+        },
+        endpoints: {
+          runs: { path: "/v1/runs" },
+          run_events: { path: "/v1/runs/{run_id}/events" },
+          run_stop: { path: "/v1/runs/{run_id}/stop" },
+        },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("run stream event mapping", () => {
+  it("maps reasoning events to reasoning text", () => {
+    expect(
+      runEventReasoningText({
+        event: "reasoning.available",
+        text: "thinking...",
+      }),
+    ).toBe("thinking...");
+  });
+
+  it("maps run tool lifecycle events to chat tool events", () => {
+    expect(
+      chatToolEventFromRunEvent({
+        event: "tool.started",
+        run_id: "run_1",
+        tool: "terminal",
+        preview: "npm test",
+      }),
+    ).toEqual({
+      callId: "run_1:terminal",
+      hasStableCallId: false,
+      name: "terminal",
+      status: "running",
+      preview: "npm test",
+    });
+
+    expect(
+      chatToolEventFromRunEvent({
+        event: "tool.completed",
+        run_id: "run_1",
+        tool: "terminal",
+      }),
+    ).toEqual({
+      callId: "run_1:terminal",
+      hasStableCallId: false,
+      name: "terminal",
+      status: "completed",
+    });
+  });
+
+  it("maps run.completed usage to renderer usage fields", () => {
+    expect(
+      runCompletedUsage({
+        event: "run.completed",
+        usage: {
+          input_tokens: 11,
+          output_tokens: 7,
+          total_tokens: 18,
+        },
+      }),
+    ).toEqual({
+      promptTokens: 11,
+      completionTokens: 7,
+      totalTokens: 18,
+    });
+  });
+
+  it("parses data-only SSE blocks with CRLF line endings", () => {
+    expect(parseRunSseBlock('data: {"event":"message.delta"}\r\n\r\n')).toEqual(
+      {
+        eventType: "",
+        data: '{"event":"message.delta"}',
+      },
+    );
+  });
+});

--- a/src/main/run-stream.ts
+++ b/src/main/run-stream.ts
@@ -1,0 +1,113 @@
+import type { ChatToolEvent } from "../shared/chat-stream";
+
+export interface HermesApiCapabilities {
+  features?: Record<string, unknown>;
+  endpoints?: Record<string, { path?: unknown } | unknown>;
+}
+
+function boolFeature(
+  capabilities: HermesApiCapabilities | null | undefined,
+  name: string,
+): boolean {
+  return capabilities?.features?.[name] === true;
+}
+
+function endpointPath(
+  capabilities: HermesApiCapabilities | null | undefined,
+  name: string,
+): string {
+  const endpoint = capabilities?.endpoints?.[name];
+  if (!endpoint || typeof endpoint !== "object") return "";
+  const path = (endpoint as { path?: unknown }).path;
+  return typeof path === "string" ? path : "";
+}
+
+export function supportsHermesRunsTransport(
+  capabilities: HermesApiCapabilities | null | undefined,
+): boolean {
+  return (
+    boolFeature(capabilities, "run_submission") &&
+    boolFeature(capabilities, "run_events_sse") &&
+    boolFeature(capabilities, "run_stop") &&
+    boolFeature(capabilities, "run_approval_response") &&
+    boolFeature(capabilities, "tool_progress_events") &&
+    endpointPath(capabilities, "runs") === "/v1/runs" &&
+    endpointPath(capabilities, "run_events") === "/v1/runs/{run_id}/events" &&
+    endpointPath(capabilities, "run_approval") ===
+      "/v1/runs/{run_id}/approval" &&
+    endpointPath(capabilities, "run_stop") === "/v1/runs/{run_id}/stop"
+  );
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function runToolName(event: Record<string, unknown>): string {
+  return stringValue(event.tool) || stringValue(event.tool_name) || "tool";
+}
+
+export function chatToolEventFromRunEvent(
+  event: Record<string, unknown>,
+): ChatToolEvent | null {
+  const eventName = stringValue(event.event);
+  if (!["tool.started", "tool.completed", "tool.failed"].includes(eventName)) {
+    return null;
+  }
+
+  const name = runToolName(event);
+  const status =
+    eventName === "tool.completed"
+      ? "completed"
+      : eventName === "tool.failed"
+        ? "failed"
+        : "running";
+  const runId = stringValue(event.run_id) || "run";
+  const preview = stringValue(event.preview);
+
+  return {
+    callId: `${runId}:${name}`,
+    hasStableCallId: false,
+    name,
+    status,
+    ...(preview ? { preview } : {}),
+  };
+}
+
+export function runEventReasoningText(event: Record<string, unknown>): string {
+  if (event.event !== "reasoning.available") return "";
+  return stringValue(event.text) || stringValue(event.delta);
+}
+
+export function runCompletedUsage(event: Record<string, unknown>): {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+} | null {
+  if (event.event !== "run.completed") return null;
+  const usage = event.usage;
+  if (!usage || typeof usage !== "object") return null;
+  const u = usage as Record<string, unknown>;
+  return {
+    promptTokens: Number(u.input_tokens) || 0,
+    completionTokens: Number(u.output_tokens) || 0,
+    totalTokens: Number(u.total_tokens) || 0,
+  };
+}
+
+export function parseRunSseBlock(
+  block: string,
+): { eventType: string; data: string } | null {
+  let eventType = "";
+  const dataLines: string[] = [];
+  for (const rawLine of block.split("\n")) {
+    const line = rawLine.replace(/\r$/, "");
+    if (line.startsWith("event: ")) {
+      eventType = line.slice(7).trim();
+    } else if (line.startsWith("data: ")) {
+      dataLines.push(line.slice(6));
+    }
+  }
+  if (dataLines.length === 0) return null;
+  return { eventType, data: dataLines.join("\n") };
+}

--- a/src/main/tui-gateway-stream.test.ts
+++ b/src/main/tui-gateway-stream.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+  gatewayCompletionSuffix,
+  gatewayMessageCompleteText,
+  gatewayMessageDelta,
+  gatewayReasoningText,
+  gatewayToolEvent,
+  gatewayUsage,
+} from "./tui-gateway-stream";
+
+describe("tui gateway stream mapping", () => {
+  it("maps message and reasoning deltas", () => {
+    expect(
+      gatewayMessageDelta({
+        type: "message.delta",
+        payload: { text: "hello" },
+      }),
+    ).toBe("hello");
+    expect(
+      gatewayReasoningText({
+        type: "reasoning.delta",
+        payload: { text: "thinking" },
+      }),
+    ).toBe("thinking");
+    expect(
+      gatewayMessageCompleteText({
+        type: "message.complete",
+        payload: { rendered: "final" },
+      }),
+    ).toBe("final");
+  });
+
+  it("uses completion text when streamed deltas were only whitespace", () => {
+    expect(gatewayCompletionSuffix("\n  ", "final answer")).toBe(
+      "final answer",
+    );
+  });
+
+  it("only appends the missing suffix when completion repeats streamed text", () => {
+    expect(gatewayCompletionSuffix("hello", "hello world")).toBe(" world");
+    expect(gatewayCompletionSuffix("hello world", "hello world")).toBe("");
+  });
+
+  it("does not duplicate unrelated completion text after visible stream text", () => {
+    expect(gatewayCompletionSuffix("partial answer", "different answer")).toBe(
+      "",
+    );
+  });
+
+  it("ignores reasoning.available previews for live reasoning", () => {
+    expect(
+      gatewayReasoningText({
+        type: "reasoning.available",
+        payload: { text: "final answer preview" },
+      }),
+    ).toBe("");
+  });
+
+  it("maps stable tool start and complete events with result payloads", () => {
+    expect(
+      gatewayToolEvent({
+        type: "tool.start",
+        session_id: "s1",
+        payload: {
+          args_text: "curl http://127.0.0.1",
+          name: "terminal",
+          tool_id: "call-1",
+        },
+      }),
+    ).toMatchObject({
+      callId: "call-1",
+      hasStableCallId: true,
+      name: "terminal",
+      preview: "curl http://127.0.0.1",
+      status: "running",
+    });
+
+    expect(
+      gatewayToolEvent({
+        type: "tool.complete",
+        session_id: "s1",
+        payload: {
+          name: "terminal",
+          result_text: "ok",
+          tool_id: "call-1",
+        },
+      }),
+    ).toMatchObject({
+      callId: "call-1",
+      name: "terminal",
+      result: "ok",
+      status: "completed",
+    });
+  });
+
+  it("formats structured tool results when result_text is absent", () => {
+    const mapped = gatewayToolEvent({
+      type: "tool.complete",
+      payload: {
+        name: "skill_view",
+        result: { answer: "done" },
+        tool_id: "call-2",
+      },
+    });
+
+    expect(mapped?.result).toContain('"answer": "done"');
+  });
+
+  it("maps message completion usage", () => {
+    expect(
+      gatewayUsage({
+        type: "message.complete",
+        payload: {
+          usage: {
+            cache_read: 2,
+            cache_write: 3,
+            input: 10,
+            output: 5,
+            total: 15,
+          },
+        },
+      }),
+    ).toEqual({
+      cacheReadTokens: 2,
+      cacheWriteTokens: 3,
+      completionTokens: 5,
+      promptTokens: 10,
+      totalTokens: 15,
+    });
+  });
+});

--- a/src/main/tui-gateway-stream.ts
+++ b/src/main/tui-gateway-stream.ts
@@ -1,0 +1,135 @@
+import type { ChatToolEvent } from "../shared/chat-stream";
+
+export interface GatewayEvent {
+  payload?: Record<string, unknown>;
+  session_id?: string;
+  type: string;
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function resultText(payload: Record<string, unknown>): string {
+  const explicit = stringValue(payload.result_text);
+  if (explicit) return explicit;
+
+  const summary = stringValue(payload.summary);
+  const result = payload.result;
+  if (typeof result === "string") return result;
+  if (result == null) return summary;
+
+  try {
+    return JSON.stringify(result, null, 2);
+  } catch {
+    return summary;
+  }
+}
+
+function previewText(payload: Record<string, unknown>): string {
+  return (
+    stringValue(payload.context) ||
+    stringValue(payload.args_text) ||
+    stringValue(payload.summary) ||
+    stringValue(payload.name)
+  );
+}
+
+export function gatewayReasoningText(event: GatewayEvent): string {
+  // `reasoning.delta` is the live reasoning callback. `reasoning.available`
+  // is a generic post-hoc preview signal from the gateway bridge; on some
+  // transports/providers it can carry visible assistant text rather than
+  // private reasoning, so canonical post-stream reasoning is left to the DB
+  // reconciliation path instead.
+  if (event.type !== "reasoning.delta") return "";
+  return stringValue(event.payload?.text);
+}
+
+export function gatewayMessageDelta(event: GatewayEvent): string {
+  if (event.type !== "message.delta") return "";
+  return stringValue(event.payload?.text);
+}
+
+export function gatewayMessageCompleteText(event: GatewayEvent): string {
+  if (event.type !== "message.complete") return "";
+  return (
+    stringValue(event.payload?.text) || stringValue(event.payload?.rendered)
+  );
+}
+
+export function gatewayCompletionSuffix(
+  streamedText: string,
+  finalText: string,
+): string {
+  if (!finalText) return "";
+  if (!streamedText.trim()) return finalText;
+  if (finalText === streamedText) return "";
+  if (finalText.startsWith(streamedText)) {
+    return finalText.slice(streamedText.length);
+  }
+  if (finalText.trim() === streamedText.trim()) return "";
+  return "";
+}
+
+export function gatewayUsage(event: GatewayEvent):
+  | {
+      promptTokens: number;
+      completionTokens: number;
+      totalTokens: number;
+      cost?: number;
+      cacheReadTokens?: number;
+      cacheWriteTokens?: number;
+    }
+  | null {
+  if (event.type !== "message.complete") return null;
+  const usage = event.payload?.usage;
+  if (!usage || typeof usage !== "object" || Array.isArray(usage)) return null;
+  const u = usage as Record<string, unknown>;
+  const promptTokens =
+    numberValue(u.input) ?? numberValue(u.prompt) ?? numberValue(u.prompt_tokens);
+  const completionTokens =
+    numberValue(u.output) ??
+    numberValue(u.completion) ??
+    numberValue(u.completion_tokens);
+  const totalTokens = numberValue(u.total) ?? undefined;
+  if (promptTokens == null && completionTokens == null && totalTokens == null) {
+    return null;
+  }
+  const prompt = promptTokens ?? 0;
+  const completion = completionTokens ?? 0;
+  return {
+    promptTokens: prompt,
+    completionTokens: completion,
+    totalTokens: totalTokens ?? prompt + completion,
+    ...(numberValue(u.cost_usd) != null ? { cost: numberValue(u.cost_usd) } : {}),
+    ...(numberValue(u.cache_read) != null
+      ? { cacheReadTokens: numberValue(u.cache_read) }
+      : {}),
+    ...(numberValue(u.cache_write) != null
+      ? { cacheWriteTokens: numberValue(u.cache_write) }
+      : {}),
+  };
+}
+
+export function gatewayToolEvent(event: GatewayEvent): ChatToolEvent | null {
+  if (event.type !== "tool.start" && event.type !== "tool.complete") {
+    return null;
+  }
+  const payload = event.payload || {};
+  const name = stringValue(payload.name) || "tool";
+  const callId = stringValue(payload.tool_id) || `${event.session_id || "gateway"}:${name}`;
+  const result = event.type === "tool.complete" ? resultText(payload) : "";
+  return {
+    callId,
+    hasStableCallId: !!payload.tool_id,
+    name,
+    status: event.type === "tool.complete" ? "completed" : "running",
+    label: name,
+    preview: previewText(payload),
+    ...(result ? { result } : {}),
+  };
+}

--- a/src/main/ws.d.ts
+++ b/src/main/ws.d.ts
@@ -1,0 +1,20 @@
+declare module "ws" {
+  type Data = string | Buffer | ArrayBuffer | Buffer[];
+
+  export default class WebSocket {
+    static readonly OPEN: number;
+
+    readonly readyState: number;
+
+    constructor(address: string);
+
+    close(code?: number, data?: string): void;
+    on(event: "close", listener: (code: number, reason: Buffer) => void): this;
+    on(event: "error", listener: (error: Error) => void): this;
+    on(event: "message", listener: (data: Data) => void): this;
+    on(event: "open", listener: () => void): this;
+    removeAllListeners(): this;
+    send(data: string): void;
+    terminate(): void;
+  }
+}

--- a/src/renderer/src/screens/Chat/HistoryRow.tsx
+++ b/src/renderer/src/screens/Chat/HistoryRow.tsx
@@ -130,6 +130,12 @@ function isToolCall(msg: ToolItem): msg is ToolCallMessage {
   return msg.kind === "tool_call";
 }
 
+export function toolActivityGroupTitle(items: ToolItem[]): string {
+  const toolCallCount = items.filter(isToolCall).length;
+  if (toolCallCount > 1) return `${toolCallCount} tools called`;
+  return items[items.length - 1]?.name ?? "tool";
+}
+
 function resultMeta(msg: ToolResultMessage): string {
   const lines = countLines(msg.content);
   const base = `${lines} ${lines === 1 ? "line" : "lines"}`;
@@ -221,6 +227,7 @@ export const ToolActivityGroup = memo(function ToolActivityGroup({
   const last = items[items.length - 1];
   const count = items.length;
   const detail = itemDetail(last);
+  const title = toolActivityGroupTitle(items);
 
   return (
     <div
@@ -249,7 +256,7 @@ export const ToolActivityGroup = memo(function ToolActivityGroup({
           ) : (
             <Wrench size={13} className="chat-tool-group-icon" />
           )}
-          <span className="chat-tool-group-name">{last.name}</span>
+          <span className="chat-tool-group-name">{title}</span>
           {detail && <span className="chat-tool-group-detail">{detail}</span>}
           <span className="chat-tool-group-count">
             {count} {count === 1 ? "step" : "steps"}

--- a/src/renderer/src/screens/Chat/hooks/useChatIPC.ts
+++ b/src/renderer/src/screens/Chat/hooks/useChatIPC.ts
@@ -1,11 +1,15 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import type { ChatMessage, UsageState } from "../types";
 import {
   dbItemsToChatMessages,
   reconcileStreamedWithDb,
   type DbHistoryItem,
 } from "../sessionHistory";
-import { upsertLiveToolEvent } from "../liveToolEvents";
+import {
+  liveToolEventFromProgress,
+  upsertLiveToolEvent,
+} from "../liveToolEvents";
+import { upsertLiveReasoningChunk } from "../liveReasoningEvents";
 
 interface UseChatIPCArgs {
   setMessages: React.Dispatch<React.SetStateAction<ChatMessage[]>>;
@@ -28,6 +32,8 @@ export function useChatIPC({
   setIsLoading,
   setUsage,
 }: UseChatIPCArgs): void {
+  const reasoningSegmentClosedRef = useRef(false);
+
   useEffect(() => {
     const cleanupChunk = window.hermesAPI.onChatChunk((chunk) => {
       setMessages((prev) => {
@@ -53,46 +59,19 @@ export function useChatIPC({
     });
 
     // Streaming reasoning / thinking bubbles for the current turn (#352).
-    // Reasoning typically arrives BEFORE content (DeepSeek, o1/o3), but
-    // we don't rely on that order — we find the reasoning row for the
-    // active turn (last agent reasoning row since the most recent user
-    // message) and append to it. If no such row exists yet, create one
-    // and place it BEFORE any assistant content bubbles in the same
-    // turn so the visual order is reasoning → answer.
+    // Keep chunk order relative to tool rows. A new thought after a tool call
+    // should become a new block there, not mutate the first thought block.
     const cleanupReasoning = window.hermesAPI.onChatReasoningChunk((chunk) => {
       if (!chunk) return;
-      setMessages((prev) => {
-        let insertAt = prev.length;
-        for (let i = prev.length - 1; i >= 0; i--) {
-          const m = prev[i];
-          if (m.role === "user") break;
-          // Append to the active turn's reasoning row if one exists.
-          if ("kind" in m && m.kind === "reasoning") {
-            return [
-              ...prev.slice(0, i),
-              { ...m, text: m.text + chunk },
-              ...prev.slice(i + 1),
-            ];
-          }
-          // Otherwise track the earliest in-turn agent row so the new
-          // reasoning bubble lands ahead of it (typical case: content
-          // bubble started first because reasoning arrived a tick late).
-          insertAt = i;
-        }
-        return [
-          ...prev.slice(0, insertAt),
-          {
-            id: `reasoning-${Date.now()}`,
-            kind: "reasoning",
-            role: "agent",
-            text: chunk,
-          },
-          ...prev.slice(insertAt),
-        ];
-      });
+      const forceNewSegment = reasoningSegmentClosedRef.current;
+      reasoningSegmentClosedRef.current = false;
+      setMessages((prev) =>
+        upsertLiveReasoningChunk(prev, chunk, Date.now(), forceNewSegment),
+      );
     });
 
     const cleanupDone = window.hermesAPI.onChatDone(async (sessionId) => {
+      reasoningSegmentClosedRef.current = false;
       if (sessionId) setHermesSessionId(sessionId);
       setToolProgress(null);
       setIsLoading(false);
@@ -122,6 +101,7 @@ export function useChatIPC({
     });
 
     const cleanupError = window.hermesAPI.onChatError((error) => {
+      reasoningSegmentClosedRef.current = false;
       setMessages((prev) => [
         ...prev,
         {
@@ -135,11 +115,17 @@ export function useChatIPC({
     });
 
     const cleanupToolProgress = window.hermesAPI.onChatToolProgress((tool) => {
-      setToolProgress(tool);
+      setToolProgress(null);
+      if (!tool.trim()) return;
+      reasoningSegmentClosedRef.current = true;
+      setMessages((prev) =>
+        upsertLiveToolEvent(prev, liveToolEventFromProgress(tool)),
+      );
     });
 
     const cleanupToolEvent = window.hermesAPI.onChatToolEvent((toolEvent) => {
       setToolProgress(null);
+      reasoningSegmentClosedRef.current = true;
       setMessages((prev) => upsertLiveToolEvent(prev, toolEvent));
     });
 

--- a/src/renderer/src/screens/Chat/liveReasoningEvents.ts
+++ b/src/renderer/src/screens/Chat/liveReasoningEvents.ts
@@ -1,0 +1,56 @@
+import type { ChatBubbleMessage, ChatMessage, ReasoningMessage } from "./types";
+
+function isAssistantBubble(msg: ChatMessage): msg is ChatBubbleMessage {
+  const kind = (msg as { kind?: string }).kind;
+  return msg.role === "agent" && (!kind || kind === "assistant");
+}
+
+function latestUserIndex(messages: ReadonlyArray<ChatMessage>): number {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === "user") return i;
+  }
+  return -1;
+}
+
+export function upsertLiveReasoningChunk(
+  messages: ReadonlyArray<ChatMessage>,
+  chunk: string,
+  now = Date.now(),
+  forceNewSegment = false,
+): ChatMessage[] {
+  if (!chunk) return [...messages];
+
+  const turnStart = latestUserIndex(messages) + 1;
+  const last = messages[messages.length - 1];
+  const insertAt =
+    messages.length > turnStart && last && isAssistantBubble(last)
+      ? messages.length - 1
+      : messages.length;
+  const previous = messages[insertAt - 1];
+
+  if (
+    !forceNewSegment &&
+    previous &&
+    previous.role === "agent" &&
+    "kind" in previous &&
+    previous.kind === "reasoning"
+  ) {
+    const updated: ReasoningMessage = {
+      ...previous,
+      text: previous.text + chunk,
+    };
+    return [
+      ...messages.slice(0, insertAt - 1),
+      updated,
+      ...messages.slice(insertAt),
+    ];
+  }
+
+  const row: ReasoningMessage = {
+    id: `reasoning-${now}-${messages.length}`,
+    kind: "reasoning",
+    role: "agent",
+    text: chunk,
+  };
+  return [...messages.slice(0, insertAt), row, ...messages.slice(insertAt)];
+}

--- a/src/renderer/src/screens/Chat/liveToolEvents.ts
+++ b/src/renderer/src/screens/Chat/liveToolEvents.ts
@@ -1,5 +1,41 @@
 import type { ChatToolEvent } from "../../../../shared/chat-stream";
-import type { ChatMessage, ToolCallMessage } from "./types";
+import type { ChatMessage, ToolCallMessage, ToolResultMessage } from "./types";
+
+const TOOL_PROGRESS_EMOJI_RE = /^(\p{Extended_Pictographic}|\p{Emoji_Presentation})\s+(.+)$/u;
+
+function toolProgressToNameAndPreview(progress: string): {
+  emoji?: string;
+  name: string;
+  preview: string;
+} {
+  const trimmed = progress.trim();
+  const emojiMatch = TOOL_PROGRESS_EMOJI_RE.exec(trimmed);
+  const emoji = emojiMatch?.[1];
+  const text = (emojiMatch?.[2] || trimmed).trim();
+  const firstWord = text.split(/\s+/)[0] || "tool";
+  const name =
+    firstWord === "python" || firstWord === "python3" || firstWord === "cmd"
+      ? "terminal"
+      : firstWord;
+  return {
+    ...(emoji ? { emoji } : {}),
+    name,
+    preview: text,
+  };
+}
+
+export function liveToolEventFromProgress(progress: string): ChatToolEvent {
+  const { emoji, name, preview } = toolProgressToNameAndPreview(progress);
+  return {
+    callId: `progress:${name}:${preview}`,
+    hasStableCallId: false,
+    name,
+    status: "running",
+    label: preview,
+    ...(emoji ? { emoji } : {}),
+    preview,
+  };
+}
 
 function toolEventArgs(event: ChatToolEvent): string {
   return event.preview || event.label || "";
@@ -18,11 +54,6 @@ function updatedToolArgs(
     return current.args;
   }
   return nextArgs;
-}
-
-function isBubbleMessage(msg: ChatMessage): boolean {
-  const kind = (msg as { kind?: string }).kind;
-  return !kind || kind === "user" || kind === "assistant";
 }
 
 function syntheticPrefix(event: ChatToolEvent): string {
@@ -75,6 +106,26 @@ function findLatestRunningSyntheticToolIndex(
   return -1;
 }
 
+function findLatestRunningSyntheticToolByNameIndex(
+  messages: ReadonlyArray<ChatMessage>,
+  event: ChatToolEvent,
+): number {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role === "user") break;
+    if (
+      "kind" in msg &&
+      msg.kind === "tool_call" &&
+      msg.status === "running" &&
+      msg.name === event.name &&
+      (msg.callId.startsWith("live-tool:") || msg.id.includes("live-tool:"))
+    ) {
+      return i;
+    }
+  }
+  return -1;
+}
+
 function activeTurnSyntheticCount(
   messages: ReadonlyArray<ChatMessage>,
   event: ChatToolEvent,
@@ -95,11 +146,57 @@ function activeTurnSyntheticCount(
 }
 
 function liveToolInsertIndex(messages: ReadonlyArray<ChatMessage>): number {
-  const last = messages[messages.length - 1];
-  if (last && last.role === "agent" && isBubbleMessage(last)) {
-    return messages.length - 1;
-  }
   return messages.length;
+}
+
+function findToolResultIndex(
+  messages: ReadonlyArray<ChatMessage>,
+  callId: string,
+): number {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role === "user") break;
+    if (
+      "kind" in msg &&
+      msg.kind === "tool_result" &&
+      msg.callId === callId
+    ) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function upsertToolResultAfterCall(
+  messages: ReadonlyArray<ChatMessage>,
+  toolIndex: number,
+  event: ChatToolEvent,
+): ChatMessage[] {
+  const result = event.result?.trim();
+  if (!result) return [...messages];
+
+  const call = messages[toolIndex] as ToolCallMessage | undefined;
+  const callId = call?.callId || event.callId;
+  const existingIndex = findToolResultIndex(messages, callId);
+  const row: ToolResultMessage = {
+    id: `tool-result-${callId}`,
+    kind: "tool_result",
+    role: "agent",
+    callId,
+    name: event.name || call?.name || "tool",
+    content: result,
+  };
+
+  if (existingIndex >= 0) {
+    return [
+      ...messages.slice(0, existingIndex),
+      row,
+      ...messages.slice(existingIndex + 1),
+    ];
+  }
+
+  const insertAt = Math.min(toolIndex + 1, messages.length);
+  return [...messages.slice(0, insertAt), row, ...messages.slice(insertAt)];
 }
 
 function findActiveTurnToolIndex(
@@ -107,7 +204,12 @@ function findActiveTurnToolIndex(
   event: ChatToolEvent,
 ): number {
   if (event.hasStableCallId !== false) {
-    return findStableToolIndex(messages, event);
+    const stableIndex = findStableToolIndex(messages, event);
+    if (stableIndex >= 0) return stableIndex;
+    if (event.status === "running") {
+      return findLatestRunningSyntheticToolByNameIndex(messages, event);
+    }
+    return -1;
   }
   if (event.status === "running") {
     return -1;
@@ -122,17 +224,22 @@ export function upsertLiveToolEvent(
   const index = findActiveTurnToolIndex(messages, event);
   if (index >= 0) {
     const current = messages[index] as ToolCallMessage;
-    return [
+    const callId =
+      event.hasStableCallId === false
+        ? current.callId
+        : event.callId || current.callId;
+    const updated = [
       ...messages.slice(0, index),
       {
         ...current,
-        callId: event.callId || current.callId,
+        callId,
         name: event.name || current.name,
         args: updatedToolArgs(current, event),
         status: event.status,
       },
       ...messages.slice(index + 1),
     ];
+    return upsertToolResultAfterCall(updated, index, event);
   }
 
   const callId =
@@ -149,5 +256,10 @@ export function upsertLiveToolEvent(
     args: toolEventArgs(event),
     status: event.status,
   };
-  return [...messages.slice(0, insertAt), row, ...messages.slice(insertAt)];
+  const inserted = [
+    ...messages.slice(0, insertAt),
+    row,
+    ...messages.slice(insertAt),
+  ];
+  return upsertToolResultAfterCall(inserted, insertAt, event);
 }

--- a/src/renderer/src/screens/Chat/liveToolEvents.ts
+++ b/src/renderer/src/screens/Chat/liveToolEvents.ts
@@ -206,9 +206,11 @@ function findActiveTurnToolIndex(
   if (event.hasStableCallId !== false) {
     const stableIndex = findStableToolIndex(messages, event);
     if (stableIndex >= 0) return stableIndex;
-    if (event.status === "running") {
-      return findLatestRunningSyntheticToolByNameIndex(messages, event);
-    }
+    const syntheticIndex = findLatestRunningSyntheticToolByNameIndex(
+      messages,
+      event,
+    );
+    if (syntheticIndex >= 0) return syntheticIndex;
     return -1;
   }
   if (event.status === "running") {

--- a/src/renderer/src/screens/Chat/sessionHistory.ts
+++ b/src/renderer/src/screens/Chat/sessionHistory.ts
@@ -228,6 +228,27 @@ function reconciliationKey(m: ChatMessage): string | null {
   return `${bubble.role}:${normalizeBubbleContentForMatch(bubble.content || "").slice(0, 200)}`;
 }
 
+function isSyntheticLiveToolMessage(m: ChatMessage): boolean {
+  return (
+    "kind" in m &&
+    (m.kind === "tool_call" || m.kind === "tool_result") &&
+    (m.callId.startsWith("live-tool:") || m.id.includes("live-tool:"))
+  );
+}
+
+function hasCanonicalToolMatch(
+  db: ReadonlyArray<ChatMessage>,
+  live: ChatMessage,
+): boolean {
+  if (!("kind" in live) || !isSyntheticLiveToolMessage(live)) return false;
+  if (live.kind !== "tool_call" && live.kind !== "tool_result") return false;
+  return db.some((m) => {
+    if (!("kind" in m) || m.kind !== live.kind) return false;
+    if (m.kind !== "tool_call" && m.kind !== "tool_result") return false;
+    return m.name === live.name && !isSyntheticLiveToolMessage(m);
+  });
+}
+
 /**
  * Merge DB-only metadata (e.g. attachments) into a streamed message
  * while preserving the streamed message's React identity (id).
@@ -349,6 +370,7 @@ export function reconcileStreamedWithDb(
     dropDbSplitArtifacts = true,
   ): boolean => {
     if (consumedIds.has(m.id)) return false;
+    if (hasCanonicalToolMatch(db, m)) return false;
     // For bubble messages, check if an equivalent already exists in the
     // result set.  Non-bubble messages (tool_call, tool_result, reasoning)
     // always pass through — they're either matched by callId above or are

--- a/src/renderer/src/screens/Chat/sessionHistory.ts
+++ b/src/renderer/src/screens/Chat/sessionHistory.ts
@@ -236,17 +236,24 @@ function isSyntheticLiveToolMessage(m: ChatMessage): boolean {
   );
 }
 
-function hasCanonicalToolMatch(
-  db: ReadonlyArray<ChatMessage>,
+function toolNameMatchKey(m: ChatMessage): string | null {
+  if (!("kind" in m)) return null;
+  if (m.kind !== "tool_call" && m.kind !== "tool_result") return null;
+  return `${m.kind}:${m.name}`;
+}
+
+function consumeCanonicalToolMatch(
+  canonicalToolMatchCounts: Map<string, number>,
   live: ChatMessage,
 ): boolean {
-  if (!("kind" in live) || !isSyntheticLiveToolMessage(live)) return false;
-  if (live.kind !== "tool_call" && live.kind !== "tool_result") return false;
-  return db.some((m) => {
-    if (!("kind" in m) || m.kind !== live.kind) return false;
-    if (m.kind !== "tool_call" && m.kind !== "tool_result") return false;
-    return m.name === live.name && !isSyntheticLiveToolMessage(m);
-  });
+  if (!isSyntheticLiveToolMessage(live)) return false;
+  const key = toolNameMatchKey(live);
+  if (!key) return false;
+  const remaining = canonicalToolMatchCounts.get(key) || 0;
+  if (remaining <= 0) return false;
+  if (remaining === 1) canonicalToolMatchCounts.delete(key);
+  else canonicalToolMatchCounts.set(key, remaining - 1);
+  return true;
 }
 
 /**
@@ -316,6 +323,7 @@ export function reconcileStreamedWithDb(
 
   const dbAssistantSplitSequences = buildDbAssistantSplitSequences(db);
   const result: ChatMessage[] = [];
+  const canonicalToolMatchCounts = new Map<string, number>();
   for (const dbMsg of db) {
     const key = reconciliationKey(dbMsg);
     const bucket = key ? streamedByKey.get(key) : undefined;
@@ -327,6 +335,13 @@ export function reconcileStreamedWithDb(
       // streamed copy.
       result.push(mergeDbMetadataIntoStreamed(streamedMatch, dbMsg));
     } else {
+      const toolKey = toolNameMatchKey(dbMsg);
+      if (toolKey && !isSyntheticLiveToolMessage(dbMsg)) {
+        canonicalToolMatchCounts.set(
+          toolKey,
+          (canonicalToolMatchCounts.get(toolKey) || 0) + 1,
+        );
+      }
       result.push(dbMsg);
     }
   }
@@ -370,7 +385,7 @@ export function reconcileStreamedWithDb(
     dropDbSplitArtifacts = true,
   ): boolean => {
     if (consumedIds.has(m.id)) return false;
-    if (hasCanonicalToolMatch(db, m)) return false;
+    if (consumeCanonicalToolMatch(canonicalToolMatchCounts, m)) return false;
     // For bubble messages, check if an equivalent already exists in the
     // result set.  Non-bubble messages (tool_call, tool_result, reasoning)
     // always pass through — they're either matched by callId above or are

--- a/src/renderer/src/screens/Gateway/Gateway.test.tsx
+++ b/src/renderer/src/screens/Gateway/Gateway.test.tsx
@@ -21,6 +21,7 @@ describe("Gateway screen recovery controls", () => {
       value: {
         getEnv: vi.fn().mockResolvedValue({}),
         gatewayStatus: vi.fn().mockResolvedValue(true),
+        getApiServerKeyStatus: vi.fn().mockResolvedValue({ hasKey: true }),
         getPlatformEnabled: vi.fn().mockResolvedValue({}),
         restartGateway: vi.fn().mockResolvedValue(false),
         startGateway: vi.fn().mockResolvedValue(false),

--- a/src/shared/chat-stream.ts
+++ b/src/shared/chat-stream.ts
@@ -6,6 +6,7 @@ export interface ChatToolEvent {
   label?: string;
   emoji?: string;
   preview?: string;
+  result?: string;
 }
 
 function stringValue(value: unknown): string {
@@ -30,6 +31,7 @@ export function chatToolEventFromPayload(
   const callId = explicitCallId || `${name}:${label}`;
   const emoji = stringValue(payload.emoji);
   const preview = stringValue(payload.preview);
+  const result = stringValue(payload.result);
 
   return {
     callId,
@@ -39,6 +41,7 @@ export function chatToolEventFromPayload(
     ...(label ? { label } : {}),
     ...(emoji ? { emoji } : {}),
     ...(preview ? { preview } : {}),
+    ...(result ? { result } : {}),
   };
 }
 

--- a/tests/live-reasoning-events.test.ts
+++ b/tests/live-reasoning-events.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import { upsertLiveReasoningChunk } from "../src/renderer/src/screens/Chat/liveReasoningEvents";
+import type { ChatMessage } from "../src/renderer/src/screens/Chat/types";
+
+describe("upsertLiveReasoningChunk", () => {
+  it("inserts reasoning before an active assistant content bubble", () => {
+    const messages: ChatMessage[] = [
+      { id: "u-1", role: "user", content: "answer" },
+      { id: "a-1", role: "agent", content: "Final text" },
+    ];
+
+    const next = upsertLiveReasoningChunk(messages, "thinking", 100);
+
+    expect(next.map((m) => m.id)).toEqual([
+      "u-1",
+      "reasoning-100-2",
+      "a-1",
+    ]);
+    expect(next[1]).toMatchObject({
+      kind: "reasoning",
+      text: "thinking",
+    });
+  });
+
+  it("appends to the reasoning block at the live insertion point", () => {
+    const messages: ChatMessage[] = [
+      { id: "u-1", role: "user", content: "answer" },
+      {
+        id: "r-1",
+        kind: "reasoning",
+        role: "agent",
+        text: "first ",
+      },
+      { id: "a-1", role: "agent", content: "Final text" },
+    ];
+
+    const next = upsertLiveReasoningChunk(messages, "second", 100);
+
+    expect(next.map((m) => m.id)).toEqual(["u-1", "r-1", "a-1"]);
+    expect(next[1]).toMatchObject({
+      kind: "reasoning",
+      text: "first second",
+    });
+  });
+
+  it("starts a new reasoning block after intervening tool rows", () => {
+    const messages: ChatMessage[] = [
+      { id: "u-1", role: "user", content: "make image" },
+      {
+        id: "r-1",
+        kind: "reasoning",
+        role: "agent",
+        text: "plan",
+      },
+      {
+        id: "tool-call-skill",
+        kind: "tool_call",
+        role: "agent",
+        callId: "call-skill",
+        name: "skill_view",
+        args: "ai-playground",
+        status: "completed",
+      },
+    ];
+
+    const next = upsertLiveReasoningChunk(messages, "after tool", 101);
+
+    expect(next.map((m) => m.id)).toEqual([
+      "u-1",
+      "r-1",
+      "tool-call-skill",
+      "reasoning-101-3",
+    ]);
+    expect(next[1]).toMatchObject({ kind: "reasoning", text: "plan" });
+    expect(next[3]).toMatchObject({
+      kind: "reasoning",
+      text: "after tool",
+    });
+  });
+
+  it("starts a new reasoning block after tools but before active content", () => {
+    const messages: ChatMessage[] = [
+      { id: "u-1", role: "user", content: "make image" },
+      {
+        id: "r-1",
+        kind: "reasoning",
+        role: "agent",
+        text: "plan",
+      },
+      {
+        id: "tool-call-skill",
+        kind: "tool_call",
+        role: "agent",
+        callId: "call-skill",
+        name: "skill_view",
+        args: "ai-playground",
+        status: "completed",
+      },
+      { id: "a-1", role: "agent", content: "Done" },
+    ];
+
+    const next = upsertLiveReasoningChunk(messages, "after tool", 102);
+
+    expect(next.map((m) => m.id)).toEqual([
+      "u-1",
+      "r-1",
+      "tool-call-skill",
+      "reasoning-102-4",
+      "a-1",
+    ]);
+    expect(next[1]).toMatchObject({ kind: "reasoning", text: "plan" });
+    expect(next[3]).toMatchObject({
+      kind: "reasoning",
+      text: "after tool",
+    });
+  });
+
+  it("can force a new reasoning segment after a tool boundary", () => {
+    const messages: ChatMessage[] = [
+      { id: "u-1", role: "user", content: "make image" },
+      {
+        id: "r-1",
+        kind: "reasoning",
+        role: "agent",
+        text: "before tool",
+      },
+      { id: "a-1", role: "agent", content: "Done" },
+    ];
+
+    const next = upsertLiveReasoningChunk(messages, "after tool", 103, true);
+
+    expect(next.map((m) => m.id)).toEqual([
+      "u-1",
+      "r-1",
+      "reasoning-103-3",
+      "a-1",
+    ]);
+    expect(next[1]).toMatchObject({
+      kind: "reasoning",
+      text: "before tool",
+    });
+    expect(next[2]).toMatchObject({
+      kind: "reasoning",
+      text: "after tool",
+    });
+  });
+});

--- a/tests/live-tool-events.test.ts
+++ b/tests/live-tool-events.test.ts
@@ -1,9 +1,53 @@
 import { describe, expect, it } from "vitest";
-import { upsertLiveToolEvent } from "../src/renderer/src/screens/Chat/liveToolEvents";
+import {
+  liveToolEventFromProgress,
+  upsertLiveToolEvent,
+} from "../src/renderer/src/screens/Chat/liveToolEvents";
 import type { ChatMessage } from "../src/renderer/src/screens/Chat/types";
 
 describe("upsertLiveToolEvent", () => {
-  it("creates a history row before the live assistant answer", () => {
+  it("renders legacy progress labels as structured running tool rows", () => {
+    const next = upsertLiveToolEvent(
+      [{ id: "u-1", role: "user", content: "make image" }],
+      liveToolEventFromProgress(
+        "💻 python C:/Users/pmos6/AppData/Local/Temp/generate_duck_bathtub.py",
+      ),
+    );
+
+    expect(next).toHaveLength(2);
+    expect(next[1]).toMatchObject({
+      kind: "tool_call",
+      name: "terminal",
+      args: "python C:/Users/pmos6/AppData/Local/Temp/generate_duck_bathtub.py",
+      status: "running",
+    });
+  });
+
+  it("lets stable tool events replace an earlier progress-created row", () => {
+    const progress = upsertLiveToolEvent(
+      [{ id: "u-1", role: "user", content: "make image" }],
+      liveToolEventFromProgress("terminal"),
+    );
+
+    const next = upsertLiveToolEvent(progress, {
+      callId: "call-terminal",
+      hasStableCallId: true,
+      name: "terminal",
+      status: "running",
+      preview: "python generate_duck.py",
+    });
+
+    expect(next).toHaveLength(2);
+    expect(next[1]).toMatchObject({
+      id: "tool-call-live-tool:progress:terminal:terminal:1",
+      callId: "call-terminal",
+      name: "terminal",
+      args: "python generate_duck.py",
+      status: "running",
+    });
+  });
+
+  it("creates a history row after the current live assistant segment", () => {
     const messages: ChatMessage[] = [
       { id: "u-1", role: "user", content: "search" },
       { id: "a-1", role: "agent", content: "Working" },
@@ -19,10 +63,10 @@ describe("upsertLiveToolEvent", () => {
 
     expect(next.map((m) => m.id)).toEqual([
       "u-1",
-      "tool-call-call-search",
       "a-1",
+      "tool-call-call-search",
     ]);
-    expect(next[1]).toMatchObject({
+    expect(next[2]).toMatchObject({
       kind: "tool_call",
       callId: "call-search",
       name: "search_web",
@@ -58,6 +102,43 @@ describe("upsertLiveToolEvent", () => {
       id: "tool-call-call-terminal",
       status: "completed",
       args: "Running command",
+    });
+  });
+
+  it("inserts a live tool result after the completed tool call", () => {
+    const messages: ChatMessage[] = [
+      { id: "u-1", role: "user", content: "run" },
+      {
+        id: "tool-call-call-terminal",
+        kind: "tool_call",
+        role: "agent",
+        callId: "call-terminal",
+        name: "terminal",
+        args: "python script.py",
+        status: "running",
+      },
+      { id: "a-1", role: "agent", content: "Working" },
+    ];
+
+    const next = upsertLiveToolEvent(messages, {
+      callId: "call-terminal",
+      hasStableCallId: true,
+      name: "terminal",
+      status: "completed",
+      result: "COMMAND OUTPUT\nok",
+    });
+
+    expect(next.map((m) => m.id)).toEqual([
+      "u-1",
+      "tool-call-call-terminal",
+      "tool-result-call-terminal",
+      "a-1",
+    ]);
+    expect(next[1]).toMatchObject({ status: "completed" });
+    expect(next[2]).toMatchObject({
+      kind: "tool_result",
+      callId: "call-terminal",
+      content: "COMMAND OUTPUT\nok",
     });
   });
 
@@ -115,8 +196,35 @@ describe("upsertLiveToolEvent", () => {
     expect(next.map((m) => m.id)).toEqual([
       "u-1",
       "tool-call-skill",
-      "tool-call-call-terminal",
       "a-1",
+      "tool-call-call-terminal",
+    ]);
+  });
+
+  it("lets later assistant chunks start after a tool boundary", () => {
+    const messages: ChatMessage[] = [
+      { id: "u-1", role: "user", content: "make image" },
+      { id: "a-1", role: "agent", content: "First, I will check setup." },
+    ];
+
+    const withTool = upsertLiveToolEvent(messages, {
+      callId: "call-terminal",
+      hasStableCallId: true,
+      name: "terminal",
+      status: "running",
+      label: "curl health check",
+    });
+    const nextChunk: ChatMessage = {
+      id: "a-2",
+      role: "agent",
+      content: "Now I will generate it.",
+    };
+
+    expect([...withTool, nextChunk].map((m) => m.id)).toEqual([
+      "u-1",
+      "a-1",
+      "tool-call-call-terminal",
+      "a-2",
     ]);
   });
 
@@ -183,6 +291,51 @@ describe("upsertLiveToolEvent", () => {
     expect(next[1]).toMatchObject({ status: "completed", args: "health check" });
     expect(next[2]).toMatchObject({
       status: "completed",
+      args: "python generate_duck.py",
+    });
+  });
+
+  it("preserves synthetic call ids after completion so later invocations get unique rows", () => {
+    const firstRunning = upsertLiveToolEvent(
+      [{ id: "u-1", role: "user", content: "make image" }],
+      {
+        callId: "run-1:terminal",
+        hasStableCallId: false,
+        name: "terminal",
+        status: "running",
+        preview: "health check",
+      },
+    );
+
+    const firstCompleted = upsertLiveToolEvent(firstRunning, {
+      callId: "run-1:terminal",
+      hasStableCallId: false,
+      name: "terminal",
+      status: "completed",
+      label: "terminal",
+    });
+
+    const secondRunning = upsertLiveToolEvent(firstCompleted, {
+      callId: "run-1:terminal",
+      hasStableCallId: false,
+      name: "terminal",
+      status: "running",
+      preview: "python generate_duck.py",
+    });
+
+    expect(secondRunning.map((m) => m.id)).toEqual([
+      "u-1",
+      "tool-call-live-tool:run-1:terminal:1",
+      "tool-call-live-tool:run-1:terminal:2",
+    ]);
+    expect(secondRunning[1]).toMatchObject({
+      callId: "live-tool:run-1:terminal:1",
+      status: "completed",
+      args: "health check",
+    });
+    expect(secondRunning[2]).toMatchObject({
+      callId: "live-tool:run-1:terminal:2",
+      status: "running",
       args: "python generate_duck.py",
     });
   });

--- a/tests/live-tool-events.test.ts
+++ b/tests/live-tool-events.test.ts
@@ -295,6 +295,46 @@ describe("upsertLiveToolEvent", () => {
     });
   });
 
+  it("matches a stable completion to a synthetic running row by name", () => {
+    const messages: ChatMessage[] = [
+      { id: "u-1", role: "user", content: "run a check" },
+      {
+        id: "tool-call-live-tool:terminal:terminal:1",
+        kind: "tool_call",
+        role: "agent",
+        callId: "live-tool:terminal:terminal:1",
+        name: "terminal",
+        args: "npm test",
+        status: "running",
+      },
+    ];
+
+    const next = upsertLiveToolEvent(messages, {
+      callId: "call-42",
+      hasStableCallId: true,
+      name: "terminal",
+      status: "completed",
+      result: "ok",
+    });
+
+    expect(next.map((m) => m.id)).toEqual([
+      "u-1",
+      "tool-call-live-tool:terminal:terminal:1",
+      "tool-result-call-42",
+    ]);
+    expect(next[1]).toMatchObject({
+      callId: "call-42",
+      name: "terminal",
+      args: "npm test",
+      status: "completed",
+    });
+    expect(next[2]).toMatchObject({
+      kind: "tool_result",
+      callId: "call-42",
+      content: "ok",
+    });
+  });
+
   it("preserves synthetic call ids after completion so later invocations get unique rows", () => {
     const firstRunning = upsertLiveToolEvent(
       [{ id: "u-1", role: "user", content: "make image" }],

--- a/tests/reconcile-streamed-with-db.test.ts
+++ b/tests/reconcile-streamed-with-db.test.ts
@@ -494,4 +494,46 @@ describe("reconcileStreamedWithDb", () => {
       ("attachments" in merged[0] && merged[0].attachments) || [],
     ).toHaveLength(1);
   });
+
+  it("drops synthetic live tool rows once matching canonical DB tool rows arrive", () => {
+    const streamed: ChatMessage[] = [
+      STREAMED_USER("make an image", "u-1"),
+      {
+        id: "tool-call-live-tool:run-1:skill_view:1",
+        kind: "tool_call",
+        role: "agent",
+        callId: "live-tool:run-1:skill_view:1",
+        name: "skill_view",
+        args: "ai-playground-image-gen",
+      },
+      {
+        id: "tool-call-live-tool:run-1:execute_code:1",
+        kind: "tool_call",
+        role: "agent",
+        callId: "live-tool:run-1:execute_code:1",
+        name: "execute_code",
+        args: "from hermes_tools import terminal",
+      },
+      STREAMED_AGENT("Done.", "a-1"),
+    ];
+    const db: ChatMessage[] = [
+      DB_USER("make an image", 60),
+      DB_TOOL_CALL("call-skill", "skill_view", "ai-playground-image-gen", 61),
+      DB_TOOL_RESULT("call-skill", "skill_view", "ok", 62),
+      DB_TOOL_CALL("call-code", "execute_code", "from hermes_tools import terminal", 63),
+      DB_TOOL_RESULT("call-code", "execute_code", "ok", 64),
+      DB_AGENT("Done.", 65),
+    ];
+
+    const merged = reconcileStreamedWithDb(streamed, db);
+
+    expect(merged.map((m) => m.id)).toEqual([
+      "u-1",
+      "db-tc-61-call-skill",
+      "db-tr-62",
+      "db-tc-63-call-code",
+      "db-tr-64",
+      "a-1",
+    ]);
+  });
 });

--- a/tests/reconcile-streamed-with-db.test.ts
+++ b/tests/reconcile-streamed-with-db.test.ts
@@ -536,4 +536,83 @@ describe("reconcileStreamedWithDb", () => {
       "a-1",
     ]);
   });
+
+  it("does not drop extra repeated same-name synthetic tools when DB has fewer canonical rows", () => {
+    const streamed: ChatMessage[] = [
+      STREAMED_USER("run checks", "u-1"),
+      {
+        id: "tool-call-live-tool:run-1:terminal:1",
+        kind: "tool_call",
+        role: "agent",
+        callId: "live-tool:run-1:terminal:1",
+        name: "terminal",
+        args: "npm test",
+      },
+      {
+        id: "tool-call-live-tool:run-1:terminal:2",
+        kind: "tool_call",
+        role: "agent",
+        callId: "live-tool:run-1:terminal:2",
+        name: "terminal",
+        args: "npm run typecheck",
+      },
+      STREAMED_AGENT("Done.", "a-1"),
+    ];
+    const db: ChatMessage[] = [
+      DB_USER("run checks", 70),
+      DB_TOOL_CALL("call-terminal-1", "terminal", "npm test", 71),
+      DB_AGENT("Done.", 72),
+    ];
+
+    const merged = reconcileStreamedWithDb(streamed, db);
+
+    expect(merged.map((m) => m.id)).toEqual([
+      "u-1",
+      "db-tc-71-call-terminal-1",
+      "a-1",
+      "tool-call-live-tool:run-1:terminal:2",
+    ]);
+    expect(merged[3]).toMatchObject({
+      kind: "tool_call",
+      name: "terminal",
+      args: "npm run typecheck",
+    });
+  });
+
+  it("does not let exact canonical tool matches consume extra synthetic same-name rows", () => {
+    const streamed: ChatMessage[] = [
+      STREAMED_USER("run checks", "u-1"),
+      {
+        id: "tool-call-call-terminal-1",
+        kind: "tool_call",
+        role: "agent",
+        callId: "call-terminal-1",
+        name: "terminal",
+        args: "npm test",
+      },
+      {
+        id: "tool-call-live-tool:run-1:terminal:2",
+        kind: "tool_call",
+        role: "agent",
+        callId: "live-tool:run-1:terminal:2",
+        name: "terminal",
+        args: "npm run typecheck",
+      },
+      STREAMED_AGENT("Done.", "a-1"),
+    ];
+    const db: ChatMessage[] = [
+      DB_USER("run checks", 80),
+      DB_TOOL_CALL("call-terminal-1", "terminal", "npm test", 81),
+      DB_AGENT("Done.", 82),
+    ];
+
+    const merged = reconcileStreamedWithDb(streamed, db);
+
+    expect(merged.map((m) => m.id)).toEqual([
+      "u-1",
+      "tool-call-call-terminal-1",
+      "a-1",
+      "tool-call-live-tool:run-1:terminal:2",
+    ]);
+  });
 });

--- a/tests/remote-history.test.ts
+++ b/tests/remote-history.test.ts
@@ -29,7 +29,7 @@ function extractExportedFunction(name: string): string {
 
 function extractLocalRecoveryFunction(): string {
   const startMatch = hermesSrc.indexOf(
-    "async function sendMessageViaApiWithLocalRecovery(",
+    "async function sendMessageViaBestApiWithLocalRecovery(",
   );
   expect(startMatch).toBeGreaterThan(-1);
 
@@ -48,20 +48,20 @@ function extractLocalRecoveryFunction(): string {
  * single-turn requests.
  */
 describe("Remote/SSH Mode History Preservation", () => {
-  it("sendMessage passes history to sendMessageViaApi in remote mode", () => {
+  it("sendMessage passes history to the API transport in remote mode", () => {
     // Extract the sendMessage function's remote mode branch
     const remoteModeBranch = hermesSrc.match(
-      /\/\/ Remote mode: always use API, no CLI fallback[\s\S]*?if \(isRemoteMode\(\)\) \{[\s\S]*?return sendMessageViaApi\([\s\S]*?\);[\s\S]*?\}/,
+      /\/\/ Remote mode: always use API, no CLI fallback[\s\S]*?if \(isRemoteMode\(\)\) \{[\s\S]*?return sendMessageViaBestApi\([\s\S]*?\);[\s\S]*?\}/,
     );
 
     expect(remoteModeBranch).toBeDefined();
 
     const branchCode = remoteModeBranch![0];
 
-    // Verify that sendMessageViaApi is called with history parameter.
+    // Verify that the API transport is called with history parameter.
     // Call signature is (message, cb, profile, resumeSessionId, history, attachments).
     const apiCallMatch = branchCode.match(
-      /return sendMessageViaApi\(([\s\S]*?)\);/,
+      /return sendMessageViaBestApi\(([\s\S]*?)\);/,
     );
 
     expect(apiCallMatch).toBeDefined();
@@ -108,7 +108,7 @@ describe("Remote/SSH Mode History Preservation", () => {
   it("local API available branch passes history to recovery wrapper", () => {
     // Extract the local API available branch
     const localApiBranch = hermesSrc.match(
-      /if \(apiServerAvailable\) \{[\s\S]*?return sendMessageViaApiWithLocalRecovery\([\s\S]*?\);[\s\S]*?\}/,
+      /if \(apiServerAvailable\) \{[\s\S]*?return sendMessageViaBestApiWithLocalRecovery\([\s\S]*?\);[\s\S]*?\}/,
     );
 
     expect(localApiBranch).toBeDefined();
@@ -116,7 +116,7 @@ describe("Remote/SSH Mode History Preservation", () => {
     const branchCode = localApiBranch![0];
 
     const wrapperCallMatch = branchCode.match(
-      /return sendMessageViaApiWithLocalRecovery\(([\s\S]*?)\);/,
+      /return sendMessageViaBestApiWithLocalRecovery\(([\s\S]*?)\);/,
     );
 
     expect(wrapperCallMatch).toBeDefined();
@@ -129,10 +129,10 @@ describe("Remote/SSH Mode History Preservation", () => {
     expect(hasHistoryArg(wrapperCallMatch![1])).toBe(true);
   });
 
-  it("local recovery wrapper forwards history to every API send", () => {
+  it("local recovery wrapper forwards history to every best-API send", () => {
     const wrapperCode = extractLocalRecoveryFunction();
     const apiCalls = Array.from(
-      wrapperCode.matchAll(/sendMessageViaApi\(([\s\S]*?)\);/g),
+      wrapperCode.matchAll(/sendMessageViaBestApi\(([\s\S]*?)\);/g),
     );
 
     // Initial local API send + retry after gateway recovery.
@@ -148,7 +148,7 @@ describe("Remote/SSH Mode History Preservation", () => {
 
     // Find all direct and local-recovery API send paths.
     const apiCalls = funcCode.matchAll(
-      /sendMessageViaApi(?:WithLocalRecovery)?\(([\s\S]*?)\);/g,
+      /sendMessageViaBestApi(?:WithLocalRecovery)?\(([\s\S]*?)\);/g,
     );
 
     const calls = Array.from(apiCalls);
@@ -160,5 +160,37 @@ describe("Remote/SSH Mode History Preservation", () => {
     for (const call of calls) {
       expect(hasHistoryArg(call[1])).toBe(true);
     }
+  });
+
+  it("sendMessageViaBestApi forwards history through chat-completions fallback", () => {
+    const bestApiMatch = hermesSrc.match(
+      /async function sendMessageViaBestApi\([\s\S]*?\): Promise<ChatHandle> \{[\s\S]*?return sendMessageViaNonGatewayApi\(([\s\S]*?)\);[\s\S]*?\}/,
+    );
+
+    expect(bestApiMatch).toBeDefined();
+
+    const bestApiParams = bestApiMatch![1]
+      .split(",")
+      .map((p) => p.trim())
+      .filter(Boolean);
+
+    expect(
+      bestApiParams.some((p) => p === "history" || p.includes("history")),
+    ).toBe(true);
+
+    const nonGatewayMatch = hermesSrc.match(
+      /async function sendMessageViaNonGatewayApi\([\s\S]*?\): Promise<ChatHandle> \{[\s\S]*?return sendMessageViaApi\(([\s\S]*?)\);[\s\S]*?\}/,
+    );
+
+    expect(nonGatewayMatch).toBeDefined();
+
+    const nonGatewayParams = nonGatewayMatch![1]
+      .split(",")
+      .map((p) => p.trim())
+      .filter(Boolean);
+
+    expect(
+      nonGatewayParams.some((p) => p === "history" || p.includes("history")),
+    ).toBe(true);
   });
 });

--- a/tests/tool-activity-group-title.test.ts
+++ b/tests/tool-activity-group-title.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { toolActivityGroupTitle } from "../src/renderer/src/screens/Chat/HistoryRow";
+import type {
+  ToolCallMessage,
+  ToolResultMessage,
+} from "../src/renderer/src/screens/Chat/types";
+
+const call = (id: string, name: string): ToolCallMessage => ({
+  id: `tool-call-${id}`,
+  kind: "tool_call",
+  role: "agent",
+  callId: id,
+  name,
+  args: "",
+  status: "completed",
+});
+
+const result = (id: string, name: string): ToolResultMessage => ({
+  id: `tool-result-${id}`,
+  kind: "tool_result",
+  role: "agent",
+  callId: id,
+  name,
+  content: "ok",
+});
+
+describe("toolActivityGroupTitle", () => {
+  it("keeps the tool name for a single call/result pair", () => {
+    expect(toolActivityGroupTitle([call("a", "terminal"), result("a", "terminal")])).toBe(
+      "terminal",
+    );
+  });
+
+  it("summarizes groups with more than one tool call", () => {
+    expect(
+      toolActivityGroupTitle([
+        call("a", "skill_view"),
+        result("a", "skill_view"),
+        call("b", "terminal"),
+        result("b", "terminal"),
+      ]),
+    ).toBe("2 tools called");
+  });
+
+  it("excludes tool results from the count", () => {
+    expect(
+      toolActivityGroupTitle([
+        call("a", "terminal"),
+        result("a", "terminal"),
+        result("b", "terminal"),
+      ]),
+    ).toBe("terminal");
+  });
+});


### PR DESCRIPTION
## Summary

Builds on #540 to use a richer live chat stream path when the active Hermes gateway supports it. The renderer can now receive structured live events for reasoning text, assistant text, tool calls, and tool results during generation, while falling back to the existing working chat path for gateways that do not expose the richer stream.

This PR is stacked as:

1. #508 fixes completed-session reconciliation for split streamed turns.
2. #540 renders structured live tool-call rows from the existing progress path.
3. This PR adds the richer stream transport and live reasoning/result handling on top.

## Details

- Adds a guarded stream-capability probe so unsupported or older gateways continue using the existing chat IPC path.
- Adds a websocket-backed stream runner in the main process and preserves cancellation behavior through the existing stop flow.
- Parses live reasoning events into structured thought rows instead of waiting for final session history.
- Parses live tool results and keeps them paired with the right invocation where the stream supplies enough identity data.
- Keeps final DB reconciliation intact so completed transcripts still converge on canonical session history.
- Adds coverage for stream parsing, gateway stream lifecycle behavior, reasoning events, tool events, and reconciliation interaction.

## Testing

- `npm test -- tests/live-tool-events.test.ts tests/live-reasoning-events.test.ts tests/reconcile-streamed-with-db.test.ts src/main/tui-gateway-stream.test.ts`
- `npm run typecheck:web`
- Live/manual desktop testing with the existing CDP harness:
  - OpenAI Codex `gpt-5.5`: tool/thought/result rows stream in chronological order and final reconciliation remains coherent.
  - DeepSeek custom provider `deepseek-v4-pro`: reasoning-capable stream content stays ordered, final answer is preserved, and final reconciliation keeps the canonical rows.
  - Repeated tool invocations no longer overwrite earlier live entries.
  - Existing fallback behavior remains available when the richer stream cannot initialize.

## Notes

This should be reviewed after #508 and #540 because it relies on both layers for coherent live and completed chat output.