### PR TITLE
fix: code block copy button not actually copying to clipboard

### DIFF
--- a/src/renderer/src/components/AgentMarkdown.tsx
+++ b/src/renderer/src/components/AgentMarkdown.tsx
@@ -70,7 +70,7 @@ function CodeBlock({
   }, [highlighterReady]);
 
   function handleCopy(): void {
-    navigator.clipboard.writeText(code);
+    window.hermesAPI.copyToClipboard(code);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   }

--- a/src/renderer/src/components/AgentMarkdown.tsx
+++ b/src/renderer/src/components/AgentMarkdown.tsx
@@ -70,7 +70,7 @@ function CodeBlock({
   }, [highlighterReady]);
 
   function handleCopy(): void {
-    window.hermesAPI.copyToClipboard(code);
+    void window.hermesAPI.copyToClipboard(code);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   }


### PR DESCRIPTION
## Problem
When clicking the copy button on generated code blocks, it shows "已复制！" (Copied!) but nothing is actually copied to the clipboard.

## Root Cause
In `src/renderer/src/components/AgentMarkdown.tsx`, the `handleCopy` function uses `navigator.clipboard.writeText()` directly:

```ts
function handleCopy(): void {
    navigator.clipboard.writeText(code);
    setCopied(true);
    setTimeout(() => setCopied(false), 2000);
}
```

In Electron, `navigator.clipboard.writeText()` may fail silently without proper permissions in the renderer process. The app already provides a proper IPC-based clipboard API via `window.hermesAPI.copyToClipboard()` which is already wired up in the preload script.

## Fix
Replace `navigator.clipboard.writeText(code)` with `window.hermesAPI.copyToClipboard(code)`.

The rest of the function (setting `copied` state for the visual feedback) remains unchanged.
