### PR TITLE
ix chat input lag in long conversations

### DIFF
--- a/lat.md/chat-performance.md
+++ b/lat.md/chat-performance.md
@@ -1,0 +1,33 @@
+# Chat message-list rendering performance
+
+Typing in the composer must stay fast no matter how long the conversation is. The transcript is not virtualized in JS, so the layout cost is bounded with CSS containment plus a single batched textarea measurement (issue #748).
+
+The symptom this guards against: in conversations with many messages, each keystroke took up to ~2.6s with an empty JS profile — the cost was entirely in Chromium's layout engine, recalculating the whole transcript on every keystroke. CPU and memory were normal; new sessions were instant.
+
+## Off-screen rows are skipped with content-visibility
+
+Every transcript row (`.chat-message`) sets `content-visibility: auto` with `contain-intrinsic-size: auto 120px`, so the browser skips layout and paint for off-screen rows. That turns a forced reflow from O(all messages) into O(visible rows).
+
+The rule lives on `.chat-message` in the renderer stylesheet (`src/renderer/src/assets/main.css`). That class is shared by user/agent bubbles, the reasoning and tool-activity rows, and the typing indicator (see [[src/renderer/src/screens/Chat/MessageList.tsx]] and [[src/renderer/src/screens/Chat/MessageRow.tsx]]), so one rule covers every heavy row.
+
+The `auto` keyword in `contain-intrinsic-size` makes the browser remember each row's real measured height after it renders once, so the scrollbar and scroll position stay accurate; the `120px` is only the first-paint estimate for never-yet-rendered rows.
+
+### Paint containment and the hover timestamp
+
+`content-visibility` implies paint containment, which clips anything drawn outside the row's box — including the hover timestamp that sits below the bubble.
+
+The timestamp (`.chat-bubble-time`) used to overflow ~15px below the bubble and would be clipped. It now sits at `bottom: 1px` inside the row's `padding-bottom: 16px`, so it stays visible while still appearing just under the bubble.
+
+## Block flow, not a flex column
+
+The scroll container `.chat-messages` is block flow, not a flex column. A flex column measures each child to lay itself out, which defeats `content-visibility` and reports a wrong `scrollHeight`.
+
+A correct `scrollHeight` matters because [[src/renderer/src/screens/Chat/hooks/useChatScroll.ts#useChatScroll]] uses `scrollHeight - scrollTop - clientHeight` to decide whether the view is pinned to the bottom; a wrong value would break auto-scroll.
+
+The flex `gap` that previously spaced rows is replaced by per-row spacing: `.chat-message` carries `padding-bottom: 16px` (which also provides the timestamp's room), and non-message children that lack it (`.chat-clarify`) carry an equivalent `margin-bottom`. Block flow also moves alignment from `align-self` to `margin-left: auto` for user rows, and the empty state fills height with `min-height: 100%` instead of `flex: 1`.
+
+## Textarea auto-resize avoids per-keystroke reflow
+
+The composer textarea auto-grows to its content. Reading `scrollHeight` to size it forces a layout flush, so it runs once per committed value in a `useLayoutEffect` keyed on the input string, not on every keystroke.
+
+In [[src/renderer/src/screens/Chat/ChatInput.tsx]] every path that changes the value (typing, history recall, voice transcription, and the imperative `setText`/`appendText`) goes through `setInput`, so the layout effect is the single owner of resizing — the other paths only set the caret and focus. Combined with the row-level `content-visibility`, the one measurement per keystroke stays O(visible rows).

--- a/lat.md/lat.md
+++ b/lat.md/lat.md
@@ -1,6 +1,7 @@
 This directory defines the high-level concepts, business logic, and architecture of this project using markdown. It is managed by [lat.md](https://www.npmjs.com/package/lat.md) — a tool that anchors source code to these definitions. Install the `lat` command with `npm i -g lat.md` and run `lat --help`.
 
 - [[chat-commands]] — how typed slash commands are routed through the gateway's `slash.exec`/`command.dispatch` pipeline instead of being sent as prompt text.
+- [[chat-performance]] — how the message list keeps typing fast in long conversations: `content-visibility` on off-screen rows, block flow for a correct `scrollHeight`, and a once-per-value textarea resize.
 - [[model-context]] — the per-model context-window override that drives the context gauge and the agent's auto-compaction.
 - [[model-selection]] — the session-scoped in-chat model override that switches the model (and provider) for one conversation without touching the global default.
 - [[web-preview]] — the in-app split-screen webview and the `partition`-based gate that lets only it load remote HTTPS while staying sandboxed.

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -3726,14 +3726,22 @@ body {
   flex: 1;
   overflow-y: auto;
   padding: 24px;
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
+  /* Block flow, NOT a flex column. `content-visibility: auto` on the rows
+     (below) lets the browser skip layout/paint for off-screen messages, which
+     is what keeps typing fast in long conversations (#748). A flex column
+     defeats that: it measures every child's intrinsic size to lay the column
+     out, forcing layout of skipped subtrees and reporting a wrong
+     `scrollHeight` — which would also break the auto-scroll math in
+     useChatScroll. Inter-row spacing that the flex `gap` used to provide now
+     comes from each row's own bottom margin/padding. */
 }
 
 /* Empty state */
 .chat-empty {
-  flex: 1;
+  /* The scroll container is block flow now (see .chat-messages), so `flex: 1`
+     no longer stretches this to fill the height. `min-height: 100%` makes it
+     fill the container so its own flex centering still works. */
+  min-height: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -3832,9 +3840,22 @@ body {
 .chat-message {
   display: flex;
   gap: 12px;
+  width: 100%;
   max-width: 85%;
   animation: messageIn 0.2s ease;
   position: relative;
+  /* Replaces the old container flex `gap` (now block flow). Also gives the
+     hover timestamp (.chat-bubble-time, ~15px below the bubble) room *inside*
+     this box so the paint containment that `content-visibility` implies does
+     not clip it. */
+  padding-bottom: 16px;
+  /* Skip layout + paint for rows scrolled out of view. This turns the
+     per-keystroke document reflow from O(all messages) into O(visible rows),
+     fixing the input lag in long conversations. `auto` for the intrinsic size
+     means the real measured height is remembered after a row renders once, so
+     the scrollbar stays accurate; 120px is only the first-paint estimate. */
+  content-visibility: auto;
+  contain-intrinsic-size: auto 120px;
 }
 
 @keyframes messageIn {
@@ -3849,13 +3870,13 @@ body {
 }
 
 .chat-message-user {
-  align-self: flex-end;
+  /* Right-align in block flow (replaces the flex-column `align-self: flex-end`).
+     `row-reverse` keeps the bubble on the outer edge with the avatar inside. */
+  margin-left: auto;
   flex-direction: row-reverse;
 }
 
-.chat-message-agent {
-  align-self: flex-start;
-}
+/* Agent rows are left-aligned by default in block flow — no rule needed. */
 
 /* Continuation rows of a turn (thinking/tool rows + answer that share one
    avatar). Pull them closer to the row above so the turn reads as one block
@@ -3943,11 +3964,13 @@ body {
 }
 
 /* Hover timestamp — sits just below the bubble, revealed on row hover.
-   Anchored to .chat-message (overflow-visible) so .chat-bubble's
-   overflow:auto doesn't clip it. */
+   Anchored inside .chat-message's bottom padding (not overflowing it): the
+   `content-visibility` on .chat-message implies paint containment, which would
+   clip anything spilling past the box, so this sits at bottom:1px within the
+   16px padding instead of overflowing at -15px. */
 .chat-bubble-time {
   position: absolute;
-  bottom: -15px;
+  bottom: 1px;
   font-size: 11px;
   line-height: 1;
   color: var(--text-secondary);
@@ -4177,6 +4200,10 @@ body {
 /* Inline clarify card — a mid-turn question rendered in the transcript. */
 .chat-clarify {
   margin-top: 8px;
+  /* Not a .chat-message, so it doesn't carry the row padding-bottom that now
+     provides inter-row spacing — add the 16px the container's flex gap used
+     to give it. */
+  margin-bottom: 16px;
   margin-left: 42px;
   padding: 14px 16px;
   border: 1px solid var(--border);

--- a/src/renderer/src/screens/Chat/ChatInput.tsx
+++ b/src/renderer/src/screens/Chat/ChatInput.tsx
@@ -2,6 +2,7 @@ import {
   useState,
   useRef,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useCallback,
   forwardRef,
@@ -112,16 +113,26 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
       el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
     }, []);
 
-    const applyHistoryText = useCallback(
-      (text: string): void => {
-        setInput(text);
-        requestAnimationFrame(() => {
-          autoResize();
-          inputRef.current?.setSelectionRange(text.length, text.length);
-        });
-      },
-      [autoResize],
-    );
+    // Resize the textarea once per committed value, in a layout effect, rather
+    // than reading `scrollHeight` inside a requestAnimationFrame on every
+    // keystroke. The synchronous scrollHeight read forces a document reflow;
+    // doing it here (post-commit, pre-paint) keeps it to a single measurement
+    // and lets `content-visibility` on off-screen rows bound its cost — this is
+    // the input-lag fix for long conversations (#748). All `setInput` paths
+    // (typing, history recall, voice, imperative setText/appendText) funnel
+    // through here, so none of them need to resize by hand.
+    // @lat: [[chat-performance#Textarea auto-resize avoids per-keystroke reflow]]
+    useLayoutEffect(() => {
+      autoResize();
+    }, [input, autoResize]);
+
+    const applyHistoryText = useCallback((text: string): void => {
+      setInput(text);
+      // Resize runs via the layout effect; just place the caret at the end.
+      requestAnimationFrame(() => {
+        inputRef.current?.setSelectionRange(text.length, text.length);
+      });
+    }, []);
 
     const history = useInputHistory({
       currentInput: input,
@@ -180,8 +191,8 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
       () => ({
         setText(text: string): void {
           setInput(text);
+          // Resize runs via the layout effect; place the caret + focus.
           requestAnimationFrame(() => {
-            autoResize();
             if (inputRef.current) {
               inputRef.current.setSelectionRange(text.length, text.length);
               inputRef.current.focus();
@@ -192,7 +203,6 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
           setInput((prev) => {
             const next = prev ? `${prev}\n${text}` : text;
             requestAnimationFrame(() => {
-              autoResize();
               if (inputRef.current) {
                 inputRef.current.setSelectionRange(next.length, next.length);
                 inputRef.current.focus();
@@ -214,7 +224,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
           return ingestFiles(files);
         },
       }),
-      [autoResize, ingestFiles],
+      [ingestFiles],
     );
 
     // Refocus the textarea when a streaming response ends
@@ -302,12 +312,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
     ): void {
       const value = e.target.value;
       setInput(value);
-
-      const target = e.target;
-      requestAnimationFrame(() => {
-        target.style.height = "auto";
-        target.style.height = `${Math.min(target.scrollHeight, 120)}px`;
-      });
+      // Height is handled by the useLayoutEffect on `input` above.
 
       if (value.startsWith("/") && !value.includes(" ")) {
         const query = value.split(" ")[0];


### PR DESCRIPTION
Closes #748.

## Problem

Typing in the composer becomes progressively slower as a conversation grows. In sessions with many messages each keystroke can take **up to ~2.6s**, while new/empty sessions stay instant. CPU and memory are normal and the JS flame graph is empty during the lag — the cost is entirely in Chromium's layout engine.

## Root cause

Two things compound:

1. **Per-keystroke forced reflow.** The auto-resizing `<textarea>` reads `scrollHeight` on every keystroke, which forces a synchronous layout flush.
2. **No virtualization.** The whole transcript (full markdown + code highlighting) is rendered as direct children of `.chat-messages`, so each forced layout is **O(total DOM)**. With 50+ messages, every keystroke re-lays-out the entire transcript.

The composer's `input` state is local to `ChatInput`, so this is not a React re-render problem — it's pure browser layout.

## Fix

Two complementary changes that address both halves of the cause:

### 1. Bound the layout cost — `content-visibility` on rows (`main.css`)

`.chat-message` now uses `content-visibility: auto` + `contain-intrinsic-size: auto 120px`, so the browser skips layout/paint for off-screen rows. The per-keystroke reflow drops from **O(all messages) → O(visible rows)**. `auto` makes each row's real height be remembered after it renders once, keeping the scrollbar accurate. The class is shared by bubbles, reasoning rows, tool groups, and the typing indicator, so one rule covers every heavy row.

### 2. Remove the per-keystroke reflow trigger (`ChatInput.tsx`)

The textarea resize moved from a per-keystroke `requestAnimationFrame(() => read scrollHeight)` into a single `useLayoutEffect` keyed on `input`. Every value-changing path (typing, history recall, voice, imperative `setText`/`appendText`) funnels through `setInput`, so the effect is the sole owner of resizing and runs once per committed value.

## Regressions handled (vs. the patch proposed in #748)

The `content-visibility` approach requires block flow, which has knock-on effects the original issue didn't account for. All are fixed here:

- **Block flow is required** — a flex column measures children's intrinsic size, which defeats `content-visibility` and corrupts `scrollHeight` (used by `useChatScroll` for auto-scroll). Converting `.chat-messages` to block flow meant re-anchoring user alignment (`margin-left: auto`) and the empty state (`min-height: 100%`).
- **Hover timestamp clipping** — `content-visibility` implies paint containment, which would clip `.chat-bubble-time` (it overflowed 15px below the bubble). It now sits inside the row's `padding-bottom`, visible and in the same position.
- **Inter-row spacing** — the flex `gap` is replaced by per-row `padding-bottom` (and `margin-bottom` on the non-`.chat-message` clarify card), preserving the grouped-turn `-8px` overlap exactly.

## Testing

- `npm run typecheck` (node + web) — clean
- Full suite: **1517 passed**, 3 pre-existing skips
- ESLint clean on changed files
- `lat check` passes

## Docs

Added `lat.md/chat-performance.md` documenting the rendering-performance design (content-visibility virtualization, block-flow/`scrollHeight` rationale, paint-containment timestamp fix, once-per-value textarea resize), indexed it in `lat.md/lat.md`, and linked it from code via a `// @lat:` ref.

## Follow-up (not in this PR)

For conversations in the hundreds-of-messages range, a virtualized list (react-window / tanstack-virtual) is the proper long-term cap on DOM size. This change makes that unnecessary for now.