### PR TITLE
feat: add floating scroll-to-bottom button

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -2685,6 +2685,7 @@ body {
 }
 
 .chat-messages {
+  position: relative;
   flex: 1;
   overflow-y: auto;
   padding: 24px;
@@ -4202,6 +4203,36 @@ body {
   color: var(--text-muted);
   padding: 2px 60px;
   animation: fadeIn 0.2s ease;
+}
+
+/* Floating "scroll to bottom" button — appears when the user scrolls up
+   away from the latest messages. */
+.chat-scroll-bottom {
+  position: sticky;
+  bottom: 12px;
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-bright);
+  border-radius: 50%;
+  color: var(--text-secondary);
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+  transition: all var(--transition);
+  z-index: 10;
+}
+
+.chat-scroll-bottom:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+  border-color: var(--border-focus, var(--accent));
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
 }
 
 /* ── Chat history sub-rows (reasoning / tool_call / tool_result) ───────

--- a/src/renderer/src/screens/Chat/Chat.tsx
+++ b/src/renderer/src/screens/Chat/Chat.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Zap } from "lucide-react";
+import { Zap, ArrowDown } from "lucide-react";
 import { ChatInput, type ChatInputHandle } from "./ChatInput";
 import { ChatEmptyState } from "./ChatEmptyState";
 import { MessageList } from "./MessageList";
@@ -174,7 +174,8 @@ function Chat({
     };
   }, []);
 
-  const { containerRef, bottomRef } = useChatScroll(messages);
+  const { containerRef, bottomRef, isScrolledUp, scrollToBottomNow } =
+    useChatScroll(messages);
   const modelConfig = useModelConfig(profile);
   const {
     fastMode,
@@ -562,6 +563,17 @@ function Chat({
             />
           )}
           <div ref={bottomRef} />
+          {isScrolledUp && (
+            <button
+              type="button"
+              className="chat-scroll-bottom"
+              onClick={scrollToBottomNow}
+              title={t("chat.scrollToBottom")}
+              aria-label={t("chat.scrollToBottom")}
+            >
+              <ArrowDown size={16} />
+            </button>
+          )}
         </div>
 
         {contextFolder && worktreeVisible && (

--- a/src/renderer/src/screens/Chat/hooks/useChatScroll.ts
+++ b/src/renderer/src/screens/Chat/hooks/useChatScroll.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { ChatMessage } from "../types";
 
 /**
@@ -6,19 +6,28 @@ import type { ChatMessage } from "../types";
  *
  * - Tracks whether the user has manually scrolled up; pauses auto-scroll in that case.
  * - Re-engages auto-scroll when a new user message is sent.
- * - Exposes the container ref and a bottom sentinel ref to be placed in JSX.
+ * - Exposes the container ref, bottom sentinel ref, and scroll state.
  */
 export function useChatScroll(messages: ChatMessage[]): {
   containerRef: React.RefObject<HTMLDivElement | null>;
   bottomRef: React.RefObject<HTMLDivElement | null>;
+  isScrolledUp: boolean;
+  scrollToBottomNow: () => void;
 } {
   const containerRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const userScrolledUpRef = useRef(false);
   const prevMessageCountRef = useRef(messages.length);
+  const [isScrolledUp, setIsScrolledUp] = useState(false);
 
   const scrollToBottom = useCallback((force?: boolean) => {
     if (!force && userScrolledUpRef.current) return;
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, []);
+
+  const scrollToBottomNow = useCallback(() => {
+    userScrolledUpRef.current = false;
+    setIsScrolledUp(false);
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, []);
 
@@ -28,8 +37,10 @@ export function useChatScroll(messages: ChatMessage[]): {
     if (!container) return;
     function handleScroll(): void {
       const el = container!;
-      const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 60;
+      const atBottom =
+        el.scrollHeight - el.scrollTop - el.clientHeight < 60;
       userScrolledUpRef.current = !atBottom;
+      setIsScrolledUp(!atBottom);
     }
     container.addEventListener("scroll", handleScroll, { passive: true });
     return () => container.removeEventListener("scroll", handleScroll);
@@ -44,11 +55,12 @@ export function useChatScroll(messages: ChatMessage[]): {
       messages[messages.length - 1]?.role === "user";
     if (userJustSent) {
       userScrolledUpRef.current = false;
+      setIsScrolledUp(false);
       scrollToBottom(true);
     } else {
       scrollToBottom();
     }
   }, [messages, scrollToBottom]);
 
-  return { containerRef, bottomRef };
+  return { containerRef, bottomRef, isScrolledUp, scrollToBottomNow };
 }

--- a/src/shared/i18n/locales/en/chat.ts
+++ b/src/shared/i18n/locales/en/chat.ts
@@ -132,6 +132,7 @@ export default {
   queuedCount: "{{count}} queued",
   queuedAttachment: "{{count}} attachment(s)",
   queuedCancel: "Remove from queue",
+  scrollToBottom: "Scroll to bottom",
   worktree: {
     loading: "Loading",
     empty: "Folder is empty",

--- a/src/shared/i18n/locales/es/chat.ts
+++ b/src/shared/i18n/locales/es/chat.ts
@@ -108,6 +108,7 @@ export default {
   },
   queued: "{{count}} mensaje(s) en cola — se enviará cuando el agente termine",
   queuedCancel: "Quitar de la cola",
+  scrollToBottom: "Ir al final",
   worktree: {
     loading: "Cargando",
     empty: "La carpeta está vacía",

--- a/src/shared/i18n/locales/id/chat.ts
+++ b/src/shared/i18n/locales/id/chat.ts
@@ -82,6 +82,7 @@ export default {
     version: "Tampilkan versi Hermes",
   },
   queuedCancel: "Batalkan pesan antrian",
+  scrollToBottom: "Gulir ke bawah",
   worktree: {
     loading: "Memuat",
     empty: "Folder kosong",

--- a/src/shared/i18n/locales/ja/chat.ts
+++ b/src/shared/i18n/locales/ja/chat.ts
@@ -81,6 +81,7 @@ export default {
     version: "Hermes バージョンを表示",
   },
   queuedCancel: "キューから削除",
+  scrollToBottom: "一番下までスクロール",
   worktree: {
     loading: "読み込み中",
     empty: "フォルダは空です",

--- a/src/shared/i18n/locales/pl/chat.ts
+++ b/src/shared/i18n/locales/pl/chat.ts
@@ -88,6 +88,7 @@ export default {
   queued:
     "{{count}} wiadomość/wiadomości w kolejce — zostaną wysłane po zakończeniu pracy agenta",
   queuedCancel: "Usuń z kolejki",
+  scrollToBottom: "Przewiń na dół",
   worktree: {
     loading: "Ładowanie",
     empty: "Folder jest pusty",

--- a/src/shared/i18n/locales/pt-BR/chat.ts
+++ b/src/shared/i18n/locales/pt-BR/chat.ts
@@ -82,6 +82,7 @@ export default {
     version: "Mostrar a versão do Hermes",
   },
   queuedCancel: "Remover da fila",
+  scrollToBottom: "Rolar para o final",
   worktree: {
     loading: "Carregando",
     empty: "A pasta está vazia",

--- a/src/shared/i18n/locales/pt-PT/chat.ts
+++ b/src/shared/i18n/locales/pt-PT/chat.ts
@@ -94,6 +94,7 @@ export default {
   queued:
     "{{count}} mensagem(ns) em fila — serão enviadas quando o agente terminar",
   queuedCancel: "Remover da fila",
+  scrollToBottom: "Descer até ao fim",
   worktree: {
     loading: "A carregar",
     empty: "A pasta está vazia",

--- a/src/shared/i18n/locales/tr/chat.ts
+++ b/src/shared/i18n/locales/tr/chat.ts
@@ -105,6 +105,7 @@ export default {
   },
   queued: "{{count}} mesaj sırada — ajan işini bitirince gönderilecek",
   queuedCancel: "Sıradan kaldır",
+  scrollToBottom: "En alta kaydır",
   worktree: {
     loading: "Yükleniyor",
     empty: "Klasör boş",

--- a/src/shared/i18n/locales/zh-CN/chat.ts
+++ b/src/shared/i18n/locales/zh-CN/chat.ts
@@ -78,6 +78,7 @@ export default {
     version: "查看 Hermes 版本",
   },
   queuedCancel: "从队列中移除",
+  scrollToBottom: "滚动到底部",
   worktree: {
     loading: "加载中",
     empty: "文件夹为空",

--- a/src/shared/i18n/locales/zh-TW/chat.ts
+++ b/src/shared/i18n/locales/zh-TW/chat.ts
@@ -67,6 +67,7 @@ export default {
   },
   queued: "{{count}} 則訊息已排隊 — 代理完成後將自動傳送",
   queuedCancel: "從佇列中移除",
+  scrollToBottom: "捲動到底部",
   worktree: {
     loading: "載入中",
     empty: "資料夾是空的",


### PR DESCRIPTION
## Feature

Show a floating scroll-to-bottom button (↓) when the user scrolls up away from the latest messages. Clicking it smooth-scrolls back to the bottom and re-engages auto-scroll for new messages.

## Changes

### useChatScroll.ts
- Added `isScrolledUp: boolean` to the return type — updated via scroll event listener
- Added `scrollToBottomNow()` imperative action — resets scrolled-up state and scrolls to bottom
- Uses `useState` alongside the existing ref so React knows when to show/hide the button

### Chat.tsx
- Destructures `isScrolledUp` and `scrollToBottomNow` from `useChatScroll`
- Renders a `.chat-scroll-bottom` button (with `ArrowDown` icon) when `isScrolledUp` is true

### main.css
- `.chat-messages` now has `position: relative` so the sticky button anchors correctly
- `.chat-scroll-bottom` — 36x36px circle, sticky at bottom, with box-shadow, hover lift effect

### i18n
- Added `scrollToBottom` key to all 10 supported locales