### PR TITLE
feat(secrets): wire the provider into key-resolution paths + vault-aware audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,87 @@ Hermes files are managed in:
 - `~/.hermes/state.db` — session history database
 - `~/.hermes/cron/jobs.json` — scheduled tasks
 
+## Secrets provider
+
+By default, API keys live in `~/.hermes/.env` (the **env** provider). No
+configuration is needed — this is byte-for-byte the historical behavior, and
+nothing changes for you.
+
+If you'd rather not keep keys in a plaintext `.env`, the opt-in **command**
+provider resolves them by running a helper command you configure. Resolution
+order everywhere is: `process.env` → `.env` → provider → unset.
+
+Per-key helper (the requested key name arrives as `$HERMES_SECRET_KEY`):
+
+```yaml
+# ~/.hermes/config.yaml
+secrets:
+  provider: command
+  command: secret-tool lookup hermes "$HERMES_SECRET_KEY"
+```
+
+Or a helper that dumps a dotenv blob (e.g. a vault that unseals into tmpfs):
+
+```yaml
+secrets:
+  provider: command
+  command: "cat /run/user/1000/hermes-secrets.env"
+```
+
+The helper's stdout may be either a single bare value (per-key helpers) or
+`KEY=VALUE` lines (dotenv dumps); both shapes are auto-detected.
+
+### Vault / secret manager integration (no TPM required)
+
+The `command` provider is **vault-agnostic** — it runs whatever helper you
+configure and reads its stdout. The helper is the only thing that needs to
+talk to your secret store. If you don't have a TPM-sealed keyfile, any of
+these work without code changes to Hermes:
+
+- **KeePassXC (password-only DB, no keyfile):** point `secrets.command` at a
+  small `kpxc-export.sh` script that does
+  `keepassxc-cli ls ~/secrets/hermes.kdbx <<<"$KPXC_PASSWORD"` and dumps
+  the relevant group as dotenv. Prompt the user for the master password
+  once per session.
+- **GnuPG with a passphrase-only key:** `gpg --batch --passphrase-fd 0
+  --decrypt ~/.keys/api-keys.gpg` works directly as the `command` value.
+  Pass the passphrase via a file descriptor or env var, never argv.
+- **`pass` (the standard unix password manager):**
+  `command: "pass show hermes/$HERMES_SECRET_KEY"` for a per-key helper,
+  or a small wrapper script for a dotenv dump.
+- **`secret-tool` (libsecret/Gnome Keyring):**
+  `command: "secret-tool lookup hermes $HERMES_SECRET_KEY"` (already
+  shown above as the canonical per-key example).
+- **Bitwarden CLI:** `bw get item "$HERMES_SECRET_KEY" | jq -r .notes`
+  (after `bw unlock` in the session).
+- **1Password CLI:** `op read "op://vault/$HERMES_SECRET_KEY/credential"`.
+- **Plain env file with user-managed permissions:**
+  `command: "cat ~/.config/hermes/secrets.env"` with `chmod 600` and
+  the file owned by your user. Not as secure as a vault, but better than
+  a world-readable `.env`.
+
+The point: **any helper that prints a value (per-key) or a dotenv blob
+(list-mode) on stdout will work**, and Hermes imposes a 3-second timeout
+and 1 MiB output cap on the helper so a misbehaving one can't wedge the
+app. The provider makes no assumptions about TPM, FIDO2, smart cards,
+or platform keychains.
+
+Security model:
+
+- The command string is your own configuration — same trust level as `.env`.
+  It runs via `/bin/sh -c`, so the command provider is POSIX-only
+  (Linux/macOS); Windows stays on the env provider.
+- The helper inherits the process environment plus `HERMES_SECRET_KEY`; the
+  key name is passed as data, never interpolated into the shell string.
+- Hard 3-second timeout (resolution is synchronous on the main process — keep
+  helpers fast and non-interactive), 1 MiB output cap, and stderr is discarded.
+- Resolved values are never logged or written to disk; failures degrade to
+  "key unset", logging only exit code/signal.
+- The gateway-spawn broadcast uses a single `list()` call, never a per-key
+  helper loop.
+
+Source of truth: [`src/main/secrets/`](src/main/secrets/).
+
 ## Tech Stack
 
 - **Electron** 39 — cross-platform desktop shell

--- a/src/main/config-health.test.ts
+++ b/src/main/config-health.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock every config dependency the audit checks touch. The tests then
+// directly call runConfigHealthCheck (the entry point the renderer hits
+// via IPC) and assert on the issues it surfaces.
+vi.mock("./config", () => ({
+  readEnv: vi.fn(),
+  getConfigValue: vi.fn(),
+  getModelConfig: vi.fn(),
+  customEndpointKeyResolvable: vi.fn(() => false),
+  hasOAuthCredentials: vi.fn(() => false),
+  setEnvValue: vi.fn(),
+  setConfigValue: vi.fn(),
+  appendConfigFixLog: vi.fn(),
+  upsertBlockChild: vi.fn(),
+  maskKey: vi.fn((v: string) => v.slice(0, 4) + "***"),
+  profilePaths: vi.fn((profile?: string) => ({
+    home: `/fake/home/.hermes`,
+    envFile: `/fake/home/.hermes/.env`,
+    configFile: `/fake/home/.hermes/config.yaml`,
+    profile: profile || "default",
+  })),
+}));
+
+vi.mock("fs", async () => {
+  const actual = await vi.importActual<typeof import("fs")>("fs");
+  return {
+    ...actual,
+    existsSync: vi.fn(
+      (p: string) =>
+        // Pretend the config file always exists; the audit gates the
+        // EMPTY_API_SERVER_KEY warning on `configExists`. The .env file
+        // existence is also gated; we treat it as existing unless the
+        // mocked readEnv() returns nothing (the tests cover both).
+        String(p).endsWith("config.yaml") || String(p).endsWith(".env"),
+    ),
+  };
+});
+
+// Per-test vault map for the command-provider tests. We mutate this object
+// (assigning new properties) instead of reassigning, so the closure inside
+// the secrets mock always reads the current value. Initialized to empty;
+// each test sets the keys it needs.
+let FAKE_VAULT: Record<string, string> = {};
+
+vi.mock("./secrets", async () => {
+  const actual = await vi.importActual<typeof import("./secrets")>("./secrets");
+  return {
+    ...actual,
+    // Default provider selection: pretend secrets.provider === "command" so
+    // getSecretsProvider() returns a command-shaped provider. Tests that
+    // specifically want the env provider can override getConfigValue to
+    // return null for "secrets.provider".
+    getSecretsProvider: () => ({
+      id: "command",
+      get: (key: string) => FAKE_VAULT[key] ?? null,
+      list: () => ({ ...FAKE_VAULT }),
+    }),
+    // Mirror the real helper's order: provider base, .env overlay,
+    // process.env overlay. FAKE_VAULT is the authoritative store; .env is
+    // empty in the vault tests.
+    resolvedSecretMap: (profile?: string) => {
+      const merged: Record<string, string> = { ...FAKE_VAULT };
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports -- mirrors the lazy require in the real resolvedSecretMap (config -> secrets -> config cycle).
+        const { readEnv } = require("./config") as typeof import("./config");
+        const env = readEnv(profile);
+        for (const [k, v] of Object.entries(env)) {
+          if (v != null && v !== "" && !merged[k]) merged[k] = v;
+        }
+      } catch {
+        // config not loadable — provider-only view is fine
+      }
+      for (const [k, v] of Object.entries(process.env)) {
+        if (v != null && v !== "" && !merged[k]) merged[k] = v;
+      }
+      return merged;
+    },
+  };
+});
+
+import {
+  readEnv,
+  getConfigValue,
+  getModelConfig,
+  customEndpointKeyResolvable,
+  hasOAuthCredentials,
+} from "./config";
+import { runConfigHealthCheck } from "./config-health";
+
+const mockedReadEnv = vi.mocked(readEnv);
+const mockedGetConfigValue = vi.mocked(getConfigValue);
+const mockedGetModelConfig = vi.mocked(getModelConfig);
+const mockedCustomEndpointKeyResolvable = vi.mocked(
+  customEndpointKeyResolvable,
+);
+const mockedHasOAuthCredentials = vi.mocked(hasOAuthCredentials);
+
+describe("config-health audit — vault awareness", () => {
+  beforeEach(() => {
+    FAKE_VAULT = {};
+    mockedReadEnv.mockReset();
+    mockedGetConfigValue.mockReset();
+    mockedGetModelConfig.mockReset();
+    mockedCustomEndpointKeyResolvable.mockReset();
+    mockedHasOAuthCredentials.mockReset();
+
+    // Defaults: empty .env, empty config.yaml. We pick `provider: "anthropic"`
+    // with no baseUrl so expectedEnvKeyForModel() returns ANTHROPIC_API_KEY
+    // (nano-gpt.com / custom isn't in the URL pattern, so it returns null and
+    // the check would silently no-op — not what we want to test). Tests that
+    // need a different model override the mock.
+    mockedReadEnv.mockReturnValue({});
+    mockedGetConfigValue.mockReturnValue(null);
+    mockedGetModelConfig.mockReturnValue({
+      provider: "anthropic",
+      model: "claude-sonnet-4.6",
+      baseUrl: "",
+    });
+    mockedCustomEndpointKeyResolvable.mockReturnValue(false);
+    mockedHasOAuthCredentials.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    // Don't leak process.env from one test to the next.
+    for (const k of [
+      "API_SERVER_KEY",
+      "NANO_GPT_API_KEY",
+      "ANTHROPIC_API_KEY",
+      "ANTHROPIC_TOKEN",
+      "CUSTOM_API_KEY",
+      "OPENAI_API_KEY",
+    ]) {
+      delete process.env[k];
+    }
+  });
+
+  describe("env provider (default) — byte-for-byte unchanged", () => {
+    it("still fires EMPTY_API_SERVER_KEY when neither .env nor vault has the key", () => {
+      const report = runConfigHealthCheck("default");
+      const codes = report.issues.map((i) => i.code);
+      expect(codes).toContain("EMPTY_API_SERVER_KEY");
+    });
+
+    it("still fires MODEL_KEY_MISSING when the active model's key is absent everywhere", () => {
+      const report = runConfigHealthCheck("default");
+      const codes = report.issues.map((i) => i.code);
+      expect(codes).toContain("MODEL_KEY_MISSING");
+    });
+
+    it("does NOT fire EMPTY_API_SERVER_KEY when the .env file has the key", () => {
+      mockedReadEnv.mockReturnValue({ API_SERVER_KEY: "from-dotenv" });
+      const report = runConfigHealthCheck("default");
+      const codes = report.issues.map((i) => i.code);
+      expect(codes).not.toContain("EMPTY_API_SERVER_KEY");
+    });
+
+    it("does NOT fire MODEL_KEY_MISSING when the .env file has the key", () => {
+      mockedReadEnv.mockReturnValue({ ANTHROPIC_API_KEY: "from-dotenv" });
+      const report = runConfigHealthCheck("default");
+      const codes = report.issues.map((i) => i.code);
+      expect(codes).not.toContain("MODEL_KEY_MISSING");
+    });
+  });
+
+  describe("command provider — vault-only user", () => {
+    it("does NOT fire EMPTY_API_SERVER_KEY when the vault has the key", () => {
+      FAKE_VAULT = { API_SERVER_KEY: "from-vault" };
+      const report = runConfigHealthCheck("default");
+      const codes = report.issues.map((i) => i.code);
+      expect(codes).not.toContain("EMPTY_API_SERVER_KEY");
+    });
+
+    it("does NOT fire MODEL_KEY_MISSING when the vault has the active model's key", () => {
+      FAKE_VAULT = { ANTHROPIC_API_KEY: "from-vault" };
+      const report = runConfigHealthCheck("default");
+      const codes = report.issues.map((i) => i.code);
+      expect(codes).not.toContain("MODEL_KEY_MISSING");
+    });
+
+    it("does NOT fire MODEL_KEY_MISSING for a custom endpoint when the vault has OPENAI_API_KEY", () => {
+      // With provider: "custom" and baseUrl "https://api.openai.com/v1",
+      // expectedEnvKeyForModel() returns OPENAI_API_KEY (URL pattern match).
+      // The audit's vault overlay should see OPENAI_API_KEY in the vault
+      // and short-circuit before the customEndpointKeyResolvable() branch.
+      mockedGetModelConfig.mockReturnValue({
+        provider: "custom",
+        model: "any-model",
+        baseUrl: "https://api.openai.com/v1",
+      });
+      mockedReadEnv.mockReturnValue({});
+      FAKE_VAULT = { OPENAI_API_KEY: "from-vault" };
+      const report = runConfigHealthCheck("default");
+      const codes = report.issues.map((i) => i.code);
+      expect(codes).not.toContain("MODEL_KEY_MISSING");
+    });
+  });
+
+  describe("process.env (vault-style env injection) — works the same way", () => {
+    it("does NOT fire EMPTY_API_SERVER_KEY when process.env has the key", () => {
+      // Many "vault" workflows just `export` the keys into the process
+      // environment (e.g. a KeePassXC unseal script that calls `setenv`).
+      // The audit must honor that.
+      process.env.API_SERVER_KEY = "from-process-env";
+      const report = runConfigHealthCheck("default");
+      const codes = report.issues.map((i) => i.code);
+      expect(codes).not.toContain("EMPTY_API_SERVER_KEY");
+    });
+
+    it("does NOT fire MODEL_KEY_MISSING when process.env has the key", () => {
+      process.env.ANTHROPIC_API_KEY = "from-process-env";
+      const report = runConfigHealthCheck("default");
+      const codes = report.issues.map((i) => i.code);
+      expect(codes).not.toContain("MODEL_KEY_MISSING");
+    });
+  });
+
+  describe("rotation + deletion — reflected on next audit", () => {
+    it("EMPTY_API_SERVER_KEY fires when the only source is removed", () => {
+      // Simulate rotation: key was in .env, then moved to the vault, then
+      // the vault entry got deleted. The audit must catch it again.
+      mockedReadEnv.mockReturnValue({ API_SERVER_KEY: "from-dotenv" });
+      let report = runConfigHealthCheck("default");
+      expect(report.issues.map((i) => i.code)).not.toContain(
+        "EMPTY_API_SERVER_KEY",
+      );
+
+      // User deletes the .env entry (vault doesn't have it either).
+      mockedReadEnv.mockReturnValue({});
+      report = runConfigHealthCheck("default");
+      expect(report.issues.map((i) => i.code)).toContain(
+        "EMPTY_API_SERVER_KEY",
+      );
+    });
+
+    it("MODEL_KEY_MISSING recovers when a vault key is added", () => {
+      // Vault is empty — warning fires.
+      let report = runConfigHealthCheck("default");
+      expect(report.issues.map((i) => i.code)).toContain("MODEL_KEY_MISSING");
+
+      // Add the key to the vault — next audit should clear the warning.
+      FAKE_VAULT = { ANTHROPIC_API_KEY: "rotated-value" };
+      report = runConfigHealthCheck("default");
+      expect(report.issues.map((i) => i.code)).not.toContain(
+        "MODEL_KEY_MISSING",
+      );
+
+      // Rotate to a new value — still no warning.
+      FAKE_VAULT = { ANTHROPIC_API_KEY: "rotated-again" };
+      report = runConfigHealthCheck("default");
+      expect(report.issues.map((i) => i.code)).not.toContain(
+        "MODEL_KEY_MISSING",
+      );
+
+      // Delete the key — warning comes back.
+      FAKE_VAULT = {};
+      report = runConfigHealthCheck("default");
+      expect(report.issues.map((i) => i.code)).toContain("MODEL_KEY_MISSING");
+    });
+  });
+});

--- a/src/main/config-health.test.ts
+++ b/src/main/config-health.test.ts
@@ -42,6 +42,13 @@ vi.mock("fs", async () => {
 // the secrets mock always reads the current value. Initialized to empty;
 // each test sets the keys it needs.
 let FAKE_VAULT: Record<string, string> = {};
+// The `.env` layer for the resolvedSecretMap mock below. Kept as an explicit
+// module-level holder (parallel to FAKE_VAULT) rather than re-reading ./config
+// from inside the mock: a runtime require("./config") inside the vi.mock factory
+// does NOT reliably resolve to the test-controlled readEnv mock under vitest, so
+// the .env overlay was silently skipped — which is exactly what let the
+// vault-wins precedence inversion hide (AIR-008). A precedence test sets this.
+let FAKE_ENV: Record<string, string> = {};
 
 vi.mock("./secrets", async () => {
   const actual = await vi.importActual<typeof import("./secrets")>("./secrets");
@@ -56,23 +63,23 @@ vi.mock("./secrets", async () => {
       get: (key: string) => FAKE_VAULT[key] ?? null,
       list: () => ({ ...FAKE_VAULT }),
     }),
-    // Mirror the real helper's order: provider base, .env overlay,
-    // process.env overlay. FAKE_VAULT is the authoritative store; .env is
-    // empty in the vault tests.
-    resolvedSecretMap: (profile?: string) => {
+    // Mirror the real resolvedSecretMap's merge DIRECTION exactly: provider is
+    // the BASE (lowest priority), then .env OVERWRITES it, then process.env
+    // OVERWRITES that — final precedence process.env > .env > provider. A
+    // `!merged[k]` guard here would invert that (vault wins), diverging from
+    // production and silently passing any future conflict test that asserts the
+    // wrong winner (Greptile #650 / AIR-008). FAKE_VAULT is the base, NOT
+    // authoritative — .env/process.env win on conflict.
+    resolvedSecretMap: () => {
+      // Provider (vault) is the BASE; .env overwrites it; process.env overwrites
+      // that — final precedence process.env > .env > provider, matching the real
+      // resolvedSecretMap exactly. No `!merged[k]` guard (that inverts it).
       const merged: Record<string, string> = { ...FAKE_VAULT };
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-require-imports -- mirrors the lazy require in the real resolvedSecretMap (config -> secrets -> config cycle).
-        const { readEnv } = require("./config") as typeof import("./config");
-        const env = readEnv(profile);
-        for (const [k, v] of Object.entries(env)) {
-          if (v != null && v !== "" && !merged[k]) merged[k] = v;
-        }
-      } catch {
-        // config not loadable — provider-only view is fine
+      for (const [k, v] of Object.entries(FAKE_ENV)) {
+        if (v != null && v !== "") merged[k] = v;
       }
       for (const [k, v] of Object.entries(process.env)) {
-        if (v != null && v !== "" && !merged[k]) merged[k] = v;
+        if (v != null && v !== "") merged[k] = v;
       }
       return merged;
     },
@@ -87,6 +94,10 @@ import {
   hasOAuthCredentials,
 } from "./config";
 import { runConfigHealthCheck } from "./config-health";
+// The mocked resolvedSecretMap (defined in the vi.mock("./secrets") factory
+// above) — imported so a precedence test can assert the merge WINNER directly,
+// not just key presence (Greptile #650 / AIR-008).
+import { resolvedSecretMap } from "./secrets";
 
 const mockedReadEnv = vi.mocked(readEnv);
 const mockedGetConfigValue = vi.mocked(getConfigValue);
@@ -99,6 +110,7 @@ const mockedHasOAuthCredentials = vi.mocked(hasOAuthCredentials);
 describe("config-health audit — vault awareness", () => {
   beforeEach(() => {
     FAKE_VAULT = {};
+    FAKE_ENV = {};
     mockedReadEnv.mockReset();
     mockedGetConfigValue.mockReset();
     mockedGetModelConfig.mockReset();
@@ -256,6 +268,33 @@ describe("config-health audit — vault awareness", () => {
       FAKE_VAULT = {};
       report = runConfigHealthCheck("default");
       expect(report.issues.map((i) => i.code)).toContain("MODEL_KEY_MISSING");
+    });
+
+    it("resolves precedence process.env > .env > provider on a key CONFLICT (AIR-008)", () => {
+      // Same key present in all three layers with DIFFERENT values. The mock
+      // must reproduce production's merge DIRECTION (provider base, .env and
+      // process.env overwrite) — not a vault-wins inversion. Presence-only
+      // tests can't catch a flipped direction; this asserts the actual winner.
+      FAKE_VAULT = { API_SERVER_KEY: "from-vault" };
+      FAKE_ENV = { API_SERVER_KEY: "from-dotenv" };
+
+      // .env beats vault when process.env is absent.
+      delete process.env.API_SERVER_KEY;
+      expect(resolvedSecretMap("default").API_SERVER_KEY).toBe("from-dotenv");
+
+      // process.env beats both when present.
+      process.env.API_SERVER_KEY = "from-process-env";
+      try {
+        expect(resolvedSecretMap("default").API_SERVER_KEY).toBe(
+          "from-process-env",
+        );
+      } finally {
+        delete process.env.API_SERVER_KEY;
+      }
+
+      // With only the vault set, the vault value is what surfaces (base layer).
+      FAKE_ENV = {};
+      expect(resolvedSecretMap("default").API_SERVER_KEY).toBe("from-vault");
     });
   });
 });

--- a/src/main/config-health.ts
+++ b/src/main/config-health.ts
@@ -33,6 +33,14 @@ import { HERMES_HOME } from "./installer";
 import { expectedEnvKeyForModel } from "./installer";
 import { expectedEnvKeyForUrl, isLocalBaseUrl } from "../shared/url-key-map";
 import { findSiblingHermesHomes } from "./wsl-detection";
+// Audit checks must consult the secrets provider too — a vault-only user has
+// their keys in the provider's backing store, not in `.env`. Importing the
+// overlay helper (rather than calling readEnv directly) makes that explicit
+// and keeps the resolution order (process.env > .env > provider) consistent
+// with getApiServerKey() and transcribeAudio(). A failure of this import (e.g.
+// during a config-only smoke test) is fine — the audit degrades to the .env
+// view.
+import { resolvedSecretMap } from "./secrets";
 
 export type Severity = "error" | "warning" | "info";
 
@@ -150,6 +158,14 @@ export function autoFixIssue(
  * getApiServerKey() handles the first case automatically; this check
  * just surfaces it so users see it happened (and re-fires if the auto
  * migration failed for some reason).
+ *
+ * Vault-aware: a `command` provider with `API_SERVER_KEY` configured in
+ * the vault satisfies the "is the key set?" check. We still surface
+ * the .env view (so a user with a value in BOTH .env and the vault can
+ * see the .env one for migration purposes) but we do NOT fire the
+ * `EMPTY_API_SERVER_KEY` warning when the provider has the key — that
+ * warning would push the user to write the key back into .env, which
+ * defeats the point of vault-only mode.
  */
 function checkApiServerKeyPlacement(profile?: string): ConfigHealthIssue[] {
   const issues: ConfigHealthIssue[] = [];
@@ -159,9 +175,17 @@ function checkApiServerKeyPlacement(profile?: string): ConfigHealthIssue[] {
   const envKey = (env.API_SERVER_KEY ?? "").trim();
   const topLevel = (getConfigValue("API_SERVER_KEY", profile) ?? "").trim();
   const nested = (getConfigValue("api_server.token", profile) ?? "").trim();
+  // Fully-resolved view (process.env > .env > provider) — a vault-only user
+  // has a non-empty value here even when envKey is empty.
+  const resolved = resolvedSecretMap(profile);
+  const resolvedKey = (resolved.API_SERVER_KEY ?? "").trim();
 
   // Multiple values: if two or more non-empty locations disagree, that's
-  // ambiguous and the user has to resolve which one wins.
+  // ambiguous and the user has to resolve which one wins. Compare the
+  // .env view against config.yaml — a vault-only user is a single-value
+  // case (no .env entry, no config.yaml entry, vault holds the key), so
+  // we don't include the provider in the disagreement check. The point
+  // of the warning is to surface file-level ambiguity, not vault-vs-file.
   const values = [envKey, topLevel, nested].filter((v) => v !== "");
   const uniqueValues = new Set(values);
   if (uniqueValues.size > 1) {
@@ -204,9 +228,12 @@ function checkApiServerKeyPlacement(profile?: string): ConfigHealthIssue[] {
     });
   }
 
-  // Empty: no key at all, and the gateway is configured to require one.
+  // Empty: no key in any checked location AND the gateway is configured
+  // to require one. Skip if the vault (via the secrets provider) already
+  // has the key — for a vault-only user, the key IS configured and
+  // writing it back to .env would defeat the vault-first workflow.
   // We can't auto-fix this — the user has to provide a secret.
-  if (!envKey && !topLevel && !nested) {
+  if (!envKey && !topLevel && !nested && !resolvedKey) {
     // Only flag if a gateway run.py / api_server is actually configured.
     // For a fresh install with no setup yet, this would be noise.
     const configExists = existsSync(configFile);
@@ -234,6 +261,11 @@ function checkApiServerKeyPlacement(profile?: string): ConfigHealthIssue[] {
  * .env. This is the *most likely* cause of chat 401s — the user has
  * picked a model in the GUI but their key isn't where the gateway
  * expects to find it.
+ *
+ * Vault-aware: consult the secrets provider before flagging. A
+ * vault-only user with `NANO_GPT_API_KEY` (or similar) in their vault
+ * is NOT missing the key — the provider's resolvedSecretMap() is the
+ * authoritative "is the key configured?" view.
  */
 function checkActiveModelKeyPresence(profile?: string): ConfigHealthIssue[] {
   const mc = getModelConfig(profile);
@@ -248,6 +280,13 @@ function checkActiveModelKeyPresence(profile?: string): ConfigHealthIssue[] {
 
   const env = readEnv(profile);
   if ((env[expectedKey] ?? "").trim()) return [];
+
+  // Vault check: a `command` provider (or env-injecting vault) with this
+  // key configured satisfies the requirement — don't warn. This is the
+  // fix for the false "NANO_GPT_API_KEY is not set in .env" warning that
+  // a vault-only user would otherwise see on every chat start.
+  const resolved = resolvedSecretMap(profile);
+  if ((resolved[expectedKey] ?? "").trim()) return [];
 
   // OpenAI-compatible / custom endpoints resolve their key from a fallback
   // chain (URL key → CUSTOM_PROVIDER_<name>_KEY → CUSTOM_API_KEY →

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -736,10 +736,14 @@ export function customEndpointKeyResolvable(
   // Vault-aware: a `command` provider with any of the fallback keys
   // configured in the vault satisfies the requirement too — don't
   // return false and trigger a cascade of "MODEL_KEY_MISSING" / "set up
-  // provider" warnings for a vault-only user. Lazy-import to avoid a
-  // circular dependency at module-load time (config -> secrets -> config).
+  // provider" warnings for a vault-only user. NOTE: ./secrets is already
+  // statically imported at the top of this file, so this lazy require does
+  // NOT break a cycle (the cycle is already established and safe because
+  // secrets constructs its providers lazily). It is required at call time
+  // only so a test that resets modules re-binds the current ./secrets;
+  // collapsing it to the top-level static import would work equally well.
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports -- intentional lazy require: breaks the config -> secrets -> config import cycle (a static import would re-create it at module-load time).
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- call-time require (see note above); not a cycle-break — ./secrets is already statically imported at the top of this file.
     const secretsMod = require("./secrets") as typeof import("./secrets");
     const resolved = secretsMod.resolvedSecretMap(profile);
     for (const k of candidates) {

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -10,6 +10,19 @@ import {
   safeWriteFile,
 } from "./utils";
 import { getYamlPath } from "./yaml-path";
+// NOTE: ./secrets imports back into this module (getConfigValue / readEnv), so
+// this is a static import that closes a cycle (config -> secrets ->
+// commandProvider -> config). It is safe ONLY because BOTH sides defer all work
+// to call time: config.ts calls the three fns below inside function bodies, and
+// secrets/index.ts constructs its providers LAZILY (no `new` at module-init).
+// If you make secrets/index.ts construct a provider at module scope again, this
+// static import will throw "X is not a constructor" on load-order-dependent
+// paths. Keep provider construction lazy there, or make this import lazy here.
+import {
+  getSecretsProvider,
+  providerListSafe,
+  invalidateProviderListCache,
+} from "./secrets";
 import { canonicalProviderBaseUrl } from "./provider-registry";
 import {
   expectedEnvKeyForUrl,
@@ -144,6 +157,23 @@ function invalidateCache(prefix: string): void {
   for (const key of _cache.keys()) {
     if (key.startsWith(prefix)) _cache.delete(key);
   }
+}
+
+/**
+ * Drop all secrets-related cache entries (the parsed `env:*` views and the
+ * resolved `apiServerKey:*` values, every profile). Call after a vault
+ * rotation / secrets-add / secrets-inject so the next `getSecret` /
+ * `getApiServerKey` lookup re-resolves through the live provider instead of
+ * serving a value cached up to 5s ago (which can 401 against a rotated key).
+ * Does NOT spawn the provider — it only clears cached values.
+ */
+export function invalidateSecretsCache(): void {
+  invalidateCache("env:");
+  invalidateCache("apiServerKey:");
+  // Also drop the secrets-layer list() cache so a vault rotation is visible
+  // on the next provider read (S1: that cache is the helper-spawn rate floor,
+  // explicit invalidation is the one sanctioned way to bust it early).
+  invalidateProviderListCache();
 }
 
 export function readEnv(profile?: string): Record<string, string> {
@@ -703,6 +733,21 @@ export function customEndpointKeyResolvable(
   for (const k of candidates) {
     if ((env[k] ?? "").trim()) return true;
   }
+  // Vault-aware: a `command` provider with any of the fallback keys
+  // configured in the vault satisfies the requirement too — don't
+  // return false and trigger a cascade of "MODEL_KEY_MISSING" / "set up
+  // provider" warnings for a vault-only user. Lazy-import to avoid a
+  // circular dependency at module-load time (config -> secrets -> config).
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- intentional lazy require: breaks the config -> secrets -> config import cycle (a static import would re-create it at module-load time).
+    const secretsMod = require("./secrets") as typeof import("./secrets");
+    const resolved = secretsMod.resolvedSecretMap(profile);
+    for (const k of candidates) {
+      if ((resolved[k] ?? "").trim()) return true;
+    }
+  } catch {
+    // secrets module not loadable — env-only view is the best we can do
+  }
   return false;
 }
 
@@ -931,6 +976,13 @@ export function getHermesHome(profile?: string): string {
 }
 
 /**
+ * `${providerId}:${profile}` pairs already warned about an unresolved
+ * API_SERVER_KEY — one diagnostic line per pair for the whole session, not one
+ * per chat message (getApiServerKey is a hot path).
+ */
+const warnedUnresolvedApiKey = new Set<string>();
+
+/**
  * Resolve the API server's shared secret. Honoured by the local hermes
  * gateway (`api_server.token` in `config.yaml` / `API_SERVER_KEY` in
  * `.env`) when present; the desktop must include it as
@@ -972,14 +1024,45 @@ export function getApiServerKey(profile?: string): string {
   const cached = getCached<string>(cacheKey);
   if (cached !== undefined) return cached;
 
-  const envForProfile = readEnv(profile);
+  // Overlay the secrets provider's enumerable map BENEATH the `.env` file view,
+  // mirroring the process.env > .env > provider resolution order used
+  // everywhere else: a key is filled from the provider only when neither the
+  // `.env` file nor process.env already has it. A no-op for the default env
+  // provider (its list() IS the `.env` map); for a `command`-provider user this
+  // is what lets a vault-stored API_SERVER_KEY reach the 6-source resolver (as
+  // its canonical `envProfile` arm — deliberately NOT a 7th source, so the
+  // env-provider resolve-precedence policy is unchanged). Copy before
+  // overlaying: readEnv() returns a shared cached object that must not be
+  // mutated with provider values.
+  const envForProfile: Record<string, string> = { ...readEnv(profile) };
+  let providerId = "env";
+  try {
+    providerId = getSecretsProvider(profile).id;
+    let contributed = 0;
+    for (const [k, v] of Object.entries(providerListSafe(profile))) {
+      if (v && !envForProfile[k] && !(process.env[k] ?? "").trim()) {
+        envForProfile[k] = v;
+        contributed++;
+      }
+    }
+    // Visible under --enable-logging so an overlay user can see it happening.
+    console.debug(
+      `[secrets] API_SERVER_KEY overlay: provider=${providerId}, contributed ${contributed} keys`,
+    );
+  } catch {
+    // secrets module not available — fall through to the env-only view
+  }
   const sources: ApiKeySources = {
     configTopLevelProfile: getConfigValue("API_SERVER_KEY", profile),
     configTopLevelDefault:
       profile && profile !== "default"
         ? getConfigValue("API_SERVER_KEY")
         : null,
-    envProfile: envForProfile.API_SERVER_KEY ?? null,
+    // Prefer the .env file value, then a runtime-injected one (e.g. a vault that
+    // unseals API_SERVER_KEY into the process environment rather than writing it
+    // to .env). This is the env arm of the secrets-provider resolution order.
+    envProfile:
+      envForProfile.API_SERVER_KEY ?? process.env.API_SERVER_KEY ?? null,
     envDefault:
       profile && profile !== "default"
         ? (readEnv().API_SERVER_KEY ?? null)
@@ -991,6 +1074,18 @@ export function getApiServerKey(profile?: string): string {
         : null,
   };
   const { value, source } = resolveApiServerKeyWithSource(sources);
+
+  // Diagnostic for "why is the key missing": one line naming the active
+  // provider, rate-limited per (provider, profile) so the hot path can't spam.
+  if (!value) {
+    const warnKey = `${providerId}:${profile || "default"}`;
+    if (!warnedUnresolvedApiKey.has(warnKey)) {
+      warnedUnresolvedApiKey.add(warnKey);
+      console.warn(
+        `[secrets] API_SERVER_KEY not resolved (provider=${providerId}, env=${profile || "default"})`,
+      );
+    }
+  }
 
   // Migration on read — if we resolved the key from a non-canonical
   // location AND the canonical `.env` slot is empty for this profile,
@@ -1039,6 +1134,31 @@ export function getApiServerKey(profile?: string): string {
 
   setCache(cacheKey, value);
   return value;
+}
+
+/**
+ * Wire shape of the `get-api-server-key-status` IPC channel. `hasKey` is the
+ * stable, required field existing renderer code relies on; `providerId` and
+ * `checkedAt` are ADDITIVE optional extras so a follow-up Settings/Gateway UI
+ * can distinguish "key resolved via vault" vs ".env" vs "missing".
+ */
+export interface ApiServerKeyStatus {
+  hasKey: boolean;
+  providerId?: string;
+  checkedAt?: number;
+}
+
+export function getApiServerKeyStatus(profile?: string): ApiServerKeyStatus {
+  const key = getApiServerKey(profile);
+  const status: ApiServerKeyStatus = { hasKey: key.length > 0 };
+  try {
+    const providerId = getSecretsProvider(profile).id;
+    if (providerId !== undefined) status.providerId = providerId;
+  } catch {
+    // secrets module unavailable — keep the legacy hasKey-only shape
+  }
+  status.checkedAt = Date.now();
+  return status;
 }
 
 /**

--- a/src/main/hermes.test.ts
+++ b/src/main/hermes.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// hermes.ts pulls in the full main-process import graph; mock the modules with
+// import-time side effects (installer → electron) and the two seams under
+// test (config's readEnv / secrets' providerListSafe). Everything else
+// (run-stream, url-key-map, …) is pure and loads for real.
+vi.mock("./installer", () => ({
+  HERMES_HOME: "/tmp/hermes-test-home",
+  HERMES_REPO: "/tmp/hermes-test-repo",
+  HERMES_PYTHON: "python3",
+  hermesCliArgs: vi.fn(() => []),
+  getEnhancedPath: vi.fn(() => ""),
+}));
+vi.mock("./config", () => ({
+  getApiServerKey: vi.fn(() => ""),
+  getConnectionConfig: vi.fn(() => ({
+    mode: "local",
+    remoteUrl: "",
+    apiKey: "",
+    ssh: {},
+  })),
+  getConfigValue: vi.fn(() => null),
+  getModelConfig: vi.fn(),
+  readEnv: vi.fn(() => ({})),
+}));
+vi.mock("./ssh-tunnel", () => ({
+  getSshTunnelUrl: vi.fn(() => null),
+  isSshTunnelActive: vi.fn(() => false),
+  isSshTunnelHealthy: vi.fn(() => false),
+  startSshTunnel: vi.fn(),
+}));
+vi.mock("./utils", () => ({
+  pidIsAliveAs: vi.fn(() => false),
+  stripAnsi: (s: string) => s,
+  profileHome: vi.fn(() => "/tmp/hermes-test-home"),
+  profilePaths: vi.fn(() => ({
+    configFile: "/tmp/hermes-test-home/config.yaml",
+    envFile: "/tmp/hermes-test-home/.env",
+  })),
+  normalizeProfileName: (p?: string) => p,
+  getActiveProfileNameSync: vi.fn(() => undefined),
+}));
+vi.mock("./gateway-ports", () => ({ getProfilePort: vi.fn(() => 8642) }));
+vi.mock("./models", () => ({ readModels: vi.fn(() => []) }));
+vi.mock("./secrets", () => ({ providerListSafe: vi.fn(() => ({})) }));
+
+import { getModelConfig, readEnv } from "./config";
+import { providerListSafe } from "./secrets";
+import { transcribeAudio } from "./hermes";
+
+const mockedGetModelConfig = vi.mocked(getModelConfig);
+const mockedReadEnv = vi.mocked(readEnv);
+const mockedProviderListSafe = vi.mocked(providerListSafe);
+
+describe("transcribeAudio API-key resolution", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    mockedGetModelConfig.mockReset();
+    mockedReadEnv.mockReset();
+    mockedProviderListSafe.mockReset();
+    mockedGetModelConfig.mockReturnValue({
+      baseUrl: "https://api.groq.com/openai/v1",
+    } as ReturnType<typeof getModelConfig>);
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ text: "transcribed" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function sentAuthHeader(): string | undefined {
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    return (init.headers as Record<string, string>).Authorization;
+  }
+
+  it("falls back to the secrets provider when .env lacks the key (vault user)", async () => {
+    mockedReadEnv.mockReturnValue({});
+    mockedProviderListSafe.mockReturnValue({ GROQ_API_KEY: "from-vault" });
+
+    await expect(
+      transcribeAudio(new Uint8Array([1, 2, 3]), "audio/webm", "default"),
+    ).resolves.toBe("transcribed");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(sentAuthHeader()).toBe("Bearer from-vault");
+  });
+
+  it(".env wins over the secrets provider (env-provider precedence unchanged)", async () => {
+    mockedReadEnv.mockReturnValue({ GROQ_API_KEY: "from-dotenv" });
+    mockedProviderListSafe.mockReturnValue({ GROQ_API_KEY: "from-vault" });
+
+    await transcribeAudio(new Uint8Array([1, 2, 3]), "audio/webm", "default");
+
+    expect(sentAuthHeader()).toBe("Bearer from-dotenv");
+  });
+
+  it("generic CUSTOM_API_KEY/OPENAI_API_KEY fallbacks also see the provider overlay", async () => {
+    mockedGetModelConfig.mockReturnValue({
+      baseUrl: "https://llm.example.com/v1",
+    } as ReturnType<typeof getModelConfig>);
+    mockedReadEnv.mockReturnValue({});
+    mockedProviderListSafe.mockReturnValue({ CUSTOM_API_KEY: "from-vault" });
+
+    await transcribeAudio(new Uint8Array([1, 2, 3]), "audio/webm", "default");
+
+    expect(sentAuthHeader()).toBe("Bearer from-vault");
+  });
+});

--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -46,6 +46,7 @@ import {
 } from "./utils";
 import { getProfilePort } from "./gateway-ports";
 import { readModels } from "./models";
+import { providerListSafe } from "./secrets";
 import { HIDDEN_SUBPROCESS_OPTIONS } from "./process-options";
 import { type Attachment, escapeXmlAttr } from "../shared/attachments";
 import { URL_KEY_MAP, OPENAI_COMPAT_PROVIDERS } from "../shared/url-key-map";
@@ -313,7 +314,16 @@ export async function transcribeAudio(
 
   // Resolve the provider key the same way the chat path does: URL-specific key
   // first, then the generic CUSTOM_API_KEY / OPENAI_API_KEY fallbacks.
-  const env = readEnv(resolved);
+  // The secrets provider's enumerable map is overlaid BENEATH the `.env` file
+  // (.env wins, mirroring the process.env > .env > provider order used
+  // everywhere else): a no-op for the default env provider, and the only way a
+  // `command`-provider user with vault-stored keys gets an Authorization header.
+  const baseEnv = readEnv(resolved);
+  const providerOverlay = providerListSafe(resolved);
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(baseEnv)) if (v) env[k] = v;
+  for (const [k, v] of Object.entries(providerOverlay))
+    if (v && !env[k]) env[k] = v;
   let apiKey = "";
   for (const { pattern, envKey } of URL_KEY_MAP) {
     if (pattern.test(baseUrl)) {
@@ -741,7 +751,7 @@ function tuiGatewayPython(): string {
   return HERMES_PYTHON;
 }
 
-function tuiGatewayEnv(profile?: string): Record<string, string> {
+export function tuiGatewayEnv(profile?: string): Record<string, string> {
   const resolved = resolveProfile(profile);
   const envPathDelimiter = process.platform === "win32" ? ";" : ":";
   const env: Record<string, string> = {
@@ -759,6 +769,12 @@ function tuiGatewayEnv(profile?: string): Record<string, string> {
   if (resolved) env.HERMES_PROFILE = resolved;
   for (const [key, value] of Object.entries(readEnv(profile))) {
     if (value) env[key] = value;
+  }
+  // Overlay provider-enumerated secrets BENEATH the values above (fill only
+  // keys still absent), so a `command`-provider user gets the same resolved
+  // key set here as on the CLI fallback path: process.env > .env > provider.
+  for (const [key, value] of Object.entries(providerListSafe(profile))) {
+    if (value && !env[key]) env[key] = value;
   }
   return env;
 }
@@ -2134,10 +2150,20 @@ function sendMessageViaCli(
     "TINKER_API_KEY",
     "WANDB_API_KEY",
   ];
+  // Resolve the configured secrets provider's enumerable secrets ONCE (not
+  // per-key): a `command` backend would otherwise spawn the helper ~30 times
+  // synchronously here, freezing the main process if the helper blocks on an
+  // unlock prompt. list() runs the helper at most once. A bare-value helper that
+  // can't enumerate returns {} — those users resolve a key via the targeted
+  // getSecret() path elsewhere, never this broadcast loop (which would otherwise
+  // spray one secret across every vendor key name).
+  const providerSecrets = providerListSafe(profile);
   for (const key of KNOWN_API_KEYS) {
-    if (profileEnv[key] && !env[key]) {
-      env[key] = profileEnv[key];
-    }
+    if (env[key]) continue; // already present (e.g. from process.env spread)
+    // Prefer the .env file value, then the provider's enumerated secrets, so a
+    // vault-resolved key reaches the agent without being written to plaintext.
+    const value = profileEnv[key] || providerSecrets[key];
+    if (value) env[key] = value;
   }
 
   const isCustomEndpoint = OPENAI_COMPAT_PROVIDERS.has(mc.provider);
@@ -2605,7 +2631,13 @@ export async function sendMessage(
 
   const mc = getModelConfig(profile);
   if (CLI_COMPAT_PROVIDER_OVERRIDE[mc.provider]) {
-    return sendMessageViaCli(message, cb, profile, resumeSessionId, attachments);
+    return sendMessageViaCli(
+      message,
+      cb,
+      profile,
+      resumeSessionId,
+      attachments,
+    );
   }
 
   // Check API server availability when the cache is cold or known-bad. Once
@@ -2735,7 +2767,7 @@ function gatewayLogPath(profile?: string): string {
   return join(logDir, "gateway-stderr.log");
 }
 
-function buildGatewayEnv(profile?: string): Record<string, string> {
+export function buildGatewayEnv(profile?: string): Record<string, string> {
   // Make sure this profile's config.yaml enables the api_server and binds the
   // profile's own port before we spawn.
   ensureApiServerConfig(profile);
@@ -2757,6 +2789,16 @@ function buildGatewayEnv(profile?: string): Record<string, string> {
   const profileEnv = readEnv(profile);
   for (const [k, value] of Object.entries(profileEnv)) {
     if (value) {
+      gatewayEnv[k] = value;
+    }
+  }
+
+  // Overlay provider-enumerated secrets BENEATH the values above (fill only
+  // keys still absent), so a `command`-provider user gets the same resolved
+  // key set on the gateway-spawn path as on the CLI fallback path:
+  // process.env > .env > provider.
+  for (const [k, value] of Object.entries(providerListSafe(profile))) {
+    if (value && !gatewayEnv[k]) {
       gatewayEnv[k] = value;
     }
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -125,7 +125,8 @@ import {
   setConnectionConfig,
   getPlatformEnabled,
   setPlatformEnabled,
-  getApiServerKey,
+  getApiServerKeyStatus,
+  invalidateSecretsCache,
 } from "./config";
 import {
   getAuxiliaryConfig,
@@ -787,9 +788,17 @@ function setupIPC(): void {
 
   // API_SERVER_KEY management — lets the renderer detect a missing key and
   // generate one with a button click (local mode) or show instructions (remote/SSH).
-  ipcMain.handle("get-api-server-key-status", (_event, profile?: string) => {
-    const key = getApiServerKey(profile);
-    return { hasKey: key.length > 0 };
+  // Additive shape: `hasKey` stays the required primary field; `providerId` /
+  // `checkedAt` are optional extras for a follow-up Settings/Gateway UI.
+  ipcMain.handle("get-api-server-key-status", (_event, profile?: string) =>
+    getApiServerKeyStatus(profile),
+  );
+
+  // Drops the cached secrets-provider values so the next status check re-reads
+  // the vault — lets the renderer's "Refresh from vault" button take effect
+  // immediately instead of waiting out the cache TTL.
+  ipcMain.handle("invalidate-secrets-cache", () => {
+    invalidateSecretsCache();
   });
 
   ipcMain.handle(

--- a/src/main/secrets/index.ts
+++ b/src/main/secrets/index.ts
@@ -254,7 +254,7 @@ export function resolvedSecretMap(profile?: string): Record<string, string> {
   // over vault values, matching the gateway's own resolution policy. The
   // .env reader is a shared cached object, so copy before mutating.
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports -- intentional lazy require: breaks the config -> secrets -> config import cycle (a static import would re-create it at module-load time).
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- readEnv is required at call time, NOT to break a cycle: getConfigValue is already statically imported from "../config" at the top of this file, so the config<->secrets cycle is already established and carried safely (providers construct lazily). The lazy require here just keeps readEnv resolution at call time so a test that resets modules (vi.resetModules) re-binds the current ../config. Collapsing it to the static import would also work; kept lazy for the resetModules test path.
     const { readEnv } = require("../config") as typeof import("../config");
     const env = readEnv(profile);
     for (const [k, v] of Object.entries(env)) {

--- a/src/main/secrets/index.ts
+++ b/src/main/secrets/index.ts
@@ -5,8 +5,22 @@ import { getConfigValue } from "../config";
 
 export type { SecretsProvider } from "./provider";
 
-const envProvider = new EnvSecretsProvider();
-const commandProvider = new CommandSecretsProvider();
+// Providers are constructed LAZILY (first use), never at module-init. Reason:
+// ./secrets sits in an import cycle (config -> secrets -> commandProvider ->
+// config). When a consumer of config.ts triggers that cycle, evaluating
+// `new CommandSecretsProvider()` at THIS module's top level can run while
+// commandProvider.ts is still mid-initialization → "CommandSecretsProvider is
+// not a constructor". Deferring construction to call time (by which point all
+// modules in the cycle are fully initialized) breaks the init-order hazard
+// without forcing every consumer to lazy-import the secrets barrel.
+let _envProvider: EnvSecretsProvider | undefined;
+let _commandProvider: CommandSecretsProvider | undefined;
+function envProviderInstance(): EnvSecretsProvider {
+  return (_envProvider ??= new EnvSecretsProvider());
+}
+function commandProviderInstance(): CommandSecretsProvider {
+  return (_commandProvider ??= new CommandSecretsProvider());
+}
 
 /** Unknown `secrets.provider` ids already warned about — one log line per id. */
 const warnedUnknownProviderIds = new Set<string>();
@@ -20,14 +34,14 @@ const warnedUnknownProviderIds = new Set<string>();
  */
 export function getSecretsProvider(profile?: string): SecretsProvider {
   const id = (getConfigValue("secrets.provider", profile) || "").trim();
-  if (id === "command") return commandProvider;
+  if (id === "command") return commandProviderInstance();
   if (id && id !== "env" && !warnedUnknownProviderIds.has(id)) {
     warnedUnknownProviderIds.add(id);
     console.warn(
       `[secrets] unknown secrets.provider "${id}"; falling back to env`,
     );
   }
-  return envProvider;
+  return envProviderInstance();
 }
 
 /**

--- a/src/main/tui-gateway-stream.test.ts
+++ b/src/main/tui-gateway-stream.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   gatewayCompletionSuffix,
   gatewayMessageCompleteText,
@@ -7,6 +7,48 @@ import {
   gatewayToolEvent,
   gatewayUsage,
 } from "./tui-gateway-stream";
+
+// Mocks so hermes.ts (which transitively reaches electron via ./installer) can
+// be imported under vitest for the gateway-env regression tests below. Only
+// the names hermes.ts imports from each module need to exist.
+vi.mock("./installer", () => ({
+  HERMES_HOME: "/tmp/hermes-test-home",
+  HERMES_REPO: "/tmp/hermes-test-repo",
+  HERMES_PYTHON: "/usr/bin/python3",
+  hermesCliArgs: vi.fn(() => []),
+  getEnhancedPath: vi.fn(() => "/usr/bin"),
+}));
+vi.mock("./config", () => ({
+  getApiServerKey: vi.fn(() => null),
+  getConnectionConfig: vi.fn(() => ({})),
+  getConfigValue: vi.fn(() => null),
+  getModelConfig: vi.fn(() => ({})),
+  readEnv: vi.fn(() => ({})),
+}));
+vi.mock("./ssh-tunnel", () => ({
+  getSshTunnelUrl: vi.fn(() => null),
+  isSshTunnelActive: vi.fn(() => false),
+  isSshTunnelHealthy: vi.fn(() => false),
+  startSshTunnel: vi.fn(),
+}));
+vi.mock("./utils", () => ({
+  pidIsAliveAs: vi.fn(() => false),
+  stripAnsi: (s: string) => s,
+  profileHome: vi.fn(() => "/tmp/hermes-test-home"),
+  // A nonexistent configFile makes ensureApiServerConfig a no-op.
+  profilePaths: vi.fn(() => ({
+    configFile: "/nonexistent/hermes-test/config.yaml",
+  })),
+  normalizeProfileName: (p?: string) => p,
+  getActiveProfileNameSync: vi.fn(() => undefined),
+}));
+vi.mock("./gateway-ports", () => ({ getProfilePort: vi.fn(() => 8642) }));
+vi.mock("./models", () => ({ readModels: vi.fn(() => []) }));
+vi.mock("./secrets", () => ({ providerListSafe: vi.fn(() => ({})) }));
+
+import { readEnv } from "./config";
+import { providerListSafe } from "./secrets";
+import { buildGatewayEnv, tuiGatewayEnv } from "./hermes";
 
 describe("tui gateway stream mapping", () => {
   it("maps message and reasoning deltas", () => {
@@ -127,5 +169,60 @@ describe("tui gateway stream mapping", () => {
       promptTokens: 10,
       totalTokens: 15,
     });
+  });
+});
+
+describe("gateway env builders consult the secrets provider", () => {
+  // Regression: provider-resolved secrets were injected only on the CLI
+  // fallback path; buildGatewayEnv/tuiGatewayEnv read only readEnv(), so a
+  // command-provider user got a gateway with silently missing API keys.
+  const savedKey = process.env.ANTHROPIC_API_KEY;
+
+  beforeEach(() => {
+    vi.mocked(readEnv).mockReset().mockReturnValue({});
+    vi.mocked(providerListSafe).mockReset().mockReturnValue({});
+    delete process.env.ANTHROPIC_API_KEY;
+  });
+  afterEach(() => {
+    if (savedKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = savedKey;
+  });
+
+  it("buildGatewayEnv injects a provider-resolved key absent from process.env and .env", () => {
+    vi.mocked(providerListSafe).mockReturnValue({
+      ANTHROPIC_API_KEY: "from-provider",
+    });
+    expect(buildGatewayEnv().ANTHROPIC_API_KEY).toBe("from-provider");
+  });
+
+  it("buildGatewayEnv keeps the .env value when both .env and provider have the key", () => {
+    vi.mocked(readEnv).mockReturnValue({ ANTHROPIC_API_KEY: "from-dotenv" });
+    vi.mocked(providerListSafe).mockReturnValue({
+      ANTHROPIC_API_KEY: "from-provider",
+    });
+    expect(buildGatewayEnv().ANTHROPIC_API_KEY).toBe("from-dotenv");
+  });
+
+  it("buildGatewayEnv keeps the process.env value over the provider's", () => {
+    process.env.ANTHROPIC_API_KEY = "from-process-env";
+    vi.mocked(providerListSafe).mockReturnValue({
+      ANTHROPIC_API_KEY: "from-provider",
+    });
+    expect(buildGatewayEnv().ANTHROPIC_API_KEY).toBe("from-process-env");
+  });
+
+  it("tuiGatewayEnv injects a provider-resolved key absent from process.env and .env", () => {
+    vi.mocked(providerListSafe).mockReturnValue({
+      ANTHROPIC_API_KEY: "from-provider",
+    });
+    expect(tuiGatewayEnv().ANTHROPIC_API_KEY).toBe("from-provider");
+  });
+
+  it("tuiGatewayEnv keeps the .env value when both .env and provider have the key", () => {
+    vi.mocked(readEnv).mockReturnValue({ ANTHROPIC_API_KEY: "from-dotenv" });
+    vi.mocked(providerListSafe).mockReturnValue({
+      ANTHROPIC_API_KEY: "from-provider",
+    });
+    expect(tuiGatewayEnv().ANTHROPIC_API_KEY).toBe("from-dotenv");
   });
 });

--- a/src/shared/i18n/locales/en/diagnose.ts
+++ b/src/shared/i18n/locales/en/diagnose.ts
@@ -18,7 +18,7 @@ export default {
   apiKeyModal: {
     title: "Set API Server Key",
     description:
-      "API_SERVER_KEY is required for the Hermes gateway to authenticate requests. Set it now to enable chat.",
+      "API_SERVER_KEY is required for the Hermes gateway to authenticate requests. Set it now to enable chat. If you keep secrets in a vault (KeePassXC, Bitwarden, etc.) and your Hermes `secrets.provider` is already pointing at it, this warning can be ignored — the provider serves the key directly.",
     label: "API Server Key",
     placeholder: "sk-… or any secret",
     autoGenerate: "Auto-generate",

--- a/tests/api-server-key-secrets-provider.test.ts
+++ b/tests/api-server-key-secrets-provider.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { join } from "path";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+
+/**
+ * getApiServerKey × secrets provider (hardening pass H2).
+ *
+ * The secrets provider's enumerable map is overlaid BENEATH the `.env` view at
+ * the top of getApiServerKey — process.env > .env > provider — so a
+ * `command`-provider user with API_SERVER_KEY in their vault stops getting 401s
+ * from claw3d.ts / mcp-servers.ts / index.ts, while the default env provider's
+ * behavior is byte-for-byte unchanged.
+ *
+ * These tests run the REAL chain (config.yaml → getSecretsProvider →
+ * CommandSecretsProvider → /bin/sh) against a temp HERMES_HOME, with a
+ * synthetic `echo` helper standing in for the vault.
+ */
+
+const TEST_DIR = join(tmpdir(), `hermes-test-secrets-key-${Date.now()}`);
+
+async function freshConfig(
+  home: string,
+): Promise<typeof import("../src/main/config")> {
+  vi.resetModules();
+  process.env.HERMES_HOME = home;
+  return await import("../src/main/config");
+}
+
+beforeEach(() => {
+  mkdirSync(TEST_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  delete process.env.HERMES_HOME;
+  delete process.env.API_SERVER_KEY;
+  vi.resetModules();
+  rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe("getApiServerKey secrets-provider overlay", () => {
+  it("resolves a vault-stored key via the command provider when .env is empty", async () => {
+    writeFileSync(
+      join(TEST_DIR, "config.yaml"),
+      [
+        "secrets:",
+        "  provider: command",
+        "  command: echo API_SERVER_KEY=from-vault",
+        "",
+      ].join("\n"),
+    );
+    // No .env file at all — previously this returned "" and consumers 401'd.
+    const { getApiServerKey } = await freshConfig(TEST_DIR);
+
+    expect(getApiServerKey()).toBe("from-vault");
+
+    // The vault value must NOT be migrated (written) to .env: it resolves as
+    // the canonical envProfile arm, and secrets never land on disk.
+    expect(existsSync(join(TEST_DIR, ".env"))).toBe(false);
+  });
+
+  it("env-provider no-regression: .env value wins and nothing changes", async () => {
+    // No secrets.* config → default env provider (its list() IS the .env map).
+    writeFileSync(join(TEST_DIR, "config.yaml"), "agent:\n  enabled: true\n");
+    writeFileSync(join(TEST_DIR, ".env"), "API_SERVER_KEY=from-dotenv\n");
+    const { getApiServerKey } = await freshConfig(TEST_DIR);
+
+    expect(getApiServerKey()).toBe("from-dotenv");
+  });
+
+  it(".env wins over the command provider when both have the key", async () => {
+    writeFileSync(
+      join(TEST_DIR, "config.yaml"),
+      [
+        "secrets:",
+        "  provider: command",
+        "  command: echo API_SERVER_KEY=from-vault",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(join(TEST_DIR, ".env"), "API_SERVER_KEY=from-dotenv\n");
+    const { getApiServerKey } = await freshConfig(TEST_DIR);
+
+    expect(getApiServerKey()).toBe("from-dotenv");
+  });
+
+  it("process.env wins over the command provider", async () => {
+    writeFileSync(
+      join(TEST_DIR, "config.yaml"),
+      [
+        "secrets:",
+        "  provider: command",
+        "  command: echo API_SERVER_KEY=from-vault",
+        "",
+      ].join("\n"),
+    );
+    process.env.API_SERVER_KEY = "from-process-env";
+    const { getApiServerKey } = await freshConfig(TEST_DIR);
+
+    expect(getApiServerKey()).toBe("from-process-env");
+  });
+});

--- a/tests/api-server-key-status.test.ts
+++ b/tests/api-server-key-status.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { join } from "path";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+
+/**
+ * getApiServerKeyStatus (vault polish V1) — the richer, ADDITIVE shape behind
+ * the `get-api-server-key-status` IPC channel, plus the rate-limited
+ * missing-key diagnostic in getApiServerKey.
+ *
+ * Runs the REAL chain (config.yaml → getSecretsProvider →
+ * CommandSecretsProvider → /bin/sh) against a temp HERMES_HOME with synthetic
+ * markers, mirroring tests/api-server-key-secrets-provider.test.ts.
+ */
+
+const TEST_DIR = join(tmpdir(), `hermes-test-key-status-${Date.now()}`);
+
+async function freshConfig(
+  home: string,
+): Promise<typeof import("../src/main/config")> {
+  vi.resetModules();
+  process.env.HERMES_HOME = home;
+  return await import("../src/main/config");
+}
+
+beforeEach(() => {
+  mkdirSync(TEST_DIR, { recursive: true });
+  delete process.env.API_SERVER_KEY;
+  // Silence the overlay debug line in test output.
+  vi.spyOn(console, "debug").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  delete process.env.HERMES_HOME;
+  delete process.env.API_SERVER_KEY;
+  vi.restoreAllMocks();
+  vi.resetModules();
+  rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe("getApiServerKeyStatus", () => {
+  it("reports hasKey=true, providerId='command' for a vault-resolved key", async () => {
+    writeFileSync(
+      join(TEST_DIR, "config.yaml"),
+      [
+        "secrets:",
+        "  provider: command",
+        "  command: echo API_SERVER_KEY=synthetic-vault-marker",
+        "",
+      ].join("\n"),
+    );
+    // No .env at all — the key comes only from the provider overlay.
+    const { getApiServerKeyStatus } = await freshConfig(TEST_DIR);
+
+    const status = getApiServerKeyStatus();
+    expect(status.hasKey).toBe(true);
+    expect(status.providerId).toBe("command");
+    expect(typeof status.checkedAt).toBe("number");
+  });
+
+  it("reports hasKey=true, providerId='env' for a .env key (no regression)", async () => {
+    writeFileSync(join(TEST_DIR, "config.yaml"), "agent:\n  enabled: true\n");
+    writeFileSync(
+      join(TEST_DIR, ".env"),
+      "API_SERVER_KEY=synthetic-dotenv-marker\n",
+    );
+    const { getApiServerKeyStatus } = await freshConfig(TEST_DIR);
+
+    const status = getApiServerKeyStatus();
+    expect(status.hasKey).toBe(true);
+    expect(status.providerId).toBe("env");
+  });
+
+  it("reports hasKey=false with the configured providerId when nothing resolves", async () => {
+    writeFileSync(
+      join(TEST_DIR, "config.yaml"),
+      ["secrets:", "  provider: command", '  command: "exit 0"', ""].join("\n"),
+    );
+    const { getApiServerKeyStatus } = await freshConfig(TEST_DIR);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const status = getApiServerKeyStatus();
+    expect(status.hasKey).toBe(false);
+    expect(status.providerId).toBe("command");
+    warnSpy.mockRestore();
+  });
+
+  it("keeps hasKey as the required primary field (additive contract)", async () => {
+    writeFileSync(join(TEST_DIR, "config.yaml"), "agent:\n  enabled: true\n");
+    const { getApiServerKeyStatus } = await freshConfig(TEST_DIR);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const status = getApiServerKeyStatus();
+    // Old renderer code reads exactly this field — it must always be present.
+    expect(Object.prototype.hasOwnProperty.call(status, "hasKey")).toBe(true);
+    expect(status.hasKey).toBe(false);
+    warnSpy.mockRestore();
+  });
+});
+
+describe("getApiServerKey missing-key diagnostic", () => {
+  it("warns exactly once per (provider, profile) pair, naming the provider", async () => {
+    writeFileSync(
+      join(TEST_DIR, "config.yaml"),
+      ["secrets:", "  provider: command", '  command: "exit 0"', ""].join("\n"),
+    );
+    const { getApiServerKey, invalidateSecretsCache } =
+      await freshConfig(TEST_DIR);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(getApiServerKey()).toBe("");
+    // Force a real re-resolution (the 5s cache would otherwise short-circuit
+    // before the diagnostic) — the rate-limit Set must still suppress it.
+    invalidateSecretsCache();
+    expect(getApiServerKey()).toBe("");
+
+    const diagnostics = warnSpy.mock.calls
+      .flat()
+      .filter(
+        (m) =>
+          typeof m === "string" && m.includes("API_SERVER_KEY not resolved"),
+      );
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toContain("provider=command");
+    expect(diagnostics[0]).toContain("env=default");
+    warnSpy.mockRestore();
+  });
+
+  it("does not warn when the key resolves", async () => {
+    writeFileSync(join(TEST_DIR, "config.yaml"), "agent:\n  enabled: true\n");
+    writeFileSync(
+      join(TEST_DIR, ".env"),
+      "API_SERVER_KEY=synthetic-present-marker\n",
+    );
+    const { getApiServerKey } = await freshConfig(TEST_DIR);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(getApiServerKey()).toBe("synthetic-present-marker");
+    const diagnostics = warnSpy.mock.calls
+      .flat()
+      .filter(
+        (m) =>
+          typeof m === "string" && m.includes("API_SERVER_KEY not resolved"),
+      );
+    expect(diagnostics).toHaveLength(0);
+    warnSpy.mockRestore();
+  });
+});

--- a/tests/invalidate-secrets-cache.test.ts
+++ b/tests/invalidate-secrets-cache.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { join } from "path";
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+
+/**
+ * invalidateSecretsCache (vault polish V2) — the exported hook that drops the
+ * `env:*` and `apiServerKey:*` cache entries so a vault rotation /
+ * secrets-add is picked up on the NEXT lookup instead of after the 5s TTL.
+ */
+
+const TEST_DIR = join(tmpdir(), `hermes-test-secrets-invalidate-${Date.now()}`);
+
+async function freshConfig(
+  home: string,
+): Promise<typeof import("../src/main/config")> {
+  vi.resetModules();
+  process.env.HERMES_HOME = home;
+  return await import("../src/main/config");
+}
+
+beforeEach(() => {
+  mkdirSync(TEST_DIR, { recursive: true });
+  delete process.env.API_SERVER_KEY;
+  writeFileSync(join(TEST_DIR, "config.yaml"), "agent:\n  enabled: true\n");
+  // Silence the overlay debug line in test output.
+  vi.spyOn(console, "debug").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  delete process.env.HERMES_HOME;
+  delete process.env.API_SERVER_KEY;
+  vi.restoreAllMocks();
+  vi.resetModules();
+  rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe("invalidateSecretsCache", () => {
+  it("clears the apiServerKey cache so a rotated key resolves immediately", async () => {
+    writeFileSync(
+      join(TEST_DIR, ".env"),
+      "API_SERVER_KEY=synthetic-old-marker\n",
+    );
+    const { getApiServerKey, invalidateSecretsCache } =
+      await freshConfig(TEST_DIR);
+
+    expect(getApiServerKey()).toBe("synthetic-old-marker");
+
+    // Rotate the key on disk. The cached value must still be served (proves
+    // the cache is live), then invalidation must surface the new value.
+    writeFileSync(
+      join(TEST_DIR, ".env"),
+      "API_SERVER_KEY=synthetic-new-marker\n",
+    );
+    expect(getApiServerKey()).toBe("synthetic-old-marker");
+
+    invalidateSecretsCache();
+    expect(getApiServerKey()).toBe("synthetic-new-marker");
+  });
+
+  it("clears the env cache so readEnv re-parses the .env file", async () => {
+    writeFileSync(join(TEST_DIR, ".env"), "SYNTHETIC_MARKER=one\n");
+    const { readEnv, invalidateSecretsCache } = await freshConfig(TEST_DIR);
+
+    expect(readEnv().SYNTHETIC_MARKER).toBe("one");
+
+    writeFileSync(join(TEST_DIR, ".env"), "SYNTHETIC_MARKER=two\n");
+    expect(readEnv().SYNTHETIC_MARKER).toBe("one"); // still cached
+
+    invalidateSecretsCache();
+    expect(readEnv().SYNTHETIC_MARKER).toBe("two");
+  });
+});


### PR DESCRIPTION
## Summary
- Wire the secrets-provider (added in #644, now merged) into the **real key-resolution paths** — this is the follow-up that makes the provider actually do something. Resolution order is preserved everywhere: **`process.env` > `.env` > provider**.
- `getApiServerKey()` gateway-env overlay fills **only** keys absent from both `.env` and (trimmed) `process.env`, so a vault value can never silently override an explicit secret.
- Gateway-spawn env (`buildGatewayEnv` / `tuiGatewayEnv`) resolves through the never-throwing `providerListSafe()`, so a misconfigured vault degrades gracefully instead of aborting a spawn.
- `config-health` audit is vault-aware via `resolvedSecretMap()` — vault-only users no longer get false "API_SERVER_KEY is not set" warnings.
- `invalidate-secrets-cache` IPC busts the `env:` / `apiServerKey:` caches and marks the provider `list()` stale — **no secret read, no unbounded helper spawn** (the 1s spawn-floor survives invalidation).
- Logs emit only provider id + key counts, **never a resolved value**; the migration path masks via `maskKey()`.

## Why lazy provider construction
config.ts statically imports `./secrets`, which closes the cycle `config → secrets → commandProvider → config`. The secrets module therefore must do **zero work at module-init**: it now constructs its providers lazily (`_x ??= new X()`). An earlier eager `new CommandSecretsProvider()` at module scope threw `"is not a constructor"` on load-order-dependent paths — a crash that hid behind `vi.mock("../config")` in unit tests and only surfaced in the unmocked property test. The import-site comment documents the invariant so the trap can't be reintroduced. (Lazy construction was chosen over lazy-importing the barrel because consumers here use `vi.resetModules()`, under which a runtime relative `require` doesn't resolve.)

## Testing
- `npm run typecheck` — `typecheck:node` clean. (`typecheck:web` has one PRE-EXISTING error in `ModelPicker.test.tsx`, unrelated to this PR — present on `main`.)
- `npm run lint` — clean for the changed lines. (3 PRE-EXISTING "unused eslint-disable" warnings in `config-health.ts` are not introduced here.)
- `npm test` — 117 passing across the affected suites, including the **unmocked** `commandProvider.property.test.ts` (which exercises the real import cycle) and `invalidate-secrets-cache.test.ts` (the `vi.resetModules()` path). New coverage: `config-health.test.ts`, `hermes.test.ts`, `tui-gateway-stream.test.ts`, `api-server-key-secrets-provider.test.ts`, `api-server-key-status.test.ts`, `invalidate-secrets-cache.test.ts`.
- `git diff --check` — clean.

## Note
Follow-up to #644 (now merged). This PR is the consumer wiring; a renderer-UI PR for selecting the provider follows. Kept to one cohesive change (provider wiring + the lazy-construction fix that wiring requires) per CONTRIBUTING — the test files are the bulk of the line count.
