### PR TITLE
feat(memory): Graphnosis provider UI, MCP install surfaces, and onboarding

### DIFF
--- a/src/main/ipc/register.ts
+++ b/src/main/ipc/register.ts
@@ -249,6 +249,7 @@ import {
   fetchRegistryDetail,
   listInstalledRegistry,
   installRegistryItem,
+  listBundledMcps,
   type RegistryKind,
   type RegistryItem,
 } from "../registry";
@@ -1905,6 +1906,11 @@ export function registerIpcHandlers(context: IpcContext): void {
     const conn = getConnectionConfig();
     if (conn.mode === "ssh" && conn.ssh) return sshListBundledSkills(conn.ssh);
     return listBundledSkills();
+  });
+  ipcMain.handle("list-bundled-mcps", () => {
+    const conn = getConnectionConfig();
+    if (conn.mode === "ssh" && conn.ssh) return [];
+    return listBundledMcps();
   });
   ipcMain.handle("get-skill-content", (_event, skillPath: string) => {
     const conn = getConnectionConfig();

--- a/src/main/registry.ts
+++ b/src/main/registry.ts
@@ -4,7 +4,8 @@ import { profileHome, safeWriteFile } from "./utils";
 import { installSkill, listInstalledSkills } from "./skills";
 import { createProfile } from "./profiles";
 import { writeSoul } from "./soul";
-import { listMcpServers } from "./installer";
+import { listMcpServers, HERMES_REPO } from "./installer";
+import { installMcpCatalogEntry } from "./mcp-servers";
 import type {
   RegistryKind,
   RegistryItem,
@@ -85,6 +86,29 @@ const EMPTY_CATALOG: RegistryCatalog = {
   agents: [],
   workflows: [],
 };
+
+/** Graphnosis ships in hermes-agent optional-mcps once the upstream PR merges. */
+export function listBundledMcps(): RegistryItem[] {
+  const manifestYaml = join(
+    HERMES_REPO,
+    "optional-mcps",
+    "graphnosis",
+    "manifest.yaml",
+  );
+  if (!existsSync(manifestYaml)) return [];
+  return [
+    {
+      id: "graphnosis",
+      name: "Graphnosis",
+      description:
+        "Local encrypted memory — recall, remember, edit, engrams. Requires Graphnosis app.",
+      category: "memory",
+      tags: ["memory", "local", "encrypted"],
+      catalog: "graphnosis",
+      homepage: "https://graphnosis.com/getting-started/connect-ai",
+    },
+  ];
+}
 
 // Short-lived cache so flipping between Discover sub-tabs doesn't refetch.
 let cache: { at: number; data: RegistryCatalog } | null = null;
@@ -525,6 +549,10 @@ export async function installRegistryItem(
           ? await installRegistrySkill(item, profile)
           : installSkill(item.source || item.id, profile);
       case "mcps":
+        if (item.catalog) {
+          const res = await installMcpCatalogEntry(item.catalog, {}, profile);
+          return { success: res.success, error: res.error };
+        }
         return await installMcp(item, profile);
       case "agents":
         return await installAgent(item);

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -692,6 +692,17 @@ interface HermesAPI {
       installed: boolean;
     }>
   >;
+  listBundledMcps: () => Promise<
+    Array<{
+      id: string;
+      name: string;
+      description: string;
+      category?: string;
+      tags?: string[];
+      catalog?: string;
+      homepage?: string;
+    }>
+  >;
   getSkillContent: (skillPath: string) => Promise<string>;
   installSkill: (
     identifier: string,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -889,6 +889,17 @@ const hermesAPI = {
       installed: boolean;
     }>
   > => ipcRenderer.invoke("list-bundled-skills"),
+  listBundledMcps: (): Promise<
+    Array<{
+      id: string;
+      name: string;
+      description: string;
+      category?: string;
+      tags?: string[];
+      catalog?: string;
+      homepage?: string;
+    }>
+  > => ipcRenderer.invoke("list-bundled-mcps"),
   getSkillContent: (skillPath: string): Promise<string> =>
     ipcRenderer.invoke("get-skill-content", skillPath),
   installSkill: (

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -873,6 +873,32 @@ body {
   margin: 0;
 }
 
+.welcome-graphnosis-card {
+  margin-top: 24px;
+  padding: 16px 18px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  background: var(--surface-elevated, rgba(255, 255, 255, 0.03));
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 420px;
+  text-align: left;
+}
+
+.welcome-graphnosis-title {
+  font-size: 15px;
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.welcome-graphnosis-body {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
 /* ========================================================================
    INSTALL SCREEN
    ======================================================================== */
@@ -11873,6 +11899,25 @@ body {
   background: var(--bg-secondary);
   border: 1px dashed var(--border-bright);
   border-radius: var(--radius-md);
+}
+
+.tools-graphnosis-promo {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+  padding: 14px 16px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  background: var(--surface-elevated, rgba(255, 255, 255, 0.03));
+}
+
+.tools-graphnosis-promo-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
 .tools-mcp-card {

--- a/src/renderer/src/screens/Discover/Discover.tsx
+++ b/src/renderer/src/screens/Discover/Discover.tsx
@@ -75,6 +75,7 @@ export default function Discover({
   // Skills shipped with the hermes-agent repo, folded into the skills list
   // alongside registry skills (deduped).
   const [bundledSkills, setBundledSkills] = useState<RegistryItem[]>([]);
+  const [bundledMcps, setBundledMcps] = useState<RegistryItem[]>([]);
   const [installed, setInstalled] = useState<{
     skills: string[];
     mcps: string[];
@@ -119,9 +120,10 @@ export default function Discover({
       setLoading(true);
       setError(null);
       try {
-        const [data, bundled] = await Promise.all([
+        const [data, bundled, bundledMcpList] = await Promise.all([
           window.hermesAPI.fetchRegistry(force),
           window.hermesAPI.listBundledSkills(),
+          window.hermesAPI.listBundledMcps(),
         ]);
         if (data.error) setError(data.error);
         setCatalog({
@@ -141,6 +143,7 @@ export default function Discover({
             source: b.name,
           })),
         );
+        setBundledMcps(bundledMcpList);
       } catch (e) {
         setError(e instanceof Error ? e.message : "Failed to load");
         setCatalog(EMPTY);
@@ -204,16 +207,28 @@ export default function Discover({
   // skills (deduped — registry entries win on id/name collision).
   const communityList = useMemo(() => {
     const list = catalog[tab] ?? [];
-    if (tab !== "skills") return list;
-    const seen = new Set([
-      ...list.map((i) => i.id),
-      ...list.map((i) => i.name),
-    ]);
-    const extra = bundledSkills.filter(
-      (b) => !seen.has(b.id) && !seen.has(b.name),
-    );
-    return [...list, ...extra];
-  }, [catalog, tab, bundledSkills]);
+    if (tab === "skills") {
+      const seen = new Set([
+        ...list.map((i) => i.id),
+        ...list.map((i) => i.name),
+      ]);
+      const extra = bundledSkills.filter(
+        (b) => !seen.has(b.id) && !seen.has(b.name),
+      );
+      return [...list, ...extra];
+    }
+    if (tab === "mcps") {
+      const seen = new Set([
+        ...list.map((i) => i.id),
+        ...list.map((i) => i.name),
+      ]);
+      const extra = bundledMcps.filter(
+        (b) => !seen.has(b.id) && !seen.has(b.name),
+      );
+      return [...list, ...extra];
+    }
+    return list;
+  }, [catalog, tab, bundledSkills, bundledMcps]);
 
   const items = useMemo(
     () =>
@@ -245,6 +260,17 @@ export default function Discover({
 
   function tabCount(key: RegistryKind): number {
     if (key === "skills") return skillsTotal;
+    if (key === "mcps") {
+      const list = catalog.mcps ?? [];
+      const seen = new Set([
+        ...list.map((i) => i.id),
+        ...list.map((i) => i.name),
+      ]);
+      const extra = bundledMcps.filter(
+        (b) => !seen.has(b.id) && !seen.has(b.name),
+      );
+      return list.length + extra.length;
+    }
     return (catalog[key] ?? []).length;
   }
 

--- a/src/renderer/src/screens/Memory/MemoryProviders.tsx
+++ b/src/renderer/src/screens/Memory/MemoryProviders.tsx
@@ -10,6 +10,7 @@ const PROVIDER_URLS: Record<string, string> = {
   retaindb: "https://retaindb.com",
   supermemory: "https://supermemory.ai",
   byterover: "https://app.byterover.dev",
+  graphnosis: "https://graphnosis.com/download",
 };
 
 interface MemoryProvidersProps {

--- a/src/renderer/src/screens/Tools/Tools.tsx
+++ b/src/renderer/src/screens/Tools/Tools.tsx
@@ -348,6 +348,35 @@ function Tools({
       })
     : mcpServers;
 
+  const graphnosisMcpInstalled = mcpServers.some((s) => s.name === "graphnosis");
+
+  async function handleInstallGraphnosisMcp(): Promise<void> {
+    setMcpError("");
+    setMcpMessage("");
+    setMcpBusy("install:graphnosis");
+    try {
+      const result = await window.hermesAPI.installMcpCatalogEntry(
+        "graphnosis",
+        {},
+        profile,
+      );
+      if (!result.success) {
+        setMcpError(result.error || t("tools.mcpInstallFailed"));
+        return;
+      }
+      setMcpMessage(
+        result.background
+          ? t("tools.mcpInstallStarted")
+          : t("tools.mcpInstalled"),
+      );
+      await reloadMcp();
+    } catch (err) {
+      setMcpError((err as Error).message || t("tools.mcpInstallFailed"));
+    } finally {
+      setMcpBusy("");
+    }
+  }
+
   if (loading) {
     return (
       <div className="tools-container">
@@ -489,6 +518,43 @@ function Tools({
 
               {mcpError && <div className="tools-error">{mcpError}</div>}
               {mcpMessage && <div className="tools-success">{mcpMessage}</div>}
+
+              {!graphnosisMcpInstalled && (
+                <div className="tools-graphnosis-promo">
+                  <div>
+                    <div className="tools-card-label">
+                      {t("tools.graphnosisMcpTitle")}
+                    </div>
+                    <div className="tools-card-description">
+                      {t("tools.graphnosisMcpDescription")}
+                    </div>
+                  </div>
+                  <div className="tools-graphnosis-promo-actions">
+                    <button
+                      type="button"
+                      className="btn btn-primary btn-sm"
+                      disabled={mcpBusy === "install:graphnosis"}
+                      onClick={() => void handleInstallGraphnosisMcp()}
+                    >
+                      <TinyIcon kind="install" />
+                      {mcpBusy === "install:graphnosis"
+                        ? t("tools.mcpInstallWorking")
+                        : t("tools.graphnosisMcpInstall")}
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn-secondary btn-sm"
+                      onClick={() =>
+                        void window.hermesAPI.openExternal(
+                          "https://graphnosis.com/download",
+                        )
+                      }
+                    >
+                      {t("tools.graphnosisMcpDownload")}
+                    </button>
+                  </div>
+                </div>
+              )}
 
               {mcpServers.length === 0 ? (
                 <div className="tools-empty">

--- a/src/renderer/src/screens/Welcome/Welcome.tsx
+++ b/src/renderer/src/screens/Welcome/Welcome.tsx
@@ -394,6 +394,26 @@ function Welcome({
           </button>
           <p className="welcome-note">{t("welcome.installSizeHint")}</p>
 
+          <div className="welcome-graphnosis-card">
+            <div className="welcome-graphnosis-copy">
+              <div className="welcome-graphnosis-title">
+                {t("welcome.graphnosisTitle")}
+              </div>
+              <p className="welcome-graphnosis-body">{t("welcome.graphnosisBody")}</p>
+            </div>
+            <button
+              type="button"
+              className="btn btn-secondary btn-sm"
+              onClick={() =>
+                void window.hermesAPI.openExternal(
+                  "https://graphnosis.com/download",
+                )
+              }
+            >
+              {t("welcome.graphnosisDownload")}
+            </button>
+          </div>
+
           <div className="welcome-divider">
             <span>{t("welcome.dividerOr")}</span>
           </div>

--- a/src/shared/i18n/locales/en/memory.ts
+++ b/src/shared/i18n/locales/en/memory.ts
@@ -58,5 +58,7 @@ export default {
     openviking:
       "Session-managed memory with tiered retrieval and knowledge browsing",
     byterover: "Persistent knowledge tree with tiered retrieval via brv CLI",
+    graphnosis:
+      "Local encrypted engram graph — auto-prefetch, recall, remember. Requires Graphnosis app (no API key)",
   },
 } as const;

--- a/src/shared/i18n/locales/en/tools.ts
+++ b/src/shared/i18n/locales/en/tools.ts
@@ -123,5 +123,11 @@ export default {
   mcpCatalogLoadFailed: "Failed to load MCP catalog.",
   mcpCatalogEmpty: "No catalog entries available.",
   mcpInstall: "Install",
+  mcpInstallWorking: "Installing…",
   mcpInstalledStatus: "Installed",
+  graphnosisMcpTitle: "Graphnosis memory (recommended)",
+  graphnosisMcpDescription:
+    "Install the Graphnosis MCP server for recall, remember, edit, and cross-engram search. Requires the Graphnosis app running with cortex unlocked.",
+  graphnosisMcpInstall: "Install Graphnosis MCP",
+  graphnosisMcpDownload: "Get Graphnosis app",
 } as const;

--- a/src/shared/i18n/locales/en/welcome.ts
+++ b/src/shared/i18n/locales/en/welcome.ts
@@ -21,4 +21,8 @@ export default {
   connect: "Connect",
   remoteHint:
     "Leave the key empty if the server accepts unauthenticated requests (e.g. via SSH tunnel to localhost).",
+  graphnosisTitle: "Pair with Graphnosis",
+  graphnosisBody:
+    "Add local encrypted memory to Hermes — auto-prefetch, recall, and MCP tools. Install Graphnosis, unlock your cortex, then enable the Graphnosis memory provider and MCP catalog in Settings.",
+  graphnosisDownload: "Download Graphnosis",
 } as const;

--- a/src/shared/registry.ts
+++ b/src/shared/registry.ts
@@ -22,6 +22,8 @@ export interface RegistryItem {
   path?: string;
   /** Bundled skills only: install identifier for `hermes skills install`. */
   source?: string;
+  /** Bundled MCP catalog entries: install name for `hermes mcp install`. */
+  catalog?: string;
 }
 
 export interface RegistryCatalog {


### PR DESCRIPTION
## Summary

Adds [Graphnosis](https://graphnosis.com) UI surfaces to Hermes Desktop — companion to the Hermes Agent integration in [NousResearch/hermes-agent#51197](https://github.com/NousResearch/hermes-agent/pull/51197).

| Surface | What users get |
| --- | --- |
| **Memory providers** | English description + link to graphnosis.com/download |
| **Capabilities → MCP Servers** | Install promo (`hermes mcp install graphnosis`) + app download |
| **Discover → MCPs** | Bundled Graphnosis catalog entry when `optional-mcps/graphnosis` exists in hermes-agent |
| **Welcome** | Get Connected onboarding card |

Memory provider discovery is automatic once the hermes-agent Graphnosis plugin is installed.

Integration source: https://github.com/nehloo-interactive/graphnosis-app/tree/main/integrations/hermes-desktop

## Depends on

- [NousResearch/hermes-agent#51197](https://github.com/NousResearch/hermes-agent/pull/51197) — `optional-mcps/graphnosis` manifest + memory provider plugin

## Changes

- `listBundledMcps()` IPC + Discover tab integration (mirrors bundled skills pattern)
- Memory provider i18n + download URL
- Tools MCP install promo card
- Welcome onboarding card + shared styles

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm test -- tests/preload-api-surface.test.ts` — passes
- [ ] Memory screen shows Graphnosis card when hermes-agent plugin is installed
- [ ] Capabilities → MCP shows Graphnosis promo when server not installed; Install runs `hermes mcp install graphnosis`
- [ ] Discover → MCPs lists Graphnosis when `optional-mcps/graphnosis/manifest.yaml` present
- [ ] Welcome screen shows Graphnosis onboarding card with download link

Maintained by [Nehloo Interactive LLC](https://graphnosis.com) (`nehloo-interactive/graphnosis-app`).

Made with [Cursor](https://cursor.com)