### PR TITLE
fix: replace prefix/suffix with interleave in reconcileStreamedWithDb

### DIFF
--- a/src/renderer/src/screens/Chat/sessionHistory.ts
+++ b/src/renderer/src/screens/Chat/sessionHistory.ts
@@ -381,13 +381,20 @@ export function reconcileStreamedWithDb(
   const shouldKeepUnconsumed = (m: ChatMessage): boolean => {
     if (consumedIds.has(m.id)) return false;
     if (consumeCanonicalToolMatch(canonicalToolMatchCounts, m)) return false;
+    // Only bubble messages (user/agent content) need dedup and split checks.
     if (!("kind" in m)) {
       const bubble = m as ChatBubbleMessage;
       const contentKey = `${bubble.role}:${normalizeBubbleContentForMatch(bubble.content || "")}`;
+      // Check for duplicates first.
       if (seenBubbleKeys.has(contentKey)) return false;
-      if (isCoveredByDbBubbleSplit(bubble, dbAssistantSplitSequences)) {
+      // For agent bubbles, also check if covered by a DB split before marking as seen.
+      if (
+        bubble.role === "agent" &&
+        isCoveredByDbBubbleSplit(bubble, dbAssistantSplitSequences)
+      ) {
         return false;
       }
+      // Only mark as seen if we're actually keeping this message.
       seenBubbleKeys.add(contentKey);
     }
     return true;

--- a/src/renderer/src/screens/Chat/sessionHistory.ts
+++ b/src/renderer/src/screens/Chat/sessionHistory.ts
@@ -357,136 +357,63 @@ export function reconcileStreamedWithDb(
   // key-based match (e.g. trailing-whitespace drift, one-frame delta
   // that didn't round-trip through the DB identically).
   const consumedIds = new Set(result.map((m) => m.id));
-  const consumedStreamIndexes: number[] = [];
-  for (let i = 0; i < streamed.length; i++) {
-    if (consumedIds.has(streamed[i].id)) consumedStreamIndexes.push(i);
-  }
-  const firstConsumedIndex =
-    consumedStreamIndexes.length > 0 ? Math.min(...consumedStreamIndexes) : -1;
 
-  const seedSeenBubbleKeys = (
-    seen: Set<string>,
-    items: ReadonlyArray<ChatMessage>,
-  ): void => {
-    for (const m of items) {
-      if (!("kind" in m)) {
-        const bubble = m as ChatBubbleMessage;
-        seen.add(
-          `${bubble.role}:${normalizeBubbleContentForMatch(bubble.content || "")}`,
-        );
-      }
-    }
-  };
-
-  const appendIfUnique = (
-    target: ChatMessage[],
-    m: ChatMessage,
-    seen: Set<string>,
-    dropDbSplitArtifacts = true,
-  ): boolean => {
-    if (consumedIds.has(m.id)) return false;
-    if (consumeCanonicalToolMatch(canonicalToolMatchCounts, m)) return false;
-    // For bubble messages, check if an equivalent already exists in the
-    // result set.  Non-bubble messages (tool_call, tool_result, reasoning)
-    // always pass through — they're either matched by callId above or are
-    // genuinely new.
-    if (!("kind" in m)) {
-      const bubble = m as ChatBubbleMessage;
-      const contentKey = `${bubble.role}:${normalizeBubbleContentForMatch(bubble.content || "")}`;
-      if (seen.has(contentKey)) return false;
-      if (
-        dropDbSplitArtifacts &&
-        isCoveredByDbBubbleSplit(bubble, dbAssistantSplitSequences)
-      ) {
-        return false;
-      }
-      seen.add(contentKey);
-    }
-    target.push(m);
-    return true;
-  };
-
-  const prefix: ChatMessage[] = [];
-  const seenPrefixBubbleKeys = new Set<string>();
-  for (let i = 0; i < streamed.length; i++) {
-    const m = streamed[i];
-    if (firstConsumedIndex >= 0 && i < firstConsumedIndex) {
-      appendIfUnique(prefix, m, seenPrefixBubbleKeys, false);
-    }
-  }
-
-  const suffix: ChatMessage[] = [];
-  const seenSuffixBubbleKeys = new Set<string>();
-  seedSeenBubbleKeys(seenSuffixBubbleKeys, prefix);
-  seedSeenBubbleKeys(seenSuffixBubbleKeys, result);
-  for (let i = 0; i < streamed.length; i++) {
-    const m = streamed[i];
-    if (firstConsumedIndex >= 0 && i < firstConsumedIndex) continue;
-    appendIfUnique(suffix, m, seenSuffixBubbleKeys);
-  }
-
-  // Build position map: for each consumed streamed message, record its
-  // index in the result array so we can interleave suffix items.
-  const consumedPosInResult = new Map<string, number>();
+  // Build a map from consumed streamed message id to its position in result,
+  // so we can interleave unconsumed messages at the correct chronological spot.
+  const resultPosById = new Map<string, number>();
   for (let ri = 0; ri < result.length; ri++) {
-    consumedPosInResult.set(result[ri].id, ri);
+    resultPosById.set(result[ri].id, ri);
   }
 
-  // Find the consumed message that immediately precedes each suffix item
-  // in the streamed order, then insert the suffix item after it in result.
-  // This fixes the bug where entire middle turns land at the bottom while
-  // preserving the existing behaviour for intra-turn items (tool calls,
-  // renderer-only messages, etc.) that should stay at the end.
-  const suffixByPredecessor = new Map<number, ChatMessage[]>();
-
-  for (const sm of suffix) {
-    // Walk backwards through the streamed messages starting from sm's index
-    // to find the closest preceding consumed message.
-    let smIndex = -1;
-    for (let i = 0; i < streamed.length; i++) {
-      if (streamed[i].id === sm.id) { smIndex = i; break; }
+  // Pre-seed dedup set with bubble keys already in the result array,
+  // so unconsumed streamed messages that are near-duplicates of DB rows
+  // (e.g. content that drifted by a trailing space during streaming)
+  // are correctly identified and skipped.
+  const seenBubbleKeys = new Set<string>();
+  for (const rm of result) {
+    if (!("kind" in rm)) {
+      const key = `${(rm as ChatBubbleMessage).role}:${normalizeBubbleContentForMatch((rm as ChatBubbleMessage).content || "")}`;
+      seenBubbleKeys.add(key);
     }
+  }
 
-    let predPos = -1; // -1 means insert before everything (like prefix)
-    if (smIndex >= 0) {
-      for (let j = smIndex - 1; j >= 0; j--) {
-        const pid = streamed[j].id;
-        const pos = consumedPosInResult.get(pid);
-        if (pos !== undefined) {
-          predPos = pos;
-          break;
+  const isBubbleDup = (m: ChatMessage): boolean => {
+    if ("kind" in m) return false;
+    const key = `${(m as ChatBubbleMessage).role}:${normalizeBubbleContentForMatch((m as ChatBubbleMessage).content || "")}`;
+    if (seenBubbleKeys.has(key)) return true;
+    seenBubbleKeys.add(key);
+    return false;
+  };
+
+  // Walk streamed in order, interleaving unconsumed messages at their
+  // correct chronological positions between consumed ones.
+  const merged: ChatMessage[] = [];
+  let resultIdx = 0;
+
+  for (let si = 0; si < streamed.length; si++) {
+    const sm = streamed[si];
+    if (consumedIds.has(sm.id)) {
+      // Flush result items up to and including this consumed message's
+      // position, then skip the streamed copy (it's already in result).
+      const rpos = resultPosById.get(sm.id);
+      if (rpos !== undefined && rpos >= resultIdx) {
+        while (resultIdx <= rpos) {
+          merged.push(result[resultIdx++]);
         }
       }
+    } else if (!consumeCanonicalToolMatch(canonicalToolMatchCounts, sm)) {
+      // Unconsumed streamed message — insert at current chronological slot.
+      // Deduplicate against DB bubbles and cover splits.
+      if (!isBubbleDup(sm) && !isCoveredByDbBubbleSplit(sm as ChatBubbleMessage, dbAssistantSplitSequences)) {
+        merged.push(sm);
+      }
     }
-
-    const bucket = suffixByPredecessor.get(predPos);
-    if (bucket) bucket.push(sm);
-    else suffixByPredecessor.set(predPos, [sm]);
   }
 
-  // Interleave suffix items into the result.
-  const merged: ChatMessage[] = [...prefix];
-  for (let ri = 0; ri < result.length; ri++) {
-    // Insert any suffix items whose predecessor is before this position
-    // and hasn't been inserted yet (predPos < 0 items go first).
-    if (ri === 0) {
-      const leading = suffixByPredecessor.get(-1);
-      if (leading) for (const m of leading) merged.push(m);
-    }
-
-    merged.push(result[ri]);
-
-    // Insert suffix items that should follow this consumed message.
-    const followers = suffixByPredecessor.get(ri);
-    if (followers) for (const m of followers) merged.push(m);
-  }
-
-  // Append any remaining suffix items whose predecessor wasn't found.
-  for (const [predPos, items] of suffixByPredecessor) {
-    if (predPos < 0) continue; // already inserted
-    if (predPos >= result.length) {
-      for (const m of items) merged.push(m);
-    }
+  // Append any remaining DB-only rows (e.g. reasoning, tool rows that
+  // never streamed, late-written assistant splits).
+  while (resultIdx < result.length) {
+    merged.push(result[resultIdx++]);
   }
 
   // Reposition inline clarify cards to their original chronological slot.

--- a/src/renderer/src/screens/Chat/sessionHistory.ts
+++ b/src/renderer/src/screens/Chat/sessionHistory.ts
@@ -357,75 +357,53 @@ export function reconcileStreamedWithDb(
   // key-based match (e.g. trailing-whitespace drift, one-frame delta
   // that didn't round-trip through the DB identically).
   const consumedIds = new Set(result.map((m) => m.id));
-  const consumedStreamIndexes: number[] = [];
-  for (let i = 0; i < streamed.length; i++) {
-    if (consumedIds.has(streamed[i].id)) consumedStreamIndexes.push(i);
-  }
-  const firstConsumedIndex =
-    consumedStreamIndexes.length > 0 ? Math.min(...consumedStreamIndexes) : -1;
 
-  const seedSeenBubbleKeys = (
-    seen: Set<string>,
-    items: ReadonlyArray<ChatMessage>,
-  ): void => {
-    for (const m of items) {
-      if (!("kind" in m)) {
-        const bubble = m as ChatBubbleMessage;
-        seen.add(
-          `${bubble.role}:${normalizeBubbleContentForMatch(bubble.content || "")}`,
-        );
-      }
-    }
+  // Build a map from consumed streamed message id to its position in result,
+  // so we can interleave unconsumed messages at the correct chronological spot.
+  const resultPosById = new Map<string, number>();
+  for (let ri = 0; ri < result.length; ri++) {
+    resultPosById.set(result[ri].id, ri);
+  }
+
+  const seenBubbleKeys = new Set<string>();
+  const isBubbleDup = (m: ChatMessage): boolean => {
+    if ("kind" in m) return false;
+    const key = `${(m as ChatBubbleMessage).role}:${normalizeBubbleContentForMatch((m as ChatBubbleMessage).content || "")}`;
+    if (seenBubbleKeys.has(key)) return true;
+    seenBubbleKeys.add(key);
+    return false;
   };
 
-  const appendIfUnique = (
-    target: ChatMessage[],
-    m: ChatMessage,
-    seen: Set<string>,
-    dropDbSplitArtifacts = true,
-  ): boolean => {
-    if (consumedIds.has(m.id)) return false;
-    if (consumeCanonicalToolMatch(canonicalToolMatchCounts, m)) return false;
-    // For bubble messages, check if an equivalent already exists in the
-    // result set.  Non-bubble messages (tool_call, tool_result, reasoning)
-    // always pass through — they're either matched by callId above or are
-    // genuinely new.
-    if (!("kind" in m)) {
-      const bubble = m as ChatBubbleMessage;
-      const contentKey = `${bubble.role}:${normalizeBubbleContentForMatch(bubble.content || "")}`;
-      if (seen.has(contentKey)) return false;
-      if (
-        dropDbSplitArtifacts &&
-        isCoveredByDbBubbleSplit(bubble, dbAssistantSplitSequences)
-      ) {
-        return false;
+  // Walk streamed in order, interleaving unconsumed messages at their
+  // correct chronological positions between consumed ones.
+  const merged: ChatMessage[] = [];
+  let resultIdx = 0;
+
+  for (let si = 0; si < streamed.length; si++) {
+    const sm = streamed[si];
+    if (consumedIds.has(sm.id)) {
+      // Flush result items up to and including this consumed message's
+      // position, then skip the streamed copy (it's already in result).
+      const rpos = resultPosById.get(sm.id);
+      if (rpos !== undefined && rpos >= resultIdx) {
+        while (resultIdx <= rpos) {
+          merged.push(result[resultIdx++]);
+        }
       }
-      seen.add(contentKey);
-    }
-    target.push(m);
-    return true;
-  };
-
-  const prefix: ChatMessage[] = [];
-  const seenPrefixBubbleKeys = new Set<string>();
-  for (let i = 0; i < streamed.length; i++) {
-    const m = streamed[i];
-    if (firstConsumedIndex >= 0 && i < firstConsumedIndex) {
-      appendIfUnique(prefix, m, seenPrefixBubbleKeys, false);
+    } else if (!consumeCanonicalToolMatch(canonicalToolMatchCounts, sm)) {
+      // Unconsumed streamed message — insert at current chronological slot.
+      // Deduplicate against DB bubbles and cover splits.
+      if (!isBubbleDup(sm) && !isCoveredByDbBubbleSplit(sm as ChatBubbleMessage, dbAssistantSplitSequences)) {
+        merged.push(sm);
+      }
     }
   }
 
-  const suffix: ChatMessage[] = [];
-  const seenSuffixBubbleKeys = new Set<string>();
-  seedSeenBubbleKeys(seenSuffixBubbleKeys, prefix);
-  seedSeenBubbleKeys(seenSuffixBubbleKeys, result);
-  for (let i = 0; i < streamed.length; i++) {
-    const m = streamed[i];
-    if (firstConsumedIndex >= 0 && i < firstConsumedIndex) continue;
-    appendIfUnique(suffix, m, seenSuffixBubbleKeys);
+  // Append any remaining DB-only rows (e.g. reasoning, tool rows that
+  // never streamed, late-written assistant splits).
+  while (resultIdx < result.length) {
+    merged.push(result[resultIdx++]);
   }
-
-  const merged = [...prefix, ...result, ...suffix];
 
   // Reposition inline clarify cards to their original chronological slot.
   // A clarify card is renderer-only — it's never written to state.db, so it

--- a/src/renderer/src/screens/Chat/sessionHistory.ts
+++ b/src/renderer/src/screens/Chat/sessionHistory.ts
@@ -365,7 +365,18 @@ export function reconcileStreamedWithDb(
     resultPosById.set(result[ri].id, ri);
   }
 
+  // Pre-seed dedup set with bubble keys already in the result array,
+  // so unconsumed streamed messages that are near-duplicates of DB rows
+  // (e.g. content that drifted by a trailing space during streaming)
+  // are correctly identified and skipped.
   const seenBubbleKeys = new Set<string>();
+  for (const rm of result) {
+    if (!("kind" in rm)) {
+      const key = `${(rm as ChatBubbleMessage).role}:${normalizeBubbleContentForMatch((rm as ChatBubbleMessage).content || "")}`;
+      seenBubbleKeys.add(key);
+    }
+  }
+
   const isBubbleDup = (m: ChatMessage): boolean => {
     if ("kind" in m) return false;
     const key = `${(m as ChatBubbleMessage).role}:${normalizeBubbleContentForMatch((m as ChatBubbleMessage).content || "")}`;

--- a/src/renderer/src/screens/Chat/sessionHistory.ts
+++ b/src/renderer/src/screens/Chat/sessionHistory.ts
@@ -357,63 +357,136 @@ export function reconcileStreamedWithDb(
   // key-based match (e.g. trailing-whitespace drift, one-frame delta
   // that didn't round-trip through the DB identically).
   const consumedIds = new Set(result.map((m) => m.id));
-
-  // Build a map from consumed streamed message id to its position in result,
-  // so we can interleave unconsumed messages at the correct chronological spot.
-  const resultPosById = new Map<string, number>();
-  for (let ri = 0; ri < result.length; ri++) {
-    resultPosById.set(result[ri].id, ri);
+  const consumedStreamIndexes: number[] = [];
+  for (let i = 0; i < streamed.length; i++) {
+    if (consumedIds.has(streamed[i].id)) consumedStreamIndexes.push(i);
   }
+  const firstConsumedIndex =
+    consumedStreamIndexes.length > 0 ? Math.min(...consumedStreamIndexes) : -1;
 
-  // Pre-seed dedup set with bubble keys already in the result array,
-  // so unconsumed streamed messages that are near-duplicates of DB rows
-  // (e.g. content that drifted by a trailing space during streaming)
-  // are correctly identified and skipped.
-  const seenBubbleKeys = new Set<string>();
-  for (const rm of result) {
-    if (!("kind" in rm)) {
-      const key = `${(rm as ChatBubbleMessage).role}:${normalizeBubbleContentForMatch((rm as ChatBubbleMessage).content || "")}`;
-      seenBubbleKeys.add(key);
+  const seedSeenBubbleKeys = (
+    seen: Set<string>,
+    items: ReadonlyArray<ChatMessage>,
+  ): void => {
+    for (const m of items) {
+      if (!("kind" in m)) {
+        const bubble = m as ChatBubbleMessage;
+        seen.add(
+          `${bubble.role}:${normalizeBubbleContentForMatch(bubble.content || "")}`,
+        );
+      }
     }
-  }
-
-  const isBubbleDup = (m: ChatMessage): boolean => {
-    if ("kind" in m) return false;
-    const key = `${(m as ChatBubbleMessage).role}:${normalizeBubbleContentForMatch((m as ChatBubbleMessage).content || "")}`;
-    if (seenBubbleKeys.has(key)) return true;
-    seenBubbleKeys.add(key);
-    return false;
   };
 
-  // Walk streamed in order, interleaving unconsumed messages at their
-  // correct chronological positions between consumed ones.
-  const merged: ChatMessage[] = [];
-  let resultIdx = 0;
+  const appendIfUnique = (
+    target: ChatMessage[],
+    m: ChatMessage,
+    seen: Set<string>,
+    dropDbSplitArtifacts = true,
+  ): boolean => {
+    if (consumedIds.has(m.id)) return false;
+    if (consumeCanonicalToolMatch(canonicalToolMatchCounts, m)) return false;
+    // For bubble messages, check if an equivalent already exists in the
+    // result set.  Non-bubble messages (tool_call, tool_result, reasoning)
+    // always pass through — they're either matched by callId above or are
+    // genuinely new.
+    if (!("kind" in m)) {
+      const bubble = m as ChatBubbleMessage;
+      const contentKey = `${bubble.role}:${normalizeBubbleContentForMatch(bubble.content || "")}`;
+      if (seen.has(contentKey)) return false;
+      if (
+        dropDbSplitArtifacts &&
+        isCoveredByDbBubbleSplit(bubble, dbAssistantSplitSequences)
+      ) {
+        return false;
+      }
+      seen.add(contentKey);
+    }
+    target.push(m);
+    return true;
+  };
 
-  for (let si = 0; si < streamed.length; si++) {
-    const sm = streamed[si];
-    if (consumedIds.has(sm.id)) {
-      // Flush result items up to and including this consumed message's
-      // position, then skip the streamed copy (it's already in result).
-      const rpos = resultPosById.get(sm.id);
-      if (rpos !== undefined && rpos >= resultIdx) {
-        while (resultIdx <= rpos) {
-          merged.push(result[resultIdx++]);
-        }
-      }
-    } else if (!consumeCanonicalToolMatch(canonicalToolMatchCounts, sm)) {
-      // Unconsumed streamed message — insert at current chronological slot.
-      // Deduplicate against DB bubbles and cover splits.
-      if (!isBubbleDup(sm) && !isCoveredByDbBubbleSplit(sm as ChatBubbleMessage, dbAssistantSplitSequences)) {
-        merged.push(sm);
-      }
+  const prefix: ChatMessage[] = [];
+  const seenPrefixBubbleKeys = new Set<string>();
+  for (let i = 0; i < streamed.length; i++) {
+    const m = streamed[i];
+    if (firstConsumedIndex >= 0 && i < firstConsumedIndex) {
+      appendIfUnique(prefix, m, seenPrefixBubbleKeys, false);
     }
   }
 
-  // Append any remaining DB-only rows (e.g. reasoning, tool rows that
-  // never streamed, late-written assistant splits).
-  while (resultIdx < result.length) {
-    merged.push(result[resultIdx++]);
+  const suffix: ChatMessage[] = [];
+  const seenSuffixBubbleKeys = new Set<string>();
+  seedSeenBubbleKeys(seenSuffixBubbleKeys, prefix);
+  seedSeenBubbleKeys(seenSuffixBubbleKeys, result);
+  for (let i = 0; i < streamed.length; i++) {
+    const m = streamed[i];
+    if (firstConsumedIndex >= 0 && i < firstConsumedIndex) continue;
+    appendIfUnique(suffix, m, seenSuffixBubbleKeys);
+  }
+
+  // Build position map: for each consumed streamed message, record its
+  // index in the result array so we can interleave suffix items.
+  const consumedPosInResult = new Map<string, number>();
+  for (let ri = 0; ri < result.length; ri++) {
+    consumedPosInResult.set(result[ri].id, ri);
+  }
+
+  // Find the consumed message that immediately precedes each suffix item
+  // in the streamed order, then insert the suffix item after it in result.
+  // This fixes the bug where entire middle turns land at the bottom while
+  // preserving the existing behaviour for intra-turn items (tool calls,
+  // renderer-only messages, etc.) that should stay at the end.
+  const suffixByPredecessor = new Map<number, ChatMessage[]>();
+
+  for (const sm of suffix) {
+    // Walk backwards through the streamed messages starting from sm's index
+    // to find the closest preceding consumed message.
+    let smIndex = -1;
+    for (let i = 0; i < streamed.length; i++) {
+      if (streamed[i].id === sm.id) { smIndex = i; break; }
+    }
+
+    let predPos = -1; // -1 means insert before everything (like prefix)
+    if (smIndex >= 0) {
+      for (let j = smIndex - 1; j >= 0; j--) {
+        const pid = streamed[j].id;
+        const pos = consumedPosInResult.get(pid);
+        if (pos !== undefined) {
+          predPos = pos;
+          break;
+        }
+      }
+    }
+
+    const bucket = suffixByPredecessor.get(predPos);
+    if (bucket) bucket.push(sm);
+    else suffixByPredecessor.set(predPos, [sm]);
+  }
+
+  // Interleave suffix items into the result.
+  const merged: ChatMessage[] = [...prefix];
+  for (let ri = 0; ri < result.length; ri++) {
+    // Insert any suffix items whose predecessor is before this position
+    // and hasn't been inserted yet (predPos < 0 items go first).
+    if (ri === 0) {
+      const leading = suffixByPredecessor.get(-1);
+      if (leading) for (const m of leading) merged.push(m);
+    }
+
+    merged.push(result[ri]);
+
+    // Insert suffix items that should follow this consumed message.
+    const followers = suffixByPredecessor.get(ri);
+    if (followers) for (const m of followers) merged.push(m);
+  }
+
+  // Append any remaining suffix items whose predecessor wasn't found.
+  for (const [predPos, items] of suffixByPredecessor) {
+    if (predPos < 0) continue; // already inserted
+    if (predPos >= result.length) {
+      for (const m of items) merged.push(m);
+    }
   }
 
   // Reposition inline clarify cards to their original chronological slot.

--- a/tests/reconcile-streamed-with-db.test.ts
+++ b/tests/reconcile-streamed-with-db.test.ts
@@ -571,8 +571,8 @@ describe("reconcileStreamedWithDb", () => {
 
     expect(merged.map((m) => m.id)).toEqual([
       "u-1",
-      "db-tc-71-call-terminal-1",
       "tool-call-live-tool:run-1:terminal:2",
+      "db-tc-71-call-terminal-1",
       "a-1",
     ]);
     expect(merged[3]).toMatchObject({

--- a/tests/reconcile-streamed-with-db.test.ts
+++ b/tests/reconcile-streamed-with-db.test.ts
@@ -575,7 +575,7 @@ describe("reconcileStreamedWithDb", () => {
       "db-tc-71-call-terminal-1",
       "a-1",
     ]);
-    expect(merged[3]).toMatchObject({
+    expect(merged[1]).toMatchObject({
       kind: "tool_call",
       name: "terminal",
       args: "npm run typecheck",

--- a/tests/reconcile-streamed-with-db.test.ts
+++ b/tests/reconcile-streamed-with-db.test.ts
@@ -380,7 +380,10 @@ describe("reconcileStreamedWithDb", () => {
 
     const merged = reconcileStreamedWithDb(streamed, db);
 
-    expect(merged[merged.length - 1]).toBe(streamedOnly);
+    // The unmatched streamed bubble should appear right after its
+    // preceding user message (u-1), preserving the streamed order
+    // rather than being forced to the bottom.
+    expect(merged[1]).toBe(streamedOnly);
   });
 
   it("does not drop a streamed answer that quotes assistant rows from different turns", () => {
@@ -569,8 +572,8 @@ describe("reconcileStreamedWithDb", () => {
     expect(merged.map((m) => m.id)).toEqual([
       "u-1",
       "db-tc-71-call-terminal-1",
-      "a-1",
       "tool-call-live-tool:run-1:terminal:2",
+      "a-1",
     ]);
     expect(merged[3]).toMatchObject({
       kind: "tool_call",
@@ -611,8 +614,8 @@ describe("reconcileStreamedWithDb", () => {
     expect(merged.map((m) => m.id)).toEqual([
       "u-1",
       "tool-call-call-terminal-1",
-      "a-1",
       "tool-call-live-tool:run-1:terminal:2",
+      "a-1",
     ]);
   });
 


### PR DESCRIPTION
## Problem

`reconcileStreamedWithDb` uses a prefix/suffix model that incorrectly places unconsumed streamed messages at the top or bottom of the merged transcript, instead of interleaving them at their correct chronological positions.

### Root Cause

The old code finds `firstConsumedIndex` (the earliest streamed message that matched a DB row — almost always 0, the first user message) and splits the streamed array into:

- **prefix**: messages before `firstConsumedIndex` → rarely populated
- **suffix**: messages at/after `firstConsumedIndex` that weren't consumed → **includes mid-conversation messages**

Since `firstConsumedIndex` ≈ 0, nearly ALL unconsumed messages from the middle of the conversation land in the suffix → at the bottom, below later DB-matched messages.

### Symptoms (user reports)

1. Agent messages from previous turns appear BELOW newer user messages instead of being interleaved
2. When the DB misses middle turns (e.g. due to session split or write timing), the ordering appears reversed — newer messages on top, older at bottom

### Scenario

```
Streamed: [turn1-u, turn1-a, turn2-u, turn2-a, turn3-u, turn3-a]
DB:       [turn1-u, turn1-a, turn3-u, turn3-a]  (turn 2 missing)
```

- **Old**: `[turn1-u, turn1-a, turn3-u, turn3-a, turn2-u, turn2-a]` ← turn 2 at bottom (BUG)
- **New**: `[turn1-u, turn1-a, turn2-u, turn2-a, turn3-u, turn3-a]` ← correct interleaved order

## Fix

Replace prefix/suffix accumulation with an interleave that walks the streamed array in order, placing each unconsumed message at its correct chronological position between consumed ones. Remaining DB-only rows (reasoning, late-written splits) are appended at the end.

The dedup logic (`isBubbleDup`, `isCoveredByDbBubbleSplit`, `consumeCanonicalToolMatch`) is preserved and integrated into the interleave pass.

## Test Plan

The `reconcileStreamedWithDb` function is pure — the fix can be verified by running the existing test suite:

```bash
npx vitest run tests/reconcile-streamed-with-db.test.ts
```

Or by reproducing with this scenario:

```js
const streamed = [
  {id:'u-1',role:'user',content:'hello'},
  {id:'a-1',role:'agent',content:'Hi'},
  {id:'u-2',role:'user',content:'how'},
  {id:'a-2',role:'agent',content:'good'},
  {id:'u-3',role:'user',content:'time?'},
  {id:'a-3',role:'agent',content:'3pm'},
];
const db = [
  {id:'db-1',role:'user',content:'hello'},
  {id:'db-2',role:'agent',content:'Hi'},
  // turn 2 missing
  {id:'db-5',role:'user',content:'time?'},
  {id:'db-6',role:'agent',content:'3pm'},
];
// Expected: u-1, a-1, u-2, a-2, u-3, a-3
// NOT: u-1, a-1, u-3, a-3, u-2, a-2
```

Closes: user-reported chat ordering issues where:
- Agent messages appear below instead of interleaved with user messages
- Newer messages appear at top when DB misses middle turns
