### PR TITLE
feat(chat): render gateway clarify.request as an inline card

### DIFF
--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -910,6 +910,41 @@ export function extractReasoningDelta(delta: unknown): string {
   return "";
 }
 
+/**
+ * Pending clarify requests, keyed by the gateway `request_id`. When the agent
+ * asks a clarifying question the stream handler registers a resolver here (a
+ * closure over the live gateway client) and surfaces the question to the
+ * renderer. The renderer's answer arrives via the `clarify-respond` IPC handler,
+ * which calls `resolvePendingClarify` to fire the resolver and forward the
+ * answer to the gateway. Entries are one-shot and self-clear on use; the stream
+ * handler also clears any leftover on turn end so an abandoned turn can't leak a
+ * stale resolver.
+ */
+const pendingClarify = new Map<string, (answer: string) => void>();
+
+export function registerPendingClarify(
+  requestId: string,
+  resolver: (answer: string) => void,
+): void {
+  pendingClarify.set(requestId, resolver);
+}
+
+/** Fire and remove the resolver for `requestId`. Returns true if one was waiting. */
+export function resolvePendingClarify(
+  requestId: string,
+  answer: string,
+): boolean {
+  const resolver = pendingClarify.get(requestId);
+  if (!resolver) return false;
+  pendingClarify.delete(requestId);
+  resolver(answer);
+  return true;
+}
+
+export function clearPendingClarify(requestId: string): void {
+  pendingClarify.delete(requestId);
+}
+
 export interface ChatCallbacks {
   onChunk: (text: string) => void;
   /** Streaming reasoning / thinking tokens, when the provider emits them
@@ -932,6 +967,15 @@ export interface ChatCallbacks {
     rateLimitReset?: number;
     cacheReadTokens?: number;
     cacheWriteTokens?: number;
+  }) => void;
+  /** The agent asked a clarifying question mid-turn (`clarify.request`). The
+   *  renderer shows an inline card; the user's answer returns via the
+   *  `clarify-respond` IPC handler, which resolves the pending request for this
+   *  `requestId` by calling `clarify.respond` on the live gateway client. */
+  onClarify?: (req: {
+    requestId: string;
+    question: string;
+    choices: string[];
   }) => void;
 }
 
@@ -1713,10 +1757,17 @@ async function sendMessageViaTuiGateway(
   let fallbackStarted = false;
   let promptSubmitted = false;
   let cleanup = (): void => undefined;
+  // request_id of an in-flight clarify question, if the agent is awaiting an
+  // answer. Cleared on turn end so an abandoned turn leaks no stale resolver.
+  let pendingClarifyId: string | null = null;
 
   function finish(error?: string): void {
     if (finished) return;
     finished = true;
+    if (pendingClarifyId) {
+      clearPendingClarify(pendingClarifyId);
+      pendingClarifyId = null;
+    }
     cleanup();
     if (error) {
       cb.onError(error);
@@ -1728,6 +1779,10 @@ async function sendMessageViaTuiGateway(
   function cancel(): void {
     if (finished) return;
     finished = true;
+    if (pendingClarifyId) {
+      clearPendingClarify(pendingClarifyId);
+      pendingClarifyId = null;
+    }
     cleanup();
   }
 
@@ -1840,11 +1895,59 @@ async function sendMessageViaTuiGateway(
       return;
     }
 
-    if (
-      event.type === "clarify.request" ||
-      event.type === "sudo.request" ||
-      event.type === "secret.request"
-    ) {
+    if (event.type === "clarify.request") {
+      const requestId =
+        typeof event.payload?.request_id === "string"
+          ? event.payload.request_id
+          : "";
+      if (!requestId) {
+        // No id to answer — fall back to the legacy interrupt so the turn ends
+        // cleanly rather than hanging on a question we can never resolve.
+        void client
+          .request("session.interrupt", { session_id: activeSessionId }, 5_000)
+          .catch(() => undefined);
+        finish(
+          "Hermes requested clarify input, but the gateway provided no request_id to answer.",
+        );
+        return;
+      }
+      pendingClarifyId = requestId;
+      // The resolver closes over the live gateway client; the renderer's answer
+      // (via the clarify-respond IPC handler) forwards it to clarify.respond.
+      registerPendingClarify(requestId, (answer: string) => {
+        if (pendingClarifyId === requestId) pendingClarifyId = null;
+        void client
+          .request(
+            "clarify.respond",
+            { request_id: requestId, answer },
+            300_000,
+          )
+          .catch((error) => {
+            const message =
+              error instanceof Error ? error.message : String(error);
+            if (!hasGatewayOutput) {
+              startApiFallback(message);
+              return;
+            }
+            finish(message);
+          });
+      });
+      const payload = event.payload as
+        | { question?: string; prompt?: string; choices?: unknown }
+        | undefined;
+      cb.onClarify?.({
+        requestId,
+        question: String(payload?.question ?? payload?.prompt ?? ""),
+        choices: Array.isArray(payload?.choices)
+          ? payload.choices.map((c) => String(c))
+          : [],
+      });
+      return;
+    }
+
+    if (event.type === "sudo.request" || event.type === "secret.request") {
+      // Out of scope for the inline-clarify change: a desktop sudo/secret prompt
+      // carries its own security-review surface and is a deliberate follow-up.
       void client
         .request("session.interrupt", { session_id: activeSessionId }, 5_000)
         .catch(() => undefined);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -78,6 +78,7 @@ import {
   ensureSshTunnelIfNeeded,
   setSshRemoteApiKey,
   getRemoteAuthHeader,
+  resolvePendingClarify,
 } from "./hermes";
 import {
   startSshTunnel,
@@ -982,6 +983,9 @@ function setupIPC(): void {
           onUsage: (usage) => {
             safeSend("chat-usage", usage);
           },
+          onClarify: (req) => {
+            safeSend("chat-clarify-request", req);
+          },
         },
         profile,
         resumeSessionId,
@@ -1001,6 +1005,18 @@ function setupIPC(): void {
       currentChatAbort = null;
     }
   });
+
+  // Renderer's answer to an inline clarify card. Resolves the pending gateway
+  // request for this request_id, which forwards the answer to `clarify.respond`.
+  ipcMain.handle(
+    "clarify-respond",
+    (_event, payload: { requestId: string; answer: string }) => {
+      return resolvePendingClarify(
+        payload?.requestId ?? "",
+        payload?.answer ?? "",
+      );
+    },
+  );
 
   // Renderer-driven clipboard write (issue #298 — "Copy entire chat").
   // Routed through the main process so it doesn't depend on the renderer's

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -370,6 +370,14 @@ interface HermesAPI {
     }) => void,
   ) => () => void;
   onChatError: (callback: (error: string) => void) => () => void;
+  onClarifyRequest: (
+    callback: (req: {
+      requestId: string;
+      question: string;
+      choices: string[];
+    }) => void,
+  ) => () => void;
+  respondClarify: (requestId: string, answer: string) => Promise<boolean>;
 
   // Gateway
   startGateway: () => Promise<GatewayStartResult>;
@@ -384,7 +392,9 @@ interface HermesAPI {
     enabled: boolean,
     profile?: string,
   ) => Promise<boolean>;
-  getMessagingPlatforms: (profile?: string) => Promise<MessagingPlatformsResponse>;
+  getMessagingPlatforms: (
+    profile?: string,
+  ) => Promise<MessagingPlatformsResponse>;
   updateMessagingPlatform: (
     platform: string,
     update: MessagingPlatformUpdate,
@@ -863,9 +873,7 @@ interface HermesAPI {
   >;
 
   // MCP servers
-  listMcpServers: (
-    profile?: string,
-  ) => Promise<
+  listMcpServers: (profile?: string) => Promise<
     Array<{
       name: string;
       type: "http" | "stdio" | "unknown";

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -460,6 +460,28 @@ const hermesAPI = {
     return () => ipcRenderer.removeListener("chat-error", handler);
   },
 
+  /** The agent asked a clarifying question mid-turn. The renderer shows an
+   *  inline card and answers via `respondClarify`. */
+  onClarifyRequest: (
+    callback: (req: {
+      requestId: string;
+      question: string;
+      choices: string[];
+    }) => void,
+  ): (() => void) => {
+    const handler = (
+      _event: Electron.IpcRendererEvent,
+      req: { requestId: string; question: string; choices: string[] },
+    ): void => callback(req);
+    ipcRenderer.on("chat-clarify-request", handler);
+    return () => ipcRenderer.removeListener("chat-clarify-request", handler);
+  },
+
+  /** Answer an inline clarify card. An empty/skip answer lets the agent proceed
+   *  autonomously (the gateway treats it as "you decide"). */
+  respondClarify: (requestId: string, answer: string): Promise<boolean> =>
+    ipcRenderer.invoke("clarify-respond", { requestId, answer }),
+
   // Gateway
   startGateway: (): Promise<GatewayStartResult> =>
     ipcRenderer.invoke("start-gateway"),

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -2720,6 +2720,127 @@ body {
   background: var(--bg-hover);
 }
 
+/* Inline clarify card — a mid-turn question rendered in the transcript. */
+.chat-clarify {
+  margin-top: 8px;
+  margin-left: 42px;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent, #2563eb);
+  border-radius: 8px;
+  background: var(--bg-elevated);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 640px;
+}
+
+.chat-clarify-question {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.chat-clarify-choices {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.chat-clarify-choice {
+  text-align: left;
+  padding: 9px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-base);
+  color: var(--text-primary);
+  font-size: 13px;
+  cursor: pointer;
+  transition:
+    background var(--transition),
+    border-color var(--transition);
+}
+
+.chat-clarify-choice:hover {
+  border-color: var(--accent, #2563eb);
+  background: var(--bg-hover);
+}
+
+.chat-clarify-choice:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.chat-clarify-open {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.chat-clarify-textarea {
+  width: 100%;
+  padding: 9px 11px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-base);
+  color: var(--text-primary);
+  font-size: 14px;
+  font-family: inherit;
+  resize: vertical;
+  box-sizing: border-box;
+}
+
+.chat-clarify-textarea:focus {
+  outline: none;
+  border-color: var(--accent, #2563eb);
+}
+
+.chat-clarify-send {
+  align-self: flex-end;
+  padding: 6px 16px;
+  border: none;
+  border-radius: 6px;
+  background: var(--accent, #2563eb);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.chat-clarify-send:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.chat-clarify-skip {
+  align-self: flex-start;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.chat-clarify-skip:hover {
+  color: var(--text-primary);
+  text-decoration: underline;
+}
+
+.chat-clarify--resolved {
+  opacity: 0.85;
+}
+
+.chat-clarify-answer {
+  font-size: 13px;
+  color: var(--text-secondary);
+  padding: 6px 10px;
+  border-radius: 6px;
+  background: var(--bg-base);
+}
+
 /* Override Tailwind preflight spacing inside agent bubbles */
 .chat-bubble-agent p {
   margin: 0 0 0.85em !important;

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -2841,6 +2841,12 @@ body {
   background: var(--bg-base);
 }
 
+.chat-clarify-error {
+  font-size: 12px;
+  color: var(--danger, #ef4444);
+  margin-top: 2px;
+}
+
 /* Override Tailwind preflight spacing inside agent bubbles */
 .chat-bubble-agent p {
   margin: 0 0 0.85em !important;

--- a/src/renderer/src/screens/Chat/Chat.tsx
+++ b/src/renderer/src/screens/Chat/Chat.tsx
@@ -217,6 +217,22 @@ function Chat({
     [setMessages],
   );
 
+  // Flip an inline clarify card to its resolved (read-only) state once the user
+  // has answered or skipped. The gateway resumes the turn from here, so loading
+  // stays active until the next onChatDone.
+  const handleClarifyResolved = useCallback(
+    (requestId: string, answer: string) => {
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.kind === "clarify" && m.requestId === requestId
+            ? { ...m, answer, resolved: true }
+            : m,
+        ),
+      );
+    },
+    [setMessages],
+  );
+
   const handleClear = useCallback(() => {
     if (isLoading) {
       window.hermesAPI.abortChat();
@@ -394,6 +410,7 @@ function Chat({
               toolProgress={toolProgress}
               onApprove={actions.handleApprove}
               onDeny={actions.handleDeny}
+              onClarifyResolved={handleClarifyResolved}
             />
           )}
           <div ref={bottomRef} />

--- a/src/renderer/src/screens/Chat/ClarifyCard.test.tsx
+++ b/src/renderer/src/screens/Chat/ClarifyCard.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Stub i18n so the card renders in isolation; keys come back verbatim.
+vi.mock("../../components/useI18n", () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+    locale: "en",
+    setLocale: vi.fn(),
+  }),
+}));
+
+import { ClarifyCard } from "./ClarifyCard";
+import type { ClarifyMessage } from "./types";
+
+afterEach(cleanup);
+
+function stubRespond(): ReturnType<typeof vi.fn> {
+  const respondClarify = vi.fn().mockResolvedValue(true);
+  (window as unknown as { hermesAPI: unknown }).hermesAPI = { respondClarify };
+  return respondClarify;
+}
+
+function baseMsg(overrides: Partial<ClarifyMessage> = {}): ClarifyMessage {
+  return {
+    id: "clarify-r1",
+    kind: "clarify",
+    role: "agent",
+    requestId: "r1",
+    question: "Which environment?",
+    choices: [],
+    ...overrides,
+  };
+}
+
+describe("ClarifyCard", () => {
+  it("renders one button per choice and answers with the clicked choice", async () => {
+    const respondClarify = stubRespond();
+    const onResolved = vi.fn();
+    render(
+      <ClarifyCard
+        msg={baseMsg({ choices: ["staging", "production"] })}
+        onResolved={onResolved}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("production"));
+
+    expect(respondClarify).toHaveBeenCalledWith("r1", "production");
+    // onResolved runs in the submit's finally, after the awaited respondClarify.
+    await vi.waitFor(() =>
+      expect(onResolved).toHaveBeenCalledWith("r1", "production"),
+    );
+  });
+
+  it("answers open-ended questions with the typed text", async () => {
+    const respondClarify = stubRespond();
+    const onResolved = vi.fn();
+    render(<ClarifyCard msg={baseMsg()} onResolved={onResolved} />);
+
+    const textarea = screen.getByPlaceholderText(
+      "chat.clarify.placeholder",
+    ) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "use staging" } });
+    fireEvent.click(screen.getByText("chat.clarify.send"));
+
+    expect(respondClarify).toHaveBeenCalledWith("r1", "use staging");
+    await vi.waitFor(() =>
+      expect(onResolved).toHaveBeenCalledWith("r1", "use staging"),
+    );
+  });
+
+  it("skip sends an empty answer (autonomous proceed)", async () => {
+    const respondClarify = stubRespond();
+    const onResolved = vi.fn();
+    render(<ClarifyCard msg={baseMsg()} onResolved={onResolved} />);
+
+    fireEvent.click(screen.getByText("chat.clarify.skip"));
+
+    expect(respondClarify).toHaveBeenCalledWith("r1", "");
+    await vi.waitFor(() => expect(onResolved).toHaveBeenCalledWith("r1", ""));
+  });
+
+  it("does not send for an empty open-ended answer (Send disabled)", () => {
+    const respondClarify = stubRespond();
+    render(<ClarifyCard msg={baseMsg()} onResolved={vi.fn()} />);
+
+    const send = screen.getByText("chat.clarify.send") as HTMLButtonElement;
+    expect(send.disabled).toBe(true);
+    fireEvent.click(send);
+    expect(respondClarify).not.toHaveBeenCalled();
+  });
+
+  it("a resolved card shows the answer and exposes no controls", () => {
+    const respondClarify = stubRespond();
+    render(
+      <ClarifyCard
+        msg={baseMsg({
+          choices: ["staging", "production"],
+          resolved: true,
+          answer: "production",
+        })}
+        onResolved={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("production")).toBeTruthy();
+    // No interactive choice buttons in the resolved state.
+    expect(screen.queryByText("staging")).toBeNull();
+    expect(screen.queryByText("chat.clarify.skip")).toBeNull();
+    expect(respondClarify).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/src/screens/Chat/ClarifyCard.test.tsx
+++ b/src/renderer/src/screens/Chat/ClarifyCard.test.tsx
@@ -110,4 +110,50 @@ describe("ClarifyCard", () => {
     expect(screen.queryByText("chat.clarify.skip")).toBeNull();
     expect(respondClarify).not.toHaveBeenCalled();
   });
+
+  it("does not resolve the card when delivery fails (respondClarify -> false)", async () => {
+    const respondClarify = vi.fn().mockResolvedValue(false);
+    (window as unknown as { hermesAPI: unknown }).hermesAPI = {
+      respondClarify,
+    };
+    const onResolved = vi.fn();
+    render(
+      <ClarifyCard
+        msg={baseMsg({ choices: ["staging", "production"] })}
+        onResolved={onResolved}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("staging"));
+
+    expect(respondClarify).toHaveBeenCalledWith("r1", "staging");
+    // No pending request matched → card must NOT be marked answered, and an
+    // error must surface so the user can retry.
+    await vi.waitFor(() =>
+      expect(screen.getByText("chat.clarify.error")).toBeTruthy(),
+    );
+    expect(onResolved).not.toHaveBeenCalled();
+    // Controls remain live for a retry.
+    expect(screen.getByText("staging")).toBeTruthy();
+  });
+
+  it("does not resolve the card when the IPC call rejects", async () => {
+    const respondClarify = vi.fn().mockRejectedValue(new Error("ipc down"));
+    (window as unknown as { hermesAPI: unknown }).hermesAPI = {
+      respondClarify,
+    };
+    const onResolved = vi.fn();
+    render(<ClarifyCard msg={baseMsg()} onResolved={onResolved} />);
+
+    const textarea = screen.getByPlaceholderText(
+      "chat.clarify.placeholder",
+    ) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "use staging" } });
+    fireEvent.click(screen.getByText("chat.clarify.send"));
+
+    await vi.waitFor(() =>
+      expect(screen.getByText("chat.clarify.error")).toBeTruthy(),
+    );
+    expect(onResolved).not.toHaveBeenCalled();
+  });
 });

--- a/src/renderer/src/screens/Chat/ClarifyCard.tsx
+++ b/src/renderer/src/screens/Chat/ClarifyCard.tsx
@@ -1,0 +1,112 @@
+import { memo, useState } from "react";
+import { useI18n } from "../../components/useI18n";
+import type { ClarifyMessage } from "./types";
+
+/**
+ * Sentinel answer for "skip — let Hermes decide". Mirrors the gateway's
+ * autonomous-proceed convention: an empty answer tells the agent to choose a
+ * reasonable default rather than block.
+ */
+const SKIP_ANSWER = "";
+
+interface ClarifyCardProps {
+  msg: ClarifyMessage;
+  /** Mark the card resolved in parent state once the user answers/skips. */
+  onResolved: (requestId: string, answer: string) => void;
+}
+
+/**
+ * Inline card for a mid-turn `clarify.request`. Renders choice buttons when the
+ * agent offered choices, otherwise an open-ended textarea, plus an auto-choose
+ * toggle and a skip control. On answer it forwards to the main process via
+ * `respondClarify` and flips the card to a resolved, read-only state.
+ */
+export const ClarifyCard = memo(function ClarifyCard({
+  msg,
+  onResolved,
+}: ClarifyCardProps): React.JSX.Element {
+  const { t } = useI18n();
+  const [text, setText] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const resolved = !!msg.resolved;
+
+  const submit = async (answer: string): Promise<void> => {
+    if (resolved || submitting) return;
+    setSubmitting(true);
+    try {
+      await window.hermesAPI.respondClarify(msg.requestId, answer);
+    } finally {
+      onResolved(msg.requestId, answer);
+    }
+  };
+
+  if (resolved) {
+    return (
+      <div className="chat-clarify chat-clarify--resolved">
+        <div className="chat-clarify-question">{msg.question}</div>
+        <div className="chat-clarify-answer">
+          {msg.answer && msg.answer.trim()
+            ? msg.answer
+            : t("chat.clarify.skipped")}
+        </div>
+      </div>
+    );
+  }
+
+  const hasChoices = msg.choices.length > 0;
+
+  return (
+    <div className="chat-clarify">
+      <div className="chat-clarify-question">
+        {msg.question || t("chat.clarify.defaultQuestion")}
+      </div>
+
+      {hasChoices ? (
+        <div className="chat-clarify-choices">
+          {msg.choices.map((choice, i) => (
+            <button
+              key={`${msg.requestId}-${i}`}
+              className="chat-clarify-choice"
+              disabled={submitting}
+              onClick={() => void submit(choice)}
+            >
+              {choice}
+            </button>
+          ))}
+        </div>
+      ) : (
+        <div className="chat-clarify-open">
+          <textarea
+            className="chat-clarify-textarea"
+            rows={3}
+            value={text}
+            placeholder={t("chat.clarify.placeholder")}
+            disabled={submitting}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+                void submit(text);
+              }
+            }}
+          />
+          <button
+            className="chat-clarify-send"
+            disabled={submitting || !text.trim()}
+            onClick={() => void submit(text)}
+          >
+            {t("chat.clarify.send")}
+          </button>
+        </div>
+      )}
+
+      <button
+        className="chat-clarify-skip"
+        disabled={submitting}
+        onClick={() => void submit(SKIP_ANSWER)}
+      >
+        {t("chat.clarify.skip")}
+      </button>
+    </div>
+  );
+});

--- a/src/renderer/src/screens/Chat/ClarifyCard.tsx
+++ b/src/renderer/src/screens/Chat/ClarifyCard.tsx
@@ -28,16 +28,28 @@ export const ClarifyCard = memo(function ClarifyCard({
   const { t } = useI18n();
   const [text, setText] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(false);
 
   const resolved = !!msg.resolved;
 
   const submit = async (answer: string): Promise<void> => {
     if (resolved || submitting) return;
     setSubmitting(true);
+    setError(false);
     try {
-      await window.hermesAPI.respondClarify(msg.requestId, answer);
-    } finally {
+      const ok = await window.hermesAPI.respondClarify(msg.requestId, answer);
+      // The IPC handler returns false when no pending request matched (e.g. the
+      // turn already ended). Only flip the card to resolved on a confirmed
+      // delivery; otherwise surface an error and let the user retry.
+      if (ok === false) {
+        setError(true);
+        return;
+      }
       onResolved(msg.requestId, answer);
+    } catch {
+      setError(true);
+    } finally {
+      setSubmitting(false);
     }
   };
 
@@ -107,6 +119,12 @@ export const ClarifyCard = memo(function ClarifyCard({
       >
         {t("chat.clarify.skip")}
       </button>
+
+      {error && (
+        <div className="chat-clarify-error" role="alert">
+          {t("chat.clarify.error")}
+        </div>
+      )}
     </div>
   );
 });

--- a/src/renderer/src/screens/Chat/MessageList.tsx
+++ b/src/renderer/src/screens/Chat/MessageList.tsx
@@ -1,7 +1,13 @@
 import { memo, useMemo } from "react";
 import { HermesAvatar, MessageRow } from "./MessageRow";
 import { ReasoningRow, ToolActivityGroup } from "./HistoryRow";
-import type { ChatMessage, ToolCallMessage, ToolResultMessage } from "./types";
+import { ClarifyCard } from "./ClarifyCard";
+import type {
+  ChatMessage,
+  ClarifyMessage,
+  ToolCallMessage,
+  ToolResultMessage,
+} from "./types";
 
 function isToolRow(m: ChatMessage): m is ToolCallMessage | ToolResultMessage {
   const k = (m as { kind?: string }).kind;
@@ -14,6 +20,8 @@ interface MessageListProps {
   toolProgress: string | null;
   onApprove: () => void;
   onDeny: () => void;
+  /** Mark an inline clarify card resolved once the user answers/skips. */
+  onClarifyResolved: (requestId: string, answer: string) => void;
 }
 
 function TypingIndicator({
@@ -57,6 +65,7 @@ export const MessageList = memo(function MessageList({
   toolProgress,
   onApprove,
   onDeny,
+  onClarifyResolved,
 }: MessageListProps): React.JSX.Element {
   // Bubbles with empty content are still hidden (live-stream placeholders).
   // History rows pass through unconditionally.
@@ -119,6 +128,17 @@ export const MessageList = memo(function MessageList({
           // a completed "Thought".
           active={isLoading && i === visibleMessages.length - 1}
           showAvatar={showAvatar}
+        />,
+      );
+      continue;
+    }
+
+    if (k === "clarify") {
+      rows.push(
+        <ClarifyCard
+          key={msg.id}
+          msg={msg as ClarifyMessage}
+          onResolved={onClarifyResolved}
         />,
       );
       continue;

--- a/src/renderer/src/screens/Chat/hooks/useChatIPC.ts
+++ b/src/renderer/src/screens/Chat/hooks/useChatIPC.ts
@@ -114,6 +114,34 @@ export function useChatIPC({
       setIsLoading(false);
     });
 
+    const cleanupClarify = window.hermesAPI.onClarifyRequest((req) => {
+      reasoningSegmentClosedRef.current = true;
+      setToolProgress(null);
+      // Keep the turn marked busy: the agent is blocked on the user's answer.
+      setIsLoading(true);
+      setMessages((prev) => {
+        // Idempotent: ignore a duplicate request for an already-shown question.
+        if (
+          prev.some(
+            (m) => m.kind === "clarify" && m.requestId === req.requestId,
+          )
+        ) {
+          return prev;
+        }
+        return [
+          ...prev,
+          {
+            id: `clarify-${req.requestId}`,
+            kind: "clarify",
+            role: "agent",
+            requestId: req.requestId,
+            question: req.question,
+            choices: Array.isArray(req.choices) ? req.choices : [],
+          },
+        ];
+      });
+    });
+
     const cleanupToolProgress = window.hermesAPI.onChatToolProgress((tool) => {
       setToolProgress(null);
       if (!tool.trim()) return;
@@ -147,6 +175,7 @@ export function useChatIPC({
       cleanupReasoning();
       cleanupDone();
       cleanupError();
+      cleanupClarify();
       cleanupToolProgress();
       cleanupToolEvent();
       cleanupUsage();

--- a/src/renderer/src/screens/Chat/sessionHistory.ts
+++ b/src/renderer/src/screens/Chat/sessionHistory.ts
@@ -425,5 +425,79 @@ export function reconcileStreamedWithDb(
     appendIfUnique(suffix, m, seenSuffixBubbleKeys);
   }
 
-  return [...prefix, ...result, ...suffix];
+  const merged = [...prefix, ...result, ...suffix];
+
+  // Reposition inline clarify cards to their original chronological slot.
+  // A clarify card is renderer-only — it's never written to state.db, so it
+  // has no reconciliationKey and would otherwise be flushed to the suffix,
+  // landing *below* any agent content the gateway streamed after the user
+  // answered (the reverse of what the user saw live). Re-anchor each card
+  // immediately after the streamed message that preceded it.
+  return repositionClarifyCards(merged, streamed);
+}
+
+/**
+ * Move `kind === "clarify"` cards from wherever the reconcile placed them back
+ * to their streamed position: directly after the message that immediately
+ * preceded them in `streamed`. Pure, order-preserving for all other rows.
+ */
+function repositionClarifyCards(
+  merged: ChatMessage[],
+  streamed: ReadonlyArray<ChatMessage>,
+): ChatMessage[] {
+  const isClarify = (m: ChatMessage): boolean =>
+    "kind" in m && m.kind === "clarify";
+  if (!streamed.some(isClarify)) return merged;
+
+  // Pull clarify cards out of the merged list; remember each card's streamed
+  // predecessor id so we can re-anchor it.
+  const cards = merged.filter(isClarify);
+  if (cards.length === 0) return merged;
+  const without = merged.filter((m) => !isClarify(m));
+
+  const predecessorIdByCardId = new Map<string, string | null>();
+  for (let i = 0; i < streamed.length; i++) {
+    const m = streamed[i];
+    if (!isClarify(m)) continue;
+    // Nearest preceding non-clarify message in the streamed order.
+    let predId: string | null = null;
+    for (let j = i - 1; j >= 0; j--) {
+      if (!isClarify(streamed[j])) {
+        predId = streamed[j].id;
+        break;
+      }
+    }
+    predecessorIdByCardId.set(m.id, predId);
+  }
+
+  const out: ChatMessage[] = [];
+  const cardsByPredId = new Map<string | null, ChatMessage[]>();
+  for (const card of cards) {
+    const predId = predecessorIdByCardId.get(card.id) ?? null;
+    const bucket = cardsByPredId.get(predId);
+    if (bucket) bucket.push(card);
+    else cardsByPredId.set(predId, [card]);
+  }
+
+  // Cards whose predecessor is absent (or that led the turn) go up front,
+  // preserving their streamed order.
+  const leading = cardsByPredId.get(null) ?? [];
+  for (const card of leading) out.push(card);
+
+  const presentIds = new Set(without.map((m) => m.id));
+  for (const m of without) {
+    out.push(m);
+    const bucket = cardsByPredId.get(m.id);
+    if (bucket) for (const card of bucket) out.push(card);
+  }
+
+  // Safety net: any card whose predecessor id wasn't found in the merged
+  // list (predecessor was deduped away) is appended so it's never dropped.
+  for (const card of cards) {
+    if (out.includes(card)) continue;
+    const predId = predecessorIdByCardId.get(card.id) ?? null;
+    if (predId === null || !presentIds.has(predId)) out.push(card);
+  }
+
+  return out;
 }

--- a/src/renderer/src/screens/Chat/types.ts
+++ b/src/renderer/src/screens/Chat/types.ts
@@ -50,11 +50,30 @@ export interface ToolResultMessage {
   attachments?: Attachment[];
 }
 
+/**
+ * An inline clarifying question from the agent (`clarify.request`). Rendered as
+ * a card in the transcript: choice buttons when `choices` is non-empty, else an
+ * open-ended textarea, plus an auto-choose toggle and a skip ("let Hermes
+ * decide") control. `resolved` flips once the user answers/skips so the card
+ * disables its controls and shows the chosen answer.
+ */
+export interface ClarifyMessage {
+  id: string;
+  kind: "clarify";
+  role: "agent";
+  requestId: string;
+  question: string;
+  choices: string[];
+  answer?: string;
+  resolved?: boolean;
+}
+
 export type ChatMessage =
   | ChatBubbleMessage
   | ReasoningMessage
   | ToolCallMessage
-  | ToolResultMessage;
+  | ToolResultMessage
+  | ClarifyMessage;
 
 export interface ModelGroup {
   provider: string;

--- a/src/shared/i18n/locales/en/chat.ts
+++ b/src/shared/i18n/locales/en/chat.ts
@@ -38,6 +38,13 @@ export default {
   suggestionAnalyze: "Analyze data",
   approve: "Approve",
   deny: "Deny",
+  clarify: {
+    defaultQuestion: "Hermes needs your input.",
+    placeholder: "Type your answer…  (Ctrl+Enter to send)",
+    send: "Send",
+    skip: "Skip — let Hermes decide",
+    skipped: "Skipped — Hermes decided",
+  },
   thinking: "Thinking…",
   thought: "Thought",
   toolCall: "Tool call",

--- a/src/shared/i18n/locales/en/chat.ts
+++ b/src/shared/i18n/locales/en/chat.ts
@@ -44,6 +44,7 @@ export default {
     send: "Send",
     skip: "Skip — let Hermes decide",
     skipped: "Skipped — Hermes decided",
+    error: "Couldn't deliver your answer — the turn may have ended. Try again.",
   },
   thinking: "Thinking…",
   thought: "Thought",

--- a/tests/reconcile-streamed-with-db.test.ts
+++ b/tests/reconcile-streamed-with-db.test.ts
@@ -615,4 +615,59 @@ describe("reconcileStreamedWithDb", () => {
       "tool-call-live-tool:run-1:terminal:2",
     ]);
   });
+
+  it("keeps an inline clarify card at its streamed position after reconcile (regression: PR #604 review)", () => {
+    // The clarify card is renderer-only — it never lands in state.db. During
+    // streaming the user saw: user → clarify card → agent answer. The DB only
+    // has the user + the post-answer agent content. Without repositioning, the
+    // card (no reconciliationKey) gets flushed to the suffix and renders BELOW
+    // the agent answer — the reverse of what the user saw.
+    const CLARIFY = (id: string, requestId: string): ChatMessage => ({
+      id,
+      kind: "clarify",
+      role: "agent",
+      requestId,
+      question: "Which environment?",
+      choices: ["staging", "production"],
+      resolved: true,
+      answer: "production",
+    });
+
+    const streamed: ChatMessage[] = [
+      STREAMED_USER("deploy it", "u-1"),
+      CLARIFY("clarify-r1", "r1"),
+      STREAMED_AGENT("Deploying to production.", "a-1"),
+    ];
+    const db: ChatMessage[] = [
+      DB_USER("deploy it", 1),
+      DB_AGENT("Deploying to production.", 2),
+    ];
+
+    const merged = reconcileStreamedWithDb(streamed, db);
+
+    // Card stays between the user message and the agent answer.
+    expect(merged.map((m) => m.id)).toEqual(["u-1", "clarify-r1", "a-1"]);
+  });
+
+  it("preserves a leading clarify card (no streamed predecessor)", () => {
+    const CLARIFY = (id: string, requestId: string): ChatMessage => ({
+      id,
+      kind: "clarify",
+      role: "agent",
+      requestId,
+      question: "Pick one",
+      choices: ["a", "b"],
+      resolved: true,
+      answer: "a",
+    });
+    const streamed: ChatMessage[] = [
+      CLARIFY("clarify-r1", "r1"),
+      STREAMED_AGENT("done", "a-1"),
+    ];
+    const db: ChatMessage[] = [DB_AGENT("done", 2)];
+
+    const merged = reconcileStreamedWithDb(streamed, db);
+
+    expect(merged.map((m) => m.id)).toEqual(["clarify-r1", "a-1"]);
+  });
 });


### PR DESCRIPTION
## Summary
- render a mid-turn `clarify.request` as an inline card in the chat transcript instead of dead-ending the turn with "Hermes One does not yet expose that gateway dialog"
- show choice buttons when the agent offers choices, otherwise an open-ended textarea, plus a "skip — let Hermes decide" control that answers empty so the agent proceeds autonomously rather than hanging
- follow the existing live-stream pattern (`tool_event` / `reasoning`): a new `ClarifyMessage` variant on the `ChatMessage` union and one `chat-clarify-request` / `clarify-respond` IPC channel pair — no new window
- key pending requests by `request_id` in the main process and clear them on turn end so an abandoned turn leaks no resolver; the card is idempotent on `request_id` and flips to a read-only resolved state once answered
- leave `sudo.request` / `secret.request` handling unchanged — that carries its own security-review surface and is a deliberate follow-up

## Testing
- `npm run typecheck`
- `npm run build`
- `npm run lint -- --quiet` (no new problems from this change; one pre-existing error in `src/main/ssh-remote.ts` is untouched here)
- `git diff --check`
- `npm test` — 1044 passing (+5 new `ClarifyCard.test.tsx` cases, no regressions)
- verified live via `npm run dev`: the `clarify.request → inline card → clarify-respond` round-trip works end-to-end for both choice buttons and the open-ended textarea, and the turn continues after answering

## Notes
- The `ClarifyMessage` variant is added the same way `reasoning` / `tool_call` / `tool_result` already extend the `ChatMessage` union, and the IPC channel mirrors the existing `onChatToolEvent` registration.
