### PR TITLE
Fix duplicate slash alias crash

### DIFF
--- a/src/renderer/src/screens/Chat/slash/commandCatalog.test.ts
+++ b/src/renderer/src/screens/Chat/slash/commandCatalog.test.ts
@@ -53,4 +53,22 @@ describe("slash command catalog", () => {
       }),
     ).toThrow("Duplicate slash command: /inspect");
   });
+
+  it("ignores alias entries that duplicate an already-registered command", () => {
+    const upstream = agentCommandsFromCatalog({
+      pairs: [
+        ["/compact", "Compact and summarize the conversation"],
+        ["/compress", "Compress conversation with optional focus topic"],
+      ],
+      canon: { compact: "compress" },
+    });
+
+    const catalog = createSlashCatalog({
+      agentCommands: upstream.commands,
+      aliases: upstream.aliases,
+    });
+
+    expect(catalog.resolve("/compact")?.name).toBe("compact");
+    expect(catalog.resolve("/compress")?.name).toBe("compress");
+  });
 });

--- a/src/renderer/src/screens/Chat/slash/commandCatalog.ts
+++ b/src/renderer/src/screens/Chat/slash/commandCatalog.ts
@@ -43,7 +43,7 @@ function registerAlias(
     );
   }
   if (byName.has(aliasKey) || aliases.has(aliasKey)) {
-    throw new Error(`Duplicate slash command alias: /${aliasKey}`);
+    return;
   }
   aliases.set(aliasKey, targetKey);
 }


### PR DESCRIPTION
Fix duplicate slash alias crash when agent catalog includes `/compact`

## Summary

The renderer crashed when the backend command catalog exposed `/compact` both as:

- a standalone command in `pairs`
- an alias mapping `compact -> compress` in `canon`

`createSlashCatalog()` registered the command first, then `registerAlias()` threw `Duplicate slash command alias: /compact`, which broke the Chat screen on connection.

## Fix

Ignore duplicate alias registrations when the canonical command is already present instead of throwing.

## Validation

- Added a regression test for `pairs: /compact, /compress` plus `canon: compact -> compress`
- Ran:

```bash
npm test -- src/renderer/src/screens/Chat/slash/commandCatalog.test.ts
```

Result: `1 passed`, `4 passed`
