### PR TITLE
fix(chat): keep IME composition Enter from sending truncated CJK text

### DIFF
--- a/src/renderer/src/screens/Chat/ChatInput.test.tsx
+++ b/src/renderer/src/screens/Chat/ChatInput.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// ChatInput pulls translations through useI18n (which requires the i18next
+// provider). Stub it so the component can render in isolation; the keys are
+// irrelevant to keyboard behavior.
+vi.mock("../../components/useI18n", () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+    locale: "en",
+    setLocale: vi.fn(),
+  }),
+}));
+
+import { ChatInput } from "./ChatInput";
+
+afterEach(cleanup);
+
+function renderInput(): {
+  onSubmit: ReturnType<typeof vi.fn>;
+  textarea: HTMLTextAreaElement;
+} {
+  const onSubmit = vi.fn();
+  render(
+    <ChatInput
+      isLoading={false}
+      hasSession={true}
+      onSubmit={onSubmit}
+      onQuickAsk={vi.fn()}
+      onAbort={vi.fn()}
+    />,
+  );
+  const textarea = screen.getByPlaceholderText(
+    "chat.typeMessage",
+  ) as HTMLTextAreaElement;
+  return { onSubmit, textarea };
+}
+
+describe("ChatInput — CJK IME Enter handling", () => {
+  // Repro: typing Korean (or any CJK IME), the final syllable stays in
+  // composition. macOS Chromium can deliver the finalizing Enter as a plain
+  // keydown (isComposing=false, keyCode=13) before compositionend commits the
+  // last syllable, so submitting on that keydown sends a truncated message.
+  it("does not submit while an IME composition is still active", () => {
+    const { onSubmit, textarea } = renderInput();
+
+    fireEvent.compositionStart(textarea);
+    // State only holds what was committed so far — last syllable not yet in.
+    fireEvent.change(textarea, { target: { value: "안녕하세" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    // Must not fire — otherwise the truncated "안녕하세" goes out.
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits the full text after composition ends", () => {
+    const { onSubmit, textarea } = renderInput();
+
+    fireEvent.compositionStart(textarea);
+    fireEvent.change(textarea, { target: { value: "안녕하세" } });
+    fireEvent.keyDown(textarea, { key: "Enter" }); // swallowed: still composing
+
+    // compositionend commits the last syllable; React flushes the full value.
+    fireEvent.compositionEnd(textarea, { target: { value: "안녕하세요" } });
+    fireEvent.change(textarea, { target: { value: "안녕하세요" } });
+    fireEvent.keyDown(textarea, { key: "Enter" }); // now a real submit
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith("안녕하세요", []);
+  });
+});

--- a/src/renderer/src/screens/Chat/ChatInput.tsx
+++ b/src/renderer/src/screens/Chat/ChatInput.tsx
@@ -85,6 +85,10 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
     const inputRef = useRef<HTMLTextAreaElement>(null);
     const slashMenuRef = useRef<HTMLDivElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
+    // Tracks an active IME composition (Korean/Japanese/Chinese). Driven by the
+    // composition events rather than the synthetic event's `isComposing` flag,
+    // which macOS Chromium can report as false on the finalizing Enter.
+    const composingRef = useRef(false);
 
     // Voice input. We snapshot whatever was already typed when recording starts
     // (`voiceBaseRef`), then rebuild the field as `base + livetranscript` on
@@ -302,7 +306,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
     }
 
     function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>): void {
-      if (isImeComposing(e)) return;
+      if (isImeComposing(e) || composingRef.current) return;
 
       // Slash menu keyboard navigation
       if (slashMenuOpen && filteredSlashCommands.length > 0) {
@@ -485,6 +489,12 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
             value={input}
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}
+            onCompositionStart={() => {
+              composingRef.current = true;
+            }}
+            onCompositionEnd={() => {
+              composingRef.current = false;
+            }}
             onPaste={handlePaste}
             rows={1}
             autoFocus


### PR DESCRIPTION
## Summary

- Stop Enter from sending a message while a CJK IME composition is still active, so the final syllable is never cut off (e.g. `안녕하세요` was being sent as `안녕하세`).
- Track composition with a ref driven by `onCompositionStart` / `onCompositionEnd` instead of trusting the synthetic event's `isComposing` flag.
- Add a `ChatInput` reproduction test.

Fixes #546.

## Root cause

This extends #115, which guarded Enter-to-send with `isImeComposing()` (the synthetic event's `nativeEvent.isComposing` / `keyCode === 229`) for the Japanese case in #106. On macOS, Chromium/Electron can deliver the composition-finalizing Enter as a *plain* keydown (`isComposing === false`, `keyCode === 13`) **before** `compositionend` commits the last syllable. The flag-based guard misses that case, and `handleSend` reads the controlled `input` state while it is still one syllable behind — sending truncated text.

Driving the guard off the actual `compositionstart`/`compositionend` lifecycle (a ref) instead of the per-event flag covers it: Enter is ignored until the composition is committed, then the full text submits.

## Testing

- `npx vitest run src/renderer/src/screens/Chat/ChatInput.test.tsx` — new reproduction test (fires `compositionStart` → `change` → `Enter`, asserts **no** submit while composing; then `compositionEnd` → `Enter`, asserts the full text submits once). Fails on `main`, passes here.
- `npx vitest run src/renderer/src/screens/Chat/keyboard.test.ts` — existing IME helper tests still pass.
- `npm run typecheck` — clean.
- `npx eslint src/renderer/src/screens/Chat/ChatInput.tsx src/renderer/src/screens/Chat/ChatInput.test.tsx` — clean.
- `npm test` — full suite passes except the pre-existing, unrelated `src/renderer/src/components/ConfigHealthBanner.test.tsx` failures, which are already present on `main`.
- Manually verified with `npm run dev` on macOS using the Korean 2-set (두벌식) IME: `안녕하세요` + Enter now sends in full.

## Scope

Two files, +82/−1. No formatting sweeps or unrelated changes.
