### PR TITLE
feat: add Ctrl+Enter / Cmd+Enter as send shortcut

### DIFF
--- a/src/renderer/src/screens/Chat/ChatInput.test.tsx
+++ b/src/renderer/src/screens/Chat/ChatInput.test.tsx
@@ -69,3 +69,33 @@ describe("ChatInput — CJK IME Enter handling", () => {
     expect(onSubmit).toHaveBeenCalledWith("안녕하세요", []);
   });
 });
+
+describe("ChatInput — Enter shortcut variants", () => {
+  it("submits on plain Enter", () => {
+    const { onSubmit, textarea } = renderInput();
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSubmit).toHaveBeenCalledWith("hello", []);
+  });
+
+  it("does not submit on Shift+Enter (newline)", () => {
+    const { onSubmit, textarea } = renderInput();
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits on Ctrl+Enter", () => {
+    const { onSubmit, textarea } = renderInput();
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    fireEvent.keyDown(textarea, { key: "Enter", ctrlKey: true });
+    expect(onSubmit).toHaveBeenCalledWith("hello", []);
+  });
+
+  it("submits on Cmd+Enter (macOS)", () => {
+    const { onSubmit, textarea } = renderInput();
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+    expect(onSubmit).toHaveBeenCalledWith("hello", []);
+  });
+});

--- a/src/renderer/src/screens/Chat/ChatInput.tsx
+++ b/src/renderer/src/screens/Chat/ChatInput.tsx
@@ -352,7 +352,8 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
         }
       }
 
-      if (e.key === "Enter" && !e.shiftKey) {
+      // Send: plain Enter (without Shift) or Ctrl/Cmd+Enter
+      if (e.key === "Enter" && (!e.shiftKey || e.ctrlKey || e.metaKey)) {
         e.preventDefault();
         handleSend();
       }


### PR DESCRIPTION
## Feature

Add Ctrl+Enter (Windows/Linux) and Cmd+Enter (macOS) as send shortcuts alongside the existing plain Enter.

## Changes

- **ChatInput.tsx**: expand the Enter key check from `!e.shiftKey` to `!e.shiftKey || e.ctrlKey || e.metaKey`, so Ctrl/Cmd+Enter also triggers send
- **ChatInput.test.tsx**: add 4 new test cases covering plain Enter, Shift+Enter (should not send), Ctrl+Enter, and Cmd+Enter

## Behavior

| Shortcut | Action |
|----------|--------|
| Enter | Send (unchanged) |
| Shift+Enter | Newline (unchanged) |
| Ctrl+Enter | Send (new) |
| Cmd+Enter | Send on macOS (new) |

The CJK IME composition guard is unaffected — Enter is still swallowed while an IME is composing.