### PR TITLE
fix: prevent previously-sent messages from jumping to bottom of chat

### DIFF
--- a/src/renderer/src/screens/Chat/sessionHistory.ts
+++ b/src/renderer/src/screens/Chat/sessionHistory.ts
@@ -397,11 +397,19 @@ export function reconcileStreamedWithDb(
   // positions instead of dumping them all into a suffix (which caused messages
   // from the *middle* of the conversation to jump to the bottom — issue #431).
   //
-  // Walk the streamed array in order.  For each consumed message, flush all
-  // result items from the current resultIdx up to its position.  For each
-  // unconsumed message that passes dedup, insert it at its streamed position.
+  // Strategy: unconsumed messages that appear BEFORE the last consumed streamed
+  // message are interleaved at their correct position.  Unconsumed messages
+  // AFTER the last consumed message (e.g. error bubbles, renderer-only warnings)
+  // are deferred to a trailing suffix — matching the original behavior.
   const merged: ChatMessage[] = [];
   let resultIdx = 0;
+  const trailingSuffix: ChatMessage[] = [];
+
+  // Find the last streamed index that was consumed (matched a DB row).
+  let lastConsumedStreamIdx = -1;
+  for (let i = 0; i < streamed.length; i++) {
+    if (consumedIds.has(streamed[i].id)) lastConsumedStreamIdx = i;
+  }
 
   for (let si = 0; si < streamed.length; si++) {
     const sm = streamed[si];
@@ -415,7 +423,17 @@ export function reconcileStreamedWithDb(
         }
       }
     } else if (shouldKeepUnconsumed(sm)) {
-      merged.push(sm);
+      // Only interleave bubble messages (user/agent content) at their
+      // correct chronological positions.  Non-bubble rows (synthetic
+      // tool_call / tool_result / reasoning) that survive dedup are
+      // always deferred to the trailing suffix — matching the original
+      // behavior where they land after all DB result rows.
+      const isBubble = !("kind" in sm);
+      if (isBubble && lastConsumedStreamIdx >= 0 && si <= lastConsumedStreamIdx) {
+        merged.push(sm);
+      } else {
+        trailingSuffix.push(sm);
+      }
     }
   }
 
@@ -425,6 +443,9 @@ export function reconcileStreamedWithDb(
     merged.push(result[resultIdx]);
     resultIdx++;
   }
+
+  // Append trailing suffix (renderer-only bubbles past the last consumed msg).
+  for (const m of trailingSuffix) merged.push(m);
 
   // Reposition inline clarify cards to their original chronological slot.
   // A clarify card is renderer-only — it's never written to state.db, so it

--- a/src/renderer/src/screens/Chat/sessionHistory.ts
+++ b/src/renderer/src/screens/Chat/sessionHistory.ts
@@ -357,75 +357,74 @@ export function reconcileStreamedWithDb(
   // key-based match (e.g. trailing-whitespace drift, one-frame delta
   // that didn't round-trip through the DB identically).
   const consumedIds = new Set(result.map((m) => m.id));
-  const consumedStreamIndexes: number[] = [];
-  for (let i = 0; i < streamed.length; i++) {
-    if (consumedIds.has(streamed[i].id)) consumedStreamIndexes.push(i);
+
+  // Map each consumed streamed message to its position in the DB-ordered result.
+  const resultPosById = new Map<string, number>();
+  for (let i = 0; i < result.length; i++) {
+    resultPosById.set(result[i].id, i);
   }
-  const firstConsumedIndex =
-    consumedStreamIndexes.length > 0 ? Math.min(...consumedStreamIndexes) : -1;
 
-  const seedSeenBubbleKeys = (
-    seen: Set<string>,
-    items: ReadonlyArray<ChatMessage>,
-  ): void => {
-    for (const m of items) {
-      if (!("kind" in m)) {
-        const bubble = m as ChatBubbleMessage;
-        seen.add(
-          `${bubble.role}:${normalizeBubbleContentForMatch(bubble.content || "")}`,
-        );
-      }
+  // Seed a dedup set from all result items so unconsumed streamed messages
+  // never duplicate what the DB already provided.
+  const seenBubbleKeys = new Set<string>();
+  for (const m of result) {
+    if (!("kind" in m)) {
+      const bubble = m as ChatBubbleMessage;
+      seenBubbleKeys.add(
+        `${bubble.role}:${normalizeBubbleContentForMatch(bubble.content || "")}`,
+      );
     }
-  };
+  }
 
-  const appendIfUnique = (
-    target: ChatMessage[],
-    m: ChatMessage,
-    seen: Set<string>,
-    dropDbSplitArtifacts = true,
-  ): boolean => {
+  // Check whether an unconsumed streamed message should be kept, applying
+  // the same dedup / canonical-tool-match / DB-split-artifact rules as before.
+  const shouldKeepUnconsumed = (m: ChatMessage): boolean => {
     if (consumedIds.has(m.id)) return false;
     if (consumeCanonicalToolMatch(canonicalToolMatchCounts, m)) return false;
-    // For bubble messages, check if an equivalent already exists in the
-    // result set.  Non-bubble messages (tool_call, tool_result, reasoning)
-    // always pass through — they're either matched by callId above or are
-    // genuinely new.
     if (!("kind" in m)) {
       const bubble = m as ChatBubbleMessage;
       const contentKey = `${bubble.role}:${normalizeBubbleContentForMatch(bubble.content || "")}`;
-      if (seen.has(contentKey)) return false;
-      if (
-        dropDbSplitArtifacts &&
-        isCoveredByDbBubbleSplit(bubble, dbAssistantSplitSequences)
-      ) {
+      if (seenBubbleKeys.has(contentKey)) return false;
+      if (isCoveredByDbBubbleSplit(bubble, dbAssistantSplitSequences)) {
         return false;
       }
-      seen.add(contentKey);
+      seenBubbleKeys.add(contentKey);
     }
-    target.push(m);
     return true;
   };
 
-  const prefix: ChatMessage[] = [];
-  const seenPrefixBubbleKeys = new Set<string>();
-  for (let i = 0; i < streamed.length; i++) {
-    const m = streamed[i];
-    if (firstConsumedIndex >= 0 && i < firstConsumedIndex) {
-      appendIfUnique(prefix, m, seenPrefixBubbleKeys, false);
+  // Interleave unconsumed streamed messages at their correct chronological
+  // positions instead of dumping them all into a suffix (which caused messages
+  // from the *middle* of the conversation to jump to the bottom — issue #431).
+  //
+  // Walk the streamed array in order.  For each consumed message, flush all
+  // result items from the current resultIdx up to its position.  For each
+  // unconsumed message that passes dedup, insert it at its streamed position.
+  const merged: ChatMessage[] = [];
+  let resultIdx = 0;
+
+  for (let si = 0; si < streamed.length; si++) {
+    const sm = streamed[si];
+    if (consumedIds.has(sm.id)) {
+      // Flush result items up to (and including) this consumed message.
+      const rpos = resultPosById.get(sm.id);
+      if (rpos !== undefined && rpos >= resultIdx) {
+        while (resultIdx <= rpos) {
+          merged.push(result[resultIdx]);
+          resultIdx++;
+        }
+      }
+    } else if (shouldKeepUnconsumed(sm)) {
+      merged.push(sm);
     }
   }
 
-  const suffix: ChatMessage[] = [];
-  const seenSuffixBubbleKeys = new Set<string>();
-  seedSeenBubbleKeys(seenSuffixBubbleKeys, prefix);
-  seedSeenBubbleKeys(seenSuffixBubbleKeys, result);
-  for (let i = 0; i < streamed.length; i++) {
-    const m = streamed[i];
-    if (firstConsumedIndex >= 0 && i < firstConsumedIndex) continue;
-    appendIfUnique(suffix, m, seenSuffixBubbleKeys);
+  // Append any remaining result items (DB-only rows past the last consumed
+  // streamed message).
+  while (resultIdx < result.length) {
+    merged.push(result[resultIdx]);
+    resultIdx++;
   }
-
-  const merged = [...prefix, ...result, ...suffix];
 
   // Reposition inline clarify cards to their original chronological slot.
   // A clarify card is renderer-only — it's never written to state.db, so it


### PR DESCRIPTION
## Problem

In multi-turn conversations, after the agent finishes replying, previously-sent messages from earlier turns sometimes jump to the very bottom of the chat dialog, breaking the Q&A chronological order.

## Root Cause

The `reconcileStreamedWithDb` function in `sessionHistory.ts` merges the live-streamed transcript with state.db after each agent reply. The old code used a prefix/suffix approach:

- prefix: unconsumed messages before `firstConsumedIndex` go to the top
- suffix: unconsumed messages at/after go to the bottom

The problem: `firstConsumedIndex` is almost always 0 (the first message matches), making prefix always empty. When the DB is missing messages from the *middle* of the conversation (session split, timing, DB write delay), those mid-conversation messages get dumped into suffix — appearing at the bottom after all newer messages.

### Reproduction

```
Streamed: [turn1-user, turn1-agent, turn2-user, turn2-agent, turn3-user, turn3-agent]
DB (missing turn2): [turn1-user, turn1-agent, turn3-user, turn3-agent]

Old result: [turn1, turn3, turn2]  <- turn2 jumps to bottom!
Fixed result: [turn1, turn2, turn3]  <- correct order
```

## Fix

Replace the `firstConsumedIndex`-based prefix/suffix approach with an interleave algorithm:

1. Build a `resultPosById` map tracking each consumed message's position in the DB-ordered result
2. Walk the streamed array in order: for consumed messages, flush result items up to their position; for unconsumed messages that pass dedup, keep them at their streamed position
3. Preserve existing dedup logic (canonical tool match, content dedup, DB split artifact detection)

## Verification

All 8 key scenarios pass:
- DB missing middle-turn messages (the main bug scenario)
- DB reasoning rows not in streamed
- DB tool_call/tool_result rows not in streamed
- Streamed reasoning + DB tool rows combined
- Duplicate content FIFO matching
- Error bubble preservation
- Split session (CLI fallback different session ID)
- Concatenated streamed agent bubble replaced by DB split

Fixes the issue where previously-sent messages appeared at the very bottom of the chat after the agent sent its reply.