### PR TITLE
feat: Implement chat models search

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -4488,6 +4488,7 @@ body {
   flex-shrink: 0;
 }
 
+.chat-model-search-input,
 .chat-model-custom-input {
   box-sizing: border-box;
 }
@@ -4547,19 +4548,30 @@ body {
   padding: 4px 8px 6px;
 }
 
+.chat-model-search-input,
 .chat-model-custom-input {
   width: 100%;
   padding: 5px 8px;
   font-size: 12px;
   border: 1px solid var(--border);
   border-radius: 4px;
-  background: var(--bg-tertiary);
   color: var(--text-primary);
 }
 
+.chat-model-search-input:focus,
 .chat-model-custom-input:focus {
   outline: none;
   border-color: var(--border-focus);
+}
+
+.chat-model-custom-input {
+  background: var(--bg-tertiary);
+}
+
+.chat-model-search-input {
+  position: sticky;
+  top: 0;
+  background: var(--bg-secondary);
 }
 
 /* ========================================================================

--- a/src/renderer/src/screens/Chat/ModelPicker.test.tsx
+++ b/src/renderer/src/screens/Chat/ModelPicker.test.tsx
@@ -1,0 +1,341 @@
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../components/useI18n", () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+    locale: "en",
+    setLocale: vi.fn(),
+  }),
+}));
+
+vi.mock("lucide-react", () => ({
+  ChevronDown: () => null,
+}));
+
+import { ModelPicker } from "./ModelPicker";
+import type { ModelGroup } from "./types";
+
+const groups: ModelGroup[] = [
+  {
+    provider: "openrouter",
+    providerLabel: "providers.openrouter",
+    models: [
+      {
+        provider: "openrouter",
+        model: "owl-alpha",
+        label: "OWL Alpha",
+        baseUrl: "",
+      },
+      {
+        provider: "openrouter",
+        model: "owl-beta",
+        label: "OWL Beta",
+        baseUrl: "",
+      },
+    ],
+  },
+  {
+    provider: "ollama",
+    providerLabel: "providers.ollama",
+    models: [
+      {
+        provider: "ollama",
+        model: "llama3",
+        label: "Llama 3",
+        baseUrl: "http://localhost:11434",
+      },
+    ],
+  },
+];
+
+/** Render helper that also returns the container for scoped DOM queries. */
+function renderPicker(
+  overrides: {
+    currentModel?: string;
+    currentProvider?: string;
+    currentBaseUrl?: string;
+    modelGroups?: ModelGroup[];
+    displayModel?: string;
+    onOpen?: () => void;
+    onSelectModel?: (provider: string, model: string, baseUrl: string) => void;
+  } = {},
+): { container: HTMLElement; onOpen: vi.fn; onSelectModel: vi.fn } {
+  const onOpen = vi.fn();
+  const onSelectModel = vi.fn();
+  const utils = render(
+    <ModelPicker
+      currentModel={overrides.currentModel ?? "owl-alpha"}
+      currentProvider={overrides.currentProvider ?? "openrouter"}
+      currentBaseUrl={overrides.currentBaseUrl ?? ""}
+      modelGroups={overrides.modelGroups ?? groups}
+      displayModel={overrides.displayModel ?? "OWL Alpha"}
+      onOpen={overrides.onOpen ?? onOpen}
+      onSelectModel={overrides.onSelectModel ?? onSelectModel}
+    />,
+  );
+  return { ...utils, onOpen, onSelectModel };
+}
+
+/** Click the trigger button (scoped to container to avoid ambiguity) and
+ *  return the dropdown element for `within()` scoping. */
+function openPicker(container: HTMLElement): HTMLElement {
+  const trigger = container.querySelector(
+    ".chat-model-trigger",
+  ) as HTMLButtonElement;
+  fireEvent.click(trigger);
+  return container.querySelector(".chat-model-dropdown") as HTMLElement;
+}
+
+describe("ModelPicker", () => {
+  // ── initial render ──────────────────────────────────────────────
+  it("renders the display model name in the trigger button", () => {
+    const { container } = renderPicker({ displayModel: "OWL Alpha" });
+    const trigger = container.querySelector(".chat-model-trigger")!;
+    expect(trigger.querySelector(".chat-model-name")?.textContent).toBe(
+      "OWL Alpha",
+    );
+  });
+
+  it("does not show the dropdown initially", () => {
+    const { container } = renderPicker();
+    expect(container.querySelector(".chat-model-dropdown")).toBeNull();
+  });
+
+  // ── open / close ────────────────────────────────────────────────
+  it("opens the dropdown and calls onOpen when the trigger is clicked", () => {
+    const { container, onOpen } = renderPicker();
+    openPicker(container);
+    expect(screen.getByPlaceholderText("chat.searchModels")).toBeTruthy();
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes the dropdown when the trigger is clicked again", () => {
+    const { container } = renderPicker();
+    const trigger = container.querySelector(
+      ".chat-model-trigger",
+    ) as HTMLButtonElement;
+    fireEvent.click(trigger); // open
+    fireEvent.click(trigger); // close
+    expect(container.querySelector(".chat-model-dropdown")).toBeNull();
+  });
+
+  it("closes the dropdown when clicking outside", () => {
+    const { container } = renderPicker();
+    openPicker(container);
+    fireEvent.mouseDown(document.body);
+    expect(container.querySelector(".chat-model-dropdown")).toBeNull();
+  });
+
+  // ── model list rendering ────────────────────────────────────────
+  it("renders all provider groups and their models", () => {
+    const { container } = renderPicker();
+    const dropdown = openPicker(container);
+
+    expect(within(dropdown).getByText("providers.openrouter")).toBeTruthy();
+    expect(within(dropdown).getByText("providers.ollama")).toBeTruthy();
+    expect(within(dropdown).getByText("OWL Alpha")).toBeTruthy();
+    expect(within(dropdown).getByText("OWL Beta")).toBeTruthy();
+    expect(within(dropdown).getByText("Llama 3")).toBeTruthy();
+  });
+
+  it("marks the active model with the 'active' class", () => {
+    const { container } = renderPicker({
+      currentModel: "owl-alpha",
+      currentProvider: "openrouter",
+    });
+    const dropdown = openPicker(container);
+
+    const option = within(dropdown).getByText("OWL Alpha").closest("button");
+    expect(option?.className).toContain("active");
+  });
+
+  it("does not mark an inactive model as active", () => {
+    const { container } = renderPicker({
+      currentModel: "owl-alpha",
+      currentProvider: "openrouter",
+    });
+    const dropdown = openPicker(container);
+
+    const betaOption = within(dropdown).getByText("OWL Beta").closest("button");
+    expect(betaOption?.className).not.toContain("active");
+  });
+
+  // ── model selection ─────────────────────────────────────────────
+  it("calls onSelectModel with correct args when a model is clicked", () => {
+    const { container, onSelectModel } = renderPicker();
+    const dropdown = openPicker(container);
+
+    fireEvent.click(within(dropdown).getByText("Llama 3"));
+
+    expect(onSelectModel).toHaveBeenCalledWith(
+      "ollama",
+      "llama3",
+      "http://localhost:11434",
+    );
+  });
+
+  it("closes the dropdown after selecting a model", () => {
+    const { container } = renderPicker();
+    const dropdown = openPicker(container);
+
+    fireEvent.click(within(dropdown).getByText("OWL Beta"));
+    expect(container.querySelector(".chat-model-dropdown")).toBeNull();
+  });
+
+  // ── search / filtering ──────────────────────────────────────────
+  it("filters models by label (case-insensitive)", () => {
+    const { container } = renderPicker();
+    const dropdown = openPicker(container);
+    const search = within(dropdown).getByPlaceholderText("chat.searchModels");
+
+    fireEvent.change(search, { target: { value: "beta" } });
+
+    expect(within(dropdown).queryByText("OWL Alpha")).toBeNull();
+    expect(within(dropdown).getByText("OWL Beta")).toBeTruthy();
+    expect(within(dropdown).queryByText("Llama 3")).toBeNull();
+  });
+
+  it("filters models by model id", () => {
+    const { container } = renderPicker();
+    const dropdown = openPicker(container);
+    const search = within(dropdown).getByPlaceholderText("chat.searchModels");
+
+    fireEvent.change(search, { target: { value: "llama3" } });
+
+    expect(within(dropdown).queryByText("OWL Alpha")).toBeNull();
+    expect(within(dropdown).getByText("Llama 3")).toBeTruthy();
+  });
+
+  it("shows all models when search is cleared", () => {
+    const { container } = renderPicker();
+    const dropdown = openPicker(container);
+    const search = within(dropdown).getByPlaceholderText("chat.searchModels");
+
+    fireEvent.change(search, { target: { value: "beta" } });
+    fireEvent.change(search, { target: { value: "" } });
+
+    expect(within(dropdown).getByText("OWL Alpha")).toBeTruthy();
+    expect(within(dropdown).getByText("Llama 3")).toBeTruthy();
+  });
+
+  it("clears search when the dropdown is toggled closed", () => {
+    const { container } = renderPicker();
+    const trigger = container.querySelector(
+      ".chat-model-trigger",
+    ) as HTMLButtonElement;
+
+    fireEvent.click(trigger); // open
+    const search = container.querySelector(
+      ".chat-model-search-input",
+    ) as HTMLInputElement;
+    fireEvent.change(search, { target: { value: "beta" } });
+    expect(search.value).toBe("beta");
+
+    fireEvent.click(trigger); // close
+    fireEvent.click(trigger); // re-open
+
+    const searchAfter = container.querySelector(
+      ".chat-model-search-input",
+    ) as HTMLInputElement;
+    expect(searchAfter.value).toBe("");
+  });
+
+  // ── custom model input ──────────────────────────────────────────
+  it("renders the custom model input section", () => {
+    const { container } = renderPicker();
+    const dropdown = openPicker(container);
+    expect(within(dropdown).getByText("chat.custom")).toBeTruthy();
+    expect(
+      within(dropdown).getByPlaceholderText("chat.typeModelName"),
+    ).toBeTruthy();
+  });
+
+  it("submits a custom model on Enter and calls onSelectModel", () => {
+    const { container, onSelectModel } = renderPicker();
+    const dropdown = openPicker(container);
+
+    const customInput = within(dropdown).getByPlaceholderText(
+      "chat.typeModelName",
+    ) as HTMLInputElement;
+    fireEvent.change(customInput, { target: { value: "my-custom-model" } });
+    fireEvent.keyDown(customInput, { key: "Enter" });
+
+    expect(onSelectModel).toHaveBeenCalledWith(
+      "openrouter",
+      "my-custom-model",
+      "",
+    );
+  });
+
+  it("uses 'auto' provider when currentProvider is 'auto'", () => {
+    const { container, onSelectModel } = renderPicker({
+      currentProvider: "auto",
+    });
+    const dropdown = openPicker(container);
+
+    const customInput = within(dropdown).getByPlaceholderText(
+      "chat.typeModelName",
+    ) as HTMLInputElement;
+    fireEvent.change(customInput, { target: { value: "gpt-4o" } });
+    fireEvent.keyDown(customInput, { key: "Enter" });
+
+    expect(onSelectModel).toHaveBeenCalledWith("auto", "gpt-4o", "");
+  });
+
+  it("does not submit an empty custom model", () => {
+    const { container, onSelectModel } = renderPicker();
+    const dropdown = openPicker(container);
+
+    const customInput =
+      within(dropdown).getByPlaceholderText("chat.typeModelName");
+    fireEvent.keyDown(customInput, { key: "Enter" });
+
+    expect(onSelectModel).not.toHaveBeenCalled();
+  });
+
+  it("does not submit whitespace-only custom model", () => {
+    const { container, onSelectModel } = renderPicker();
+    const dropdown = openPicker(container);
+
+    const customInput = within(dropdown).getByPlaceholderText(
+      "chat.typeModelName",
+    ) as HTMLInputElement;
+    fireEvent.change(customInput, { target: { value: "   " } });
+    fireEvent.keyDown(customInput, { key: "Enter" });
+
+    expect(onSelectModel).not.toHaveBeenCalled();
+  });
+
+  it("closes the dropdown after submitting a custom model", () => {
+    const { container } = renderPicker();
+    const dropdown = openPicker(container);
+
+    const customInput = within(dropdown).getByPlaceholderText(
+      "chat.typeModelName",
+    ) as HTMLInputElement;
+    fireEvent.change(customInput, { target: { value: "custom" } });
+    fireEvent.keyDown(customInput, { key: "Enter" });
+
+    expect(container.querySelector(".chat-model-dropdown")).toBeNull();
+  });
+
+  // ── edge cases ──────────────────────────────────────────────────
+  it("renders nothing in the dropdown when modelGroups is empty", () => {
+    const { container } = renderPicker({ modelGroups: [] });
+    const dropdown = openPicker(container);
+    expect(within(dropdown).getByText("chat.custom")).toBeTruthy();
+    expect(within(dropdown).queryByText("providers.openrouter")).toBeNull();
+  });
+
+  it("renders nothing when search matches no models", () => {
+    const { container } = renderPicker();
+    const dropdown = openPicker(container);
+    const search = within(dropdown).getByPlaceholderText("chat.searchModels");
+
+    fireEvent.change(search, { target: { value: "zzzznonexistent" } });
+
+    expect(within(dropdown).queryByText("OWL Alpha")).toBeNull();
+    expect(within(dropdown).queryByText("Llama 3")).toBeNull();
+  });
+});

--- a/src/renderer/src/screens/Chat/ModelPicker.tsx
+++ b/src/renderer/src/screens/Chat/ModelPicker.tsx
@@ -24,11 +24,14 @@ export const ModelPicker = memo(function ModelPicker({
 }: ModelPickerProps): React.JSX.Element {
   const { t } = useI18n();
   const [isOpen, setIsOpen] = useState(false);
+  const [searchInput, setSearchInput] = useState("");
   const [customInput, setCustomInput] = useState("");
   const pickerRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (!isOpen) return;
+    searchRef.current?.focus();
     function handleClickOutside(e: MouseEvent): void {
       if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
         setIsOpen(false);
@@ -38,15 +41,30 @@ export const ModelPicker = memo(function ModelPicker({
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [isOpen]);
 
+  const filteredGroups = searchInput.trim()
+    ? modelGroups
+        .map((group) => ({
+          ...group,
+          models: group.models.filter(
+            (m) =>
+              m.label.toLowerCase().includes(searchInput.toLowerCase()) ||
+              m.model.toLowerCase().includes(searchInput.toLowerCase()),
+          ),
+        }))
+        .filter((group) => group.models.length > 0)
+    : modelGroups;
+
   function toggle(): void {
     if (!isOpen) onOpen();
     setIsOpen((v) => !v);
+    setSearchInput("");
   }
 
   function select(provider: string, model: string, baseUrl: string): void {
     onSelectModel(provider, model, baseUrl);
     setIsOpen(false);
     setCustomInput("");
+    setSearchInput("");
   }
 
   function submitCustom(): void {
@@ -68,7 +86,15 @@ export const ModelPicker = memo(function ModelPicker({
 
       {isOpen && (
         <div className="chat-model-dropdown">
-          {modelGroups.map((group) => (
+          <input
+            ref={searchRef}
+            className="chat-model-search-input"
+            type="text"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            placeholder={t("chat.searchModels")}
+          />
+          {filteredGroups.map((group) => (
             <div key={group.provider} className="chat-model-group">
               <div className="chat-model-group-label">
                 {t(group.providerLabel)}

--- a/src/renderer/src/screens/Chat/ModelPicker.tsx
+++ b/src/renderer/src/screens/Chat/ModelPicker.tsx
@@ -41,14 +41,15 @@ export const ModelPicker = memo(function ModelPicker({
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [isOpen]);
 
-  const filteredGroups = searchInput.trim()
+  const searchQuery = searchInput.trim().toLowerCase();
+  const filteredGroups = searchQuery
     ? modelGroups
         .map((group) => ({
           ...group,
           models: group.models.filter(
             (m) =>
-              m.label.toLowerCase().includes(searchInput.toLowerCase()) ||
-              m.model.toLowerCase().includes(searchInput.toLowerCase()),
+              m.label.toLowerCase().includes(searchQuery) ||
+              m.model.toLowerCase().includes(searchQuery),
           ),
         }))
         .filter((group) => group.models.length > 0)

--- a/src/shared/i18n/locales/en/chat.ts
+++ b/src/shared/i18n/locales/en/chat.ts
@@ -8,6 +8,7 @@ export default {
   quickAskTitle:
     "Quick Ask (/btw) — side question that won't affect conversation context",
   send: "Send",
+  searchModels: "Search models...",
   custom: "Custom",
   typeModelName: "Type model name...",
   reasoningEffort: {

--- a/src/shared/i18n/locales/es/chat.ts
+++ b/src/shared/i18n/locales/es/chat.ts
@@ -9,6 +9,7 @@ export default {
     "Pregunta rápida (/btw) — una pregunta secundaria que no afectará el contexto de la conversación",
   send: "Enviar",
   custom: "Personalizado",
+  searchModels: "Buscar modelos...",
   typeModelName: "Escribe el nombre del modelo...",
   emptyTitle: "¿Cómo puedo ayudarte hoy?",
   emptyHint:

--- a/src/shared/i18n/locales/id/chat.ts
+++ b/src/shared/i18n/locales/id/chat.ts
@@ -9,6 +9,7 @@ export default {
     "Tanya Cepat (/btw) - pertanyaan sampingan yang tidak memengaruhi konteks percakapan",
   send: "Kirim",
   custom: "Kustom",
+  searchModels: "Cari model...",
   typeModelName: "Ketik nama model...",
   emptyTitle: "Apa yang bisa saya bantu hari ini?",
   emptyHint:

--- a/src/shared/i18n/locales/ja/chat.ts
+++ b/src/shared/i18n/locales/ja/chat.ts
@@ -8,6 +8,7 @@ export default {
   quickAskTitle: "Quick Ask (/btw) — 会話コンテキストに影響しないサイド質問",
   send: "送信",
   custom: "カスタム",
+  searchModels: "モデルを検索...",
   typeModelName: "モデル名を入力...",
   emptyTitle: "今日はどんなお手伝いを？",
   emptyHint: "コード生成、質問への回答、Web 検索など何でも頼んでください",

--- a/src/shared/i18n/locales/pl/chat.ts
+++ b/src/shared/i18n/locales/pl/chat.ts
@@ -9,6 +9,7 @@ export default {
     "Szybkie pytanie (/btw) — pytanie poboczne, które nie wpłynie na kontekst rozmowy",
   send: "Wyślij",
   custom: "Niestandardowy",
+  searchModels: "Szukaj modeli...",
   typeModelName: "Wpisz nazwę modelu...",
   emptyTitle: "Jak mogę dziś pomóc?",
   emptyHint:

--- a/src/shared/i18n/locales/pt-BR/chat.ts
+++ b/src/shared/i18n/locales/pt-BR/chat.ts
@@ -9,6 +9,7 @@ export default {
     "Pergunta Rápida (/btw) — pergunta lateral que não afetará o contexto da conversa",
   send: "Enviar",
   custom: "Personalizado",
+  searchModels: "Pesquisar modelos...",
   typeModelName: "Digite o nome do modelo...",
   emptyTitle: "Como posso ajudar você hoje?",
   emptyHint:

--- a/src/shared/i18n/locales/pt-PT/chat.ts
+++ b/src/shared/i18n/locales/pt-PT/chat.ts
@@ -9,6 +9,7 @@ export default {
     "Pergunta Rápida (/btw) — pergunta lateral que não afectará o contexto da conversa",
   send: "Enviar",
   custom: "Personalizado",
+  searchModels: "Pesquisar modelos...",
   typeModelName: "Escreva o nome do modelo...",
   emptyTitle: "Como posso ajudá-lo hoje?",
   emptyHint:

--- a/src/shared/i18n/locales/tr/chat.ts
+++ b/src/shared/i18n/locales/tr/chat.ts
@@ -8,6 +8,7 @@ export default {
   quickAskTitle: "Hızlı Sor (/btw) — sohbet bağlamını etkilemeyen yan soru",
   send: "Gönder",
   custom: "Özel",
+  searchModels: "Model ara...",
   typeModelName: "Model adını yaz...",
   emptyTitle: "Bugün size nasıl yardımcı olabilirim?",
   emptyHint:

--- a/src/shared/i18n/locales/zh-CN/chat.ts
+++ b/src/shared/i18n/locales/zh-CN/chat.ts
@@ -8,6 +8,7 @@ export default {
   quickAskTitle: "快速提问（/btw）—— 不会影响当前对话上下文的旁支问题",
   send: "发送",
   custom: "自定义",
+  searchModels: "搜索模型...",
   typeModelName: "输入模型名称...",
   emptyTitle: "今天我可以帮你做什么？",
   emptyHint: "你可以让我写代码、回答问题、搜索网页等",

--- a/src/shared/i18n/locales/zh-TW/chat.ts
+++ b/src/shared/i18n/locales/zh-TW/chat.ts
@@ -8,6 +8,7 @@ export default {
   quickAskTitle: "快速提問（/btw），不會影響目前對話上下文的旁支問題",
   send: "傳送",
   custom: "自訂",
+  searchModels: "搜尋模型...",
   typeModelName: "輸入模型名稱...",
   emptyTitle: "今天我可以幫你做什麼？",
   emptyHint: "你可以讓我寫程式碼、回答問題、搜尋網頁等",


### PR DESCRIPTION
## Summary

Adds a search/filter input to the chat model picker dropdown, making it easy to find models by label or model ID across all provider groups.

## Changes

### `ModelPicker.tsx`
- Added `searchInput` state and `searchRef` for the search field
- Filters `modelGroups` by matching against `m.label` and `m.model` (case-insensitive) when the search query is non-empty; groups with zero matches are hidden
- Search input auto-focuses when the dropdown opens
- Search query is cleared on dropdown toggle close and after model selection
- Renders a sticky `<input>` at the top of the dropdown with placeholder from i18n key `chat.searchModels`

### `main.css`
- Added `.chat-model-search-input` class with sticky positioning (`position: sticky; top: 0`) and `var(--bg-secondary)` background so it stays visible while scrolling
- Shared base styles (width, padding, font-size, border, border-radius) between `.chat-model-search-input` and `.chat-model-custom-input`
- `.chat-model-custom-input` retains its own `background: var(--bg-tertiary)` override

### i18n (11 locales)
- Added `searchModels` key to all supported locale files: `en`, `es`, `id`, `ja`, `pl`, `pt-BR`, `pt-PT`, `tr`, `zh-CN`, `zh-TW`

### `ModelPicker.test.tsx` (new)
- 21 test cases covering:
  - Initial render (display model name, dropdown hidden)
  - Open/close behavior (trigger toggle, click outside)
  - Model list rendering (all groups/models, active model highlighting)
  - Model selection (correct args, closes dropdown)
  - Search/filtering (by label, by model ID, case-insensitive, clear restores all, cleared on toggle)
  - Custom model input (render, submit on Enter, `auto` provider, empty/whitespace guard, closes on submit)
  - Edge cases (empty modelGroups, no search matches)