### PR TITLE
fix(chat): preserve streamed text across tool-call boundaries

### DIFF
--- a/lat.md/chat-commands.md
+++ b/lat.md/chat-commands.md
@@ -30,6 +30,18 @@ Every dashboard turn first connects a JSON-RPC WebSocket to the gateway; that ha
 
 [[src/renderer/src/screens/Chat/dashboardGatewayClient.ts#DashboardGatewayClient#connect]] resolves on `open`, rejects on `error` or an early `close`, **and** rejects on a connect-timeout (default 10s). A WebSocket stuck in `CONNECTING` — TCP accepted but the upgrade never completing, e.g. when a busy renderer starves the handshake — fires none of those events on its own, so without the timer the connect promise never settles. When it never settles, `ensureClient` in [[src/renderer/src/screens/Chat/hooks/useDashboardChatTransport.ts#useDashboardChatTransport]] never resolves, its cached `connectingRef` promise poisons every later send, `setIsLoading(false)` never runs, and the user sees a permanent loading spinner. The timeout makes the promise reject so auto mode falls back to the legacy HTTP transport (and explicit-dashboard mode surfaces a real error) instead of hanging. Per-request calls are separately bounded by their own 30s timeout.
 
+## Completion text reconciliation
+
+On `message.complete` the desktop reconciles the text streamed via `message.delta` with the turn's `final_response`, because a last-turn-only final would otherwise clobber text streamed before a tool call (#746).
+
+[[src/renderer/src/screens/Chat/dashboardEventAdapter.ts#completeAssistantWithFinalText]] rewrites the last assistant bubble through [[src/renderer/src/screens/Chat/dashboardEventAdapter.ts#mergeStreamedWithFinal]], which compares whitespace-insensitively and: uses the final text when it already contains the streamed text; keeps the streamed text when it contains the final (preserving pre-tool-call content); stitches a re-streamed boundary by dropping the duplicated word-aligned seam (rejecting coincidental mid-word overlaps); and otherwise concatenates the two with a blank-line separator so segments never run together. On the remote/SSH path deltas are not rendered (`renderAssistantDeltas: false`), so the bubble starts empty and the final text is used verbatim.
+
+## Reasoning & tool activity rows
+
+Streamed reasoning and tool calls are folded into compact, collapsible transcript rows rather than stacked bubbles, so a turn with heavy thinking or many tool calls stays scannable.
+
+[[src/renderer/src/screens/Chat/HistoryRow.tsx#ReasoningRow]] renders the `Thought` / `Thinking…` row and [[src/renderer/src/screens/Chat/HistoryRow.tsx#ToolActivityGroup]] folds a contiguous run of tool calls/results into one row titled by [[src/renderer/src/screens/Chat/HistoryRow.tsx#toolActivityGroupTitle]]. Each row is collapsed by default and borderless (Codex-style): dim at rest, it brightens and reveals an expand chevron beside the title on hover/focus, and clicking toggles the body open. While the turn is still streaming the leading icon is a `Grid` loader (purple for reasoning, blue for tools); once finished it shows the brain/tool glyph.
+
 ## Renderer-native commands
 
 A few non-local commands have dedicated desktop handling and must NOT be diverted to the gateway slash pipeline, or they'd lose their behaviour.

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -5139,10 +5139,6 @@ body {
 
 .chat-tool-group {
   width: 100%;
-  border: 1px solid var(--border, rgba(127, 127, 127, 0.18));
-  border-radius: 10px;
-  background: transparent;
-  overflow: hidden;
 }
 
 .chat-tool-group-summary {
@@ -5150,32 +5146,50 @@ body {
   align-items: center;
   gap: 8px;
   width: 100%;
-  padding: 7px 12px;
+  padding: 4px 6px;
   border: none;
+  border-radius: 6px;
   background: transparent;
   cursor: pointer;
   text-align: left;
   font: inherit;
-  color: var(--text-secondary);
+  /* Normal state: dim. Brightens on hover (see below). */
+  color: var(--text-muted);
 }
 
-.chat-tool-group-summary:hover {
-  background: var(--hover, rgba(127, 127, 127, 0.06));
+.chat-tool-group-summary:hover,
+.chat-tool-group-summary:focus-visible {
+  color: var(--text-primary);
 }
 
+/* Chevron lives on the right and only appears on hover (or while expanded),
+   matching the Codex-style collapsible row. */
 .chat-tool-group-chevron {
   flex-shrink: 0;
   color: var(--text-muted);
-  transition: transform 0.18s ease;
+  opacity: 0;
+  transition:
+    opacity 0.15s ease,
+    transform 0.18s ease;
+}
+
+.chat-tool-group-summary:hover .chat-tool-group-chevron,
+.chat-tool-group-summary:focus-visible .chat-tool-group-chevron {
+  opacity: 1;
 }
 
 .chat-tool-group-chevron--open {
+  opacity: 1;
   transform: rotate(90deg);
 }
 
 .chat-tool-group-icon {
   flex-shrink: 0;
   color: var(--text-muted);
+}
+
+.chat-tool-group-summary:hover .chat-tool-group-icon {
+  color: var(--text-secondary);
 }
 
 .chat-tool-group-spinner {
@@ -5186,7 +5200,7 @@ body {
 .chat-tool-group-name {
   font-size: 13px;
   font-weight: 600;
-  color: var(--text-primary);
+  color: inherit;
   flex-shrink: 0;
 }
 
@@ -5196,27 +5210,16 @@ body {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  flex: 1;
+  /* Size to content (capped) so it doesn't stretch and shove the chevron to
+     the far edge — the chevron stays beside the title cluster. */
+  flex: 0 1 auto;
   min-width: 0;
-}
-
-.chat-tool-group-count {
-  font-size: 11px;
-  color: var(--text-muted);
-  background: var(--bg-tertiary, rgba(127, 127, 127, 0.1));
-  padding: 1px 8px;
-  border-radius: 10px;
-  flex-shrink: 0;
-  margin-left: auto;
+  max-width: 340px;
 }
 
 /* ── Reasoning group (mirrors tool-group styling) ───────────────────── */
 .chat-reasoning-group {
   width: 100%;
-  border: 1px solid var(--border, rgba(127, 127, 127, 0.18));
-  border-radius: 10px;
-  background: transparent;
-  overflow: hidden;
 }
 
 .chat-reasoning-group-summary {
@@ -5224,26 +5227,38 @@ body {
   align-items: center;
   gap: 8px;
   width: 100%;
-  padding: 7px 12px;
+  padding: 4px 6px;
   border: none;
+  border-radius: 6px;
   background: transparent;
   cursor: pointer;
   text-align: left;
   font: inherit;
-  color: var(--text-secondary);
+  /* Normal state: dim. Brightens on hover (see below). */
+  color: var(--text-muted);
 }
 
-.chat-reasoning-group-summary:hover {
-  background: var(--hover, rgba(127, 127, 127, 0.06));
+.chat-reasoning-group-summary:hover,
+.chat-reasoning-group-summary:focus-visible {
+  color: var(--text-primary);
 }
 
 .chat-reasoning-group-chevron {
   flex-shrink: 0;
   color: var(--text-muted);
-  transition: transform 0.18s ease;
+  opacity: 0;
+  transition:
+    opacity 0.15s ease,
+    transform 0.18s ease;
+}
+
+.chat-reasoning-group-summary:hover .chat-reasoning-group-chevron,
+.chat-reasoning-group-summary:focus-visible .chat-reasoning-group-chevron {
+  opacity: 1;
 }
 
 .chat-reasoning-group-chevron--open {
+  opacity: 1;
   transform: rotate(90deg);
 }
 
@@ -5252,27 +5267,20 @@ body {
   color: var(--text-muted);
 }
 
+.chat-reasoning-group-summary:hover .chat-reasoning-group-icon {
+  color: var(--text-secondary);
+}
+
 .chat-reasoning-group-spinner {
   flex-shrink: 0;
-  color: var(--accent, #8b7cf6);
-  animation: spin 0.8s linear infinite;
+  display: inline-flex;
 }
 
 .chat-reasoning-group-title {
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 600;
-  color: var(--text-primary);
+  color: inherit;
   flex-shrink: 0;
-}
-
-.chat-reasoning-group-meta {
-  font-size: 11px;
-  color: var(--text-muted);
-  background: var(--bg-tertiary, rgba(127, 127, 127, 0.1));
-  padding: 1px 8px;
-  border-radius: 10px;
-  flex-shrink: 0;
-  margin-left: auto;
 }
 
 /* Smooth height animation without measuring: 0fr → 1fr collapses the row. */

--- a/src/renderer/src/screens/Chat/HistoryRow.tsx
+++ b/src/renderer/src/screens/Chat/HistoryRow.tsx
@@ -1,6 +1,6 @@
 import { memo, useState } from "react";
 import { Grid } from "react-loader-spinner";
-import { Brain, ChevronRight, Spinner, Wrench } from "../../assets/icons";
+import { Brain, ChevronRight, Wrench } from "../../assets/icons";
 import { useI18n } from "../../components/useI18n";
 import { AttachmentChip } from "../../components/AttachmentChip";
 import { ToolGlyph, humanizeToolName } from "../../components/toolMeta";
@@ -29,7 +29,6 @@ export const ReasoningRow = memo(function ReasoningRow({
 }): React.JSX.Element {
   const { t } = useI18n();
   const [open, setOpen] = useState(false);
-  const lineCount = msg.text.split("\n").length;
   return (
     <div
       className={`chat-message chat-message-agent chat-message-history${
@@ -48,23 +47,28 @@ export const ReasoningRow = memo(function ReasoningRow({
           aria-expanded={open}
           onClick={() => setOpen((o) => !o)}
         >
-          <ChevronRight
-            size={14}
-            className={`chat-reasoning-group-chevron${
-              open ? " chat-reasoning-group-chevron--open" : ""
-            }`}
-          />
           {active ? (
-            <Spinner size={13} className="chat-reasoning-group-spinner" />
+            <Grid
+              visible={true}
+              height={13}
+              width={13}
+              radius={15}
+              color="#8b7cf6"
+              ariaLabel="thinking-loading"
+              wrapperClass="chat-reasoning-group-spinner"
+            />
           ) : (
             <Brain size={13} className="chat-reasoning-group-icon" />
           )}
           <span className="chat-reasoning-group-title">
             {active ? t("chat.thinking") : t("chat.thought")}
           </span>
-          <span className="chat-reasoning-group-meta">
-            {lineCount} {lineCount === 1 ? "line" : "lines"}
-          </span>
+          <ChevronRight
+            size={14}
+            className={`chat-reasoning-group-chevron${
+              open ? " chat-reasoning-group-chevron--open" : ""
+            }`}
+          />
         </button>
         <div
           className={`chat-tool-collapse${
@@ -245,7 +249,6 @@ export const ToolActivityGroup = memo(function ToolActivityGroup({
 }): React.JSX.Element {
   const [open, setOpen] = useState(false);
   const last = items[items.length - 1];
-  const count = items.length;
   const detail = itemDetail(last);
   const title = toolActivityGroupTitle(items);
   const soloTool = singleToolName(items);
@@ -267,12 +270,6 @@ export const ToolActivityGroup = memo(function ToolActivityGroup({
           aria-expanded={open}
           onClick={() => setOpen((o) => !o)}
         >
-          <ChevronRight
-            size={14}
-            className={`chat-tool-group-chevron${
-              open ? " chat-tool-group-chevron--open" : ""
-            }`}
-          />
           {active ? (
             <Grid
               visible={true}
@@ -294,9 +291,12 @@ export const ToolActivityGroup = memo(function ToolActivityGroup({
           )}
           <span className="chat-tool-group-name">{title}</span>
           {detail && <span className="chat-tool-group-detail">{detail}</span>}
-          <span className="chat-tool-group-count">
-            {count} {count === 1 ? "step" : "steps"}
-          </span>
+          <ChevronRight
+            size={14}
+            className={`chat-tool-group-chevron${
+              open ? " chat-tool-group-chevron--open" : ""
+            }`}
+          />
         </button>
         <div
           className={`chat-tool-collapse${open ? " chat-tool-collapse--open" : ""}`}

--- a/src/renderer/src/screens/Chat/dashboardEventAdapter.test.ts
+++ b/src/renderer/src/screens/Chat/dashboardEventAdapter.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import {
+  applyDashboardStreamEvent,
+  mergeStreamedWithFinal,
+  type DashboardEventState,
+} from "./dashboardEventAdapter";
+import type { ChatMessage } from "./types";
+
+describe("mergeStreamedWithFinal", () => {
+  it("uses final when nothing was streamed (remote / suppressed-delta path)", () => {
+    expect(mergeStreamedWithFinal("", "Final answer")).toBe("Final answer");
+    expect(mergeStreamedWithFinal("   ", "Final answer")).toBe("Final answer");
+  });
+
+  it("keeps streamed text when final is empty", () => {
+    expect(mergeStreamedWithFinal("Streamed text", "")).toBe("Streamed text");
+  });
+
+  it("prefers final when it already contains the streamed text", () => {
+    expect(
+      mergeStreamedWithFinal("It's sunny.", "Let me check. It's sunny."),
+    ).toBe("Let me check. It's sunny.");
+  });
+
+  it("prefers streamed when it contains final plus pre-tool-call text", () => {
+    expect(
+      mergeStreamedWithFinal("Let me check. It's sunny.", "It's sunny."),
+    ).toBe("Let me check. It's sunny.");
+  });
+
+  it("compares whitespace-insensitively", () => {
+    // Differs only by collapsed whitespace ⇒ treated as fully contained.
+    expect(mergeStreamedWithFinal("Hello   world", "Hello world")).toBe(
+      "Hello world",
+    );
+  });
+
+  it("concatenates disjoint segments with a blank-line separator", () => {
+    expect(
+      mergeStreamedWithFinal("Let me check the weather.", "It's sunny."),
+    ).toBe("Let me check the weather.\n\nIt's sunny.");
+  });
+
+  it("does not mash words when concatenating without trailing punctuation", () => {
+    const merged = mergeStreamedWithFinal("Let me check", "It is sunny");
+    expect(merged).toBe("Let me check\n\nIt is sunny");
+    expect(merged).not.toContain("checkIt");
+  });
+
+  it("stitches a re-streamed boundary, dropping the duplicated seam", () => {
+    // Tail of streamed repeats the head of final at a word boundary.
+    expect(mergeStreamedWithFinal("The answer is 4", "answer is 4.")).toBe(
+      "The answer is 4.",
+    );
+  });
+
+  it("does not stitch a coincidental mid-word overlap", () => {
+    // The shared "d" is mid-word ("worl|d") so it must not be spliced.
+    expect(mergeStreamedWithFinal("Hello world", "dog runs")).toBe(
+      "Hello world\n\ndog runs",
+    );
+  });
+
+  it("returns trimmed output regardless of branch", () => {
+    expect(mergeStreamedWithFinal("  Hello  ", "  Hello there  ")).toBe(
+      "Hello there",
+    );
+  });
+});
+
+describe("applyDashboardStreamEvent — message.complete text reconciliation", () => {
+  const userTurn = (): ChatMessage => ({
+    id: "u1",
+    role: "user",
+    content: "weather?",
+  });
+
+  it("preserves pre-tool-call streamed text on completion (#746)", () => {
+    // Model streamed text, called a tool, then finalized with a short
+    // last-turn-only final_response. The pre-tool text lives in the last
+    // assistant bubble and must not be clobbered.
+    const state: DashboardEventState = {
+      messages: [
+        userTurn(),
+        {
+          id: "a1",
+          role: "agent",
+          kind: "assistant",
+          content: "Let me check the weather. ",
+          pending: true,
+        },
+        {
+          id: "tc1",
+          role: "agent",
+          kind: "tool_call",
+          callId: "c1",
+          name: "weather",
+          args: "",
+        },
+        {
+          id: "tr1",
+          role: "agent",
+          kind: "tool_result",
+          callId: "c1",
+          name: "weather",
+          content: "sunny",
+        },
+      ],
+      reasoningSegmentClosed: false,
+    };
+
+    const next = applyDashboardStreamEvent(state, {
+      type: "message.complete",
+      payload: { text: "Done." },
+    });
+
+    const bubble = next.messages.find((m) => m.id === "a1");
+    expect(bubble).toBeDefined();
+    expect((bubble as { content: string }).content).toBe(
+      "Let me check the weather.\n\nDone.",
+    );
+    expect((bubble as { pending?: boolean }).pending).toBe(false);
+  });
+
+  it("uses the fuller final_response when it supersets the streamed text", () => {
+    const state: DashboardEventState = {
+      messages: [
+        userTurn(),
+        {
+          id: "a1",
+          role: "agent",
+          kind: "assistant",
+          content: "Hello",
+          pending: true,
+        },
+      ],
+      reasoningSegmentClosed: false,
+    };
+
+    const next = applyDashboardStreamEvent(state, {
+      type: "message.complete",
+      payload: { text: "Hello there, friend." },
+    });
+
+    expect(
+      (next.messages.find((m) => m.id === "a1") as { content: string }).content,
+    ).toBe("Hello there, friend.");
+  });
+
+  it("falls back to final_response when deltas are suppressed (remote path)", () => {
+    const afterDelta = applyDashboardStreamEvent(
+      { messages: [userTurn()], reasoningSegmentClosed: false },
+      { type: "message.delta", payload: { text: "ignored stream" } },
+      { renderAssistantDeltas: false },
+    );
+    // No assistant bubble is created while deltas are suppressed.
+    expect(afterDelta.messages.some((m) => m.role === "agent")).toBe(false);
+
+    const next = applyDashboardStreamEvent(
+      afterDelta,
+      { type: "message.complete", payload: { text: "Remote answer" } },
+      { renderAssistantDeltas: false },
+    );
+    const bubble = next.messages.find((m) => m.role === "agent");
+    expect(bubble).toBeDefined();
+    expect((bubble as { content: string }).content).toBe("Remote answer");
+  });
+});

--- a/src/renderer/src/screens/Chat/dashboardEventAdapter.ts
+++ b/src/renderer/src/screens/Chat/dashboardEventAdapter.ts
@@ -394,6 +394,65 @@ function normalizeText(value: string): string {
   return value.replace(/\s+/g, " ").trim();
 }
 
+/**
+ * Length of the longest suffix of `a` that is also a prefix of `b`, used to
+ * stitch a re-streamed boundary without duplicating the shared run. The
+ * overlap is rejected when it would splice the middle of a word on either
+ * side (e.g. `"…worl" + "d…"`), so a coincidental shared character isn't
+ * treated as a real seam. Punctuation and whitespace are valid seams.
+ */
+function tailHeadOverlap(a: string, b: string): number {
+  const word = /\w/;
+  const max = Math.min(a.length, b.length);
+  for (let k = max; k > 0; k--) {
+    if (!a.endsWith(b.slice(0, k))) continue;
+    const aStart = a.length - k;
+    const startsMidWord =
+      aStart > 0 && word.test(a[aStart - 1]) && word.test(a[aStart]);
+    const endsMidWord = k < b.length && word.test(b[k - 1]) && word.test(b[k]);
+    if (!startsMidWord && !endsMidWord) return k;
+  }
+  return 0;
+}
+
+/**
+ * Reconcile the text accumulated from streamed `message.delta` chunks with the
+ * `final_response` delivered on `message.complete`.
+ *
+ * The streamed bubble can hold text produced *before* a tool call, while
+ * `final_response` may carry only the last turn's text — so blindly
+ * overwriting with the final text drops the pre-tool-call content (#746).
+ * Other times the final text is the fuller version. Resolve both:
+ *   - empty streamed   → final (the remote path never renders deltas, so the
+ *                        bubble starts empty and final is all we have)
+ *   - final ⊇ streamed → final
+ *   - streamed ⊇ final → streamed (keeps the pre-tool-call text)
+ *   - tail/head overlap → stitch, dropping the duplicated seam
+ *   - otherwise        → concatenate with a blank-line separator so the two
+ *                        segments don't run together ("check.It's" / "4answer")
+ *
+ * Comparison is whitespace-insensitive; every branch returns trimmed text so
+ * the result doesn't depend on which branch ran.
+ */
+export function mergeStreamedWithFinal(
+  streamed: string,
+  final: string,
+): string {
+  const streamedContent = streamed.trim();
+  const finalContent = final.trim();
+  if (!streamedContent) return finalContent;
+  if (!finalContent) return streamedContent;
+
+  const normStreamed = normalizeText(streamedContent);
+  const normFinal = normalizeText(finalContent);
+  if (normFinal.includes(normStreamed)) return finalContent;
+  if (normStreamed.includes(normFinal)) return streamedContent;
+
+  const overlap = tailHeadOverlap(streamedContent, finalContent);
+  if (overlap > 0) return `${streamedContent}${finalContent.slice(overlap)}`;
+  return `${streamedContent}\n\n${finalContent}`;
+}
+
 function findLastUserIndex(messages: ReadonlyArray<ChatMessage>): number {
   for (let i = messages.length - 1; i >= 0; i--) {
     if (messages[i].role === "user") return i;
@@ -509,26 +568,10 @@ function completeAssistantWithFinalText(
     if (!isAssistantBubble(msg) || msg.error) continue;
     if (activeTurn && msg.turnId && msg.turnId !== activeTurn.turnId) continue;
 
-    // Merge streamed text with finalText so content before tool calls
-    // is preserved.  final_response may only contain the last turn's text;
-    // streamed deltas already hold earlier text accumulated before tool calls.
-    const streamedContent = msg.content.trim();
-    const normFinal = normalizeText(finalText);
-    const normStreamed = normalizeText(streamedContent);
-
-    let merged: string;
-    if (!streamedContent) {
-      merged = finalText;
-    } else if (normFinal.includes(normStreamed)) {
-      // Final already contains everything streamed — use final.
-      merged = finalText;
-    } else if (normStreamed.includes(normFinal)) {
-      // Streamed contains final plus pre-tool-call text — prefer streamed.
-      merged = streamedContent;
-    } else {
-      // Neither fully contains the other — concatenate.
-      merged = streamedContent + finalText;
-    }
+    // Merge streamed text with finalText so content streamed before tool
+    // calls is preserved rather than clobbered by a last-turn-only
+    // final_response (#746).
+    const merged = mergeStreamedWithFinal(msg.content, finalText);
 
     return [
       ...messagesWithoutDuplicateReasoning.slice(0, i),

--- a/src/renderer/src/screens/Chat/dashboardEventAdapter.ts
+++ b/src/renderer/src/screens/Chat/dashboardEventAdapter.ts
@@ -509,11 +509,32 @@ function completeAssistantWithFinalText(
     if (!isAssistantBubble(msg) || msg.error) continue;
     if (activeTurn && msg.turnId && msg.turnId !== activeTurn.turnId) continue;
 
+    // Merge streamed text with finalText so content before tool calls
+    // is preserved.  final_response may only contain the last turn's text;
+    // streamed deltas already hold earlier text accumulated before tool calls.
+    const streamedContent = msg.content.trim();
+    const normFinal = normalizeText(finalText);
+    const normStreamed = normalizeText(streamedContent);
+
+    let merged: string;
+    if (!streamedContent) {
+      merged = finalText;
+    } else if (normFinal.includes(normStreamed)) {
+      // Final already contains everything streamed — use final.
+      merged = finalText;
+    } else if (normStreamed.includes(normFinal)) {
+      // Streamed contains final plus pre-tool-call text — prefer streamed.
+      merged = streamedContent;
+    } else {
+      // Neither fully contains the other — concatenate.
+      merged = streamedContent + finalText;
+    }
+
     return [
       ...messagesWithoutDuplicateReasoning.slice(0, i),
       {
         ...msg,
-        content: finalText,
+        content: merged,
         pending: false,
         turnId: msg.turnId || activeTurn?.turnId,
       },


### PR DESCRIPTION
## 问题

多条消息里，`completeAssistantWithFinalText` 用 `finalText` 直接覆盖整个 bubble 的 `content`，
丢弃了工具调用前通过 `message.delta` 流式累积的文本。用户看到的消息从头尾被截断。

## 修复

改为合并流式文本与最终文本，处理三种情况：
- `finalText` 已包含全部 → 用 finalText
- 流式文本已包含 finalText → 用流式文本（保留工具调用前内容）
- 互不包含 → 拼接

对应的后端修复（显示回调通道）在 `NousResearch/hermes-agent` 提。