### PR TITLE
feat(sessions): show sub-task indicator for agent-delegated sessions

### DIFF
--- a/src/main/remote-sessions.ts
+++ b/src/main/remote-sessions.ts
@@ -234,6 +234,7 @@ function normalizeCachedSession(row: RemoteRecord): CachedSession {
     source: summary.source,
     messageCount: summary.messageCount,
     model: summary.model,
+    parentId: null,
   };
 }
 
@@ -304,6 +305,7 @@ export async function remoteSearchSessions(
       messageCount: numberValue(row.message_count),
       model: stringValue(row.model),
       snippet: stringValue(row.snippet),
+      parentId: null,
     };
   });
 
@@ -354,6 +356,7 @@ async function remoteSearchRecentSessionMessages(
             messageCount: session.messageCount,
             model: session.model,
             snippet: highlightTextMatch(match, query).slice(0, 500),
+            parentId: null,
           } satisfies SearchResult;
         } catch {
           return null;

--- a/src/main/session-cache.ts
+++ b/src/main/session-cache.ts
@@ -32,6 +32,7 @@ export interface CachedSession {
   source: string;
   messageCount: number;
   model: string;
+  parentId: string | null;
 }
 
 interface CacheData {
@@ -104,7 +105,7 @@ export function syncSessionCache(): CachedSession[] {
     // Fetch sessions newer than last sync, or all if first sync
     const rows = db
       .prepare(
-        `SELECT s.id, s.started_at, s.source, s.message_count, s.model, s.title
+        `SELECT s.id, s.started_at, s.source, s.message_count, s.model, s.title, s.parent_session_id
          FROM sessions s
          WHERE s.started_at > ?
          ORDER BY s.started_at DESC`,
@@ -116,6 +117,7 @@ export function syncSessionCache(): CachedSession[] {
       message_count: number;
       model: string;
       title: string | null;
+      parent_session_id: string | null;
     }>;
 
     // Index existing sessions by id once so the per-row update below is
@@ -132,12 +134,14 @@ export function syncSessionCache(): CachedSession[] {
       const existing = existingById.get(row.id);
       if (existing) {
         existing.messageCount = row.message_count;
+        existing.parentId = row.parent_session_id || null;
         if (row.model) existing.model = row.model;
         if (row.title) existing.title = row.title;
         continue;
       }
 
       let title = row.title || "";
+      const parentId = row.parent_session_id || null;
       if (!title) {
         try {
           const msg = db
@@ -162,6 +166,7 @@ export function syncSessionCache(): CachedSession[] {
         source: row.source,
         messageCount: row.message_count,
         model: row.model || "",
+        parentId,
       });
     }
 

--- a/src/main/sessions.ts
+++ b/src/main/sessions.ts
@@ -180,6 +180,7 @@ export interface SearchResult {
   messageCount: number;
   model: string;
   snippet: string;
+  parentId: string | null;
 }
 
 export function dedupeSearchRowsBySession<T extends { session_id: string }>(
@@ -315,7 +316,8 @@ export function searchSessions(query: string, limit = 20): SearchResult[] {
           s.started_at,
           s.source,
           s.message_count,
-          s.model
+          s.model,
+          s.parent_session_id
         FROM sessions s
         WHERE LOWER(COALESCE(s.title, '')) LIKE ? ESCAPE '\\'
           OR LOWER(s.id) LIKE ? ESCAPE '\\'
@@ -333,6 +335,7 @@ export function searchSessions(query: string, limit = 20): SearchResult[] {
       source: string;
       message_count: number;
       model: string;
+      parent_session_id: string | null;
     }>;
 
     const titleMatches = titleRows.map((r) => ({
@@ -365,6 +368,7 @@ export function searchSessions(query: string, limit = 20): SearchResult[] {
               s.source,
               s.message_count,
               s.model,
+              s.parent_session_id,
               snippet(messages_fts, 0, '<<', '>>', '...', 40) as snippet
             FROM messages_fts
             JOIN messages m ON m.id = messages_fts.rowid
@@ -380,6 +384,7 @@ export function searchSessions(query: string, limit = 20): SearchResult[] {
           source: string;
           message_count: number;
           model: string;
+          parent_session_id: string | null;
           snippet: string;
         }>)
       : [];
@@ -394,7 +399,8 @@ export function searchSessions(query: string, limit = 20): SearchResult[] {
           s.started_at,
           s.source,
           s.message_count,
-          s.model
+          s.model,
+          s.parent_session_id
         FROM messages m
         JOIN sessions s ON s.id = m.session_id
         WHERE LOWER(COALESCE(m.content, '')) LIKE ? ESCAPE '\\'
@@ -413,6 +419,7 @@ export function searchSessions(query: string, limit = 20): SearchResult[] {
       source: string;
       message_count: number;
       model: string;
+      parent_session_id: string | null;
     }>;
 
     const messageMatches = messageRows.map((r) => ({
@@ -422,6 +429,7 @@ export function searchSessions(query: string, limit = 20): SearchResult[] {
       source: r.source,
       message_count: r.message_count,
       model: r.model,
+      parent_session_id: r.parent_session_id,
       snippet: decodeSearchSnippet(r.content, r.message_id, trimmedQuery),
     }));
 
@@ -436,6 +444,7 @@ export function searchSessions(query: string, limit = 20): SearchResult[] {
       source: r.source,
       messageCount: r.message_count,
       model: r.model || "",
+      parentId: r.parent_session_id || null,
       snippet: r.snippet || "",
     }));
   } catch {

--- a/src/main/ssh-remote.ts
+++ b/src/main/ssh-remote.ts
@@ -2166,6 +2166,7 @@ export async function sshListCachedSessions(
     source: s.source,
     messageCount: s.messageCount,
     model: s.model,
+    parentId: null,
   }));
 }
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -677,6 +677,7 @@ interface HermesAPI {
       source: string;
       messageCount: number;
       model: string;
+      parentId: string | null;
     }>
   >;
   syncSessionCache: () => Promise<
@@ -687,6 +688,7 @@ interface HermesAPI {
       source: string;
       messageCount: number;
       model: string;
+      parentId: string | null;
     }>
   >;
   updateSessionTitle: (sessionId: string, title: string) => Promise<void>;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -853,6 +853,7 @@ const hermesAPI = {
       source: string;
       messageCount: number;
       model: string;
+      parentId: string | null;
     }>
   > => ipcRenderer.invoke("list-cached-sessions", limit, offset),
 
@@ -864,6 +865,7 @@ const hermesAPI = {
       source: string;
       messageCount: number;
       model: string;
+      parentId: string | null;
     }>
   > => ipcRenderer.invoke("sync-session-cache"),
 

--- a/src/renderer/src/screens/Sessions/Sessions.tsx
+++ b/src/renderer/src/screens/Sessions/Sessions.tsx
@@ -9,6 +9,7 @@ interface CachedSession {
   source: string;
   messageCount: number;
   model: string;
+  parentId: string | null;
 }
 
 interface SearchResult {
@@ -234,6 +235,11 @@ const SessionCard = memo(function SessionCard({
         <span className="sessions-tag sessions-tag--source">
           {session.source}
         </span>
+        {session.parentId && (
+          <span className="sessions-tag sessions-tag--child" title="Agent sub-task">
+            sub-task
+          </span>
+        )}
         <span className="sessions-tag">
           {session.messageCount} msg{session.messageCount !== 1 ? "s" : ""}
         </span>


### PR DESCRIPTION
## Summary

Adds a visual indicator on the Sessions page to distinguish sessions created by agent delegation (sub-tasks) from manually created sessions.

## Changes

- **session-cache.ts**: Added `parent_session_id` to the SQL query and `parentId` to the `CachedSession` interface
- **sessions.ts**: Added `parentId` to `SearchResult` and all session search queries
- **Sessions.tsx**: Display an orange `sub-task` tag next to session cards when `session.parentId` is set
- **remote-sessions.ts / ssh-remote.ts / preload**: Updated all session list/search return types with `parentId` for compatibility

## Screenshots

(Add screenshots after visual verification)

## Testing

- [x] TypeScript typecheck passes (`npm run typecheck`)
- [ ] Visual verification: run `npm run dev` and check Sessions page shows orange `sub-task` badge for delegated sessions