### PR TITLE
feat: add line numbers and horizontal scroll to code blocks

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -2920,6 +2920,7 @@ body {
 .chat-code-block {
   border-radius: 6px;
   overflow: hidden;
+  overflow-x: auto;
   margin: 6px 0 !important;
 }
 
@@ -2965,6 +2966,16 @@ body {
   margin: 0 !important;
   padding: 12px !important;
   background: var(--code-bg) !important;
+  overflow-x: auto;
+}
+
+/* Line numbers inside code blocks */
+.chat-code-block .linenumber {
+  min-width: 2.5em;
+  padding-right: 1em;
+  color: #636d83;
+  user-select: none;
+  text-align: right;
 }
 
 .chat-code-block span[class*="token"] {

--- a/src/renderer/src/components/AgentMarkdown.tsx
+++ b/src/renderer/src/components/AgentMarkdown.tsx
@@ -108,12 +108,27 @@ function CodeBlock({
           style={_oneDark}
           language={language || "text"}
           PreTag="div"
+          showLineNumbers={code.split("\n").length > 1}
+          wrapLines={true}
+          lineNumberStyle={{
+            minWidth: "2.5em",
+            paddingRight: "1em",
+            color: "#636d83",
+            userSelect: "none",
+            textAlign: "right",
+          }}
           customStyle={{
             margin: 0,
             borderRadius: 0,
             fontSize: "13px",
             padding: "12px",
             background: "transparent",
+            overflowX: "auto",
+          }}
+          codeTagProps={{
+            style: {
+              whiteSpace: "pre",
+            },
           }}
         >
           {code}


### PR DESCRIPTION
## Feature

Add line numbers to multi-line code blocks and enable independent horizontal scrolling for long lines.

## Changes

### AgentMarkdown.tsx
- `showLineNumbers={true}` for code blocks with more than one line
- `wrapLines={true}` so each line gets its own row with a line number
- `lineNumberStyle` — dimmed (#636d83), non-selectable, right-aligned
- `codeTagProps={{ style: { whiteSpace: "pre" }}}` — preserves formatting and enables horizontal scroll for long lines

### main.css
- `.chat-code-block` — added `overflow-x: auto` for horizontal scroll
- `.chat-bubble-agent .chat-code-block pre/div` — added `overflow-x: auto`
- `.chat-code-block .linenumber` — styling for line number column