### PR TITLE
Chat Context folder fix and Sessions UX

### DIFF
--- a/src/renderer/src/assets/icons/index.tsx
+++ b/src/renderer/src/assets/icons/index.tsx
@@ -5,6 +5,7 @@ export {
   Building,
   ChevronDown,
   ChevronRight,
+  Circle,
   Clock,
   Compass,
   Copy,

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1361,11 +1361,11 @@ body {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 11px 14px;
+  padding: 8px 14px;
   border-radius: var(--radius-md);
   cursor: pointer;
   transition: all var(--transition);
-  font-size: 13px;
+  font-size: 12px;
 
   color: var(--text-secondary);
   border: none;
@@ -1405,6 +1405,114 @@ body {
 
 .sidebar-collapsed .sidebar-nav-label {
   display: none;
+}
+
+/* Collapsible Sessions section (ChatGPT-style recent chats) */
+.sidebar-nav-sessions {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.sidebar-nav-row {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.sidebar-nav-row .sidebar-nav-item {
+  flex: 1;
+  min-width: 0;
+}
+
+.sidebar-nav-chevron {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  background: none;
+  border-radius: var(--radius-md);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.sidebar-nav-chevron:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.sidebar-recent-sessions-wrap {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition:
+    grid-template-rows 200ms ease,
+    opacity 200ms ease;
+  opacity: 0;
+}
+
+.sidebar-recent-sessions-wrap.expanded {
+  grid-template-rows: 1fr;
+  opacity: 1;
+}
+
+.sidebar-recent-sessions {
+  /* min-height:0 + overflow:hidden let the grid 0fr/1fr track clip cleanly. */
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  /* Align titles with the nav-item label (icon 16 + gap 10 + padding 14). */
+  padding-left: 14px;
+  margin-bottom: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidebar-recent-sessions-wrap {
+    transition: none;
+  }
+}
+
+.sidebar-recent-session {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 6px 10px;
+  border: none;
+  background: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  text-align: left;
+  font-family: var(--font-sans);
+  font-size: 12px;
+  color: var(--text-secondary);
+  transition: all var(--transition);
+}
+
+.sidebar-recent-session-dot {
+  flex-shrink: 0;
+  color: var(--text-muted);
+}
+
+.sidebar-recent-session:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.sidebar-recent-session.active {
+  background: var(--accent-subtle);
+  color: var(--accent-text);
+}
+
+.sidebar-recent-session-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Sidebar footer with theme switcher */

--- a/src/renderer/src/screens/Chat/Chat.tsx
+++ b/src/renderer/src/screens/Chat/Chat.tsx
@@ -62,7 +62,8 @@ function Chat({
   // held in memory; reset on session switch / new chat below.
   const [contextFolder, setContextFolder] = useState<string | null>(null);
   // Whether the worktree panel is visible (only applies when contextFolder is set)
-  const [worktreeVisible, setWorktreeVisible] = useState<boolean>(true);
+  // Default false so the panel doesn't open automatically and interfere with scrolling
+  const [worktreeVisible, setWorktreeVisible] = useState<boolean>(false);
   const dragCounter = useRef(0);
   const chatInputRef = useRef<ChatInputHandle>(null);
   const queueRef = useRef<QueuedMessage[]>([]);

--- a/src/renderer/src/screens/Chat/ChatInput.tsx
+++ b/src/renderer/src/screens/Chat/ChatInput.tsx
@@ -7,7 +7,7 @@ import {
   forwardRef,
   useImperativeHandle,
 } from "react";
-import { Send, Square as Stop, Slash, Paperclip, Mic } from "lucide-react";
+import { Square as Stop, Slash, Paperclip, Mic, ArrowUp } from "lucide-react";
 import { isImeComposing } from "./keyboard";
 import { useI18n } from "../../components/useI18n";
 import { SLASH_COMMANDS, type SlashCommand } from "./slashCommands";
@@ -574,7 +574,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
                   disabled={!canSend}
                   title={t("chat.send")}
                 >
-                  <Send size={16} />
+                  <ArrowUp size={20} />
                 </button>
               </>
             )}

--- a/src/renderer/src/screens/Layout/Layout.tsx
+++ b/src/renderer/src/screens/Layout/Layout.tsx
@@ -8,6 +8,7 @@ import Sessions from "../Sessions/Sessions";
 import Agents from "../Agents/Agents";
 import Discover from "../Discover/Discover";
 import ProfileSwitcher from "./ProfileSwitcher";
+import SidebarRecentSessions from "./SidebarRecentSessions";
 import Settings from "../Settings/Settings";
 import Skills from "../Skills/Skills";
 import Memory from "../Memory/Memory";
@@ -37,6 +38,8 @@ import {
   Download,
   PanelLeftClose,
   PanelLeftOpen,
+  ChevronDown,
+  ChevronRight,
 } from "../../assets/icons";
 import type { LucideIcon } from "lucide-react";
 import { useI18n } from "../../components/useI18n";
@@ -77,6 +80,7 @@ const NAV_ITEMS: { view: View; icon: LucideIcon; labelKey: string }[] = [
 ];
 
 const SIDEBAR_COLLAPSED_KEY = "hermes.sidebar.collapsed";
+const SESSIONS_EXPANDED_KEY = "hermes.sidebar.sessionsExpanded";
 
 interface LayoutProps {
   verifyWarning?: boolean;
@@ -99,6 +103,15 @@ function Layout({
       return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === "true";
     } catch {
       return false;
+    }
+  });
+  // Sessions nav section expanded → shows the last few chats inline
+  // (ChatGPT-style). Defaults to expanded; persisted across launches.
+  const [sessionsExpanded, setSessionsExpanded] = useState(() => {
+    try {
+      return localStorage.getItem(SESSIONS_EXPANDED_KEY) !== "false";
+    } catch {
+      return true;
     }
   });
   // Tabs lazy-mount on first visit, then stay mounted (display:none toggle).
@@ -278,6 +291,18 @@ function Layout({
     });
   }, []);
 
+  const toggleSessionsExpanded = useCallback(() => {
+    setSessionsExpanded((expanded) => {
+      const next = !expanded;
+      try {
+        localStorage.setItem(SESSIONS_EXPANDED_KEY, String(next));
+      } catch {
+        /* ignore persistence failures */
+      }
+      return next;
+    });
+  }, []);
+
   const sidebarToggleLabel = sidebarCollapsed
     ? t("navigation.expandSidebar")
     : t("navigation.collapseSidebar");
@@ -312,18 +337,61 @@ function Layout({
         </div>
 
         <nav className="sidebar-nav">
-          {NAV_ITEMS.map(({ view: v, icon: Icon, labelKey }) => (
-            <button
-              key={v}
-              className={`sidebar-nav-item ${view === v ? "active" : ""}`}
-              onClick={() => goTo(v)}
-              title={t(labelKey)}
-              aria-label={t(labelKey)}
-            >
-              <Icon size={16} />
-              <span className="sidebar-nav-label">{t(labelKey)}</span>
-            </button>
-          ))}
+          {NAV_ITEMS.map(({ view: v, icon: Icon, labelKey }) => {
+            if (v === "sessions") {
+              const recentToggleLabel = sessionsExpanded
+                ? t("navigation.hideRecentSessions")
+                : t("navigation.showRecentSessions");
+              return (
+                <div key={v} className="sidebar-nav-sessions">
+                  <div className="sidebar-nav-row">
+                    <button
+                      className={`sidebar-nav-item ${view === v ? "active" : ""}`}
+                      onClick={() => goTo(v)}
+                      title={t(labelKey)}
+                      aria-label={t(labelKey)}
+                    >
+                      <Icon size={16} />
+                      <span className="sidebar-nav-label">{t(labelKey)}</span>
+                    </button>
+                    {!sidebarCollapsed && (
+                      <button
+                        className="sidebar-nav-chevron"
+                        type="button"
+                        onClick={toggleSessionsExpanded}
+                        title={recentToggleLabel}
+                        aria-label={recentToggleLabel}
+                        aria-expanded={sessionsExpanded}
+                      >
+                        {sessionsExpanded ? (
+                          <ChevronDown size={14} />
+                        ) : (
+                          <ChevronRight size={14} />
+                        )}
+                      </button>
+                    )}
+                  </div>
+                  <SidebarRecentSessions
+                    open={sessionsExpanded && !sidebarCollapsed}
+                    currentSessionId={currentSessionId}
+                    onSelect={handleResumeSession}
+                  />
+                </div>
+              );
+            }
+            return (
+              <button
+                key={v}
+                className={`sidebar-nav-item ${view === v ? "active" : ""}`}
+                onClick={() => goTo(v)}
+                title={t(labelKey)}
+                aria-label={t(labelKey)}
+              >
+                <Icon size={16} />
+                <span className="sidebar-nav-label">{t(labelKey)}</span>
+              </button>
+            );
+          })}
         </nav>
 
         <div className="sidebar-footer">

--- a/src/renderer/src/screens/Layout/SidebarRecentSessions.tsx
+++ b/src/renderer/src/screens/Layout/SidebarRecentSessions.tsx
@@ -81,17 +81,21 @@ const SidebarRecentSessions = memo(function SidebarRecentSessions({
 
   // Initial load when the section opens: paint from the JSON cache
   // immediately (no DB access), then sync once for anything new.
+  // Sequenced so sync always wins over cache (avoids race where stale
+  // cache overwrites fresh sync if sync resolves first).
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
-    window.hermesAPI
-      .listCachedSessions(RECENT_SESSIONS_LIMIT)
-      .then((cached) => {
-        if (!cancelled && cached.length > 0) applySessions(cached);
-      })
-      .catch(() => {});
-    lastRefreshRef.current = Date.now();
     void (async () => {
+      try {
+        const cached = await window.hermesAPI.listCachedSessions(
+          RECENT_SESSIONS_LIMIT,
+        );
+        if (!cancelled && cached.length > 0) applySessions(cached);
+      } catch {
+        /* ignore cache read errors */
+      }
+      lastRefreshRef.current = Date.now();
       try {
         const synced = await window.hermesAPI.syncSessionCache();
         if (!cancelled) applySessions(synced);
@@ -120,8 +124,10 @@ const SidebarRecentSessions = memo(function SidebarRecentSessions({
   }, [open, refresh]);
 
   // Resuming/switching sessions reorders recency — refresh (throttled).
+  // Also refreshes when going to "New Chat" (currentSessionId becomes null)
+  // so the just-left session appears in the list immediately.
   useEffect(() => {
-    if (open && currentSessionId) void refresh();
+    if (open) void refresh();
   }, [open, currentSessionId, refresh]);
 
   // Keep the wrapper mounted so the collapse/expand animates (CSS grid-rows

--- a/src/renderer/src/screens/Layout/SidebarRecentSessions.tsx
+++ b/src/renderer/src/screens/Layout/SidebarRecentSessions.tsx
@@ -1,0 +1,165 @@
+import { useCallback, useEffect, useRef, useState, memo } from "react";
+import { useI18n } from "../../components/useI18n";
+import { Circle } from "../../assets/icons";
+
+interface RecentSession {
+  id: string;
+  title: string;
+}
+
+// ChatGPT-style recent list under the Sessions nav item.
+export const RECENT_SESSIONS_LIMIT = 5;
+
+// Re-sync cadence while the list is visible. Deliberately slower than the
+// Sessions screen (30s) — the sidebar is always on screen, so this interval
+// runs for the whole app lifetime when the section is expanded.
+const RECENT_REFRESH_MS = 60_000;
+
+// Minimum gap between event-driven refreshes (focus, session switch) so a
+// burst of focus/blur events doesn't hammer state.db.
+const REFRESH_THROTTLE_MS = 5_000;
+
+function sameSessions(a: RecentSession[], b: RecentSession[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].id !== b[i].id || a[i].title !== b[i].title) return false;
+  }
+  return true;
+}
+
+/**
+ * Recent-sessions list rendered under the "Sessions" nav item in the sidebar
+ * (like ChatGPT's sidebar chat list). Owns its own data so Layout re-renders
+ * (view switches, update banners, …) never trigger fetches, and `memo` keeps
+ * it off the render hot path entirely.
+ *
+ * Fetch strategy, cheapest first:
+ *  - on open: instant read from the sessions.json cache (no DB), then one
+ *    sync against state.db to pick up sessions created since the last sync
+ *  - while open: refresh on window focus and on a slow interval, throttled
+ *  - closed (collapsed section or icon-only sidebar): zero work, renders null
+ */
+const SidebarRecentSessions = memo(function SidebarRecentSessions({
+  open,
+  currentSessionId,
+  onSelect,
+}: {
+  open: boolean;
+  currentSessionId: string | null;
+  onSelect: (sessionId: string) => void;
+}): React.JSX.Element | null {
+  const { t } = useI18n();
+  const [sessions, setSessions] = useState<RecentSession[]>([]);
+  const lastRefreshRef = useRef(0);
+
+  const applySessions = useCallback(
+    (list: Array<{ id: string; title: string }>): void => {
+      const next = list
+        .slice(0, RECENT_SESSIONS_LIMIT)
+        .map(({ id, title }) => ({ id, title }));
+      // Skip the state update (and re-render) when nothing changed — the
+      // common case for periodic refreshes.
+      setSessions((prev) => (sameSessions(prev, next) ? prev : next));
+    },
+    [],
+  );
+
+  const refresh = useCallback(
+    async (force = false): Promise<void> => {
+      const now = Date.now();
+      if (!force && now - lastRefreshRef.current < REFRESH_THROTTLE_MS) return;
+      lastRefreshRef.current = now;
+      try {
+        const synced = await window.hermesAPI.syncSessionCache();
+        applySessions(synced);
+      } catch {
+        // keep whatever we had — the list is best-effort UI sugar
+      }
+    },
+    [applySessions],
+  );
+
+  // Initial load when the section opens: paint from the JSON cache
+  // immediately (no DB access), then sync once for anything new.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    window.hermesAPI
+      .listCachedSessions(RECENT_SESSIONS_LIMIT)
+      .then((cached) => {
+        if (!cancelled && cached.length > 0) applySessions(cached);
+      })
+      .catch(() => {});
+    lastRefreshRef.current = Date.now();
+    void (async () => {
+      try {
+        const synced = await window.hermesAPI.syncSessionCache();
+        if (!cancelled) applySessions(synced);
+      } catch {
+        // cache read above already painted something
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, applySessions]);
+
+  // While open: pick up background sessions (gateway, cron, other devices)
+  // on focus and on a slow timer. No listeners or timers at all when closed.
+  useEffect(() => {
+    if (!open) return;
+    const timer = setInterval(() => void refresh(), RECENT_REFRESH_MS);
+    const onFocus = (): void => {
+      void refresh();
+    };
+    window.addEventListener("focus", onFocus);
+    return () => {
+      clearInterval(timer);
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [open, refresh]);
+
+  // Resuming/switching sessions reorders recency — refresh (throttled).
+  useEffect(() => {
+    if (open && currentSessionId) void refresh();
+  }, [open, currentSessionId, refresh]);
+
+  // Keep the wrapper mounted so the collapse/expand animates (CSS grid-rows
+  // trick). Returning null would make it pop in/out. Effects above are still
+  // gated on `open`, so a closed section does no fetching — it just keeps the
+  // last-loaded list in the DOM to animate shut. Stay unmounted only until the
+  // first sessions arrive, so a brand-new profile renders nothing.
+  if (sessions.length === 0) return null;
+
+  const expanded = open;
+
+  return (
+    <div
+      className={`sidebar-recent-sessions-wrap ${expanded ? "expanded" : ""}`}
+      aria-hidden={!expanded}
+    >
+      <div className="sidebar-recent-sessions">
+        {sessions.map((s) => {
+          const title = s.title || t("sessions.newConversation");
+          return (
+            <button
+              key={s.id}
+              type="button"
+              className={`sidebar-recent-session ${
+                currentSessionId === s.id ? "active" : ""
+              }`}
+              onClick={() => onSelect(s.id)}
+              title={title}
+              tabIndex={expanded ? 0 : -1}
+            >
+              <Circle className="sidebar-recent-session-dot" size={7} />
+              <span className="sidebar-recent-session-title">{title}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+});
+
+export default SidebarRecentSessions;

--- a/src/shared/i18n/locales/en/navigation.ts
+++ b/src/shared/i18n/locales/en/navigation.ts
@@ -16,4 +16,6 @@ export default {
   settings: "Settings",
   collapseSidebar: "Collapse sidebar",
   expandSidebar: "Expand sidebar",
+  showRecentSessions: "Show recent sessions",
+  hideRecentSessions: "Hide recent sessions",
 } as const;


### PR DESCRIPTION
## Summary

This PR improves the chat user experience with two key changes:
1. **Fixes accidental worktree panel interference** (Issue #649)
2. **Adds ChatGPT-style recent sessions in sidebar** for quick navigation

---

## Changes

### 1. Chat: Worktree Panel Default Hidden (Issue #649)

**Problem:** When a context folder/worktree panel was available, the right-side panel would open by default, taking up 240px of space and interfering with the chat scrollbar. Users trying to scroll the chat would accidentally interact with the panel.

**Solution:** Changed the default state of `worktreeVisible` from `true` to `false`.

**File:** `src/renderer/src/screens/Chat/Chat.tsx`

```typescript
// Before:
const [worktreeVisible, setWorktreeVisible] = useState<boolean>(true);

// After:
// Default false so the panel doesn't open automatically and interfere with scrolling
const [worktreeVisible, setWorktreeVisible] = useState<boolean>(false);
```

**User Impact:**
- The worktree panel no longer appears automatically when a context folder is set
- Users must explicitly click the folder tree icon (📁) in the chat toolbar to show the panel
- Chat scrolling is no longer obstructed by the panel

---

### 2. Sidebar: ChatGPT-Style Recent Sessions

**New Feature:** Added a collapsible "Recent Sessions" section in the sidebar under the Sessions nav item, similar to ChatGPT's conversation history.

**Files Added/Modified:**
- `src/renderer/src/screens/Layout/SidebarRecentSessions.tsx` (new)
- `src/renderer/src/screens/Layout/Layout.tsx`
- `src/renderer/src/assets/main.css`
- `src/renderer/src/assets/icons/index.tsx`
- `src/shared/i18n/locales/en/navigation.ts`

**Features:**
- Shows last 5 recent sessions inline in the sidebar
- Expandable/collapsible with a chevron toggle
- Persists expanded state to `localStorage`
- Highlights the current active session
- One-click resume to any recent session
- Responsive: Hidden when sidebar is collapsed

**UI Changes:**
- New `SidebarRecentSessions` component renders recent session list
- Added `ChevronDown`/`ChevronRight` icons for expand/collapse
- Added `Circle` icon for session list items
- New CSS classes for styling the recent sessions list
- Added translation keys: `showRecentSessions`, `hideRecentSessions`

**Persistence:**
- Key: `hermes.sidebar.sessionsExpanded`
- Defaults to `true` (expanded)
- Persists across app launches

---

## Files Changed

| File | Change Type | Description |
|------|-------------|-------------|
| `src/renderer/src/screens/Chat/Chat.tsx` | Modified | Worktree panel default: `true` → `false` |
| `src/renderer/src/screens/Layout/Layout.tsx` | Modified | Added SidebarRecentSessions integration, toggle logic |
| `src/renderer/src/screens/Layout/SidebarRecentSessions.tsx` | Added | New component for recent sessions list |
| `src/renderer/src/assets/main.css` | Modified | Styles for sidebar nav, recent sessions, session items |
| `src/renderer/src/assets/icons/index.tsx` | Modified | Exported `Circle` icon |
| `src/shared/i18n/locales/en/navigation.ts` | Modified | Added `showRecentSessions`, `hideRecentSessions` |

---

## Testing Notes

1. **Worktree Panel:**
   - Set a context folder in chat
   - Verify panel does NOT appear automatically
   - Click folder tree icon to toggle panel
   - Verify scrolling works without interference

2. **Recent Sessions:**
   - Create multiple chat sessions
   - Check sidebar shows "Sessions" section with chevron
   - Click chevron to collapse/expand
   - Verify persistence after restart
   - Click a recent session to resume it
   - Verify current session is highlighted

---

## Related Issues

- Closes #649 - Right-side worktree panel can open while trying to use the chat scrollbar
