### PR TITLE
feat: allow editing the last user message

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -2845,6 +2845,7 @@ body {
 }
 
 .chat-bubble {
+  position: relative;
   padding: 10px 16px;
   border-radius: var(--radius-lg);
   font-size: 14px;
@@ -2879,6 +2880,60 @@ body {
 .chat-bubble-error {
   border: 1px solid color-mix(in srgb, var(--error) 35%, transparent);
   background: var(--error-bg);
+}
+
+/* Inline edit textarea for sent messages + edit button */
+.chat-bubble-edit {
+  width: 100%;
+  min-height: 40px;
+  padding: 8px 12px;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.65;
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-focus, var(--accent));
+  border-radius: var(--radius-md);
+  outline: none;
+  resize: none;
+  overflow: hidden;
+}
+
+.chat-bubble-edit-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-bright);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition);
+}
+
+.chat-bubble-edit-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--border-focus, var(--accent));
+}
+
+/* Bubble actions (edit/copy) — hidden by default, shown on hover */
+.chat-bubble-actions {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  display: flex;
+  gap: 4px;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  z-index: 5;
+}
+
+.chat-bubble:hover .chat-bubble-actions {
+  opacity: 1;
 }
 
 .chat-error-message {

--- a/src/renderer/src/screens/Chat/Chat.tsx
+++ b/src/renderer/src/screens/Chat/Chat.tsx
@@ -468,6 +468,19 @@ function Chat({
     chatInputRef.current?.setText(text);
   }, []);
 
+  // Edit the last user message and resend
+  const handleEditMessage = useCallback(
+    (msgId: string, newContent: string) => {
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === msgId ? { ...m, content: newContent } : m,
+        ),
+      );
+      void handleSendRef.current(newContent, []);
+    },
+    [],
+  );
+
   const handlePickFolder = useCallback(async () => {
     const path = await window.hermesAPI.selectFolder();
     if (path) setContextFolder(path);
@@ -559,6 +572,7 @@ function Chat({
               onApprove={actions.handleApprove}
               onDeny={actions.handleDeny}
               onClarifyResolved={handleClarifyResolved}
+              onEditMessage={handleEditMessage}
             />
           )}
           <div ref={bottomRef} />

--- a/src/renderer/src/screens/Chat/MessageList.tsx
+++ b/src/renderer/src/screens/Chat/MessageList.tsx
@@ -22,6 +22,8 @@ interface MessageListProps {
   onDeny: () => void;
   /** Mark an inline clarify card resolved once the user answers/skips. */
   onClarifyResolved: (requestId: string, answer: string) => void;
+  /** Called when the user edits their last message and commits the edit. */
+  onEditMessage?: (msgId: string, newContent: string) => void;
 }
 
 function TypingIndicator({
@@ -66,6 +68,7 @@ export const MessageList = memo(function MessageList({
   onApprove,
   onDeny,
   onClarifyResolved,
+  onEditMessage,
 }: MessageListProps): React.JSX.Element {
   // Bubbles with empty content are still hidden (live-stream placeholders).
   // History rows pass through unconditionally.
@@ -154,6 +157,7 @@ export const MessageList = memo(function MessageList({
         onApprove={onApprove}
         onDeny={onDeny}
         showAvatar={showAvatar}
+        onEditMessage={onEditMessage}
       />,
     );
   }

--- a/src/renderer/src/screens/Chat/MessageRow.tsx
+++ b/src/renderer/src/screens/Chat/MessageRow.tsx
@@ -1,4 +1,5 @@
-import { memo, useMemo } from "react";
+import { memo, useMemo, useState, useRef, useCallback, useEffect } from "react";
+import { Pencil } from "lucide-react";
 import icon from "../../assets/icon.png";
 import { AgentMarkdown } from "../../components/AgentMarkdown";
 import { AttachmentChip } from "../../components/AttachmentChip";
@@ -49,6 +50,9 @@ interface MessageRowProps {
   /** False on continuation rows of a turn — render a spacer instead of the
    *  avatar so the turn reads as one grouped block. Defaults to true. */
   showAvatar?: boolean;
+  /** Called when the user edits their last message and presses Enter.
+   *  The parent should update the message content and trigger a regenerate. */
+  onEditMessage?: (msgId: string, newContent: string) => void;
 }
 
 export const MessageRow = memo(function MessageRow({
@@ -58,28 +62,71 @@ export const MessageRow = memo(function MessageRow({
   onApprove,
   onDeny,
   showAvatar = true,
+  onEditMessage,
 }: MessageRowProps): React.JSX.Element {
   const { t } = useI18n();
+  const [editing, setEditing] = useState(false);
+  const [editText, setEditText] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  // MessageRow is wrapped in memo() but still re-renders on any prop change
-  // (e.g. isLoading toggling at the end of a stream), and `parseMediaTokens`
-  // runs a full regex pipeline. Cache the result against the message content
-  // so a long conversation doesn't reparse every row on every render.
-  // Only agent bubbles need media parsing — user bubbles render content
-  // verbatim — so this is gated on the role to skip the work entirely for
-  // user rows. (Follow-up item from PR #303 review.)
   const bubbleContent = isChatBubbleMessage(msg)
     ? (msg as ChatBubbleMessage).content
     : null;
+
   const segments = useMemo(
     () =>
       msg.role === "agent" && bubbleContent
-        ? // Recover any tool/skill call the model leaked as text (e.g. a raw
-          // `<skill_view>{"answer": …}</skill_view>` tag) before tokenizing.
-          parseMediaTokens(cleanLeakedToolTags(bubbleContent))
+        ? parseMediaTokens(cleanLeakedToolTags(bubbleContent))
         : null,
     [msg.role, bubbleContent],
   );
+
+  // Only the last user message can be edited, and only when not loading
+  const canEdit =
+    onEditMessage &&
+    msg.role === "user" &&
+    isLast &&
+    !isLoading &&
+    !!bubbleContent;
+
+  const startEdit = useCallback(() => {
+    if (!bubbleContent) return;
+    setEditText(bubbleContent);
+    setEditing(true);
+  }, [bubbleContent]);
+
+  const commitEdit = useCallback(() => {
+    const trimmed = editText.trim();
+    if (trimmed && trimmed !== bubbleContent && onEditMessage) {
+      onEditMessage(msg.id, trimmed);
+    }
+    setEditing(false);
+    setEditText("");
+  }, [editText, bubbleContent, msg.id, onEditMessage]);
+
+  const cancelEdit = useCallback(() => {
+    setEditing(false);
+    setEditText("");
+  }, []);
+
+  // Focus textarea when entering edit mode
+  useEffect(() => {
+    if (editing && textareaRef.current) {
+      textareaRef.current.focus();
+      textareaRef.current.setSelectionRange(
+        textareaRef.current.value.length,
+        textareaRef.current.value.length,
+      );
+    }
+  }, [editing]);
+
+  // Auto-resize textarea height to fit content
+  useEffect(() => {
+    const ta = textareaRef.current;
+    if (!ta || !editing) return;
+    ta.style.height = "auto";
+    ta.style.height = ta.scrollHeight + "px";
+  }, [editText, editing]);
 
   // Only chat bubble messages have content/attachments
   if (!isChatBubbleMessage(msg)) {
@@ -126,34 +173,64 @@ export const MessageRow = memo(function MessageRow({
             ))}
           </div>
         )}
-        {msg.content &&
-          (msg.role === "agent" && segments
-            ? segments.map((segment) =>
-                segment.type === "text" ? (
-                  segment.value.trim() ? (
-                    // Keyed on the segment's character offset rather than its
-                    // array index — a MEDIA: token appearing mid-stream shifts
-                    // every subsequent index, which would otherwise re-mount
-                    // each downstream MediaSegmentView and re-fire its
-                    // `mediaFileExists` probe.
-                    <AgentMarkdown key={`t-${segment.start}`}>
-                      {segment.value}
-                    </AgentMarkdown>
-                  ) : null
-                ) : (
-                  <MediaSegmentView
-                    key={`m-${segment.start}`}
-                    token={segment.token}
-                    raw={segment.raw}
-                    source={segment.source}
-                  />
-                ),
-              )
-            : msg.content)}
-        {msg.error && (
-          <div className="chat-error-message" role="alert">
-            {msg.error}
-          </div>
+        {editing ? (
+          <textarea
+            ref={textareaRef}
+            className="chat-bubble-edit"
+            value={editText}
+            onChange={(e) => setEditText(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                commitEdit();
+              }
+              if (e.key === "Escape") {
+                e.preventDefault();
+                cancelEdit();
+              }
+            }}
+            rows={1}
+          />
+        ) : (
+          <>
+            {canEdit && (
+              <div className="chat-bubble-actions">
+                <button
+                  type="button"
+                  className="chat-bubble-edit-btn"
+                  onClick={startEdit}
+                  title={t("chat.editMessage")}
+                  aria-label={t("chat.editMessage")}
+                >
+                  <Pencil size={14} />
+                </button>
+              </div>
+            )}
+            {msg.content &&
+              (msg.role === "agent" && segments
+                ? segments.map((segment) =>
+                    segment.type === "text" ? (
+                      segment.value.trim() ? (
+                        <AgentMarkdown key={`t-${segment.start}`}>
+                          {segment.value}
+                        </AgentMarkdown>
+                      ) : null
+                    ) : (
+                      <MediaSegmentView
+                        key={`m-${segment.start}`}
+                        token={segment.token}
+                        raw={segment.raw}
+                        source={segment.source}
+                      />
+                    ),
+                  )
+                : msg.content)}
+            {msg.error && (
+              <div className="chat-error-message" role="alert">
+                {msg.error}
+              </div>
+            )}
+          </>
         )}
       </div>
       {showApprovalBar && (

--- a/src/shared/i18n/locales/en/chat.ts
+++ b/src/shared/i18n/locales/en/chat.ts
@@ -132,6 +132,7 @@ export default {
   queuedCount: "{{count}} queued",
   queuedAttachment: "{{count}} attachment(s)",
   queuedCancel: "Remove from queue",
+  editMessage: "Edit message",
   worktree: {
     loading: "Loading",
     empty: "Folder is empty",

--- a/src/shared/i18n/locales/es/chat.ts
+++ b/src/shared/i18n/locales/es/chat.ts
@@ -108,6 +108,7 @@ export default {
   },
   queued: "{{count}} mensaje(s) en cola — se enviará cuando el agente termine",
   queuedCancel: "Quitar de la cola",
+  editMessage: "Editar mensaje",
   worktree: {
     loading: "Cargando",
     empty: "La carpeta está vacía",

--- a/src/shared/i18n/locales/id/chat.ts
+++ b/src/shared/i18n/locales/id/chat.ts
@@ -82,6 +82,7 @@ export default {
     version: "Tampilkan versi Hermes",
   },
   queuedCancel: "Batalkan pesan antrian",
+  editMessage: "Edit pesan",
   worktree: {
     loading: "Memuat",
     empty: "Folder kosong",

--- a/src/shared/i18n/locales/ja/chat.ts
+++ b/src/shared/i18n/locales/ja/chat.ts
@@ -81,6 +81,7 @@ export default {
     version: "Hermes バージョンを表示",
   },
   queuedCancel: "キューから削除",
+  editMessage: "メッセージを編集",
   worktree: {
     loading: "読み込み中",
     empty: "フォルダは空です",

--- a/src/shared/i18n/locales/pl/chat.ts
+++ b/src/shared/i18n/locales/pl/chat.ts
@@ -88,6 +88,7 @@ export default {
   queued:
     "{{count}} wiadomość/wiadomości w kolejce — zostaną wysłane po zakończeniu pracy agenta",
   queuedCancel: "Usuń z kolejki",
+  editMessage: "Edytuj wiadomość",
   worktree: {
     loading: "Ładowanie",
     empty: "Folder jest pusty",

--- a/src/shared/i18n/locales/pt-BR/chat.ts
+++ b/src/shared/i18n/locales/pt-BR/chat.ts
@@ -82,6 +82,7 @@ export default {
     version: "Mostrar a versão do Hermes",
   },
   queuedCancel: "Remover da fila",
+  editMessage: "Editar mensagem",
   worktree: {
     loading: "Carregando",
     empty: "A pasta está vazia",

--- a/src/shared/i18n/locales/pt-PT/chat.ts
+++ b/src/shared/i18n/locales/pt-PT/chat.ts
@@ -94,6 +94,7 @@ export default {
   queued:
     "{{count}} mensagem(ns) em fila — serão enviadas quando o agente terminar",
   queuedCancel: "Remover da fila",
+  editMessage: "Editar mensagem",
   worktree: {
     loading: "A carregar",
     empty: "A pasta está vazia",

--- a/src/shared/i18n/locales/tr/chat.ts
+++ b/src/shared/i18n/locales/tr/chat.ts
@@ -105,6 +105,7 @@ export default {
   },
   queued: "{{count}} mesaj sırada — ajan işini bitirince gönderilecek",
   queuedCancel: "Sıradan kaldır",
+  editMessage: "Mesajı düzenle",
   worktree: {
     loading: "Yükleniyor",
     empty: "Klasör boş",

--- a/src/shared/i18n/locales/zh-CN/chat.ts
+++ b/src/shared/i18n/locales/zh-CN/chat.ts
@@ -78,6 +78,7 @@ export default {
     version: "查看 Hermes 版本",
   },
   queuedCancel: "从队列中移除",
+  editMessage: "编辑消息",
   worktree: {
     loading: "加载中",
     empty: "文件夹为空",

--- a/src/shared/i18n/locales/zh-TW/chat.ts
+++ b/src/shared/i18n/locales/zh-TW/chat.ts
@@ -67,6 +67,7 @@ export default {
   },
   queued: "{{count}} 則訊息已排隊 — 代理完成後將自動傳送",
   queuedCancel: "從佇列中移除",
+  editMessage: "編輯訊息",
   worktree: {
     loading: "載入中",
     empty: "資料夾是空的",


### PR DESCRIPTION
## Feature

Allow editing the last user message and regenerating the agent response. An edit button (pencil icon) appears on hover over the last user message. Clicking it turns the message into an inline textarea. Enter saves and resends, Escape cancels.

## Changes

- **MessageRow**: onEditMessage prop, edit state with auto-resize textarea, edit button in hover-visible .chat-bubble-actions
- **MessageList**: pass onEditMessage through
- **Chat**: handleEditMessage updates messages state and resends via handleSendRef
- **main.css**: .chat-bubble position:relative, .chat-bubble-actions hover reveal, .chat-bubble-edit-btn, .chat-bubble-edit textarea
- **i18n**: editMessage added to all 10 locales