### PR TITLE
fix(chat): read gateway usage keys so context gauge shows exact tokens

### DIFF
--- a/src/renderer/src/screens/Chat/Chat.tsx
+++ b/src/renderer/src/screens/Chat/Chat.tsx
@@ -901,10 +901,15 @@ function Chat({
   );
 
   // Context-gauge data: the latest turn's prompt tokens vs the model's window.
+  // Denominator priority: gateway-reported context_max (authoritative — knows
+  // the actual model config) > provider /models catalogue > static heuristic.
   const contextUsage: ContextUsage | null = usage?.contextTokens
     ? {
         used: usage.contextTokens,
-        window: realContextWindow ?? contextWindowForModel(chatCurrentModel),
+        window:
+          usage.contextWindowTokens ??
+          realContextWindow ??
+          contextWindowForModel(chatCurrentModel),
         cacheReadTokens: usage.cacheReadTokens,
         cacheWriteTokens: usage.cacheWriteTokens,
       }

--- a/src/renderer/src/screens/Chat/contextWindows.ts
+++ b/src/renderer/src/screens/Chat/contextWindows.ts
@@ -18,6 +18,9 @@ const CONTEXT_WINDOWS: Array<[RegExp, number]> = [
   [/gpt-4o|gpt-4\.1|gpt-4-turbo|^o[1-4]|gpt-5/i, 128000],
   [/gpt-3\.5/i, 16385],
   // Anthropic
+  // Mythos-class named models (claude-fable-5, …) — 1M context. Must come
+  // before the generic /claude/ rule (first match wins).
+  [/claude-fable/i, 1000000],
   [/claude/i, 200000],
   // Google
   [/gemini-1\.5|gemini-2|gemini-3/i, 1048576],

--- a/src/renderer/src/screens/Chat/hooks/usageFromPayload.test.ts
+++ b/src/renderer/src/screens/Chat/hooks/usageFromPayload.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { usageFromPayload } from "./useDashboardChatTransport";
+
+describe("usageFromPayload", () => {
+  it("reads the Hermes gateway snake-case keys (input/prompt/context_used)", () => {
+    // Shape emitted by tui_gateway/server.py `_get_usage` on message.complete.
+    const result = usageFromPayload({
+      usage: {
+        model: "claude-opus-4-8",
+        input: 12000,
+        output: 800,
+        prompt: 12000,
+        completion: 800,
+        total: 12800,
+        context_used: 45000,
+        context_max: 200000,
+        context_percent: 23,
+      },
+    });
+    expect(result).not.toBeNull();
+    expect(result?.promptTokens).toBe(12000);
+    expect(result?.completionTokens).toBe(800);
+    expect(result?.totalTokens).toBe(12800);
+    // Gauge must use the live context occupancy, not the cross-turn prompt sum.
+    expect(result?.contextTokens).toBe(45000);
+  });
+
+  it("falls back to prompt tokens for context when compressor is inactive", () => {
+    const result = usageFromPayload({
+      usage: { input: 5000, output: 200, total: 5200 },
+    });
+    expect(result?.contextTokens).toBe(5000);
+  });
+
+  it("still reads legacy OpenAI-style *_tokens keys", () => {
+    const result = usageFromPayload({
+      usage: {
+        prompt_tokens: 3000,
+        completion_tokens: 150,
+        total_tokens: 3150,
+      },
+    });
+    expect(result?.promptTokens).toBe(3000);
+    expect(result?.completionTokens).toBe(150);
+    expect(result?.totalTokens).toBe(3150);
+    expect(result?.contextTokens).toBe(3000);
+  });
+
+  it("reads camelCase keys", () => {
+    const result = usageFromPayload({
+      usage: { promptTokens: 700, completionTokens: 50, totalTokens: 750 },
+    });
+    expect(result?.promptTokens).toBe(700);
+    expect(result?.contextTokens).toBe(700);
+  });
+
+  it("derives totalTokens from prompt + completion when absent", () => {
+    const result = usageFromPayload({ usage: { input: 100, output: 40 } });
+    expect(result?.totalTokens).toBe(140);
+  });
+
+  it("returns a gauge value when only context_used is present", () => {
+    const result = usageFromPayload({ usage: { context_used: 9000 } });
+    expect(result).not.toBeNull();
+    expect(result?.contextTokens).toBe(9000);
+  });
+
+  it("returns null when there is no usable usage data", () => {
+    expect(usageFromPayload({ usage: {} })).toBeNull();
+    expect(usageFromPayload({})).toBeNull();
+    expect(usageFromPayload(null)).toBeNull();
+    expect(
+      usageFromPayload({
+        usage: { input: 0, output: 0, total: 0, context_used: 0 },
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/renderer/src/screens/Chat/hooks/usageFromPayload.test.ts
+++ b/src/renderer/src/screens/Chat/hooks/usageFromPayload.test.ts
@@ -24,6 +24,15 @@ describe("usageFromPayload", () => {
     expect(result?.totalTokens).toBe(12800);
     // Gauge must use the live context occupancy, not the cross-turn prompt sum.
     expect(result?.contextTokens).toBe(45000);
+    // Denominator comes from the gateway's authoritative context_max.
+    expect(result?.contextWindowTokens).toBe(200000);
+  });
+
+  it("omits contextWindowTokens when the gateway doesn't report context_max", () => {
+    const result = usageFromPayload({
+      usage: { input: 5000, output: 200, total: 5200 },
+    });
+    expect(result?.contextWindowTokens).toBeUndefined();
   });
 
   it("falls back to prompt tokens for context when compressor is inactive", () => {

--- a/src/renderer/src/screens/Chat/hooks/useDashboardChatTransport.ts
+++ b/src/renderer/src/screens/Chat/hooks/useDashboardChatTransport.ts
@@ -616,21 +616,48 @@ function logDashboardEvent(
   console.info("[Hermes dashboard event]", summary);
 }
 
-function usageFromPayload(payload: unknown): Partial<UsageState> | null {
+export function usageFromPayload(payload: unknown): Partial<UsageState> | null {
   const usage = asRecord(asRecord(payload).usage);
-  const promptTokens = Number(usage.prompt_tokens ?? usage.promptTokens ?? 0);
+  // The Hermes gateway (`_get_usage` in tui_gateway/server.py) emits
+  // snake-case, non-`_tokens` keys: input/output/prompt/completion/total plus
+  // context_used/context_max/context_percent when the context compressor is
+  // active. Older OpenAI-style payloads use prompt_tokens/promptTokens. Read
+  // every spelling so the context gauge works regardless of which backend/
+  // provider produced the usage record — no chars/4 estimate needed because
+  // the gateway already reports exact counts.
+  const promptTokens = Number(
+    usage.input ??
+      usage.prompt ??
+      usage.prompt_tokens ??
+      usage.promptTokens ??
+      0,
+  );
   const completionTokens = Number(
-    usage.completion_tokens ?? usage.completionTokens ?? 0,
+    usage.output ??
+      usage.completion ??
+      usage.completion_tokens ??
+      usage.completionTokens ??
+      0,
   );
   const totalTokens = Number(
-    usage.total_tokens ?? usage.totalTokens ?? promptTokens + completionTokens,
+    usage.total ??
+      usage.total_tokens ??
+      usage.totalTokens ??
+      promptTokens + completionTokens,
   );
-  if (!promptTokens && !completionTokens && !totalTokens) return null;
+  // context_used = the current turn's prompt-token occupancy of the context
+  // window (compressor's last_prompt_tokens), which is exactly what the gauge
+  // wants — a live snapshot, not a cross-turn sum. Fall back to the latest
+  // prompt count when the compressor hasn't reported yet.
+  const contextUsed = Number(usage.context_used ?? 0);
+  if (!promptTokens && !completionTokens && !totalTokens && !contextUsed) {
+    return null;
+  }
   return {
     promptTokens,
     completionTokens,
     totalTokens,
-    contextTokens: promptTokens || undefined,
+    contextTokens: contextUsed || promptTokens || undefined,
   };
 }
 

--- a/src/renderer/src/screens/Chat/hooks/useDashboardChatTransport.ts
+++ b/src/renderer/src/screens/Chat/hooks/useDashboardChatTransport.ts
@@ -650,6 +650,7 @@ export function usageFromPayload(payload: unknown): Partial<UsageState> | null {
   // wants — a live snapshot, not a cross-turn sum. Fall back to the latest
   // prompt count when the compressor hasn't reported yet.
   const contextUsed = Number(usage.context_used ?? 0);
+  const contextMax = Number(usage.context_max ?? 0);
   if (!promptTokens && !completionTokens && !totalTokens && !contextUsed) {
     return null;
   }
@@ -658,6 +659,7 @@ export function usageFromPayload(payload: unknown): Partial<UsageState> | null {
     completionTokens,
     totalTokens,
     contextTokens: contextUsed || promptTokens || undefined,
+    contextWindowTokens: contextMax || undefined,
   };
 }
 
@@ -999,6 +1001,8 @@ export function useDashboardChatTransport({
             totalTokens: (prev?.totalTokens || 0) + (usage.totalTokens || 0),
             cost: prev?.cost,
             contextTokens: usage.contextTokens || prev?.contextTokens,
+            contextWindowTokens:
+              usage.contextWindowTokens || prev?.contextWindowTokens,
             cacheReadTokens: prev?.cacheReadTokens,
             cacheWriteTokens: prev?.cacheWriteTokens,
           }));

--- a/src/renderer/src/screens/Chat/types.ts
+++ b/src/renderer/src/screens/Chat/types.ts
@@ -113,6 +113,10 @@ export interface UsageState {
   /** Latest turn's prompt tokens = current context-window occupancy (NOT
    *  summed across turns, unlike promptTokens). Drives the context gauge. */
   contextTokens?: number;
+  /** Model's total context window as reported by the backend gateway
+   *  (`context_max` from the compressor) — the authoritative denominator for
+   *  the gauge. Falls back to the static heuristic table when absent. */
+  contextWindowTokens?: number;
   /** Latest turn's prompt-cache read/write tokens, if the provider reports them. */
   cacheReadTokens?: number;
   cacheWriteTokens?: number;


### PR DESCRIPTION
## What does this PR do?

The context gauge at the bottom-right of the chat never appears for **local /
dashboard-transport sessions running against the built-in Hermes gateway**,
regardless of provider.

### Root cause

`useDashboardChatTransport`'s `usageFromPayload` only read
`usage.prompt_tokens` / `usage.promptTokens`. But the Hermes gateway
(`_get_usage` in `tui_gateway/server.py`) emits usage on `message.complete`
with **snake-case, non-`_tokens`** keys:

```
model, input, output, reasoning, prompt, completion, total, calls
# + context_used, context_max, context_percent  (when the context compressor is active)
```

So `prompt_tokens`/`promptTokens` are both absent → `promptTokens = 0` →
`contextTokens = undefined` → `ChatInput`'s `contextUsage.used > 0` guard is
never satisfied → the gauge silently does not render.

(The legacy IPC path in `useChatIPC` works because the Electron main process
already normalizes `u.input ?? u.prompt ?? u.prompt_tokens` before forwarding.
The dashboard transport parses `event.payload.usage` directly and skipped that
normalization.)

### Fix

Read every spelling in `usageFromPayload` — gateway snake-case
(`input`/`output`/`prompt`/`completion`/`total`), legacy OpenAI `*_tokens`, and
camelCase — and prefer `context_used` for the gauge value.

`context_used` is the compressor's live context-window occupancy
(`last_prompt_tokens`): a **snapshot of the current turn**, which is exactly
what the gauge documents it wants (see the `contextTokens` doc comment in
`types.ts` — "current context-window occupancy, NOT summed across turns").

### Relationship to #789

This is an alternative to #789. #789 falls back to a `chars / 4` **estimate**
when tokens are missing. This PR instead reads the **exact** counts the gateway
already reports, so no estimation is needed for the common case (built-in
gateway, any provider). The two are complementary — an estimate could still be
layered on for truly usage-less third-party providers — but the gauge-blank
symptom that #789 targets is, for the built-in gateway, a key-mismatch bug that
this PR fixes at the source.

## How to Test

1. Run a local session against the built-in gateway with any provider
   (e.g. `anthropic` / `claude-opus-4-8`).
2. Send a message — the context gauge now appears bottom-right and tracks the
   real context-window occupancy reported by the gateway.
3. Legacy OpenAI-style providers that return `prompt_tokens` continue to work
   unchanged.

`npm test` (adds `usageFromPayload.test.ts`, 7 cases covering all key
spellings + the no-usable-data → null path), `npm run typecheck`, and
`npm run lint` all pass.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
