### PR TITLE
fix: use per-provider env key for custom providers in Models dialog

### DIFF
--- a/lat.md/provider-setup.md
+++ b/lat.md/provider-setup.md
@@ -36,6 +36,12 @@ Custom providers in the Models library ([[src/renderer/src/screens/Models/Models
 
 Renaming a custom provider or deleting it changes or removes its derived key; `handleSave` and `handleDelete` call the new [[src/main/config.ts#deleteEnvValue]] (through `hermesAPI.deleteEnv` → the `delete-env` IPC handler, mirroring `setEnv`/`set-env`) to remove the old `CUSTOM_PROVIDER_<OLDNAME>_KEY` line so it doesn't linger in `.env`. [[src/main/ssh-remote.ts#sshDeleteEnvValue]] is the remote-mode equivalent, selected by the same `conn.mode === "ssh"` branch `set-env` already uses.
 
+### Cleanup never deletes a key another entry still resolves to
+
+Before either cleanup path deletes a key, [[src/renderer/src/screens/Models/Models.tsx#envKeyUsedByOtherModel]] checks whether another entry still resolves to it, and skips the delete if so.
+
+Two entries can legitimately derive the *same* key: two custom providers on the same known vendor host both fall back to that vendor's shared key (e.g. `GROQ_API_KEY`), or two unknown-host providers with the same display name derive the same per-name key. `envKeyUsedByOtherModel` scans the in-memory `models` list, excluding the entry being edited/deleted, for any other entry resolving to that key — without this guard, renaming or removing one entry would silently wipe the vendor key a sibling entry still depends on.
+
 ## Provider icons
 
 Each card's logo is resolved by [[src/renderer/src/components/common/BrandLogo.tsx]] from the provider id, falling back to a generic robot for unknown ids.

--- a/lat.md/provider-setup.md
+++ b/lat.md/provider-setup.md
@@ -28,6 +28,14 @@ For compatible/custom endpoints, an inline **API Key** field appears under Base 
 
 Ids the agent can't resolve by id are listed in `OPENAI_COMPATIBLE_BASE_URLS` ([[src/renderer/src/constants.ts]]) — openai, perplexity, and every `LOCAL_PRESETS` chip (local servers + remote endpoints like groq, deepseek, atlascloud, mistral, …). This map MUST contain every preset id, or selecting that chip mis-routes; a test in `tests/constants.test.ts` enforces it. Selecting one autofills its base URL and shows the base-URL field; on save it is persisted as `provider: custom` + `base_url`, which the gateway accepts and uses to host-derive the API key (`runtime_provider._host_derived_api_key`, e.g. `api.groq.com` → `GROQ_API_KEY`). `displayProviderFromConfig` reverse-maps a stored `custom` + known base URL back to the brand id so the dropdown re-selects it on load. Native providers (the gateway hardcodes their base URL) clear the field instead.
 
+## Models library: per-provider keys for unknown URLs
+
+Custom providers in the Models library ([[src/renderer/src/screens/Models/Models.tsx]]) that point at an unrecognized base URL each get their own env key instead of sharing one bucket, and that key is cleaned up when the provider is renamed or deleted.
+
+`expectedEnvKeyForUrl` falls back to the shared `CUSTOM_API_KEY` for any host not in [[src/shared/url-key-map.ts]], which meant every unknown-URL custom provider overwrote the same env var. [[src/renderer/src/screens/Models/Models.tsx#customProviderEnvKey]] derives `CUSTOM_PROVIDER_<NAME>_KEY` from the provider's display name in that case, used by `openEditModal` (read, with a `CUSTOM_API_KEY` fallback for entries saved before this existed) and `handleSave` (write). [[src/main/config.ts#customEndpointKeyResolvable]] mirrors the same derivation — via a call-time `require("./models")` to avoid a static import cycle — so the config-health audit checks every model sharing that base URL, not just the first `readModels()` match.
+
+Renaming a custom provider or deleting it changes or removes its derived key; `handleSave` and `handleDelete` call the new [[src/main/config.ts#deleteEnvValue]] (through `hermesAPI.deleteEnv` → the `delete-env` IPC handler, mirroring `setEnv`/`set-env`) to remove the old `CUSTOM_PROVIDER_<OLDNAME>_KEY` line so it doesn't linger in `.env`. [[src/main/ssh-remote.ts#sshDeleteEnvValue]] is the remote-mode equivalent, selected by the same `conn.mode === "ssh"` branch `set-env` already uses.
+
 ## Provider icons
 
 Each card's logo is resolved by [[src/renderer/src/components/common/BrandLogo.tsx]] from the provider id, falling back to a generic robot for unknown ids.

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -269,6 +269,30 @@ export function setEnvValue(
   safeWriteFile(envFile, lines.join("\n"));
 }
 
+/**
+ * Remove a single key from the profile's .env file, if present. Used to
+ * clean up `CUSTOM_PROVIDER_<NAME>_KEY` entries that would otherwise be
+ * orphaned when a custom provider is renamed or deleted.
+ */
+export function deleteEnvValue(key: string, profile?: string): void {
+  const { envFile } = profilePaths(profile);
+  invalidateCache(`env:${profile || "default"}`);
+  if (key === "API_SERVER_KEY") invalidateCache("apiServerKey:");
+
+  if (!existsSync(envFile)) return;
+
+  const content = readFileSync(envFile, "utf-8");
+  const lines = content.split("\n");
+  const escaped = escapeRegex(key);
+  const filtered = lines.filter(
+    (line) => !line.trim().match(new RegExp(`^#?\\s*${escaped}\\s*=`)),
+  );
+
+  if (filtered.length !== lines.length) {
+    safeWriteFile(envFile, filtered.join("\n"));
+  }
+}
+
 export function validateEnvEntry(key: string, value: string): void {
   if (!ENV_KEY_RE.test(key)) {
     throw new Error(
@@ -756,10 +780,10 @@ export function getModelContextLengthOverride(
  * does. Returns false for providers the runtime does NOT route through the
  * custom path, so their specific-key checks still apply.
  *
- * (The runtime also consults a per-model `CUSTOM_PROVIDER_<name>_KEY` ahead of
- * the generic keys; that lookup needs models.json and is intentionally omitted
- * here to keep config.ts free of a models.ts import — the generic chain covers
- * the reported cases.)
+ * The runtime also consults a per-model `CUSTOM_PROVIDER_<name>_KEY` ahead of
+ * the generic keys, so this looks up every model matching `baseUrl` (via a
+ * call-time `require("./models")` to avoid a static import cycle) and adds
+ * all of their per-provider keys as candidates.
  */
 export function customEndpointKeyResolvable(
   provider: string,
@@ -781,11 +805,15 @@ export function customEndpointKeyResolvable(
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports -- call-time require; models.ts has no dep on config.ts so no cycle.
     const modelsMod = require("./models") as typeof import("./models");
-    const matching = modelsMod.readModels().find((m) => m.baseUrl === baseUrl);
-    if (matching) {
+    // Use filter(), not find(): multiple differently-named providers can
+    // share the same unknown base URL, each with its own per-provider key.
+    // Only checking the first match left the others falsely reported as
+    // "key missing".
+    const matches = modelsMod.readModels().filter((m) => m.baseUrl === baseUrl);
+    for (const m of matches) {
       candidates.add(
         "CUSTOM_PROVIDER_" +
-          matching.name.replace(/[^A-Za-z0-9]/g, "_").toUpperCase() +
+          m.name.replace(/[^A-Za-z0-9]/g, "_").toUpperCase() +
           "_KEY",
       );
     }

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -775,6 +775,23 @@ export function customEndpointKeyResolvable(
     "CUSTOM_API_KEY",
     "OPENAI_API_KEY",
   ]);
+  // Mirror the runtime lookup in hermes.ts: the GUI dialog and seedDefaults()
+  // write CUSTOM_PROVIDER_<NAME>_KEY for unknown-URL providers. Without this,
+  // config-health reports "key missing" even though the gateway can resolve it.
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- call-time require; models.ts has no dep on config.ts so no cycle.
+    const modelsMod = require("./models") as typeof import("./models");
+    const matching = modelsMod.readModels().find((m) => m.baseUrl === baseUrl);
+    if (matching) {
+      candidates.add(
+        "CUSTOM_PROVIDER_" +
+          matching.name.replace(/[^A-Za-z0-9]/g, "_").toUpperCase() +
+          "_KEY",
+      );
+    }
+  } catch {
+    /* ignore */
+  }
   for (const k of candidates) {
     if ((env[k] ?? "").trim()) return true;
   }

--- a/src/main/ipc/register.ts
+++ b/src/main/ipc/register.ts
@@ -23,7 +23,7 @@ import { getDashboardStatus, startDashboard, stopDashboard } from "../dashboard"
 import { startSshTunnel, ensureSshTunnel, getSshTunnelUrl, stopSshTunnel, testSshConnection, isSshTunnelActive, isSshTunnelHealthy } from "../ssh-tunnel";
 import { getClaw3dStatus, setupClaw3d, startDevServer, stopDevServer, startAdapter, stopAdapter, startAll as startClaw3dAll, stopAll as stopClaw3d, getClaw3dLogs, setClaw3dPort, getClaw3dPort, setClaw3dWsUrl, getClaw3dWsUrl, waitForClaw3dReady, type Claw3dSetupProgress } from "../claw3d";
 import { startOfficeStack } from "../office-start";
-import { readEnv, setEnvValue, getConfigValue, setConfigValue, getHermesHome, getModelConfig, setModelConfig, getCredentialPool, setCredentialPool, addCredentialPoolEntry, getConnectionConfig, getPublicConnectionConfig, normalizeRemoteChatTransport, resolveConnectionApiKeyUpdate, setConnectionConfig, getPlatformEnabled, setPlatformEnabled, getApiServerKeyStatus, invalidateSecretsCache, type ConnectionConfig } from "../config";
+import { readEnv, setEnvValue, deleteEnvValue, getConfigValue, setConfigValue, getHermesHome, getModelConfig, setModelConfig, getCredentialPool, setCredentialPool, addCredentialPoolEntry, getConnectionConfig, getPublicConnectionConfig, normalizeRemoteChatTransport, resolveConnectionApiKeyUpdate, setConnectionConfig, getPlatformEnabled, setPlatformEnabled, getApiServerKeyStatus, invalidateSecretsCache, type ConnectionConfig } from "../config";
 import { getAuxiliaryConfig, setAuxiliaryTask, resetAuxiliaryToAuto } from "../auxiliary-config";
 import { applySessionLocalOverlays, listSessions, getSessionMessages, searchSessions, deleteSession, deleteSessions } from "../sessions";
 import { syncSessionCache, listCachedSessions, updateSessionTitle } from "../session-cache";
@@ -44,7 +44,7 @@ import { listCronJobs, createCronJob, removeCronJob, pauseCronJob, resumeCronJob
 import { applyMessagingPlatformUpdate, buildDesktopMessagingPlatforms, fetchRemoteMessagingPlatforms, readLocalGatewayPlatformStates, testDesktopMessagingPlatform, testRemoteMessagingPlatform, updateRemoteMessagingPlatform } from "../messaging-platforms";
 import { listBoards as kanbanListBoards, currentBoard as kanbanCurrentBoard, switchBoard as kanbanSwitchBoard, createBoard as kanbanCreateBoard, removeBoard as kanbanRemoveBoard, listTasks as kanbanListTasks, getTask as kanbanGetTask, createTask as kanbanCreateTask, assignTask as kanbanAssignTask, completeTask as kanbanCompleteTask, blockTask as kanbanBlockTask, unblockTask as kanbanUnblockTask, archiveTask as kanbanArchiveTask, specifyTask as kanbanSpecifyTask, reclaimTask as kanbanReclaimTask, commentTask as kanbanCommentTask, dispatchOnce as kanbanDispatchOnce, listClaw3dHqTasks as kanbanListClaw3dHqTasks, type CreateTaskInput } from "../kanban";
 import { getAppLocale, setAppLocale } from "../locale";
-import { sshListInstalledSkills, sshGetSkillContent, sshInstallSkill, sshUninstallSkill, sshListBundledSkills, sshReadMemory, sshAddMemoryEntry, sshUpdateMemoryEntry, sshRemoveMemoryEntry, sshWriteUserProfile, sshReadSoul, sshWriteSoul, sshResetSoul, sshGetToolsets, sshGetPlatformToolsets, sshSetToolsetEnabled, sshSetMessagingPlatformToolsetEnabled, sshReadEnv, sshSetEnvValue, sshGetConfigValue, sshSetConfigValue, sshGetHermesHome, sshGetModelConfig, sshSetModelConfig, sshListSessions, sshGetSessionMessages, sshSearchSessions, sshListProfiles, sshCreateProfile, sshDeleteProfile, sshGatewayStatus, sshStartGateway, sshStopGateway, sshReadRemoteApiKey, sshReadDirectory, sshGetHermesVersion, sshReadLogs, sshGetPlatformEnabled, sshSetPlatformEnabled, sshListCachedSessions, sshRunDoctor, sshListModels, sshAddModel, sshRemoveModel, sshUpdateModel, sshRunUpdate, sshRunDump, sshDiscoverMemoryProviders } from "../ssh-remote";
+import { sshListInstalledSkills, sshGetSkillContent, sshInstallSkill, sshUninstallSkill, sshListBundledSkills, sshReadMemory, sshAddMemoryEntry, sshUpdateMemoryEntry, sshRemoveMemoryEntry, sshWriteUserProfile, sshReadSoul, sshWriteSoul, sshResetSoul, sshGetToolsets, sshGetPlatformToolsets, sshSetToolsetEnabled, sshSetMessagingPlatformToolsetEnabled, sshReadEnv, sshSetEnvValue, sshDeleteEnvValue, sshGetConfigValue, sshSetConfigValue, sshGetHermesHome, sshGetModelConfig, sshSetModelConfig, sshListSessions, sshGetSessionMessages, sshSearchSessions, sshListProfiles, sshCreateProfile, sshDeleteProfile, sshGatewayStatus, sshStartGateway, sshStopGateway, sshReadRemoteApiKey, sshReadDirectory, sshGetHermesVersion, sshReadLogs, sshGetPlatformEnabled, sshSetPlatformEnabled, sshListCachedSessions, sshRunDoctor, sshListModels, sshAddModel, sshRemoveModel, sshUpdateModel, sshRunUpdate, sshRunDump, sshDiscoverMemoryProviders } from "../ssh-remote";
 
 export interface IpcContext {
   activeRuns: Map<string, () => void>;
@@ -378,6 +378,19 @@ export function registerIpcHandlers(context: IpcContext): void {
       if (isGatewayRunning(profile) && looksLikeCredential) {
         restartGateway(profile);
       }
+      return true;
+    },
+  );
+
+  ipcMain.handle(
+    "delete-env",
+    async (_event, key: string, profile?: string) => {
+      const conn = getConnectionConfig();
+      if (conn.mode === "ssh" && conn.ssh) {
+        await sshDeleteEnvValue(conn.ssh, key, profile);
+        return true;
+      }
+      deleteEnvValue(key, profile);
       return true;
     },
   );

--- a/src/main/ssh-remote.ts
+++ b/src/main/ssh-remote.ts
@@ -998,6 +998,26 @@ export async function sshSetEnvValue(
   await sshWriteFile(config, envPath, lines.join("\n"));
 }
 
+export async function sshDeleteEnvValue(
+  config: SshConfig,
+  key: string,
+  profile?: string,
+): Promise<void> {
+  const envPath = remoteEnvPath(profile);
+  const content = await sshReadFile(config, envPath);
+  if (!content.trim()) return;
+
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const lines = content.split("\n");
+  const filtered = lines.filter(
+    (line) => !line.trim().match(new RegExp(`^#?\\s*${escaped}\\s*=`)),
+  );
+
+  if (filtered.length !== lines.length) {
+    await sshWriteFile(config, envPath, filtered.join("\n"));
+  }
+}
+
 // ─── Dotted-path YAML helpers (mirror of the local-mode fix) ───────────────
 //
 // The previous implementation used `^\s*<key>:` against the whole remote

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -248,6 +248,7 @@ interface HermesAPI {
   // Configuration (profile-aware)
   getEnv: (profile?: string) => Promise<Record<string, string>>;
   setEnv: (key: string, value: string, profile?: string) => Promise<boolean>;
+  deleteEnv: (key: string, profile?: string) => Promise<boolean>;
   validateChatReadiness: (profile?: string) => Promise<{
     ok: boolean;
     code?:

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -165,6 +165,9 @@ const hermesAPI = {
   setEnv: (key: string, value: string, profile?: string): Promise<boolean> =>
     ipcRenderer.invoke("set-env", key, value, profile),
 
+  deleteEnv: (key: string, profile?: string): Promise<boolean> =>
+    ipcRenderer.invoke("delete-env", key, profile),
+
   validateChatReadiness: (
     profile?: string,
   ): Promise<{

--- a/src/renderer/src/screens/Models/Models.test.tsx
+++ b/src/renderer/src/screens/Models/Models.test.tsx
@@ -8,7 +8,11 @@ vi.mock("../../components/useI18n", () => ({
   }),
 }));
 
-import { modelConfigBaseUrlForProvider } from "./Models";
+import {
+  modelConfigBaseUrlForProvider,
+  envKeyUsedByOtherModel,
+  type SavedModel,
+} from "./Models";
 
 describe("modelConfigBaseUrlForProvider", () => {
   it("preserves explicit custom local-provider URLs when syncing the active model", () => {
@@ -33,5 +37,50 @@ describe("modelConfigBaseUrlForProvider", () => {
     expect(
       modelConfigBaseUrlForProvider("custom", " https://custom.local/v1 "),
     ).toBe("https://custom.local/v1");
+  });
+});
+
+function makeModel(overrides: Partial<SavedModel>): SavedModel {
+  return {
+    id: "id",
+    name: "name",
+    provider: "custom",
+    model: "model",
+    baseUrl: "https://unknown-host.example/v1",
+    createdAt: 0,
+    ...overrides,
+  };
+}
+
+describe("envKeyUsedByOtherModel", () => {
+  it("is false when no other model shares the derived key, so it's safe to delete", () => {
+    const models = [
+      makeModel({ id: "a", name: "Alpha", baseUrl: "https://a.example/v1" }),
+      makeModel({ id: "b", name: "Beta", baseUrl: "https://b.example/v1" }),
+    ];
+    expect(
+      envKeyUsedByOtherModel("CUSTOM_PROVIDER_ALPHA_KEY", "a", models),
+    ).toBe(false);
+  });
+
+  it("is true when two custom entries on a known vendor host share the vendor key", () => {
+    // Both point at Groq's base URL, so both resolve to GROQ_API_KEY —
+    // deleting/renaming "a" must not wipe the key "b" still relies on.
+    const groqUrl = "https://api.groq.com/openai/v1";
+    const models = [
+      makeModel({ id: "a", name: "My Groq", baseUrl: groqUrl }),
+      makeModel({ id: "b", name: "Other Groq", baseUrl: groqUrl }),
+    ];
+    expect(envKeyUsedByOtherModel("GROQ_API_KEY", "a", models)).toBe(true);
+  });
+
+  it("is true when two unknown-URL custom entries derive the same name-based key", () => {
+    const models = [
+      makeModel({ id: "a", name: "Same Name", baseUrl: "https://a.example/v1" }),
+      makeModel({ id: "b", name: "Same Name", baseUrl: "https://b.example/v1" }),
+    ];
+    expect(
+      envKeyUsedByOtherModel("CUSTOM_PROVIDER_SAME_NAME_KEY", "a", models),
+    ).toBe(true);
   });
 });

--- a/src/renderer/src/screens/Models/Models.tsx
+++ b/src/renderer/src/screens/Models/Models.tsx
@@ -50,7 +50,24 @@ function customProviderEnvKey(name: string, baseUrl: string): string {
   );
 }
 
-interface SavedModel {
+// True if some other entry in the library still resolves to this env key —
+// either another unknown-URL custom provider with the same derived name key,
+// or any model (custom or native) on the same known vendor host sharing its
+// key (e.g. two Groq-compatible entries both resolving to GROQ_API_KEY).
+// Callers must skip deleteEnv when this is true, or they'd wipe a key a
+// sibling entry still depends on.
+export function envKeyUsedByOtherModel(
+  key: string,
+  excludeId: string,
+  allModels: SavedModel[],
+): boolean {
+  return allModels.some(
+    (m) =>
+      m.id !== excludeId && customProviderEnvKey(m.name, m.baseUrl) === key,
+  );
+}
+
+export interface SavedModel {
   id: string;
   name: string;
   provider: string;
@@ -413,7 +430,10 @@ function Models({ visible }: ModelsProps = {}): React.JSX.Element {
         editingModel.baseUrl,
       );
       const newEnvKey = customProviderEnvKey(name, formBaseUrl.trim());
-      if (oldEnvKey !== newEnvKey) {
+      if (
+        oldEnvKey !== newEnvKey &&
+        !envKeyUsedByOtherModel(oldEnvKey, editingModel.id, models)
+      ) {
         await window.hermesAPI.deleteEnv(oldEnvKey);
       }
     }
@@ -428,9 +448,10 @@ function Models({ visible }: ModelsProps = {}): React.JSX.Element {
     // Clean up the per-provider env key so deleting a custom provider
     // doesn't leave CUSTOM_PROVIDER_<NAME>_KEY orphaned in .env.
     if (model && model.provider === "custom") {
-      await window.hermesAPI.deleteEnv(
-        customProviderEnvKey(model.name, model.baseUrl),
-      );
+      const envKey = customProviderEnvKey(model.name, model.baseUrl);
+      if (!envKeyUsedByOtherModel(envKey, model.id, models)) {
+        await window.hermesAPI.deleteEnv(envKey);
+      }
     }
     setConfirmDelete(null);
     await loadModels();

--- a/src/renderer/src/screens/Models/Models.tsx
+++ b/src/renderer/src/screens/Models/Models.tsx
@@ -32,6 +32,11 @@ import {
   expectedEnvKeyForUrl,
   CUSTOM_API_KEY_ENV,
 } from "../../../../shared/url-key-map";
+import type {
+  ModelRegistry,
+  RegistryModelProvider,
+  RegistryModel,
+} from "../../../../shared/registry";
 
 // For unknown URLs, generate a per-provider env key to avoid all custom
 // providers colliding on the shared CUSTOM_API_KEY bucket.
@@ -44,11 +49,6 @@ function customProviderEnvKey(name: string, baseUrl: string): string {
     "_KEY"
   );
 }
-import type {
-  ModelRegistry,
-  RegistryModelProvider,
-  RegistryModel,
-} from "../../../../shared/registry";
 
 interface SavedModel {
   id: string;
@@ -404,12 +404,34 @@ function Models({ visible }: ModelsProps = {}): React.JSX.Element {
       await window.hermesAPI.setEnv(envKey, formApiKey.trim());
     }
 
+    // Renaming a custom provider (or changing its base URL) changes its
+    // derived CUSTOM_PROVIDER_<NAME>_KEY — clean up the old key so it
+    // doesn't linger orphaned in .env.
+    if (editingModel && editingModel.provider === "custom") {
+      const oldEnvKey = customProviderEnvKey(
+        editingModel.name,
+        editingModel.baseUrl,
+      );
+      const newEnvKey = customProviderEnvKey(name, formBaseUrl.trim());
+      if (oldEnvKey !== newEnvKey) {
+        await window.hermesAPI.deleteEnv(oldEnvKey);
+      }
+    }
+
     closeModal();
     await loadModels();
   }
 
   async function handleDelete(id: string): Promise<void> {
+    const model = models.find((m) => m.id === id);
     await window.hermesAPI.removeModel(id);
+    // Clean up the per-provider env key so deleting a custom provider
+    // doesn't leave CUSTOM_PROVIDER_<NAME>_KEY orphaned in .env.
+    if (model && model.provider === "custom") {
+      await window.hermesAPI.deleteEnv(
+        customProviderEnvKey(model.name, model.baseUrl),
+      );
+    }
     setConfirmDelete(null);
     await loadModels();
   }

--- a/src/renderer/src/screens/Models/Models.tsx
+++ b/src/renderer/src/screens/Models/Models.tsx
@@ -28,7 +28,22 @@ import { useI18n } from "../../components/useI18n";
 import BrandLogo from "../../components/common/BrandLogo";
 import { detectProviderFromUrl } from "./detect-provider";
 import { useDiscoveredModels } from "../../hooks/useDiscoveredModels";
-import { expectedEnvKeyForUrl } from "../../../../shared/url-key-map";
+import {
+  expectedEnvKeyForUrl,
+  CUSTOM_API_KEY_ENV,
+} from "../../../../shared/url-key-map";
+
+// For unknown URLs, generate a per-provider env key to avoid all custom
+// providers colliding on the shared CUSTOM_API_KEY bucket.
+function customProviderEnvKey(name: string, baseUrl: string): string {
+  const urlKey = expectedEnvKeyForUrl(baseUrl);
+  if (urlKey !== CUSTOM_API_KEY_ENV) return urlKey;
+  return (
+    "CUSTOM_PROVIDER_" +
+    name.replace(/[^A-Za-z0-9]/g, "_").toUpperCase() +
+    "_KEY"
+  );
+}
 import type {
   ModelRegistry,
   RegistryModelProvider,
@@ -266,11 +281,11 @@ function Models({ visible }: ModelsProps = {}): React.JSX.Element {
     // URL via the shared URL_KEY_MAP (or CUSTOM_API_KEY fallback for
     // unknown hosts).
     setFormApiKey("");
-    const envKey = expectedEnvKeyForUrl(m.baseUrl);
+    const envKey = customProviderEnvKey(m.name, m.baseUrl);
     window.hermesAPI
       .getEnv()
       .then((env) => {
-        const saved = env[envKey];
+        const saved = env[envKey] ?? env[CUSTOM_API_KEY_ENV];
         if (saved) setFormApiKey(saved);
       })
       .catch(() => {
@@ -385,7 +400,7 @@ function Models({ visible }: ModelsProps = {}): React.JSX.Element {
     }
 
     if (formApiKey.trim() && formProvider === "custom") {
-      const envKey = expectedEnvKeyForUrl(formBaseUrl.trim());
+      const envKey = customProviderEnvKey(formName.trim(), formBaseUrl.trim());
       await window.hermesAPI.setEnv(envKey, formApiKey.trim());
     }
 

--- a/tests/delete-env-value.test.ts
+++ b/tests/delete-env-value.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+let testHome: string;
+
+async function loadConfigModule(): Promise<
+  typeof import("../src/main/config")
+> {
+  vi.resetModules();
+  vi.stubEnv("HERMES_HOME", testHome);
+  return await import("../src/main/config");
+}
+
+describe("deleteEnvValue", () => {
+  beforeEach(() => {
+    testHome = mkdtempSync(join(tmpdir(), "hermes-delete-env-"));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    rmSync(testHome, { recursive: true, force: true });
+  });
+
+  it("removes a matching key and keeps the rest of the file intact", async () => {
+    const { readEnv, setEnvValue, deleteEnvValue } = await loadConfigModule();
+
+    setEnvValue("CUSTOM_PROVIDER_OLDNAME_KEY", "sk-old");
+    setEnvValue("OPENAI_API_KEY", "sk-openai");
+
+    deleteEnvValue("CUSTOM_PROVIDER_OLDNAME_KEY");
+
+    expect(readEnv()).toEqual({ OPENAI_API_KEY: "sk-openai" });
+  });
+
+  it("is a no-op when the key is not present", async () => {
+    const { readEnv, setEnvValue, deleteEnvValue } = await loadConfigModule();
+
+    setEnvValue("OPENAI_API_KEY", "sk-openai");
+    deleteEnvValue("CUSTOM_PROVIDER_NEVER_SET_KEY");
+
+    expect(readEnv()).toEqual({ OPENAI_API_KEY: "sk-openai" });
+  });
+
+  it("is a no-op when the .env file does not exist yet", async () => {
+    const { deleteEnvValue } = await loadConfigModule();
+
+    expect(() => deleteEnvValue("CUSTOM_PROVIDER_FOO_KEY")).not.toThrow();
+    expect(existsSync(join(testHome, ".env"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

When adding multiple custom providers with unrecognised base URLs, they all resolve to the shared `CUSTOM_API_KEY` env var via `expectedEnvKeyForUrl()`. The second provider's key silently overwrites the first, making it impossible to run two custom providers simultaneously. Closes #681.

## Root cause

`expectedEnvKeyForUrl()` returns `CUSTOM_API_KEY` as a fallback for any URL not in `URL_KEY_MAP`. The save path in `handleSave()` and the read-back path in `openEditModal()` both use this function, so all unknown-URL providers share one bucket.

Note: `seedDefaults()` in `models.ts` already writes `CUSTOM_PROVIDER_<NAME>_KEY` correctly for providers seeded from `config.yaml`. This fix brings the GUI dialog into alignment with that existing behavior.

## Fix

Introduce `customProviderEnvKey(name, baseUrl)` — a thin wrapper over `expectedEnvKeyForUrl` that falls back to `CUSTOM_PROVIDER_<NAME>_KEY` (same naming as `seedDefaults`) instead of the shared `CUSTOM_API_KEY` when the URL is unknown.

Three call-site changes, all in `Models.tsx`:
- `handleSave()` — writes the per-provider key
- `openEditModal()` — reads the per-provider key, falls back to `CUSTOM_API_KEY` for keys written by older versions

## Testing

1. Add two custom providers with different unrecognised base URLs and distinct API keys
2. Verify each model persists its own key in `.env` (`CUSTOM_PROVIDER_<NAME>_KEY`)
3. Re-open each model's edit dialog and confirm the correct key is shown