### PR TITLE
Fix SSH tunnel chat routing for switched profiles

### DIFF
--- a/lat.md/sidebar-navigation.md
+++ b/lat.md/sidebar-navigation.md
@@ -38,6 +38,12 @@ The footer profile switcher keeps the selected shell profile aligned with the vi
 
 Opening a sidebar session after switching profiles consumes that blank selected-profile run instead of appending beside it. [[src/renderer/src/screens/Layout/chatRuns.ts#openSessionRunTransition]] replaces the active scratch run when it belongs to the same profile as the resumed session, so the tab strip shows the previous session without an extra "New conversation" tab.
 
+### SSH tunnel profile routing
+
+SSH tunnel chat must retarget the tunnel to the selected profile's configured API port before sending a turn.
+
+[[src/main/ipc/register.ts]] resolves the selected profile's remote `platforms.api_server.extra.port` and calls [[src/main/ssh-tunnel.ts#ensureSshTunnel]] with that port before legacy/basic SSH chat sends. [[src/main/ssh-remote.ts#sshResolveApiServerPort]] auto-allocates and persists a remote profile port when one is missing, while [[src/main/dashboard.ts]] applies the same profile-aware tunnel resolution before dashboard-over-SSH probes. This prevents a dashboard fallback from reusing a default-profile tunnel and making non-default profile chats answer as default.
+
 ## Footer action row
 
 Administrative destinations sit beside the profile switcher so the conversation nav stays short.

--- a/src/main/dashboard.ts
+++ b/src/main/dashboard.ts
@@ -24,6 +24,7 @@ import { ensureSshTunnel, getSshTunnelUrl } from "./ssh-tunnel";
 import {
   sshGatewayStatus,
   sshReadRemoteApiKey,
+  sshResolveApiServerPort,
   sshStartGateway,
 } from "./ssh-remote";
 import {
@@ -135,11 +136,12 @@ async function sshDashboardConnectionFromConfig(
 
   await ensureSshDashboardCompatibility(config.ssh);
 
-  if (!(await sshGatewayStatus(config.ssh))) {
-    await sshStartGateway(config.ssh);
+  if (!(await sshGatewayStatus(config.ssh, profile))) {
+    await sshStartGateway(config.ssh, profile);
   }
 
-  await ensureSshTunnel(config.ssh);
+  const remotePort = await sshResolveApiServerPort(config.ssh, profile);
+  await ensureSshTunnel({ ...config.ssh, remotePort });
   return sshDashboardConnectionFromTunnel(
     config,
     getSshTunnelUrl(),

--- a/src/main/ipc/register.ts
+++ b/src/main/ipc/register.ts
@@ -44,7 +44,7 @@ import { listCronJobs, createCronJob, removeCronJob, pauseCronJob, resumeCronJob
 import { applyMessagingPlatformUpdate, buildDesktopMessagingPlatforms, fetchRemoteMessagingPlatforms, readLocalGatewayPlatformStates, testDesktopMessagingPlatform, testRemoteMessagingPlatform, updateRemoteMessagingPlatform } from "../messaging-platforms";
 import { listBoards as kanbanListBoards, currentBoard as kanbanCurrentBoard, switchBoard as kanbanSwitchBoard, createBoard as kanbanCreateBoard, removeBoard as kanbanRemoveBoard, listTasks as kanbanListTasks, getTask as kanbanGetTask, createTask as kanbanCreateTask, assignTask as kanbanAssignTask, completeTask as kanbanCompleteTask, blockTask as kanbanBlockTask, unblockTask as kanbanUnblockTask, archiveTask as kanbanArchiveTask, promoteTask as kanbanPromoteTask, scheduleTask as kanbanScheduleTask, specifyTask as kanbanSpecifyTask, reclaimTask as kanbanReclaimTask, commentTask as kanbanCommentTask, dispatchOnce as kanbanDispatchOnce, listClaw3dHqTasks as kanbanListClaw3dHqTasks, type CreateTaskInput } from "../kanban";
 import { getAppLocale, setAppLocale } from "../locale";
-import { sshListInstalledSkills, sshGetSkillContent, sshInstallSkill, sshUninstallSkill, sshListBundledSkills, sshReadMemory, sshAddMemoryEntry, sshUpdateMemoryEntry, sshRemoveMemoryEntry, sshWriteUserProfile, sshReadSoul, sshWriteSoul, sshResetSoul, sshGetToolsets, sshGetPlatformToolsets, sshSetToolsetEnabled, sshSetMessagingPlatformToolsetEnabled, sshReadEnv, sshSetEnvValue, sshGetConfigValue, sshSetConfigValue, sshGetHermesHome, sshGetModelConfig, sshSetModelConfig, sshListSessions, sshGetSessionMessages, sshSearchSessions, sshListProfiles, sshCreateProfile, sshDeleteProfile, sshGatewayStatus, sshStartGateway, sshStopGateway, sshReadRemoteApiKey, sshReadDirectory, sshGetHermesVersion, sshReadLogs, sshGetPlatformEnabled, sshSetPlatformEnabled, sshListCachedSessions, sshRunDoctor, sshListModels, sshAddModel, sshRemoveModel, sshUpdateModel, sshRunUpdate, sshRunDump, sshDiscoverMemoryProviders } from "../ssh-remote";
+import { sshListInstalledSkills, sshGetSkillContent, sshInstallSkill, sshUninstallSkill, sshListBundledSkills, sshReadMemory, sshAddMemoryEntry, sshUpdateMemoryEntry, sshRemoveMemoryEntry, sshWriteUserProfile, sshReadSoul, sshWriteSoul, sshResetSoul, sshGetToolsets, sshGetPlatformToolsets, sshSetToolsetEnabled, sshSetMessagingPlatformToolsetEnabled, sshReadEnv, sshSetEnvValue, sshGetConfigValue, sshSetConfigValue, sshGetHermesHome, sshGetModelConfig, sshSetModelConfig, sshListSessions, sshGetSessionMessages, sshSearchSessions, sshListProfiles, sshCreateProfile, sshDeleteProfile, sshGatewayStatus, sshStartGateway, sshStopGateway, sshReadRemoteApiKey, sshResolveApiServerPort, sshReadDirectory, sshGetHermesVersion, sshReadLogs, sshGetPlatformEnabled, sshSetPlatformEnabled, sshListCachedSessions, sshRunDoctor, sshListModels, sshAddModel, sshRemoveModel, sshUpdateModel, sshRunUpdate, sshRunDump, sshDiscoverMemoryProviders } from "../ssh-remote";
 
 export interface IpcContext {
   activeRuns: Map<string, () => void>;
@@ -58,10 +58,11 @@ const APP_NAME = process.env.HERMES_DESKTOP_APP_NAME?.trim() || "Hermes One";
 
 type RemoteSessionBridgeConfig = RemoteSessionConfig;
 
-async function getSshDashboardSessionConfig(conn: ConnectionConfig): Promise<RemoteSessionBridgeConfig> {
+async function getSshDashboardSessionConfig(conn: ConnectionConfig, profile?: string): Promise<RemoteSessionBridgeConfig> {
   if (conn.mode !== "ssh" || !conn.ssh) throw new Error("SSH connection is not configured.");
-  if (!(await sshGatewayStatus(conn.ssh))) await sshStartGateway(conn.ssh);
-  await ensureSshTunnel(conn.ssh);
+  if (!(await sshGatewayStatus(conn.ssh, profile))) await sshStartGateway(conn.ssh, profile);
+  const remotePort = await sshResolveApiServerPort(conn.ssh, profile);
+  await ensureSshTunnel({ ...conn.ssh, remotePort });
   const remoteUrl = getSshTunnelUrl();
   const apiKey = conn.apiKey.trim() || (await sshReadRemoteApiKey(conn.ssh));
   if (!remoteUrl) throw new Error("SSH tunnel is not active.");
@@ -70,20 +71,20 @@ async function getSshDashboardSessionConfig(conn: ConnectionConfig): Promise<Rem
   return { remoteUrl, apiKey };
 }
 
-async function withSshDashboardSessions<T>(conn: ConnectionConfig, dashboardOperation: (config: RemoteSessionBridgeConfig) => Promise<T>, legacyOperation?: () => Promise<T> | T): Promise<T> {
+async function withSshDashboardSessions<T>(conn: ConnectionConfig, dashboardOperation: (config: RemoteSessionBridgeConfig) => Promise<T>, legacyOperation?: () => Promise<T> | T, profile?: string): Promise<T> {
   if (conn.sshChatTransport === "legacy") {
     if (legacyOperation) return legacyOperation();
     throw new Error("This SSH session operation requires dashboard transport.");
   }
   try {
-    return await dashboardOperation(await getSshDashboardSessionConfig(conn));
+    return await dashboardOperation(await getSshDashboardSessionConfig(conn, profile));
   } catch (err) {
     if (conn.sshChatTransport === "auto" && legacyOperation) return legacyOperation();
     throw err;
   }
 }
 
-async function withSshDashboardModelLibrary<T>(conn: ConnectionConfig, dashboardOperation: (config: RemoteSessionBridgeConfig) => Promise<T>, legacyOperation: () => Promise<T> | T): Promise<T> {
+async function withSshDashboardModelLibrary<T>(conn: ConnectionConfig, dashboardOperation: (config: RemoteSessionBridgeConfig) => Promise<T>, legacyOperation: () => Promise<T> | T, profile?: string): Promise<T> {
   if (conn.mode !== "ssh" || !conn.ssh) throw new Error("SSH connection is not configured.");
   if (conn.sshChatTransport === "legacy") return legacyOperation();
   const compat = await ensureSshDashboardCompatibility(conn.ssh);
@@ -92,9 +93,9 @@ async function withSshDashboardModelLibrary<T>(conn: ConnectionConfig, dashboard
   } else if (compat.applied) {
     try { await sshStopGateway(conn.ssh); } catch (err) { console.warn("[ssh-model-library] Failed to stop patched gateway", err); }
     stopSshTunnel();
-    await sshStartGateway(conn.ssh);
+    await sshStartGateway(conn.ssh, profile);
   }
-  return dashboardOperation(await getSshDashboardSessionConfig(conn));
+  return dashboardOperation(await getSshDashboardSessionConfig(conn, profile));
 }
 
 async function withRemoteDashboard<T>(conn: ConnectionConfig, dashboardOperation: () => Promise<T>, legacyOperation: () => Promise<T> | T): Promise<T> {
@@ -749,12 +750,13 @@ export function registerIpcHandlers(context: IpcContext): void {
       await ensureSshTunnelIfNeeded();
       const conn = getConnectionConfig();
       if (conn.mode === "ssh" && conn.ssh) {
-        const gatewayRunning = await sshGatewayStatus(conn.ssh);
+        const gatewayRunning = await sshGatewayStatus(conn.ssh, profile);
         const tunnelHealthy = await isSshTunnelHealthy();
+        const remotePort = await sshResolveApiServerPort(conn.ssh, profile);
         if (!gatewayRunning || !tunnelHealthy) {
-          await sshStartGateway(conn.ssh);
-          await ensureSshTunnel(conn.ssh);
+          await sshStartGateway(conn.ssh, profile);
         }
+        await ensureSshTunnel({ ...conn.ssh, remotePort });
         // Always ensure the API key is cached — the key may not have been
         // read yet if the app-launch auto-start failed silently (#212).
         if (!getRemoteAuthHeader().Authorization) {

--- a/src/main/ssh-remote.test.ts
+++ b/src/main/ssh-remote.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildGatewayStartCommand,
+  buildGatewayStatusCommand,
+  buildGatewayStopCommand,
+} from "./ssh-remote";
+
+describe("SSH remote profile gateway commands", () => {
+  it("uses the default systemd-aware gateway command for the default profile", () => {
+    const command = buildGatewayStartCommand();
+
+    expect(command).toContain("systemctl start hermes.service");
+    expect(command).toContain("hermes gateway start");
+    expect(command).not.toContain("--profile");
+  });
+
+  it("targets the named profile gateway pid and CLI flag", () => {
+    const start = buildGatewayStartCommand("research");
+    const status = buildGatewayStatusCommand("research");
+    const stop = buildGatewayStopCommand("research");
+
+    expect(start).toContain("$HOME/.hermes/profiles/research");
+    expect(start).toContain("--profile");
+    expect(start).toContain("research");
+    expect(status).toContain("$HOME/.hermes/profiles/research/gateway.pid");
+    expect(stop).toContain("$HOME/.hermes/profiles/research/gateway.pid");
+  });
+});

--- a/src/main/ssh-remote.ts
+++ b/src/main/ssh-remote.ts
@@ -1807,7 +1807,28 @@ const SYSTEMD_HERMES_UNIT_TEST =
  * start (the status check will then report it as down). The detached
  * `nohup` start is used only when there is no unit to collide with.
  */
-export function buildGatewayStartCommand(): string {
+function remoteGatewayPidPath(profile?: string): string {
+  return profile && profile !== "default"
+    ? `$HOME/.hermes/profiles/${profile}/gateway.pid`
+    : "$HOME/.hermes/gateway.pid";
+}
+
+function remoteGatewayLogPath(profile?: string): string {
+  return profile && profile !== "default"
+    ? `$HOME/.hermes/profiles/${profile}/gateway.log`
+    : "$HOME/.hermes/gateway.log";
+}
+
+export function buildGatewayStartCommand(profile?: string): string {
+  if (profile && profile !== "default") {
+    return (
+      `mkdir -p $HOME/.hermes/profiles/${profile}; ` +
+      `(nohup ${buildRemoteHermesCmd(
+        ["--profile", profile, "gateway", "start"],
+        ` > ${remoteGatewayLogPath(profile)} 2>&1`,
+      )} &);`
+    );
+  }
   return (
     `if ${SYSTEMD_HERMES_UNIT_TEST}; then ` +
     `sudo -n systemctl start hermes.service 2>/dev/null || ` +
@@ -1825,7 +1846,16 @@ export function buildGatewayStartCommand(): string {
  * otherwise it falls back to `hermes gateway stop` and, last resort, the
  * recorded pid.
  */
-export function buildGatewayStopCommand(): string {
+export function buildGatewayStopCommand(profile?: string): string {
+  if (profile && profile !== "default") {
+    const pidPath = remoteGatewayPidPath(profile);
+    return (
+      `${buildRemoteHermesCmd(["--profile", profile, "gateway", "stop"], " 2>/dev/null")} || ` +
+      `(if [ -f ${pidPath} ]; then ` +
+      `pid=$(python3 -c "import json; d=json.load(open('${pidPath}')); print(d['pid'] if isinstance(d,dict) else d)" 2>/dev/null); ` +
+      `[ -n "$pid" ] && kill $pid 2>/dev/null; fi); true`
+    );
+  }
   return (
     `if ${SYSTEMD_HERMES_UNIT_TEST}; then ` +
     `sudo -n systemctl stop hermes.service 2>/dev/null || ` +
@@ -1845,7 +1875,16 @@ export function buildGatewayStopCommand(): string {
  * it is a liveness check on the recorded pid. Prints `active` or `running`
  * when up, anything else when not.
  */
-export function buildGatewayStatusCommand(): string {
+export function buildGatewayStatusCommand(profile?: string): string {
+  if (profile && profile !== "default") {
+    const pidPath = remoteGatewayPidPath(profile);
+    return (
+      `if [ -f ${pidPath} ]; then ` +
+      `pid=$(python3 -c "import json,sys; d=json.load(open('${pidPath}')); print(d.get('pid',d) if isinstance(d,dict) else d)" 2>/dev/null || cat ${pidPath}); ` +
+      `kill -0 $pid 2>/dev/null && echo "running" || echo "stopped"; ` +
+      `else echo "stopped"; fi`
+    );
+  }
   return (
     `if ${SYSTEMD_HERMES_UNIT_TEST}; then ` +
     `systemctl is-active hermes.service 2>/dev/null || true; ` +
@@ -1858,9 +1897,12 @@ export function buildGatewayStatusCommand(): string {
   );
 }
 
-export async function sshGatewayStatus(config: SshConfig): Promise<boolean> {
+export async function sshGatewayStatus(
+  config: SshConfig,
+  profile?: string,
+): Promise<boolean> {
   try {
-    const out = await sshExec(config, buildGatewayStatusCommand());
+    const out = await sshExec(config, buildGatewayStatusCommand(profile));
     const state = out.trim();
     return state === "running" || state === "active";
   } catch {
@@ -1868,20 +1910,170 @@ export async function sshGatewayStatus(config: SshConfig): Promise<boolean> {
   }
 }
 
-export async function sshStartGateway(config: SshConfig): Promise<void> {
+export async function sshStartGateway(
+  config: SshConfig,
+  profile?: string,
+): Promise<void> {
   try {
-    await sshExec(config, buildGatewayStartCommand());
+    await sshExec(config, buildGatewayStartCommand(profile));
   } catch {
     // best effort
   }
 }
 
-export async function sshStopGateway(config: SshConfig): Promise<void> {
+export async function sshStopGateway(
+  config: SshConfig,
+  profile?: string,
+): Promise<void> {
   try {
-    await sshExec(config, buildGatewayStopCommand());
+    await sshExec(config, buildGatewayStopCommand(profile));
   } catch {
     // best effort
   }
+}
+
+export async function sshResolveApiServerPort(
+  config: SshConfig,
+  profile?: string,
+): Promise<number> {
+  if (!profile || profile === "default") return config.remotePort || 8642;
+  const fallbackPort = config.remotePort || 8642;
+  const script = `
+import json, os, re, sys
+
+payload = json.loads(sys.stdin.read() or "{}")
+profile = payload.get("profile")
+fallback_port = int(payload.get("fallbackPort") or 8642)
+home = os.path.expanduser("~/.hermes")
+profiles_dir = os.path.join(home, "profiles")
+
+def config_path(name):
+    if name and name != "default":
+        return os.path.join(profiles_dir, name, "config.yaml")
+    return os.path.join(home, "config.yaml")
+
+def read(path):
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return f.read()
+    except FileNotFoundError:
+        return ""
+
+def line_indent(line):
+    return len(line) - len(line.lstrip(" "))
+
+def api_server_bounds(lines):
+    for i, line in enumerate(lines):
+        if re.match(r"^\\s*api_server\\s*:\\s*(?:#.*)?$", line):
+            indent = line_indent(line)
+            end = len(lines)
+            for j in range(i + 1, len(lines)):
+                if lines[j].strip() and line_indent(lines[j]) <= indent:
+                    end = j
+                    break
+            return i, end, indent
+    return None
+
+def configured_port(text):
+    lines = text.splitlines()
+    bounds = api_server_bounds(lines)
+    if not bounds:
+        return None
+    start, end, _ = bounds
+    for line in lines[start + 1:end]:
+        m = re.match(r"^\\s*port\\s*:\\s*[\\\"']?(\\d+)[\\\"']?\\s*(?:#.*)?$", line)
+        if m:
+            port = int(m.group(1))
+            if 0 < port < 65536:
+                return port
+    return None
+
+def existing_ports():
+    ports = {fallback_port}
+    paths = [config_path(None)]
+    if os.path.isdir(profiles_dir):
+        for name in os.listdir(profiles_dir):
+            p = os.path.join(profiles_dir, name)
+            if os.path.isdir(p):
+                paths.append(os.path.join(p, "config.yaml"))
+    for path in paths:
+        port = configured_port(read(path))
+        if port:
+            ports.add(port)
+    return ports
+
+def allocate_port():
+    used = existing_ports()
+    for port in range(fallback_port + 1, min(65535, fallback_port + 100) + 1):
+        if port not in used:
+            return port
+    return fallback_port
+
+def ensure_profile_port(path, port):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    text = read(path)
+    lines = text.splitlines()
+    bounds = api_server_bounds(lines)
+    if bounds:
+        start, end, indent = bounds
+        for i in range(start + 1, end):
+            if re.match(r"^\\s*port\\s*:", lines[i]):
+                lines[i] = " " * line_indent(lines[i]) + f"port: {port}"
+                break
+        else:
+            extra_index = None
+            extra_indent = indent + 2
+            for i in range(start + 1, end):
+                if re.match(r"^\\s*extra\\s*:\\s*(?:#.*)?$", lines[i]):
+                    extra_index = i
+                    extra_indent = line_indent(lines[i])
+                    break
+            if extra_index is not None:
+                lines.insert(extra_index + 1, " " * (extra_indent + 2) + f"port: {port}")
+            else:
+                lines.insert(start + 1, " " * (indent + 2) + "enabled: true")
+                lines.insert(start + 2, " " * (indent + 2) + "extra:")
+                lines.insert(start + 3, " " * (indent + 4) + f"port: {port}")
+    else:
+        platforms_index = None
+        for i, line in enumerate(lines):
+            if re.match(r"^\\s*platforms\\s*:\\s*(?:#.*)?$", line):
+                platforms_index = i
+                break
+        block = ["  api_server:", "    enabled: true", "    extra:", f"      port: {port}"]
+        if platforms_index is not None:
+            lines[platforms_index + 1:platforms_index + 1] = block
+        else:
+            if lines and lines[-1].strip():
+                lines.append("")
+            lines.extend(["platforms:", *block])
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("\\n".join(lines) + "\\n")
+
+path = config_path(profile)
+current = configured_port(read(path))
+if current:
+    print(current)
+else:
+    port = allocate_port()
+    ensure_profile_port(path, port)
+    print(port)
+`;
+  try {
+    const out = await sshPython(
+      config,
+      script,
+      pythonJsonInput({ profile, fallbackPort }),
+    );
+    const port = parseInt(out.trim(), 10);
+    if (port > 0 && port < 65536) return port;
+  } catch (err) {
+    console.warn(
+      "[ssh] Failed to allocate remote profile API port:",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+  return fallbackPort;
 }
 
 // ── Remote API key (for chat auth through SSH tunnel) ─────────────────────────

--- a/src/main/ssh-tunnel.ts
+++ b/src/main/ssh-tunnel.ts
@@ -18,6 +18,7 @@ export interface SshConfig {
 
 let tunnelProcess: ChildProcess | null = null;
 let activeConfig: SshConfig | null = null;
+let activeTargetKey: string | null = null;
 let tunnelRunning = false;
 let tunnelStartPromise: Promise<void> | null = null;
 
@@ -119,6 +120,16 @@ function buildSshArgs(config: SshConfig, localPort: number): string[] {
   ];
 }
 
+function tunnelTargetKey(config: SshConfig): string {
+  return [
+    config.host,
+    config.port || 22,
+    config.username,
+    config.keyPath || join(homedir(), ".ssh", "id_rsa"),
+    config.remotePort,
+  ].join("\n");
+}
+
 async function startSshTunnelInner(config: SshConfig): Promise<void> {
   stopSshTunnel();
 
@@ -129,6 +140,7 @@ async function startSshTunnelInner(config: SshConfig): Promise<void> {
 
   const localPort = await findFreePort(config.localPort || 18642);
   activeConfig = { ...config, localPort };
+  activeTargetKey = tunnelTargetKey(config);
   tunnelRunning = false;
 
   let spawnError: Error | null = null;
@@ -148,6 +160,7 @@ async function startSshTunnelInner(config: SshConfig): Promise<void> {
       if (!healthy) {
         tunnelRunning = false;
         activeConfig = null;
+        activeTargetKey = null;
       }
     });
   });
@@ -163,6 +176,7 @@ async function startSshTunnelInner(config: SshConfig): Promise<void> {
     }
     tunnelRunning = false;
     activeConfig = null;
+    activeTargetKey = null;
   });
 
   try {
@@ -213,10 +227,17 @@ export function stopSshTunnel(): void {
   }
   tunnelRunning = false;
   activeConfig = null;
+  activeTargetKey = null;
 }
 
 export async function ensureSshTunnel(config: SshConfig): Promise<void> {
-  if (isSshTunnelActive() && (await isSshTunnelHealthy())) return;
+  if (
+    isSshTunnelActive() &&
+    activeTargetKey === tunnelTargetKey(config) &&
+    (await isSshTunnelHealthy())
+  ) {
+    return;
+  }
   await startSshTunnel(config);
 }
 


### PR DESCRIPTION
## Summary

Fixes profile switching in SSH Tunnel mode when dashboard chat falls back to basic/API chat.

Previously, the fallback chat path could keep using the default profile’s SSH tunnel/API port, so messages sent after switching profiles were still handled by the default profile on the VPS.

## Changes

- Resolve the selected SSH profile’s remote API server port before chat sends
- Auto-allocate and persist a profile API port when missing
- Retarget the SSH tunnel when the selected profile maps to a different remote port
- Apply the same profile-aware tunnel routing to dashboard-over-SSH probes
- Add regression coverage for named-profile SSH gateway commands
- Document the behavior in `lat.md`

## Verification

- `npm test -- src/main/ssh-remote.test.ts`
- `npm run typecheck:node`
- `lat check`
- `git diff --check`