### PR TITLE
docs: fix dead issue links (NousResearch/hermes-desktop → fathah/hermes-desktop)

### DIFF
--- a/CONTRIBUTING.ja-JP.md
+++ b/CONTRIBUTING.ja-JP.md
@@ -62,7 +62,7 @@ PR は小さく目的を絞ってください — その方がレビューもマ
 
 ## バグ報告
 
-バグを見つけた場合は、以下の情報を添えて [Issue を作成してください](https://github.com/NousResearch/hermes-desktop/issues/new)。
+バグを見つけた場合は、以下の情報を添えて [Issue を作成してください](https://github.com/fathah/hermes-desktop/issues/new)。
 
 - 明確なタイトルと説明
 - 再現手順
@@ -71,7 +71,7 @@ PR は小さく目的を絞ってください — その方がレビューもマ
 
 ## 機能リクエスト
 
-アイデアがある場合は、[Issue を作成して](https://github.com/NousResearch/hermes-desktop/issues/new)以下を記述してください。
+アイデアがある場合は、[Issue を作成して](https://github.com/fathah/hermes-desktop/issues/new)以下を記述してください。
 
 - 解決したい問題
 - どのように動作してほしいか

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ A maintainer will review your PR and may request changes. Once approved, it will
 
 ## Reporting Bugs
 
-Found a bug? [Open an issue](https://github.com/NousResearch/hermes-desktop/issues/new) with:
+Found a bug? [Open an issue](https://github.com/fathah/hermes-desktop/issues/new) with:
 
 - A clear title and description.
 - Steps to reproduce the issue.
@@ -71,7 +71,7 @@ Found a bug? [Open an issue](https://github.com/NousResearch/hermes-desktop/issu
 
 ## Requesting Features
 
-Have an idea? [Open an issue](https://github.com/NousResearch/hermes-desktop/issues/new) and describe:
+Have an idea? [Open an issue](https://github.com/fathah/hermes-desktop/issues/new) and describe:
 
 - The problem you're trying to solve.
 - How you'd like it to work.

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -62,7 +62,7 @@
 
 ## 报告 Bug
 
-如果你发现了 bug，请在 GitHub 上 [提交 issue](https://github.com/NousResearch/hermes-desktop/issues/new)，并尽量包含：
+如果你发现了 bug，请在 GitHub 上 [提交 issue](https://github.com/fathah/hermes-desktop/issues/new)，并尽量包含：
 
 - 清晰的标题和描述
 - 复现步骤
@@ -71,7 +71,7 @@
 
 ## 功能请求
 
-如果你有新想法，也欢迎 [提交 issue](https://github.com/NousResearch/hermes-desktop/issues/new)，并描述：
+如果你有新想法，也欢迎 [提交 issue](https://github.com/fathah/hermes-desktop/issues/new)，并描述：
 
 - 你想解决的问题
 - 你希望它如何工作

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -259,7 +259,7 @@ Hermes のファイルは以下の場所で管理されます。
 
 ## コントリビューション
 
-コントリビューションを歓迎します！始め方は[コントリビューションガイド](CONTRIBUTING.md)をご覧ください。どこから手を付ければよいか分からない場合は、[Open Issues](https://github.com/NousResearch/hermes-desktop/issues) を確認してください。バグを見つけた、または機能要望がある場合は [Issue を作成してください](https://github.com/NousResearch/hermes-desktop/issues/new)。
+コントリビューションを歓迎します！始め方は[コントリビューションガイド](CONTRIBUTING.md)をご覧ください。どこから手を付ければよいか分からない場合は、[Open Issues](https://github.com/fathah/hermes-desktop/issues) を確認してください。バグを見つけた、または機能要望がある場合は [Issue を作成してください](https://github.com/fathah/hermes-desktop/issues/new)。
 
 ## 関連プロジェクト
 

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Hermes files are managed in:
 
 ## Contributing
 
-Contributions are welcome! Check out the [Contributing Guide](CONTRIBUTING.md) to get started. If you're not sure where to begin, take a look at the [open issues](https://github.com/NousResearch/hermes-desktop/issues). Found a bug or have a feature request? [File an issue](https://github.com/NousResearch/hermes-desktop/issues/new).
+Contributions are welcome! Check out the [Contributing Guide](CONTRIBUTING.md) to get started. If you're not sure where to begin, take a look at the [open issues](https://github.com/fathah/hermes-desktop/issues). Found a bug or have a feature request? [File an issue](https://github.com/fathah/hermes-desktop/issues/new).
 
 ## Related Project
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -259,7 +259,7 @@ Hermes 的相关文件统一管理于以下目录：
 
 ## 参与贡献
 
-欢迎大家参与贡献！查看 [参与贡献指南 (Contributing Guide)](CONTRIBUTING.md) 以开始。如果您不知从何入手，可以看一看 [开启的 Issues](https://github.com/NousResearch/hermes-desktop/issues)。发现了 Bug 或是对功能有新的需求？ [提交一个 Issue](https://github.com/NousResearch/hermes-desktop/issues/new)。
+欢迎大家参与贡献！查看 [参与贡献指南 (Contributing Guide)](CONTRIBUTING.md) 以开始。如果您不知从何入手，可以看一看 [开启的 Issues](https://github.com/fathah/hermes-desktop/issues)。发现了 Bug 或是对功能有新的需求？ [提交一个 Issue](https://github.com/fathah/hermes-desktop/issues/new)。
 
 ## 相关项目
 


### PR DESCRIPTION
## Summary

- The contribution docs linked bug/feature reporting to `github.com/NousResearch/hermes-desktop`, which **does not exist (404)** — so clicking "Open an issue" / "File an issue" / "open issues" lands contributors on a dead page.
- This repo lives at `fathah/hermes-desktop`; point the links there across the English, Japanese, and Simplified Chinese docs.

## Changes

`NousResearch/hermes-desktop` → `fathah/hermes-desktop` in:

- `CONTRIBUTING.md`, `CONTRIBUTING.ja-JP.md`, `CONTRIBUTING.zh-CN.md` (Reporting Bugs / Requesting Features)
- `README.md`, `README.ja-JP.md`, `README.zh-CN.md` (Contributing section)

Link-only change, 9 lines. The `NousResearch/hermes-agent` and `discord.gg/NousResearch` links are intentionally left untouched — those are correct.

## Note

This assumes the desktop app's canonical home is `fathah/hermes-desktop` (matching the badges, releases, and license links already in the README). If a move to a `NousResearch` org is planned instead, let me know and I'll repoint these the other way.
