### PR TITLE
Fix WS Gateway Timeout

### DIFF
--- a/lat.md/chat-commands.md
+++ b/lat.md/chat-commands.md
@@ -24,6 +24,12 @@ Slash commands run on the gateway's **persistent slash-worker subprocess**, conc
 
 Because no global loading state is set, the slash branch shows its own feedback: it inserts an in-place `⏳ Running …` agent bubble, buffers the pipeline output, and replaces that bubble with the result (or `error: …`) when the command resolves — otherwise a slow or unreachable gateway would leave the user staring at nothing.
 
+## Transport connection lifecycle
+
+Every dashboard turn first connects a JSON-RPC WebSocket to the gateway; that handshake must be time-bounded or a stalled socket wedges the whole transport with no error and no fallback (issue #718).
+
+[[src/renderer/src/screens/Chat/dashboardGatewayClient.ts#DashboardGatewayClient#connect]] resolves on `open`, rejects on `error` or an early `close`, **and** rejects on a connect-timeout (default 10s). A WebSocket stuck in `CONNECTING` — TCP accepted but the upgrade never completing, e.g. when a busy renderer starves the handshake — fires none of those events on its own, so without the timer the connect promise never settles. When it never settles, `ensureClient` in [[src/renderer/src/screens/Chat/hooks/useDashboardChatTransport.ts#useDashboardChatTransport]] never resolves, its cached `connectingRef` promise poisons every later send, `setIsLoading(false)` never runs, and the user sees a permanent loading spinner. The timeout makes the promise reject so auto mode falls back to the legacy HTTP transport (and explicit-dashboard mode surfaces a real error) instead of hanging. Per-request calls are separately bounded by their own 30s timeout.
+
 ## Renderer-native commands
 
 A few non-local commands have dedicated desktop handling and must NOT be diverted to the gateway slash pipeline, or they'd lose their behaviour.

--- a/src/renderer/src/screens/Chat/dashboardGatewayClient.test.ts
+++ b/src/renderer/src/screens/Chat/dashboardGatewayClient.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DashboardGatewayClient } from "./dashboardGatewayClient";
+
+// A controllable WebSocket stand-in: it never opens, errors, or closes on its
+// own, so each test drives the readyState transition explicitly. This lets us
+// exercise the connect handshake — in particular the stalled CONNECTING case
+// that wedged the transport before issue #718 added a connect timeout.
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static last: FakeWebSocket | null = null;
+
+  readyState = FakeWebSocket.CONNECTING;
+  closeCalls = 0;
+  private listeners: Record<string, ((event: unknown) => void)[]> = {};
+
+  constructor(public url: string) {
+    FakeWebSocket.last = this;
+  }
+
+  addEventListener(type: string, handler: (event: unknown) => void): void {
+    (this.listeners[type] ??= []).push(handler);
+  }
+
+  removeEventListener(type: string, handler: (event: unknown) => void): void {
+    this.listeners[type] = (this.listeners[type] ?? []).filter(
+      (candidate) => candidate !== handler,
+    );
+  }
+
+  close(): void {
+    this.closeCalls += 1;
+    this.readyState = FakeWebSocket.CLOSED;
+  }
+
+  emit(type: string, event: unknown = {}): void {
+    for (const handler of this.listeners[type] ?? []) handler(event);
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  FakeWebSocket.last = null;
+  (globalThis as unknown as { WebSocket: typeof WebSocket }).WebSocket =
+    FakeWebSocket as unknown as typeof WebSocket;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("DashboardGatewayClient.connect", () => {
+  it("rejects and closes the socket when the handshake stalls", async () => {
+    const client = new DashboardGatewayClient({ connectTimeoutMs: 1_000 });
+    const connecting = client.connect("ws://localhost/api/ws");
+    const assertion = expect(connecting).rejects.toThrow(/timed out/i);
+
+    // Socket never fires open/error/close — only the timeout should settle it.
+    await vi.advanceTimersByTimeAsync(1_000);
+    await assertion;
+
+    expect(FakeWebSocket.last?.closeCalls).toBe(1);
+    expect(client.connected).toBe(false);
+  });
+
+  it("resolves on open and cancels the timeout", async () => {
+    const client = new DashboardGatewayClient({ connectTimeoutMs: 1_000 });
+    const connecting = client.connect("ws://localhost/api/ws");
+
+    const socket = FakeWebSocket.last;
+    if (!socket) throw new Error("socket not created");
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+    await connecting;
+
+    expect(client.connected).toBe(true);
+    // A late timeout firing must not tear down a healthy socket.
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(socket.closeCalls).toBe(0);
+    expect(client.connected).toBe(true);
+  });
+
+  it("rejects when the socket closes before the handshake settles", async () => {
+    const client = new DashboardGatewayClient({ connectTimeoutMs: 10_000 });
+    const connecting = client.connect("ws://localhost/api/ws");
+    const assertion = expect(connecting).rejects.toThrow(/closed/i);
+
+    FakeWebSocket.last?.emit("close", {});
+    await assertion;
+  });
+});

--- a/src/renderer/src/screens/Chat/dashboardGatewayClient.ts
+++ b/src/renderer/src/screens/Chat/dashboardGatewayClient.ts
@@ -5,6 +5,12 @@ export interface DashboardRpcEvent<T = unknown> {
 }
 
 export interface DashboardGatewayClientOptions {
+  /** How long `connect()` waits for the WebSocket handshake before giving up.
+   *  Without this, a socket stuck in CONNECTING (TCP accepted but the upgrade
+   *  never completes — e.g. when the renderer is starved) leaves the connect
+   *  promise pending forever, wedging the whole transport with no error and no
+   *  fallback (issue #718). */
+  connectTimeoutMs?: number;
   onClose?: (event: CloseEvent) => void;
   onError?: (event: Event) => void;
   onEvent?: (event: DashboardRpcEvent) => void;
@@ -33,6 +39,7 @@ interface PendingRequest<T = unknown> {
 }
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -88,10 +95,13 @@ export class DashboardGatewayClient {
   private pending = new Map<number | string, PendingRequest>();
   private socket: WebSocket | null = null;
   private readonly requestTimeoutMs: number;
+  private readonly connectTimeoutMs: number;
 
   constructor(private readonly options: DashboardGatewayClientOptions = {}) {
     this.requestTimeoutMs =
       options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    this.connectTimeoutMs =
+      options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
   }
 
   get connected(): boolean {
@@ -104,8 +114,28 @@ export class DashboardGatewayClient {
     return new Promise((resolve, reject) => {
       const socket = new WebSocket(wsUrl);
       this.socket = socket;
+      let settled = false;
+
+      // Bound the handshake: a socket stuck in CONNECTING fires neither `open`
+      // nor `error`, so without this timer the promise would never settle and
+      // the transport would wedge forever (issue #718). On timeout we reject and
+      // close the half-open socket so `ensureClient` can fall back to legacy.
+      const timeout = window.setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        if (this.socket === socket) this.socket = null;
+        try {
+          socket.close();
+        } catch {
+          // Best-effort teardown of the stalled socket.
+        }
+        reject(new Error("Hermes dashboard WebSocket connection timed out"));
+      }, this.connectTimeoutMs);
 
       const failOpen = (event: Event): void => {
+        if (settled) return;
+        settled = true;
+        window.clearTimeout(timeout);
         if (this.socket === socket) this.socket = null;
         reject(new Error(`Could not connect to Hermes dashboard WebSocket`));
         this.options.onError?.(event);
@@ -114,6 +144,9 @@ export class DashboardGatewayClient {
       socket.addEventListener(
         "open",
         () => {
+          if (settled) return;
+          settled = true;
+          window.clearTimeout(timeout);
           socket.removeEventListener("error", failOpen);
           resolve();
         },
@@ -123,6 +156,14 @@ export class DashboardGatewayClient {
       socket.addEventListener("message", (event) => this.handleMessage(event));
       socket.addEventListener("close", (event) => {
         if (this.socket === socket) this.socket = null;
+        // A close before the handshake settles must still reject the connect
+        // promise — otherwise a CONNECTING→CLOSED transition with no `error`
+        // event would hang it until the timeout fires.
+        if (!settled) {
+          settled = true;
+          window.clearTimeout(timeout);
+          reject(new Error("Hermes dashboard WebSocket closed"));
+        }
         this.rejectPending("Hermes dashboard WebSocket closed");
         this.options.onClose?.(event);
       });


### PR DESCRIPTION
# Fix dashboard chat hanging forever on a stalled WebSocket handshake (#718)

**Base:** `main` ← **Head:** `fix-ws-gateway-timeout`

## Problem

On a local connection, desktop chat rides the dashboard JSON-RPC WebSocket (not the legacy HTTP `sendMessage`). `DashboardGatewayClient.connect()` resolved only on the socket's `open` event and rejected only on `error` — it had **no timeout**. A WebSocket stuck in `CONNECTING` (TCP accepted but the upgrade never completing, e.g. when a busy renderer starves the handshake) fires neither event, so the connect promise never settled.

That single unsettled promise wedged the entire transport:

- `ensureClient()` never resolved, and its cached `connectingRef` promise poisoned **every** subsequent send (`if (connectingRef.current) return connectingRef.current`).
- `sendMessage` awaited it forever, so the auto-mode fallback to legacy HTTP never ran and `failActiveTurn` never ran.
- `setIsLoading(false)` was never called → permanent "loding" spinner, **no error toast**, and nothing ever reached the gateway (zero desktop-originated sessions in `state.db`).
- With `isLoading` stuck `true`, `handleSend`'s guard then silently dropped every later send too — 100% reproducible, surviving UI restarts.

This matches issue #718 exactly: idle renderer, gateway healthy via `curl`, no errors, no DB rows, spinner forever.

## Fix

Time-bound the handshake in `DashboardGatewayClient.connect()`:

- New `connectTimeoutMs` option (default **10s**) rejects the connect promise and closes the half-open socket if the handshake stalls.
- An early `close` (CONNECTING→CLOSED with no `error` event) now also rejects the promise instead of leaving it pending.
- A `settled` guard makes the `open` / `error` / `close` / timeout race resolve cleanly and prevents a late timer from tearing down a healthy socket.

With `connect()` now rejecting on timeout, `ensureClient` rejects → auto mode falls back to the legacy HTTP transport (which reaches the gateway), and explicit-dashboard mode surfaces a real error instead of hanging. Per-request RPCs remain separately bounded by their existing 30s timeout.

## Changes

- `src/renderer/src/screens/Chat/dashboardGatewayClient.ts` — connect timeout + early-close rejection + `settled` race guard.
- `src/renderer/src/screens/Chat/dashboardGatewayClient.test.ts` — new tests: stalled→timeout+close, normal open, early close.
- `lat.md/chat-commands.md` — new "Transport connection lifecycle" section documenting the timeout/fallback contract.

## Testing

- `npx vitest run src/renderer/src/screens/Chat` — 14 files / 130 tests pass (incl. 3 new).
- `npm run typecheck:web` — clean.
- `eslint` on changed files — clean.
- `lat check` — all links and code refs pass.

## Scope / caveats

- Addresses the **renderer-side wedge** that explains every symptom in the issue body.
- The second commenter's "background-review worker deadlock / memory-limit thrash" is a separate **hermes-agent backend** issue (different repo) and is **not** addressed here.
- Verified via typecheck + unit tests, not against a live stalled socket on Windows — worth a manual smoke test before closing #718.

Closes #718.