### PR TITLE
feat: add copy button to message bubbles

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -2845,6 +2845,7 @@ body {
 }
 
 .chat-bubble {
+  position: relative;
   padding: 10px 16px;
   border-radius: var(--radius-lg);
   font-size: 14px;
@@ -2879,6 +2880,42 @@ body {
 .chat-bubble-error {
   border: 1px solid color-mix(in srgb, var(--error) 35%, transparent);
   background: var(--error-bg);
+}
+
+/* Copy button — hidden by default, shown on bubble hover */
+.chat-bubble-actions {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  display: flex;
+  gap: 4px;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.chat-bubble:hover .chat-bubble-actions {
+  opacity: 1;
+}
+
+.chat-bubble-copy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-bright);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.chat-bubble-copy:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--border-focus, var(--accent));
 }
 
 .chat-error-message {

--- a/src/renderer/src/screens/Chat/MessageRow.tsx
+++ b/src/renderer/src/screens/Chat/MessageRow.tsx
@@ -1,4 +1,5 @@
-import { memo, useMemo } from "react";
+import { memo, useMemo, useState, useCallback } from "react";
+import { Copy, Check } from "lucide-react";
 import icon from "../../assets/icon.png";
 import { AgentMarkdown } from "../../components/AgentMarkdown";
 import { AttachmentChip } from "../../components/AttachmentChip";
@@ -60,6 +61,7 @@ export const MessageRow = memo(function MessageRow({
   showAvatar = true,
 }: MessageRowProps): React.JSX.Element {
   const { t } = useI18n();
+  const [copied, setCopied] = useState(false);
 
   // MessageRow is wrapped in memo() but still re-renders on any prop change
   // (e.g. isLoading toggling at the end of a stream), and `parseMediaTokens`
@@ -80,6 +82,17 @@ export const MessageRow = memo(function MessageRow({
         : null,
     [msg.role, bubbleContent],
   );
+
+  const handleCopy = useCallback(async () => {
+    if (!bubbleContent) return;
+    try {
+      await window.hermesAPI.copyToClipboard(bubbleContent);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback: clipboard write may fail in some environments
+    }
+  }, [bubbleContent]);
 
   // Only chat bubble messages have content/attachments
   if (!isChatBubbleMessage(msg)) {
@@ -119,6 +132,19 @@ export const MessageRow = memo(function MessageRow({
           msg.error ? " chat-bubble-error" : ""
         }`}
       >
+        {msg.content && !isLoading && (
+          <div className="chat-bubble-actions">
+            <button
+              type="button"
+              className="chat-bubble-copy"
+              onClick={handleCopy}
+              title={copied ? t("common.copied") : t("chat.copyMessage")}
+              aria-label={copied ? t("common.copied") : t("chat.copyMessage")}
+            >
+              {copied ? <Check size={14} /> : <Copy size={14} />}
+            </button>
+          </div>
+        )}
         {hasAttachments && (
           <div className="chat-message-attachments">
             {msg.attachments!.map((att) => (

--- a/src/shared/i18n/locales/en/chat.ts
+++ b/src/shared/i18n/locales/en/chat.ts
@@ -132,6 +132,7 @@ export default {
   queuedCount: "{{count}} queued",
   queuedAttachment: "{{count}} attachment(s)",
   queuedCancel: "Remove from queue",
+  copyMessage: "Copy message",
   worktree: {
     loading: "Loading",
     empty: "Folder is empty",

--- a/src/shared/i18n/locales/es/chat.ts
+++ b/src/shared/i18n/locales/es/chat.ts
@@ -108,6 +108,7 @@ export default {
   },
   queued: "{{count}} mensaje(s) en cola — se enviará cuando el agente termine",
   queuedCancel: "Quitar de la cola",
+  copyMessage: "Copiar mensaje",
   worktree: {
     loading: "Cargando",
     empty: "La carpeta está vacía",

--- a/src/shared/i18n/locales/id/chat.ts
+++ b/src/shared/i18n/locales/id/chat.ts
@@ -82,6 +82,7 @@ export default {
     version: "Tampilkan versi Hermes",
   },
   queuedCancel: "Batalkan pesan antrian",
+  copyMessage: "Salin pesan",
   worktree: {
     loading: "Memuat",
     empty: "Folder kosong",

--- a/src/shared/i18n/locales/ja/chat.ts
+++ b/src/shared/i18n/locales/ja/chat.ts
@@ -81,6 +81,7 @@ export default {
     version: "Hermes バージョンを表示",
   },
   queuedCancel: "キューから削除",
+  copyMessage: "メッセージをコピー",
   worktree: {
     loading: "読み込み中",
     empty: "フォルダは空です",

--- a/src/shared/i18n/locales/pl/chat.ts
+++ b/src/shared/i18n/locales/pl/chat.ts
@@ -88,6 +88,7 @@ export default {
   queued:
     "{{count}} wiadomość/wiadomości w kolejce — zostaną wysłane po zakończeniu pracy agenta",
   queuedCancel: "Usuń z kolejki",
+  copyMessage: "Kopiuj wiadomość",
   worktree: {
     loading: "Ładowanie",
     empty: "Folder jest pusty",

--- a/src/shared/i18n/locales/pt-BR/chat.ts
+++ b/src/shared/i18n/locales/pt-BR/chat.ts
@@ -82,6 +82,7 @@ export default {
     version: "Mostrar a versão do Hermes",
   },
   queuedCancel: "Remover da fila",
+  copyMessage: "Copiar mensagem",
   worktree: {
     loading: "Carregando",
     empty: "A pasta está vazia",

--- a/src/shared/i18n/locales/pt-PT/chat.ts
+++ b/src/shared/i18n/locales/pt-PT/chat.ts
@@ -94,6 +94,7 @@ export default {
   queued:
     "{{count}} mensagem(ns) em fila — serão enviadas quando o agente terminar",
   queuedCancel: "Remover da fila",
+  copyMessage: "Copiar mensagem",
   worktree: {
     loading: "A carregar",
     empty: "A pasta está vazia",

--- a/src/shared/i18n/locales/tr/chat.ts
+++ b/src/shared/i18n/locales/tr/chat.ts
@@ -105,6 +105,7 @@ export default {
   },
   queued: "{{count}} mesaj sırada — ajan işini bitirince gönderilecek",
   queuedCancel: "Sıradan kaldır",
+  copyMessage: "Mesajı kopyala",
   worktree: {
     loading: "Yükleniyor",
     empty: "Klasör boş",

--- a/src/shared/i18n/locales/zh-CN/chat.ts
+++ b/src/shared/i18n/locales/zh-CN/chat.ts
@@ -78,6 +78,7 @@ export default {
     version: "查看 Hermes 版本",
   },
   queuedCancel: "从队列中移除",
+  copyMessage: "复制消息",
   worktree: {
     loading: "加载中",
     empty: "文件夹为空",

--- a/src/shared/i18n/locales/zh-TW/chat.ts
+++ b/src/shared/i18n/locales/zh-TW/chat.ts
@@ -67,6 +67,7 @@ export default {
   },
   queued: "{{count}} 則訊息已排隊 — 代理完成後將自動傳送",
   queuedCancel: "從佇列中移除",
+  copyMessage: "複製訊息",
   worktree: {
     loading: "載入中",
     empty: "資料夾是空的",


### PR DESCRIPTION
## Feature

Add a Copy button to each chat message bubble. The button appears on hover (top-right corner) and copies the full message content to clipboard with a brief feedback animation.

## Changes

### MessageRow.tsx
- Added Copy / Check icon toggle with useState
- handleCopy calls window.hermesAPI.copyToClipboard() and shows the Check icon for 2 seconds on success
- Button is only rendered when the message has content and is not currently streaming

### main.css
- .chat-bubble now has position: relative so the absolute-positioned action buttons anchor inside it
- .chat-bubble-actions — flex container, hidden at opacity: 0, fades in on .chat-bubble:hover
- .chat-bubble-copy — 28x28px icon button with border, matches the design system

### i18n
- Added copyMessage key to all 10 supported locales