### PR TITLE
fix: resolve import backup file path

### DIFF
--- a/src/renderer/src/screens/Settings/Settings.tsx
+++ b/src/renderer/src/screens/Settings/Settings.tsx
@@ -384,7 +384,7 @@ function Settings({ profile }: { profile?: string }): React.JSX.Element {
       if (!file) return;
       setImporting(true);
       setImportResult(null);
-      const filePath = (file as File & { path: string }).path;
+      const filePath = window.hermesAPI.getPathForFile(file);
       const result = await window.hermesAPI.runHermesImport(filePath, profile);
       setImporting(false);
       if (result.success) {


### PR DESCRIPTION
## Summary
- use the preload getPathForFile helper for backup archive imports
- stop relying on Electron's removed renderer File.path property
- keep the existing import IPC flow unchanged once the path is resolved

Fixes #555

## Testing
- npm run typecheck:web