### PR TITLE
fix(chat): drop canon alias that duplicates a pairs command

### DIFF
--- a/lat.md/chat-commands.md
+++ b/lat.md/chat-commands.md
@@ -69,6 +69,8 @@ The router's attachment guard rejects a command run with staged attachments unle
 
 The command palette and executor share a catalog built by [[src/renderer/src/screens/Chat/slash/commandCatalog.ts#createSlashCatalog]]. Hermes Agent metadata comes from `commands.catalog`; Desktop commands are merged after collision validation, and upstream names/aliases are normalized from `/name` to the router's canonical `name`.
 
+[[src/renderer/src/screens/Chat/slash/commandCatalog.ts#agentCommandsFromCatalog]] reconciles the gateway's two-part catalog — the flat `pairs` command list and the `canon` alias map — into a self-consistent shape before it reaches `createSlashCatalog`. Because `createSlashCatalog` deliberately throws on a name registered twice (to catch genuine desktop-authoring conflicts), the reconciler drops any `canon` alias whose name is already a first-class `pairs` command: the backend can legitimately expose the same name as both (e.g. `/compact` is a standalone TUI command _and_ an alias of `/compress`), and without this guard the merge would throw and crash the app on agent connect.
+
 ### Desktop commands
 
 Desktop commands in [[src/renderer/src/screens/Chat/slash/desktopCommands.ts#DESKTOP_SLASH_COMMANDS]] handle local Electron/renderer UI operations such as opening settings, triggering the active chat's model picker, and switching navigation views without sending prompts.

--- a/src/renderer/src/screens/Chat/slash/commandCatalog.test.ts
+++ b/src/renderer/src/screens/Chat/slash/commandCatalog.test.ts
@@ -53,4 +53,37 @@ describe("slash command catalog", () => {
       }),
     ).toThrow("Duplicate slash command: /inspect");
   });
+
+  it("drops a canon alias whose name is already a standalone command", () => {
+    // Regression for #802 / #804: the backend can expose the same name both as
+    // a first-class command (via `pairs`) and as an alias of another command
+    // (via `canon`) — e.g. `/compact` is a standalone TUI command *and* an
+    // alias of `/compress`. The reconciled catalog must not list the name in
+    // both `commands` and `aliases`, or createSlashCatalog throws and the app
+    // crashes on agent connect.
+    const discovered = agentCommandsFromCatalog({
+      pairs: [
+        ["/compress", "Compress conversation context"],
+        ["/compact", "Toggle compact display mode"],
+      ],
+      canon: { "/compact": "/compress" },
+    });
+
+    expect(discovered.aliases).not.toHaveProperty("compact");
+    expect(discovered.commands.map((c) => c.name)).toContain("compact");
+
+    expect(() =>
+      createSlashCatalog({
+        agentCommands: discovered.commands,
+        aliases: discovered.aliases,
+      }),
+    ).not.toThrow();
+
+    const catalog = createSlashCatalog({
+      agentCommands: discovered.commands,
+      aliases: discovered.aliases,
+    });
+    // The standalone command wins deterministically.
+    expect(catalog.resolve("/compact")?.name).toBe("compact");
+  });
 });

--- a/src/renderer/src/screens/Chat/slash/commandCatalog.ts
+++ b/src/renderer/src/screens/Chat/slash/commandCatalog.ts
@@ -121,6 +121,12 @@ export function agentCommandsFromCatalog(
     const alias = normalizeName(rawAlias);
     const target = normalizeName(rawTarget);
     if (!alias || !target || alias === target || !seen.has(target)) continue;
+    // A name that is already a first-class command (from `pairs`) can't also be
+    // an alias — the backend can expose both (e.g. `/compact` as a standalone
+    // TUI command and as an alias of `/compress`). Dropping the redundant alias
+    // keeps the reconciled catalog self-consistent so createSlashCatalog does
+    // not throw on the collision and crash the app. See #802 / #804.
+    if (seen.has(alias)) continue;
     aliases[alias] = target;
   }
 


### PR DESCRIPTION
## Summary

Fixes a crash on agent connect: `Duplicate slash command alias: /compact`.

The desktop reconciles the gateway's two-part command catalog — the flat `pairs` command list and the `canon` alias map — in `agentCommandsFromCatalog()`. When building the alias map it validated the alias's **target** (`seen.has(target)`) but never checked whether the **alias name itself** was already a first-class command from `pairs`.

The backend can legitimately expose the same name as both:

- `/compact` ships as a standalone TUI command in `_TUI_EXTRA` → lands in `pairs`.
- Since hermes-agent [PR #57029](https://github.com/NousResearch/hermes-agent/pull/57029), `/compact` is also an alias of `/compress` → populates `canon["/compact"] = "/compress"`.

So the reconciled catalog listed `/compact` in **both** `commands` and `aliases`. `createSlashCatalog()` then registered it as a command and again as an alias, and `registerAlias()` threw `Duplicate slash command alias: /compact`, crashing the app during the initial "getting started" flow.

## Fix

Skip any `canon` alias whose normalized name is already a `pairs`-derived command, so the reconciled catalog is self-consistent:

```ts
if (seen.has(alias)) continue;
```

The standalone command wins deterministically. I deliberately fixed this at the reconciliation source rather than loosening `createSlashCatalog`'s throw-on-collision check — that throw is intentional validation for genuine desktop-authoring conflicts and is covered by existing tests, so it stays intact.

## Verification

- Added a regression test (`drops a canon alias whose name is already a standalone command`) that reproduces the exact `/compact` scenario. It **fails without this change** and passes with it.
- `npm test` — full suite green except 3 pre-existing failures in `ConfigHealthBanner.test.tsx` (`localStorage.clear is not a function`, a jsdom mock issue on `main`), unrelated to this change.
- `npm run lint` — 0 errors; the touched files are prettier- and eslint-clean.
- `npm run typecheck` — passes.

**Honesty note:** I verified this via the unit test that reproduces the crash path. I did not run the packaged Electron app against a live hermes-agent v0.18 backend (no paired backend in my environment), so end-to-end confirmation on-device would be welcome.

Fixes #802
Fixes #804
