### PR TITLE
fix: model picker in chat no longer overwrites the global default model

### DIFF
--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -2449,11 +2449,15 @@ async function sendMessageViaBestApi(
   modelOverride?: string,
 ): Promise<ChatHandle> {
   const approvalCommand = /^\/(?:approve|deny)\b/i.test(message.trim());
+  // Skip the TUI gateway when a session-scoped model override is active — the
+  // TUI gateway reads its model from config.yaml and has no per-request
+  // override mechanism. The API path below already honours modelOverride.
   if (
     shouldUseTuiGatewayClient() &&
     !isRemoteMode() &&
     !attachments?.length &&
-    !approvalCommand
+    !approvalCommand &&
+    !modelOverride
   ) {
     try {
       return await sendMessageViaTuiGateway(

--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -1109,6 +1109,7 @@ function sendMessageViaApi(
   history?: Array<{ role: string; content: string }>,
   attachments?: Attachment[],
   contextFolder?: string,
+  modelOverride?: string,
 ): ChatHandle {
   const mc = getModelConfig(profile);
   const controller = new AbortController();
@@ -1138,7 +1139,7 @@ function sendMessageViaApi(
 
   const reasoningEffort = reasoningEffortForProfile(profile);
   const bodyObj: Record<string, unknown> = {
-    model: mc.model || "hermes-agent",
+    model: modelOverride || mc.model || "hermes-agent",
     messages,
     stream: true,
     ...(_resumeSessionId ? { session_id: _resumeSessionId } : {}),
@@ -1224,7 +1225,7 @@ function sendMessageViaApi(
   function probeRealError(): void {
     // When streaming returns empty, make a non-streaming request to surface the real error
     const probeBodyObj: Record<string, unknown> = {
-      model: mc.model || "hermes-agent",
+      model: modelOverride || mc.model || "hermes-agent",
       messages: [{ role: "user", content: userContent }],
       stream: false,
     };
@@ -1513,6 +1514,7 @@ function sendMessageViaRuns(
   history?: Array<{ role: string; content: string }>,
   attachments?: Attachment[],
   contextFolder?: string,
+  modelOverride?: string,
 ): ChatHandle {
   const mc = getModelConfig(profile);
   const controller = new AbortController();
@@ -1523,7 +1525,7 @@ function sendMessageViaRuns(
     (headersForAuth.Authorization ? `desk-${Date.now()}-${randomUUID()}` : "");
   const ctxSystem = contextFolderSystemMessage(contextFolder);
   const bodyObj: Record<string, unknown> = {
-    model: mc.model || "hermes-agent",
+    model: modelOverride || mc.model || "hermes-agent",
     input: message,
     conversation_history: apiHistory(history),
   };
@@ -2077,6 +2079,7 @@ function sendMessageViaCli(
   profile?: string,
   resumeSessionId?: string,
   attachments?: Attachment[],
+  modelOverride?: string,
 ): ChatHandle {
   // CLI fallback can't pipe multimodal content; inline text-file attachments
   // and ignore images.  The gateway is the supported attachment path; this
@@ -2108,8 +2111,8 @@ function sendMessageViaCli(
     args.push("--resume", resumeSessionId);
   }
 
-  if (mc.model) {
-    args.push("-m", mc.model);
+  if (modelOverride || mc.model) {
+    args.push("-m", modelOverride || mc.model);
   }
 
   const cliProvider = CLI_COMPAT_PROVIDER_OVERRIDE[mc.provider];
@@ -2404,6 +2407,7 @@ async function sendMessageViaNonGatewayApi(
   history?: Array<{ role: string; content: string }>,
   attachments?: Attachment[],
   contextFolder?: string,
+  modelOverride?: string,
 ): Promise<ChatHandle> {
   const approvalCommand = /^\/(?:approve|deny)\b/i.test(message.trim());
   if (!attachments?.length && !approvalCommand) {
@@ -2417,6 +2421,7 @@ async function sendMessageViaNonGatewayApi(
           history,
           attachments,
           contextFolder,
+          modelOverride,
         );
       }
   }
@@ -2429,6 +2434,7 @@ async function sendMessageViaNonGatewayApi(
     history,
     attachments,
     contextFolder,
+    modelOverride,
   );
 }
 
@@ -2440,6 +2446,7 @@ async function sendMessageViaBestApi(
   history?: Array<{ role: string; content: string }>,
   attachments?: Attachment[],
   contextFolder?: string,
+  modelOverride?: string,
 ): Promise<ChatHandle> {
   const approvalCommand = /^\/(?:approve|deny)\b/i.test(message.trim());
   if (
@@ -2473,6 +2480,7 @@ async function sendMessageViaBestApi(
     history,
     attachments,
     contextFolder,
+    modelOverride,
   );
 }
 
@@ -2484,6 +2492,7 @@ async function sendMessageViaBestApiWithLocalRecovery(
   history?: Array<{ role: string; content: string }>,
   attachments?: Attachment[],
   contextFolder?: string,
+  modelOverride?: string,
 ): Promise<ChatHandle> {
   let aborted = false;
   let retrying = false;
@@ -2528,6 +2537,7 @@ async function sendMessageViaBestApiWithLocalRecovery(
         history,
         attachments,
         contextFolder,
+        modelOverride,
       );
       return;
     }
@@ -2538,6 +2548,7 @@ async function sendMessageViaBestApiWithLocalRecovery(
       profile,
       resumeSessionId,
       attachments,
+      modelOverride,
     );
   };
 
@@ -2615,6 +2626,7 @@ async function sendMessageViaBestApiWithLocalRecovery(
     history,
     attachments,
     contextFolder,
+    modelOverride,
   );
 
   return handle;
@@ -2628,6 +2640,7 @@ export async function sendMessage(
   history?: Array<{ role: string; content: string }>,
   attachments?: Attachment[],
   contextFolder?: string,
+  modelOverride?: string,
 ): Promise<ChatHandle> {
   ensureInitialized();
 
@@ -2641,6 +2654,7 @@ export async function sendMessage(
       history,
       attachments,
       contextFolder,
+      modelOverride,
     );
   }
 
@@ -2652,6 +2666,7 @@ export async function sendMessage(
       profile,
       resumeSessionId,
       attachments,
+      modelOverride,
     );
   }
 
@@ -2675,11 +2690,12 @@ export async function sendMessage(
       history,
       attachments,
       contextFolder,
+      modelOverride,
     );
   }
 
   // Fallback to CLI
-  return sendMessageViaCli(message, cb, profile, resumeSessionId, attachments);
+  return sendMessageViaCli(message, cb, profile, resumeSessionId, attachments, modelOverride);
 }
 
 // Lazy init — called on first sendMessage or gateway start

--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -1569,6 +1569,7 @@ function sendMessageViaRuns(
       history,
       attachments,
       contextFolder,
+      modelOverride,
     );
   }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1247,6 +1247,7 @@ function setupIPC(): void {
       attachments?: Attachment[],
       contextFolder?: string,
       runId?: string,
+      modelOverride?: string,
     ) => {
       // Each conversation has a stable runId minted by the renderer. Fall back
       // to a generated id for legacy callers so the run is still tracked.
@@ -1391,6 +1392,7 @@ function setupIPC(): void {
         history,
         attachments,
         contextFolder,
+        modelOverride,
       );
 
       activeRuns.set(chatRunId, handle.abort);

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -368,6 +368,7 @@ interface HermesAPI {
     attachments?: Attachment[],
     contextFolder?: string,
     runId?: string,
+    modelOverride?: string,
   ) => Promise<{ response: string; sessionId?: string }>;
   abortChat: (runId?: string) => Promise<void>;
   transcribeAudio: (

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -367,6 +367,7 @@ const hermesAPI = {
     attachments?: Attachment[],
     contextFolder?: string,
     runId?: string,
+    modelOverride?: string,
   ): Promise<{ response: string; sessionId?: string }> =>
     ipcRenderer.invoke(
       "send-message",
@@ -377,6 +378,7 @@ const hermesAPI = {
       attachments,
       contextFolder,
       runId,
+      modelOverride,
     ),
 
   abortChat: (runId?: string): Promise<void> =>

--- a/src/renderer/src/screens/Chat/Chat.tsx
+++ b/src/renderer/src/screens/Chat/Chat.tsx
@@ -418,6 +418,7 @@ function Chat({
     localCommands,
     activeTurnRef,
     contextFolder,
+    sessionModel: modelConfig.currentModel || undefined,
     sendViaDashboard: dashboardTransport.enabled
       ? dashboardTransport.sendMessage
       : undefined,
@@ -595,7 +596,11 @@ function Chat({
                 modelGroups={modelConfig.modelGroups}
                 displayModel={modelConfig.displayModel}
                 onOpen={modelConfig.reload}
-                onSelectModel={modelConfig.selectModel}
+                onSelectModel={(provider, model, baseUrl) =>
+                  void modelConfig.selectModel(provider, model, baseUrl, {
+                    persist: false,
+                  })
+                }
               />
               <ReasoningEffortPicker
                 value={reasoningEffort}

--- a/src/renderer/src/screens/Chat/Chat.tsx
+++ b/src/renderer/src/screens/Chat/Chat.tsx
@@ -117,6 +117,13 @@ function Chat({
   // Whether the worktree panel is visible (only applies when contextFolder is set)
   // Default false so the panel doesn't open automatically and interfere with scrolling
   const [worktreeVisible, setWorktreeVisible] = useState<boolean>(false);
+  // Explicit session-scoped model override — set only when the user picks
+  // from the chat-screen picker (persist:false). Undefined until then so the
+  // TUI gateway bypass in sendMessageViaBestApi is not triggered for normal
+  // chats where the user never changed the model (issue #688).
+  const [sessionModelOverride, setSessionModelOverride] = useState<
+    string | undefined
+  >(undefined);
   const dragCounter = useRef(0);
   const chatInputRef = useRef<ChatInputHandle>(null);
   const queueRef = useRef<QueuedMessage[]>([]);
@@ -418,7 +425,7 @@ function Chat({
     localCommands,
     activeTurnRef,
     contextFolder,
-    sessionModel: modelConfig.currentModel || undefined,
+    sessionModel: sessionModelOverride,
     sendViaDashboard: dashboardTransport.enabled
       ? dashboardTransport.sendMessage
       : undefined,
@@ -596,11 +603,12 @@ function Chat({
                 modelGroups={modelConfig.modelGroups}
                 displayModel={modelConfig.displayModel}
                 onOpen={modelConfig.reload}
-                onSelectModel={(provider, model, baseUrl) =>
+                onSelectModel={(provider, model, baseUrl) => {
                   void modelConfig.selectModel(provider, model, baseUrl, {
                     persist: false,
-                  })
-                }
+                  });
+                  setSessionModelOverride(model || undefined);
+                }}
               />
               <ReasoningEffortPicker
                 value={reasoningEffort}

--- a/src/renderer/src/screens/Chat/hooks/useChatActions.ts
+++ b/src/renderer/src/screens/Chat/hooks/useChatActions.ts
@@ -24,6 +24,9 @@ interface UseChatActionsArgs {
   activeTurnRef: React.MutableRefObject<ActiveTurn | null>;
   /** Working folder bound to this conversation (issue #27), or null. */
   contextFolder: string | null;
+  /** Session-local model override — selected via the chat picker without
+   *  persisting to config.yaml (issue #688). */
+  sessionModel?: string;
   sendViaDashboard?: (
     text: string,
     attachments?: Attachment[],
@@ -62,14 +65,17 @@ export function useChatActions({
   localCommands,
   activeTurnRef,
   contextFolder,
+  sessionModel,
   sendViaDashboard,
   abortDashboard,
 }: UseChatActionsArgs): UseChatActionsResult {
   const messagesRef = useRef(messages);
   const isLoadingRef = useRef(isLoading);
+  const sessionModelRef = useRef(sessionModel);
   useEffect(() => {
     messagesRef.current = messages;
     isLoadingRef.current = isLoading;
+    sessionModelRef.current = sessionModel;
   });
 
   const pushUser = useCallback(
@@ -108,6 +114,7 @@ export function useChatActions({
           attachments,
           contextFolder ?? undefined,
           runId,
+          sessionModelRef.current || undefined,
         );
       } catch {
         // onChatError IPC already surfaces this to the user

--- a/src/renderer/src/screens/Chat/hooks/useModelConfig.ts
+++ b/src/renderer/src/screens/Chat/hooks/useModelConfig.ts
@@ -49,6 +49,7 @@ interface UseModelConfigResult {
     provider: string,
     model: string,
     baseUrl: string,
+    options?: { persist?: boolean },
   ) => Promise<void>;
 }
 
@@ -134,8 +135,12 @@ export function useModelConfig(profile?: string): UseModelConfigResult {
   }, [reload]);
 
   const selectModel = useCallback(
-    async (provider: string, model: string, baseUrl: string): Promise<void> => {
-      const seq = ++loadSeqRef.current;
+    async (
+      provider: string,
+      model: string,
+      baseUrl: string,
+      { persist = true }: { persist?: boolean } = {},
+    ): Promise<void> => {
       // Named providers (deepseek, groq, anthropic, …) have a hardcoded
       // canonical base_url in `hermes-agent`'s PROVIDER_REGISTRY.  A stored
       // model entry that carries a stale `baseUrl` from an earlier confused
@@ -148,6 +153,10 @@ export function useModelConfig(profile?: string): UseModelConfigResult {
       setCurrentModel(model);
       setCurrentProvider(provider);
       setCurrentBaseUrl(effectiveBaseUrl);
+      // Session-only selection: update local state only, do not write to
+      // config.yaml so the global default model is preserved (issue #688).
+      if (!persist) return;
+      const seq = ++loadSeqRef.current;
       try {
         await window.hermesAPI.setModelConfig(
           provider,

--- a/src/renderer/src/screens/Chat/hooks/useModelConfig.ts
+++ b/src/renderer/src/screens/Chat/hooks/useModelConfig.ts
@@ -155,7 +155,13 @@ export function useModelConfig(profile?: string): UseModelConfigResult {
       setCurrentBaseUrl(effectiveBaseUrl);
       // Session-only selection: update local state only, do not write to
       // config.yaml so the global default model is preserved (issue #688).
-      if (!persist) return;
+      // Advance the sequence counter so any in-flight reload() triggered by
+      // onConnectionConfigChanged / onModelLibraryChanged cannot clobber the
+      // session-scoped selection with the persisted value.
+      if (!persist) {
+        ++loadSeqRef.current;
+        return;
+      }
       const seq = ++loadSeqRef.current;
       try {
         await window.hermesAPI.setModelConfig(


### PR DESCRIPTION
## Problem

Selecting a model from the bottom-panel picker in a chat session permanently changes the user's global default model in Settings — even when the intent is only to try a different model for that one conversation. Closes #688.

**Steps to reproduce:**
1. Note the current default model in Settings.
2. Start a new chat and select a different model from the bottom panel.
3. Open Settings → the default model has been permanently overwritten.

## Root cause

`useModelConfig.selectModel` always called `setModelConfig()`, which writes to `config.yaml`. The chat-screen picker and the Settings screen shared the same code path with no distinction between "use for this session" and "save as my default".

## Fix

**Renderer side (`useModelConfig`, `Chat.tsx`, `useChatActions`):**
- `selectModel` gains a `{ persist?: boolean }` option (default `true` — existing callers are unaffected).
- When `persist: false`, the local React state updates immediately (so the picker UI reflects the choice) but `setModelConfig` / `getModelConfig` IPC calls are skipped — `config.yaml` stays untouched.
- The chat-screen `ModelPicker` now passes `persist: false`; the Settings screen keeps using the default (`persist: true`).
- `useChatActions` accepts a `sessionModel` prop and tracks it via a ref so `sendToAgent` always reads the latest session-scoped model without adding it to the callback's dependency array.

**IPC pipeline (`preload`, `index.ts`, `hermes.ts`):**
- A `modelOverride?: string` parameter is added to every link in the send chain: `sendMessage` export → `sendMessageViaBestApi*` → `sendMessageViaNonGatewayApi` → `sendMessageViaRuns` / `sendMessageViaApi` / `sendMessageViaCli`.
- Each leaf function uses `modelOverride || mc.model || "hermes-agent"` so the session choice reaches the gateway without touching persisted config.

**No behaviour change for existing callers** — all new parameters are optional and default to the current behaviour.

## Test plan

1. Set a default model in Settings (e.g. `claude-3-5-sonnet`).
2. Start a new chat, pick a different model from the bottom panel (e.g. `gpt-4o`).
3. Send a message — the response comes from `gpt-4o` (check the session tag in the sidebar).
4. Open Settings → default model is still `claude-3-5-sonnet`. ✅
5. Start another new chat without picking — it uses `claude-3-5-sonnet`. ✅
