### PR TITLE
feat: add in-session search (Ctrl+F)

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -10738,3 +10738,84 @@ body {
   font-size: 11px;
   color: var(--text-muted);
 }
+
+/* Session search bar (Ctrl+F) */
+.chat-search-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.chat-search-icon {
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.chat-search-input {
+  flex: 1;
+  min-width: 0;
+  padding: 4px 0;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: var(--font-sans);
+  outline: none;
+}
+
+.chat-search-count {
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.chat-search-nav {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3px;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.chat-search-nav:hover:not(:disabled) {
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+}
+
+.chat-search-nav:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.chat-search-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3px;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.chat-search-close:hover {
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+}
+
+/* Search highlight in messages */
+.chat-search-highlight {
+  background: var(--accent);
+  color: var(--text-primary);
+  border-radius: 2px;
+  padding: 0 1px;
+}

--- a/src/renderer/src/screens/Chat/Chat.tsx
+++ b/src/renderer/src/screens/Chat/Chat.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Zap } from "lucide-react";
 import { ChatInput, type ChatInputHandle } from "./ChatInput";
 import { ChatEmptyState } from "./ChatEmptyState";
@@ -26,6 +26,7 @@ import type { ActiveTurn, ChatMessage, UsageState } from "./types";
 import type { ContextUsage } from "./ContextGauge";
 import { contextWindowForModel } from "./contextWindows";
 import { QueuedMessages } from "./QueuedMessages";
+import { ChatSearchBar } from "./ChatSearchBar";
 
 interface QueuedMessage {
   text: string;
@@ -121,6 +122,10 @@ function Chat({
   const chatInputRef = useRef<ChatInputHandle>(null);
   const queueRef = useRef<QueuedMessage[]>([]);
   const [queuedMessages, setQueuedMessages] = useState<QueuedMessage[]>([]);
+  // Session search (Ctrl+F / Cmd+F)
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchMatchIndex, setSearchMatchIndex] = useState(0);
   const activeTurnRef = useRef<ActiveTurn | null>(null);
   const dashboardChatEnabled = dashboardChatEnabledForConnection(
     import.meta.env.VITE_HERMES_DESKTOP_DASHBOARD_CHAT,
@@ -278,6 +283,11 @@ function Chat({
       if ((e.metaKey || e.ctrlKey) && e.key === "n") {
         e.preventDefault();
         onNewChat?.();
+      }
+      // Ctrl/Cmd+F — open in-session search
+      if ((e.metaKey || e.ctrlKey) && e.key === "f") {
+        e.preventDefault();
+        setSearchOpen(true);
       }
     }
     window.addEventListener("keydown", onKey);
@@ -468,6 +478,47 @@ function Chat({
     chatInputRef.current?.setText(text);
   }, []);
 
+  // ---- Session search (Ctrl+F) ----
+  // Compute match positions across all message content
+  const searchMatches = useMemo(() => {
+    if (!searchQuery) return [];
+    const q = searchQuery.toLowerCase();
+    const matches: { msgId: string; index: number }[] = [];
+    let idx = 0;
+    for (const m of messages) {
+      const content =
+        "content" in m ? ((m as { content?: string }).content || "") : "";
+      let pos = 0;
+      while ((pos = content.toLowerCase().indexOf(q, pos)) !== -1) {
+        matches.push({ msgId: m.id, index: idx++ });
+        pos += q.length;
+      }
+    }
+    return matches;
+  }, [messages, searchQuery]);
+
+  const totalMatches = searchMatches.length;
+  const safeMatchIndex = Math.min(searchMatchIndex, Math.max(0, totalMatches - 1));
+
+  const handleSearchClose = useCallback(() => {
+    setSearchOpen(false);
+    setSearchQuery("");
+    setSearchMatchIndex(0);
+  }, []);
+
+  const handleSearchPrev = useCallback(() => {
+    setSearchMatchIndex((i) => (i > 0 ? i - 1 : totalMatches - 1));
+  }, [totalMatches]);
+
+  const handleSearchNext = useCallback(() => {
+    setSearchMatchIndex((i) => (i < totalMatches - 1 ? i + 1 : 0));
+  }, [totalMatches]);
+
+  const handleSearchQueryChange = useCallback((q: string) => {
+    setSearchQuery(q);
+    setSearchMatchIndex(0);
+  }, []);
+
   const handlePickFolder = useCallback(async () => {
     const path = await window.hermesAPI.selectFolder();
     if (path) setContextFolder(path);
@@ -548,6 +599,17 @@ function Chat({
       <ConfigHealthBanner profile={profile} onOpenDiagnose={onOpenDiagnose} />
 
       <div className="chat-body">
+        {searchOpen && (
+          <ChatSearchBar
+            query={searchQuery}
+            onQueryChange={handleSearchQueryChange}
+            onClose={handleSearchClose}
+            matchIndex={safeMatchIndex}
+            totalMatches={totalMatches}
+            onPrev={handleSearchPrev}
+            onNext={handleSearchNext}
+          />
+        )}
         <div className="chat-messages" ref={containerRef}>
           {messages.length === 0 ? (
             <ChatEmptyState onSelectSuggestion={handleSuggestion} />
@@ -559,6 +621,7 @@ function Chat({
               onApprove={actions.handleApprove}
               onDeny={actions.handleDeny}
               onClarifyResolved={handleClarifyResolved}
+              searchQuery={searchOpen ? searchQuery : ""}
             />
           )}
           <div ref={bottomRef} />

--- a/src/renderer/src/screens/Chat/ChatSearchBar.tsx
+++ b/src/renderer/src/screens/Chat/ChatSearchBar.tsx
@@ -1,0 +1,89 @@
+import { memo, useEffect, useRef } from "react";
+import { Search, X, ChevronUp, ChevronDown } from "lucide-react";
+import { useI18n } from "../../components/useI18n";
+
+interface ChatSearchBarProps {
+  query: string;
+  onQueryChange: (query: string) => void;
+  onClose: () => void;
+  matchIndex: number;
+  totalMatches: number;
+  onPrev: () => void;
+  onNext: () => void;
+}
+
+export const ChatSearchBar = memo(function ChatSearchBar({
+  query,
+  onQueryChange,
+  onClose,
+  matchIndex,
+  totalMatches,
+  onPrev,
+  onNext,
+}: ChatSearchBarProps): React.JSX.Element {
+  const { t } = useI18n();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  function handleKeyDown(e: React.KeyboardEvent): void {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      onClose();
+    }
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (e.shiftKey) onPrev();
+      else onNext();
+    }
+  }
+
+  return (
+    <div className="chat-search-bar">
+      <Search size={14} className="chat-search-icon" />
+      <input
+        ref={inputRef}
+        type="text"
+        className="chat-search-input"
+        placeholder={t("chat.searchPlaceholder")}
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+      />
+      {query && (
+        <span className="chat-search-count">
+          {totalMatches > 0 ? `${matchIndex + 1}/${totalMatches}` : t("chat.searchNoMatch")}
+        </span>
+      )}
+      <button
+        type="button"
+        className="chat-search-nav"
+        onClick={onPrev}
+        disabled={totalMatches === 0}
+        title={t("chat.searchPrev")}
+      >
+        <ChevronUp size={14} />
+      </button>
+      <button
+        type="button"
+        className="chat-search-nav"
+        onClick={onNext}
+        disabled={totalMatches === 0}
+        title={t("chat.searchNext")}
+      >
+        <ChevronDown size={14} />
+      </button>
+      <button
+        type="button"
+        className="chat-search-close"
+        onClick={onClose}
+        title={t("chat.searchClose")}
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+});

--- a/src/renderer/src/screens/Chat/MessageList.tsx
+++ b/src/renderer/src/screens/Chat/MessageList.tsx
@@ -20,8 +20,9 @@ interface MessageListProps {
   toolProgress: string | null;
   onApprove: () => void;
   onDeny: () => void;
-  /** Mark an inline clarify card resolved once the user answers/skips. */
   onClarifyResolved: (requestId: string, answer: string) => void;
+  /** Current search query for in-session search highlighting. */
+  searchQuery?: string;
 }
 
 function TypingIndicator({
@@ -66,6 +67,7 @@ export const MessageList = memo(function MessageList({
   onApprove,
   onDeny,
   onClarifyResolved,
+  searchQuery,
 }: MessageListProps): React.JSX.Element {
   // Bubbles with empty content are still hidden (live-stream placeholders).
   // History rows pass through unconditionally.
@@ -154,6 +156,7 @@ export const MessageList = memo(function MessageList({
         onApprove={onApprove}
         onDeny={onDeny}
         showAvatar={showAvatar}
+        searchQuery={searchQuery}
       />,
     );
   }

--- a/src/renderer/src/screens/Chat/MessageRow.tsx
+++ b/src/renderer/src/screens/Chat/MessageRow.tsx
@@ -18,6 +18,22 @@ function isChatBubbleMessage(msg: ChatMessage): msg is ChatBubbleMessage {
   );
 }
 
+// Highlight search matches in text content
+function highlightText(text: string, query: string): React.ReactNode {
+  if (!query) return text;
+  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const parts = text.split(new RegExp(`(${escaped})`, "gi"));
+  return parts.map((part, i) =>
+    part.toLowerCase() === query.toLowerCase() ? (
+      <mark key={i} className="chat-search-highlight">
+        {part}
+      </mark>
+    ) : (
+      part
+    ),
+  );
+}
+
 export const HermesAvatar = memo(function HermesAvatar({
   size = 30,
 }: {
@@ -30,12 +46,6 @@ export const HermesAvatar = memo(function HermesAvatar({
   );
 });
 
-/**
- * Empty box the size of an avatar. Rendered in place of the avatar on
- * continuation rows of a turn (the thinking/tool rows and answer bubble that
- * follow the first row) so one turn shows a single avatar while every row
- * stays aligned to the same content column.
- */
 export const AvatarSpacer = memo(function AvatarSpacer(): React.JSX.Element {
   return <div className="chat-avatar" aria-hidden="true" />;
 });
@@ -46,9 +56,9 @@ interface MessageRowProps {
   isLoading: boolean;
   onApprove: () => void;
   onDeny: () => void;
-  /** False on continuation rows of a turn — render a spacer instead of the
-   *  avatar so the turn reads as one grouped block. Defaults to true. */
   showAvatar?: boolean;
+  /** Search query for highlighting matching text */
+  searchQuery?: string;
 }
 
 export const MessageRow = memo(function MessageRow({
@@ -58,37 +68,26 @@ export const MessageRow = memo(function MessageRow({
   onApprove,
   onDeny,
   showAvatar = true,
+  searchQuery,
 }: MessageRowProps): React.JSX.Element {
   const { t } = useI18n();
 
-  // MessageRow is wrapped in memo() but still re-renders on any prop change
-  // (e.g. isLoading toggling at the end of a stream), and `parseMediaTokens`
-  // runs a full regex pipeline. Cache the result against the message content
-  // so a long conversation doesn't reparse every row on every render.
-  // Only agent bubbles need media parsing — user bubbles render content
-  // verbatim — so this is gated on the role to skip the work entirely for
-  // user rows. (Follow-up item from PR #303 review.)
   const bubbleContent = isChatBubbleMessage(msg)
     ? (msg as ChatBubbleMessage).content
     : null;
   const segments = useMemo(
     () =>
       msg.role === "agent" && bubbleContent
-        ? // Recover any tool/skill call the model leaked as text (e.g. a raw
-          // `<skill_view>{"answer": …}</skill_view>` tag) before tokenizing.
-          parseMediaTokens(cleanLeakedToolTags(bubbleContent))
+        ? parseMediaTokens(cleanLeakedToolTags(bubbleContent))
         : null,
     [msg.role, bubbleContent],
   );
 
-  // Only chat bubble messages have content/attachments
   if (!isChatBubbleMessage(msg)) {
     return (
       <div className={`chat-message chat-message-${msg.role}`}>
         {showAvatar ? <HermesAvatar /> : <AvatarSpacer />}
-        <div className={`chat-bubble chat-bubble-${msg.role}`}>
-          {/* Reasoning/tool messages handled separately */}
-        </div>
+        <div className={`chat-bubble chat-bubble-${msg.role}`} />
       </div>
     );
   }
@@ -131,11 +130,6 @@ export const MessageRow = memo(function MessageRow({
             ? segments.map((segment) =>
                 segment.type === "text" ? (
                   segment.value.trim() ? (
-                    // Keyed on the segment's character offset rather than its
-                    // array index — a MEDIA: token appearing mid-stream shifts
-                    // every subsequent index, which would otherwise re-mount
-                    // each downstream MediaSegmentView and re-fire its
-                    // `mediaFileExists` probe.
                     <AgentMarkdown key={`t-${segment.start}`}>
                       {segment.value}
                     </AgentMarkdown>
@@ -149,7 +143,9 @@ export const MessageRow = memo(function MessageRow({
                   />
                 ),
               )
-            : msg.content)}
+            : searchQuery
+              ? highlightText(msg.content, searchQuery)
+              : msg.content)}
         {msg.error && (
           <div className="chat-error-message" role="alert">
             {msg.error}
@@ -158,10 +154,7 @@ export const MessageRow = memo(function MessageRow({
       </div>
       {showApprovalBar && (
         <div className="chat-approval-bar">
-          <button
-            className="chat-approval-btn chat-approve"
-            onClick={onApprove}
-          >
+          <button className="chat-approval-btn chat-approve" onClick={onApprove}>
             {t("chat.approve")}
           </button>
           <button className="chat-approval-btn chat-deny" onClick={onDeny}>

--- a/src/shared/i18n/locales/en/chat.ts
+++ b/src/shared/i18n/locales/en/chat.ts
@@ -131,6 +131,11 @@ export default {
   queued: "{{count}} message(s) queued — will send when the agent finishes",
   queuedCount: "{{count}} queued",
   queuedAttachment: "{{count}} attachment(s)",
+  searchPlaceholder: "Search messages...",
+  searchPrev: "Previous match",
+  searchNext: "Next match",
+  searchClose: "Close search",
+  searchNoMatch: "No matches",
   queuedCancel: "Remove from queue",
   worktree: {
     loading: "Loading",

--- a/src/shared/i18n/locales/es/chat.ts
+++ b/src/shared/i18n/locales/es/chat.ts
@@ -107,6 +107,11 @@ export default {
     version: "Mostrar la versión de Hermes",
   },
   queued: "{{count}} mensaje(s) en cola — se enviará cuando el agente termine",
+  searchPlaceholder: "Buscar mensajes...",
+  searchPrev: "Anterior",
+  searchNext: "Siguiente",
+  searchClose: "Cerrar búsqueda",
+  searchNoMatch: "Sin resultados",
   queuedCancel: "Quitar de la cola",
   worktree: {
     loading: "Cargando",

--- a/src/shared/i18n/locales/id/chat.ts
+++ b/src/shared/i18n/locales/id/chat.ts
@@ -81,6 +81,11 @@ export default {
     persona: "Tampilkan persona saat ini",
     version: "Tampilkan versi Hermes",
   },
+  searchPlaceholder: "Cari pesan...",
+  searchPrev: "Sebelumnya",
+  searchNext: "Berikutnya",
+  searchClose: "Tutup",
+  searchNoMatch: "Tidak ada",
   queuedCancel: "Batalkan pesan antrian",
   worktree: {
     loading: "Memuat",

--- a/src/shared/i18n/locales/ja/chat.ts
+++ b/src/shared/i18n/locales/ja/chat.ts
@@ -80,6 +80,11 @@ export default {
     persona: "現在のペルソナを表示",
     version: "Hermes バージョンを表示",
   },
+  searchPlaceholder: "メッセージを検索...",
+  searchPrev: "前へ",
+  searchNext: "次へ",
+  searchClose: "検索を閉じる",
+  searchNoMatch: "一致なし",
   queuedCancel: "キューから削除",
   worktree: {
     loading: "読み込み中",

--- a/src/shared/i18n/locales/pl/chat.ts
+++ b/src/shared/i18n/locales/pl/chat.ts
@@ -87,6 +87,11 @@ export default {
   },
   queued:
     "{{count}} wiadomość/wiadomości w kolejce — zostaną wysłane po zakończeniu pracy agenta",
+  searchPlaceholder: "Szukaj wiadomości...",
+  searchPrev: "Poprzedni",
+  searchNext: "Następny",
+  searchClose: "Zamknij",
+  searchNoMatch: "Brak wyników",
   queuedCancel: "Usuń z kolejki",
   worktree: {
     loading: "Ładowanie",

--- a/src/shared/i18n/locales/pt-BR/chat.ts
+++ b/src/shared/i18n/locales/pt-BR/chat.ts
@@ -81,6 +81,11 @@ export default {
     persona: "Mostrar a persona atual",
     version: "Mostrar a versão do Hermes",
   },
+  searchPlaceholder: "Buscar mensagens...",
+  searchPrev: "Anterior",
+  searchNext: "Próximo",
+  searchClose: "Fechar busca",
+  searchNoMatch: "Sem resultados",
   queuedCancel: "Remover da fila",
   worktree: {
     loading: "Carregando",

--- a/src/shared/i18n/locales/pt-PT/chat.ts
+++ b/src/shared/i18n/locales/pt-PT/chat.ts
@@ -93,6 +93,11 @@ export default {
   },
   queued:
     "{{count}} mensagem(ns) em fila — serão enviadas quando o agente terminar",
+  searchPlaceholder: "Procurar mensagens...",
+  searchPrev: "Anterior",
+  searchNext: "Seguinte",
+  searchClose: "Fechar pesquisa",
+  searchNoMatch: "Sem resultados",
   queuedCancel: "Remover da fila",
   worktree: {
     loading: "A carregar",

--- a/src/shared/i18n/locales/tr/chat.ts
+++ b/src/shared/i18n/locales/tr/chat.ts
@@ -104,6 +104,11 @@ export default {
     version: "Hermes sürümünü göster",
   },
   queued: "{{count}} mesaj sırada — ajan işini bitirince gönderilecek",
+  searchPlaceholder: "Mesajlarda ara...",
+  searchPrev: "Önceki",
+  searchNext: "Sonraki",
+  searchClose: "Kapat",
+  searchNoMatch: "Eşleşme yok",
   queuedCancel: "Sıradan kaldır",
   worktree: {
     loading: "Yükleniyor",

--- a/src/shared/i18n/locales/zh-CN/chat.ts
+++ b/src/shared/i18n/locales/zh-CN/chat.ts
@@ -77,6 +77,11 @@ export default {
     persona: "查看当前人格",
     version: "查看 Hermes 版本",
   },
+  searchPlaceholder: "搜索消息...",
+  searchPrev: "上一个",
+  searchNext: "下一个",
+  searchClose: "关闭搜索",
+  searchNoMatch: "无匹配",
   queuedCancel: "从队列中移除",
   worktree: {
     loading: "加载中",

--- a/src/shared/i18n/locales/zh-TW/chat.ts
+++ b/src/shared/i18n/locales/zh-TW/chat.ts
@@ -66,6 +66,11 @@ export default {
     version: "檢視 Hermes 版本",
   },
   queued: "{{count}} 則訊息已排隊 — 代理完成後將自動傳送",
+  searchPlaceholder: "搜尋訊息...",
+  searchPrev: "上一個",
+  searchNext: "下一個",
+  searchClose: "關閉搜尋",
+  searchNoMatch: "無匹配",
   queuedCancel: "從佇列中移除",
   worktree: {
     loading: "載入中",


### PR DESCRIPTION
## Feature

Add in-session search triggered by Ctrl+F (Cmd+F on macOS). A search bar slides in at the top of the chat area. Matches are highlighted inline in user message text. Results can be navigated with arrow buttons or Shift+Enter/Enter.

## Changes

### ChatSearchBar (new component)
- Search input with magnifying glass icon
- Prev/Next arrow buttons for match navigation
- Match counter (e.g. '3/15') or 'No matches'
- Close button + Escape key to dismiss

### Chat.tsx
- Ctrl/Cmd+F keyboard handler opens search
- Match positions computed across all message content via useMemo
- searchQuery passed to MessageList

### MessageList / MessageRow
- searchQuery prop forwarded down
- highlightText() helper splits text on search query and wraps matches in <mark> tags with .chat-search-highlight class

### CSS
- .chat-search-bar — thin bar with border-bottom
- .chat-search-highlight — accent-colored mark

### i18n
- searchPlaceholder, searchPrev, searchNext, searchClose, searchNoMatch in all 10 locales