### PR TITLE
Persist `model.api_mode` on model switch (fix lost connection between OpenAI- and Anthropic-compatible endpoints)

### DIFF
--- a/lat.md/provider-setup.md
+++ b/lat.md/provider-setup.md
@@ -38,6 +38,8 @@ The gateway's runtime-provider resolver honors a persisted `model.api_mode` (`an
 
 [[src/main/config.ts#setModelConfig]] takes an optional `apiMode` argument, handled exactly like `context_length`: a non-empty string sets `model.api_mode`, `null`/empty removes it (so auto-detection resumes), `undefined` leaves it untouched. The `set-model-config` IPC handler ([[src/main/ipc/register.ts]]) resolves it from the activated model's `apiMode` library field ([[src/main/models.ts#SavedModel]]) — `null` when the entry has none — alongside the `contextLength` mirror, on both the pure-local and remote-fallback local writes. Custom-provider library entries carry `apiMode` because `loadCustomProviders` reads `api_mode` from each `custom_providers:` block.
 
+The library lookup runs through [[src/main/ipc/register.ts#resolveLibraryModelEntry]], which disambiguates by base URL when several entries share the same provider+model — e.g. two `custom` endpoints exposing the same model id over different transports. A bare provider+model match would return the first entry and persist its `api_mode` for the other endpoint, routing it over the wrong protocol; matching the base URL too keeps each endpoint's transport correct. Single-entry activations are unaffected.
+
 ## Provider icons
 
 Each card's logo is resolved by [[src/renderer/src/components/common/BrandLogo.tsx]] from the provider id, falling back to a generic robot for unknown ids.

--- a/lat.md/provider-setup.md
+++ b/lat.md/provider-setup.md
@@ -30,6 +30,14 @@ For compatible/custom endpoints, an inline **API Key** field appears under Base 
 
 Ids the agent can't resolve by id are listed in `OPENAI_COMPATIBLE_BASE_URLS` ([[src/renderer/src/constants.ts]]) — openai, perplexity, and every `LOCAL_PRESETS` chip (local servers + remote endpoints like groq, deepseek, atlascloud, mistral, …). This map MUST contain every preset id, or selecting that chip mis-routes; a test in `tests/constants.test.ts` enforces it. Selecting one autofills its base URL and shows the base-URL field; on save it is persisted as `provider: custom` + `base_url`, which the gateway accepts and uses to host-derive the API key (`runtime_provider._host_derived_api_key`, e.g. `api.groq.com` → `GROQ_API_KEY`). `displayProviderFromConfig` reverse-maps a stored `custom` + known base URL back to the brand id so the dropdown re-selects it on load. Native providers (the gateway hardcodes their base URL) clear the field instead.
 
+## Switching providers rewrites the transport (`api_mode`)
+
+Activating a model must rewrite or clear `model.api_mode`, or a stale protocol from the previous model routes the new endpoint over the wrong transport — dropping connections when switching OpenAI- and Anthropic-compatible custom endpoints.
+
+The gateway's runtime-provider resolver honors a persisted `model.api_mode` (`anthropic_messages` vs `chat_completions`, …) for `custom`/compatible providers, and only auto-detects from the base URL (`/anthropic` suffix, `api.openai.com`, …) when the key is absent. So a leftover `anthropic_messages` would keep an OpenAI-compatible endpoint pointed at `/v1/messages` (404 / lost connection).
+
+[[src/main/config.ts#setModelConfig]] takes an optional `apiMode` argument, handled exactly like `context_length`: a non-empty string sets `model.api_mode`, `null`/empty removes it (so auto-detection resumes), `undefined` leaves it untouched. The `set-model-config` IPC handler ([[src/main/ipc/register.ts]]) resolves it from the activated model's `apiMode` library field ([[src/main/models.ts#SavedModel]]) — `null` when the entry has none — alongside the `contextLength` mirror, on both the pure-local and remote-fallback local writes. Custom-provider library entries carry `apiMode` because `loadCustomProviders` reads `api_mode` from each `custom_providers:` block.
+
 ## Provider icons
 
 Each card's logo is resolved by [[src/renderer/src/components/common/BrandLogo.tsx]] from the provider id, falling back to a generic robot for unknown ids.

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -942,6 +942,13 @@ export function setModelConfig(
   // for callers that don't manage it); a positive number sets it; `null` or a
   // non-positive number removes it (auto-detection / heuristic resumes).
   contextLength?: number | null,
+  // Optional API-protocol override mirrored into `model.api_mode` (the agent's
+  // runtime-provider resolver reads it to pick the transport for
+  // custom/compatible endpoints). `undefined` leaves the key untouched
+  // (back-compat); a non-empty string (e.g. `"anthropic_messages"`,
+  // `"chat_completions"`) sets it; `null`/empty removes it so the agent
+  // re-detects the transport from the base URL.
+  apiMode?: string | null,
 ): void {
   invalidateCache(`mc:${profile || "default"}`);
   const { configFile } = profilePaths(profile);
@@ -1067,6 +1074,26 @@ export function setModelConfig(
       );
     } else {
       content = removeBlockChild(content, "model", "context_length");
+    }
+  }
+
+  // Mirror the activated model's API-protocol override into `model.api_mode`.
+  // This MUST be rewritten on every switch: the gateway honors a persisted
+  // `model.api_mode` for custom/compatible providers, so a value left behind
+  // by a previously-active model would route the new endpoint over the wrong
+  // protocol — e.g. switching from an Anthropic-compatible endpoint
+  // (api_mode: anthropic_messages) to an OpenAI-compatible one would keep
+  // hitting /v1/messages and 404 / drop the connection (fathah/hermes-desktop
+  // — "connection lost switching OpenAI- and Anthropic-compatible models").
+  // Skip when `undefined` so callers that don't track it leave any user-set
+  // value alone; a non-empty string sets it; `null`/empty removes it so the
+  // agent auto-detects the transport from `base_url` again.
+  if (apiMode !== undefined) {
+    const trimmedMode = (apiMode || "").trim();
+    if (trimmedMode) {
+      content = upsertBlockChild(content, "model", "api_mode", trimmedMode);
+    } else {
+      content = removeBlockChild(content, "model", "api_mode");
     }
   }
 

--- a/src/main/ipc/register.ts
+++ b/src/main/ipc/register.ts
@@ -30,7 +30,13 @@ import { syncSessionCache, listCachedSessions, updateSessionTitle } from "../ses
 import { remoteDeleteSession, remoteDeleteSessions, remoteGetSessionMessages, remoteListCachedSessions, remoteListSessions, remoteReadMediaAsDataUrl, remoteSearchSessions, remoteUpdateSessionTitle, type RemoteSessionConfig } from "../remote-sessions";
 import { remoteGetHermesHome, remoteGetHermesVersion } from "../remote-metadata";
 import { remoteAddModel, remoteGetModelConfig, remoteListModels, remoteRemoveModel, remoteSetModelConfig, remoteUpdateModel } from "../remote-models";
-import { listModels, addModel, removeModel, updateModel } from "../models";
+import {
+  listModels,
+  addModel,
+  removeModel,
+  updateModel,
+  type SavedModel,
+} from "../models";
 import { validateChatReadiness } from "../validation";
 import { runConfigHealthCheck, autoFixIssue, readConfigFixLog, type IssueCode } from "../config-health";
 import { listProfiles, createProfile, deleteProfile, setActiveProfile } from "../profiles";
@@ -140,6 +146,30 @@ async function mediaFileExistsForCurrentConnection(filePath: string): Promise<bo
 async function resolveMediaForSave(src: string): Promise<string> {
   if (src.startsWith("data:") || /^https?:\/\//i.test(src)) return src;
   return (await readMediaForCurrentConnection(src)) ?? src;
+}
+
+/**
+ * Resolve the saved-model library entry for an activated (provider, model) so
+ * its `apiMode`/`contextLength` can be mirrored into config.yaml. When several
+ * entries share the same provider+model — e.g. two `custom` endpoints exposing
+ * the same model id over different transports/base URLs — a bare provider+model
+ * `find` would return the wrong one and persist its transport, routing requests
+ * over the wrong protocol. Disambiguate by base URL in that case; fall back to
+ * the first match when none align (single-entry activations are unaffected).
+ */
+function resolveLibraryModelEntry(
+  provider: string,
+  model: string,
+  baseUrl: string,
+): SavedModel | undefined {
+  const matches = listModels().filter(
+    (m) => m.provider === provider && m.model === model,
+  );
+  if (matches.length <= 1) return matches[0];
+  const norm = (u: string | undefined): string =>
+    (u || "").trim().replace(/\/+$/, "");
+  const target = norm(baseUrl);
+  return matches.find((m) => norm(m.baseUrl) === target) ?? matches[0];
 }
 
 export function registerIpcHandlers(context: IpcContext): void {
@@ -454,9 +484,7 @@ export function registerIpcHandlers(context: IpcContext): void {
             // Same library-mirroring as the pure-local path below: carry the
             // activated model's context-window and api_mode into config.yaml
             // so this local fallback write doesn't leave a stale transport.
-            const libEntry = listModels().find(
-              (m) => m.provider === provider && m.model === model,
-            );
+            const libEntry = resolveLibraryModelEntry(provider, model, baseUrl);
             setModelConfig(
               provider,
               model,
@@ -511,9 +539,7 @@ export function registerIpcHandlers(context: IpcContext): void {
       // clears any stale value left by a previously-active model — critical for
       // `api_mode`, since a leftover `anthropic_messages`/`chat_completions`
       // would otherwise route the new endpoint over the wrong protocol.
-      const libEntry = listModels().find(
-        (m) => m.provider === provider && m.model === model,
-      );
+      const libEntry = resolveLibraryModelEntry(provider, model, baseUrl);
       setModelConfig(
         provider,
         model,

--- a/src/main/ipc/register.ts
+++ b/src/main/ipc/register.ts
@@ -451,7 +451,20 @@ export function registerIpcHandlers(context: IpcContext): void {
           () => remoteSetModelConfig(conn, provider, model, baseUrl),
           () => {
             const prev = getModelConfig(profile);
-            setModelConfig(provider, model, baseUrl, profile);
+            // Same library-mirroring as the pure-local path below: carry the
+            // activated model's context-window and api_mode into config.yaml
+            // so this local fallback write doesn't leave a stale transport.
+            const libEntry = listModels().find(
+              (m) => m.provider === provider && m.model === model,
+            );
+            setModelConfig(
+              provider,
+              model,
+              baseUrl,
+              profile,
+              libEntry?.contextLength ?? null,
+              libEntry?.apiMode ?? null,
+            );
             if (
               isGatewayRunning(profile) &&
               (prev.provider !== provider ||
@@ -491,19 +504,23 @@ export function registerIpcHandlers(context: IpcContext): void {
         );
       }
       const prev = getModelConfig(profile);
-      // Mirror the activated model's context-window override (if any) into
-      // config.yaml so the gauge and the agent's auto-compaction threshold use
-      // it. Passing `null` when the library entry has none clears any stale
-      // value left by a previously-active model.
-      const libContextLength = listModels().find(
+      // Mirror the activated model's context-window override and API-protocol
+      // mode (if any) into config.yaml so the gauge, the agent's
+      // auto-compaction threshold, and the runtime transport all match the
+      // model being activated. Passing `null` when the library entry has none
+      // clears any stale value left by a previously-active model — critical for
+      // `api_mode`, since a leftover `anthropic_messages`/`chat_completions`
+      // would otherwise route the new endpoint over the wrong protocol.
+      const libEntry = listModels().find(
         (m) => m.provider === provider && m.model === model,
-      )?.contextLength;
+      );
       setModelConfig(
         provider,
         model,
         baseUrl,
         profile,
-        libContextLength ?? null,
+        libEntry?.contextLength ?? null,
+        libEntry?.apiMode ?? null,
       );
 
       // Restart gateway when provider, model, or endpoint changes so it picks up new config

--- a/tests/config-model-block.test.ts
+++ b/tests/config-model-block.test.ts
@@ -402,3 +402,92 @@ describe("setModelConfig — context_length override", () => {
     expect(getModelContextLengthOverride()).toBeNull();
   });
 });
+
+// Regression for the cross-provider switch bug: switching between an
+// Anthropic-compatible and an OpenAI-compatible custom endpoint left a stale
+// `model.api_mode` behind, so the new endpoint was hit over the wrong protocol
+// (e.g. /v1/messages against a chat/completions server → 404 / lost
+// connection). setModelConfig must rewrite or clear api_mode on every switch.
+describe("setModelConfig — api_mode override", () => {
+  it("writes model.api_mode when a non-empty mode is passed", async () => {
+    writeFileSync(
+      join(TEST_DIR, "config.yaml"),
+      [
+        "model:",
+        '  default: "claude-sonnet-4"',
+        '  provider: "custom"',
+        '  base_url: "https://example.com/anthropic"',
+        "",
+      ].join("\n"),
+    );
+
+    const { setModelConfig } = await importConfigWithHome(TEST_DIR);
+    setModelConfig(
+      "custom",
+      "claude-sonnet-4",
+      "https://example.com/anthropic",
+      undefined,
+      undefined,
+      "anthropic_messages",
+    );
+
+    const after = readFileSync(join(TEST_DIR, "config.yaml"), "utf-8");
+    expect(after).toContain('api_mode: "anthropic_messages"');
+  });
+
+  it("leaves an existing api_mode untouched when passed undefined", async () => {
+    writeFileSync(
+      join(TEST_DIR, "config.yaml"),
+      [
+        "model:",
+        '  default: "claude-sonnet-4"',
+        '  provider: "custom"',
+        '  api_mode: "anthropic_messages"',
+        "",
+      ].join("\n"),
+    );
+
+    const { setModelConfig } = await importConfigWithHome(TEST_DIR);
+    // No 6th arg — a plain provider/model write must not disturb api_mode.
+    setModelConfig("custom", "claude-sonnet-4", "");
+
+    const after = readFileSync(join(TEST_DIR, "config.yaml"), "utf-8");
+    expect(after).toContain('api_mode: "anthropic_messages"');
+  });
+
+  it("clears a stale api_mode when null is passed (the switch-provider fix)", async () => {
+    // Start on an Anthropic-compatible endpoint with an explicit mode...
+    writeFileSync(
+      join(TEST_DIR, "config.yaml"),
+      [
+        "model:",
+        '  default: "claude-sonnet-4"',
+        '  provider: "custom"',
+        '  base_url: "https://example.com/anthropic"',
+        '  api_mode: "anthropic_messages"',
+        "",
+      ].join("\n"),
+    );
+
+    const { setModelConfig } = await importConfigWithHome(TEST_DIR);
+    // ...then switch to an OpenAI-compatible endpoint that has no explicit
+    // mode (apiMode = null). The stale anthropic_messages must be removed so
+    // the agent re-detects chat_completions from the new base_url.
+    setModelConfig(
+      "custom",
+      "gpt-4o",
+      "https://api.openai-compatible.example/v1",
+      undefined,
+      undefined,
+      null,
+    );
+
+    const after = readFileSync(join(TEST_DIR, "config.yaml"), "utf-8");
+    expect(after).not.toContain("api_mode");
+    // Sibling keys must survive the line removal.
+    expect(after).toContain('default: "gpt-4o"');
+    expect(after).toContain(
+      'base_url: "https://api.openai-compatible.example/v1"',
+    );
+  });
+});


### PR DESCRIPTION

## Summary

Switching between an OpenAI-compatible and an Anthropic-compatible custom endpoint silently broke the connection. The desktop's `setModelConfig` rewrote `provider`, `default`, `base_url`, and `api_key` on every switch but **never touched `model.api_mode`** — so the protocol left over from the previous model leaked into the new one.

The bundled agent honors a persisted `model.api_mode` for `custom`/compatible providers (it only auto-detects the transport from the base URL when that key is absent). So after switching from an Anthropic-style endpoint (`api_mode: anthropic_messages`) to an OpenAI-style one, the client kept POSTing to `/v1/messages` against a `chat/completions` server → 404 / dropped connection. Users worked around it by backing up and overwriting `config.yaml` by hand.

This makes `setModelConfig` write or clear `model.api_mode` on activation, exactly like it already does for `model.context_length`.

## Root cause

In the agent (`hermes_cli/runtime_provider.py`), for a `custom` provider `_provider_supports_explicit_api_mode("custom", "custom")` returns `True`, so the runtime resolver uses the persisted `model.api_mode` and skips URL auto-detection:

```python
configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
...
elif configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
    api_mode = configured_mode          # stale value wins
else:
    detected = _detect_api_mode_for_url(base_url)  # never reached
```

Because the desktop never rewrote the key, a stale `anthropic_messages` (or `chat_completions`) survived the switch and routed the new endpoint over the wrong protocol.

> Verified against the agent source at `../hermes-agent` (`main`) — the relevant files (`runtime_provider.py`, `models.py`, `providers.py`) are byte-identical to the installed runtime copy at `~/.hermes/hermes-agent`.

## Changes

- **`src/main/config.ts`** — `setModelConfig` gains an optional `apiMode` argument. Mirrors the `context_length` contract: a non-empty string sets `model.api_mode`; `null`/empty **removes** it (so the agent re-detects the transport from `base_url`); `undefined` leaves it untouched (back-compat for callers that don't manage it).
- **`src/main/ipc/register.ts`** — the `set-model-config` handler resolves the activated model's `apiMode` from its library entry (alongside the existing `contextLength` lookup) and passes it through. An entry with no explicit mode passes `null`, clearing any stale value. Applied to both the pure-local write and the remote-fallback local write.
- **`tests/config-model-block.test.ts`** — 3 regression tests: writes `api_mode` when set, leaves it untouched on a plain write, and clears a stale `api_mode` on a cross-provider switch.
- **`lat.md/provider-setup.md`** — documents the `api_mode` persistence behavior; `lat check` passes.

No IPC/preload signature changes — `apiMode` is resolved in the main process from the model library (the same source of truth as `contextLength`), so no renderer caller changes were needed. Custom-provider library entries already carry `apiMode`, read from each `custom_providers:` block by `loadCustomProviders`.

## Behavior

| Activated model | `model.api_mode` written |
|---|---|
| Custom entry with explicit `api_mode` (e.g. Anthropic-compatible) | set to that value |
| Custom/native entry with no explicit `api_mode` | key removed → agent auto-detects from `base_url` |
| Native provider (anthropic, openai-codex, …) | key removed; agent forces its own transport anyway |

Switching between two protocol-incompatible endpoints always changes `model` (and usually `base_url`), so the gateway already restarts and re-reads the now-correct `api_mode`.

## Testing

- `npx vitest run tests/config-model-block.test.ts tests/config-context-length-yaml.test.ts tests/set-model-config-base-url.test.ts tests/custom-provider-auto-key.test.ts src/renderer/src/screens/Chat/hooks/useModelConfig.test.tsx` → 39 passed
- `npm run typecheck:node` → clean
- `lat check` → all checks passed

## Out of scope / follow-up

- **Surface `opencode-go` / `opencode-zen` as provider cards.** "OpenCode Go" is already a canonical provider in the agent (display name "OpenCode Go", "Open models subscription"), but it isn't in the desktop's provider grid, so it's only reachable by hand-editing config. Adding it as a first-class card (`constants.ts`) is a separate change.
- Remote (SSH/remote-dashboard, non-fallback) writes don't propagate `api_mode` yet — same limitation that already exists for `context_length`.
