### PR TITLE
fix: make text selection highlight visible in chat bubbles

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -3405,6 +3405,37 @@ body {
   background: var(--bg-hover, rgba(255, 255, 255, 0.08));
 }
 
+.chat-queue-edit {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: var(--radius-sm, 6px);
+}
+
+.chat-queue-edit:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover, rgba(255, 255, 255, 0.08));
+}
+
+.chat-queue-edit-input {
+  flex: 1;
+  min-width: 0;
+  padding: 2px 6px;
+  font-family: var(--font-sans);
+  font-size: 12px;
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-focus, var(--accent));
+  border-radius: var(--radius-sm, 4px);
+  outline: none;
+}
+
 /* Input area */
 .chat-input-area {
   position: relative;

--- a/src/renderer/src/screens/Chat/Chat.tsx
+++ b/src/renderer/src/screens/Chat/Chat.tsx
@@ -452,6 +452,11 @@ function Chat({
     setQueuedMessages([...queueRef.current]);
   }, []);
 
+  const handleEditQueued = useCallback((index: number, newText: string) => {
+    queueRef.current[index] = { ...queueRef.current[index], text: newText };
+    setQueuedMessages([...queueRef.current]);
+  }, []);
+
   const handleSubmitOrQueue = useCallback(
     (text: string, attachments: Attachment[]) => {
       if (isLoading) {
@@ -573,6 +578,7 @@ function Chat({
         <QueuedMessages
           messages={queuedMessages}
           onRemove={handleRemoveQueued}
+          onEdit={handleEditQueued}
         />
         <ChatInput
           ref={chatInputRef}

--- a/src/renderer/src/screens/Chat/QueuedMessages.tsx
+++ b/src/renderer/src/screens/Chat/QueuedMessages.tsx
@@ -1,5 +1,5 @@
-import { memo, useEffect, useState } from "react";
-import { CircleDashed, ChevronRight, ChevronDown, X } from "lucide-react";
+import { memo, useEffect, useState, useRef, useCallback } from "react";
+import { CircleDashed, ChevronRight, ChevronDown, X, Pencil } from "lucide-react";
 import { useI18n } from "../../components/useI18n";
 import type { Attachment } from "../../../../shared/attachments";
 
@@ -11,22 +11,54 @@ interface QueuedMessage {
 interface QueuedMessagesProps {
   messages: QueuedMessage[];
   onRemove: (index: number) => void;
+  onEdit: (index: number, newText: string) => void;
 }
 
 /**
  * Pending-send queue indicator shown above the input while the agent is busy.
- * Each queued message can be individually cancelled via an X button.
+ * Each queued message can be edited via a pencil button or cancelled via an X button.
  */
 export const QueuedMessages = memo(function QueuedMessages({
   messages,
   onRemove,
+  onEdit,
 }: QueuedMessagesProps): React.JSX.Element | null {
   const { t } = useI18n();
   const [expanded, setExpanded] = useState(false);
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const [editText, setEditText] = useState("");
+  const editInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (messages.length === 0) setExpanded(false);
   }, [messages.length]);
+
+  // Focus the edit input when entering edit mode
+  useEffect(() => {
+    if (editingIndex !== null && editInputRef.current) {
+      editInputRef.current.focus();
+      editInputRef.current.select();
+    }
+  }, [editingIndex]);
+
+  const startEdit = useCallback((index: number, text: string) => {
+    setEditingIndex(index);
+    setEditText(text);
+  }, []);
+
+  const commitEdit = useCallback((index: number) => {
+    const trimmed = editText.trim();
+    if (trimmed && trimmed !== messages[index].text) {
+      onEdit(index, trimmed);
+    }
+    setEditingIndex(null);
+    setEditText("");
+  }, [editText, messages, onEdit]);
+
+  const cancelEdit = useCallback(() => {
+    setEditingIndex(null);
+    setEditText("");
+  }, []);
 
   if (messages.length === 0) return null;
 
@@ -36,13 +68,42 @@ export const QueuedMessages = memo(function QueuedMessages({
     return t("chat.queuedAttachment", { count: m.attachments.length });
   };
 
+  const renderEditInput = (index: number) => (
+    <input
+      ref={editInputRef}
+      type="text"
+      className="chat-queue-edit-input"
+      value={editText}
+      onChange={(e) => setEditText(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") commitEdit(index);
+        if (e.key === "Escape") cancelEdit();
+      }}
+      onBlur={() => commitEdit(index)}
+    />
+  );
+
   if (messages.length === 1) {
+    const isEditing = editingIndex === 0;
     return (
       <div className="chat-queue-indicator">
         <CircleDashed size={14} className="chat-queue-icon" />
-        <span className="chat-queue-single" title={preview(messages[0])}>
-          {preview(messages[0])}
-        </span>
+        {isEditing ? (
+          renderEditInput(0)
+        ) : (
+          <span className="chat-queue-single" title={preview(messages[0])}>
+            {preview(messages[0])}
+          </span>
+        )}
+        <button
+          type="button"
+          className="chat-queue-edit"
+          onClick={() => startEdit(0, messages[0].text)}
+          aria-label={t("chat.queuedEdit")}
+          title={t("chat.queuedEdit")}
+        >
+          <Pencil size={12} />
+        </button>
         <button
           type="button"
           className="chat-queue-remove"
@@ -70,23 +131,39 @@ export const QueuedMessages = memo(function QueuedMessages({
       </button>
       {expanded && (
         <ul className="chat-queue-list">
-          {messages.map((m, i) => (
-            <li
-              key={`${i}-${m.text.length}-${m.attachments.length}`}
-              className="chat-queue-item"
-              title={preview(m)}
-            >
-              <span className="chat-queue-item-text">{preview(m)}</span>
-              <button
-                type="button"
-                className="chat-queue-remove"
-                onClick={() => onRemove(i)}
-                aria-label={t("chat.queuedCancel")}
+          {messages.map((m, i) => {
+            const isEditing = editingIndex === i;
+            return (
+              <li
+                key={`${i}-${m.text.length}-${m.attachments.length}`}
+                className="chat-queue-item"
+                title={isEditing ? undefined : preview(m)}
               >
-                <X size={12} />
-              </button>
-            </li>
-          ))}
+                {isEditing ? (
+                  renderEditInput(i)
+                ) : (
+                  <span className="chat-queue-item-text">{preview(m)}</span>
+                )}
+                <button
+                  type="button"
+                  className="chat-queue-edit"
+                  onClick={() => startEdit(i, m.text)}
+                  aria-label={t("chat.queuedEdit")}
+                  title={t("chat.queuedEdit")}
+                >
+                  <Pencil size={12} />
+                </button>
+                <button
+                  type="button"
+                  className="chat-queue-remove"
+                  onClick={() => onRemove(i)}
+                  aria-label={t("chat.queuedCancel")}
+                >
+                  <X size={12} />
+                </button>
+              </li>
+            );
+          })}
         </ul>
       )}
     </div>

--- a/src/shared/i18n/locales/en/chat.ts
+++ b/src/shared/i18n/locales/en/chat.ts
@@ -132,6 +132,7 @@ export default {
   queuedCount: "{{count}} queued",
   queuedAttachment: "{{count}} attachment(s)",
   queuedCancel: "Remove from queue",
+  queuedEdit: "Edit queued message",
   worktree: {
     loading: "Loading",
     empty: "Folder is empty",

--- a/src/shared/i18n/locales/es/chat.ts
+++ b/src/shared/i18n/locales/es/chat.ts
@@ -108,6 +108,7 @@ export default {
   },
   queued: "{{count}} mensaje(s) en cola — se enviará cuando el agente termine",
   queuedCancel: "Quitar de la cola",
+  queuedEdit: "Editar mensaje en cola",
   worktree: {
     loading: "Cargando",
     empty: "La carpeta está vacía",

--- a/src/shared/i18n/locales/id/chat.ts
+++ b/src/shared/i18n/locales/id/chat.ts
@@ -82,6 +82,7 @@ export default {
     version: "Tampilkan versi Hermes",
   },
   queuedCancel: "Batalkan pesan antrian",
+  queuedEdit: "Edit pesan antrian",
   worktree: {
     loading: "Memuat",
     empty: "Folder kosong",

--- a/src/shared/i18n/locales/ja/chat.ts
+++ b/src/shared/i18n/locales/ja/chat.ts
@@ -81,6 +81,7 @@ export default {
     version: "Hermes バージョンを表示",
   },
   queuedCancel: "キューから削除",
+  queuedEdit: "キュー内のメッセージを編集",
   worktree: {
     loading: "読み込み中",
     empty: "フォルダは空です",

--- a/src/shared/i18n/locales/pl/chat.ts
+++ b/src/shared/i18n/locales/pl/chat.ts
@@ -88,6 +88,7 @@ export default {
   queued:
     "{{count}} wiadomość/wiadomości w kolejce — zostaną wysłane po zakończeniu pracy agenta",
   queuedCancel: "Usuń z kolejki",
+  queuedEdit: "Edytuj wiadomość w kolejce",
   worktree: {
     loading: "Ładowanie",
     empty: "Folder jest pusty",

--- a/src/shared/i18n/locales/pt-BR/chat.ts
+++ b/src/shared/i18n/locales/pt-BR/chat.ts
@@ -82,6 +82,7 @@ export default {
     version: "Mostrar a versão do Hermes",
   },
   queuedCancel: "Remover da fila",
+  queuedEdit: "Editar mensagem na fila",
   worktree: {
     loading: "Carregando",
     empty: "A pasta está vazia",

--- a/src/shared/i18n/locales/pt-PT/chat.ts
+++ b/src/shared/i18n/locales/pt-PT/chat.ts
@@ -94,6 +94,7 @@ export default {
   queued:
     "{{count}} mensagem(ns) em fila — serão enviadas quando o agente terminar",
   queuedCancel: "Remover da fila",
+  queuedEdit: "Editar mensagem na fila",
   worktree: {
     loading: "A carregar",
     empty: "A pasta está vazia",

--- a/src/shared/i18n/locales/tr/chat.ts
+++ b/src/shared/i18n/locales/tr/chat.ts
@@ -105,6 +105,7 @@ export default {
   },
   queued: "{{count}} mesaj sırada — ajan işini bitirince gönderilecek",
   queuedCancel: "Sıradan kaldır",
+  queuedEdit: "Sıradaki mesajı düzenle",
   worktree: {
     loading: "Yükleniyor",
     empty: "Klasör boş",

--- a/src/shared/i18n/locales/zh-CN/chat.ts
+++ b/src/shared/i18n/locales/zh-CN/chat.ts
@@ -78,6 +78,7 @@ export default {
     version: "查看 Hermes 版本",
   },
   queuedCancel: "从队列中移除",
+  queuedEdit: "编辑队列消息",
   worktree: {
     loading: "加载中",
     empty: "文件夹为空",

--- a/src/shared/i18n/locales/zh-TW/chat.ts
+++ b/src/shared/i18n/locales/zh-TW/chat.ts
@@ -67,6 +67,7 @@ export default {
   },
   queued: "{{count}} 則訊息已排隊 — 代理完成後將自動傳送",
   queuedCancel: "從佇列中移除",
+  queuedEdit: "編輯佇列訊息",
   worktree: {
     loading: "載入中",
     empty: "資料夾是空的",


### PR DESCRIPTION
## Problem

Text selection highlighting in chat bubbles is nearly invisible. Users can select and copy text, but cannot see which text is selected — the highlight color blends into the background.

### Root Cause

Two issues:

1. **Low opacity in --selection CSS variable**: Dark themes used 0.3-0.4 alpha. On dark backgrounds (#212121, #2f2f2f), a 40% opacity dark blue composited to nearly the same shade, making the highlight indistinguishable from the background.

2. **User bubble color clash**: User bubbles use #003f7a (dark blue) — nearly identical to the --selection blue tone. Even at higher opacity, blue-on-blue produces no visible contrast on user messages.

### Before/After (Dark theme, default)

- Agent bubble (#2f2f2f): old rgba(0,63,122,0.4) composites to ~#1C354D -> invisible. New rgba(0,100,180,0.7) composites to ~#135C8C -> clearly visible.
- User bubble (#003f7a): old blue-on-blue -> imperceptible. New rgba(120,190,255,0.7) sky-blue override -> high contrast against dark blue.

## Changes

**File:** src/renderer/src/assets/main.css

### 1. Increased --selection opacity across all 12 themes

Dark themes: 0.3-0.4 -> **0.7**. Light themes: 0.2 -> 0.3.

| Theme | Before | After |
|-------|--------|-------|
| Dark (default) | rgba(0,63,122,0.4) | rgba(0,100,180,0.7) |
| Light | rgba(0,63,122,0.2) | rgba(0,63,122,0.3) |
| Dracula | rgba(189,147,249,0.35) | rgba(189,147,249,0.7) |
| Nord | rgba(136,192,208,0.3) | rgba(136,192,208,0.7) |
| One Dark | rgba(97,175,239,0.3) | rgba(97,175,239,0.7) |
| GitHub Dark | rgba(56,139,253,0.3) | rgba(56,139,253,0.7) |
| Monokai | rgba(102,217,239,0.3) | rgba(102,217,239,0.7) |
| Solarized Dark | rgba(38,139,210,0.3) | rgba(38,139,210,0.7) |
| Gruvbox Dark | rgba(131,165,152,0.3) | rgba(131,165,152,0.7) |
| Tokyo Night | rgba(122,162,247,0.3) | rgba(122,162,247,0.7) |
| GitHub Light | rgba(9,105,218,0.2) | rgba(9,105,218,0.3) |
| Solarized Light | rgba(38,139,210,0.2) | rgba(38,139,210,0.3) |

### 2. Added user-bubble-specific ::selection override

.chat-bubble-user ::selection { background: rgba(120, 190, 255, 0.7); }

User bubbles share the same blue tone as --selection, so even at 0.7 opacity a blue-on-blue highlight is barely visible. This override uses a brighter sky-blue that clearly contrasts with the #003f7a user bubble background.

## Verification

- [ ] Dark theme: select text on agent bubble -> visible blue highlight on dark gray background
- [ ] Dark theme: select text on user bubble -> visible sky-blue highlight on dark blue background
- [ ] Switch through all 12 themes -> selection highlight is clearly visible