### PR TITLE
fix(chat): parse multi-line slash command arguments

### DIFF
--- a/lat.md/chat-commands.md
+++ b/lat.md/chat-commands.md
@@ -8,6 +8,8 @@ The desktop talks to the hermes-agent gateway over JSON-RPC. A normal message go
 
 The pure routing logic lives in [[src/renderer/src/screens/Chat/slashExec.ts#executeSlash]]: try `slash.exec`, accept either rendered output or a structured dispatch result, and on rejection fall back to `command.dispatch`, returning `done`, `send`, or `error`.
 
+The name/argument split is done by [[src/renderer/src/screens/Chat/slashExec.ts#parseSlash]], which matches with the dotAll flag so a command's argument may span multiple lines (e.g. a multi-line `/remember` note) — an empty name is what `executeSlash` rejects as an empty command, so a multi-line body must not collapse the match.
+
 It mirrors hermes-agent's reference client (`web/src/lib/slashExec.ts`) so every front-end implements the same contract. Pending-input commands such as `/learn` can return `{type: "send"}` directly from `slash.exec`; that prompt still passes through the central model-submission path.
 
 ## Local vs gateway commands

--- a/src/renderer/src/screens/Chat/slashExec.test.ts
+++ b/src/renderer/src/screens/Chat/slashExec.test.ts
@@ -10,6 +10,16 @@ describe("parseSlash", () => {
     expect(parseSlash("/compact")).toEqual({ name: "compact", arg: "" });
     expect(parseSlash("/")).toEqual({ name: "", arg: "" });
   });
+
+  it("captures a multi-line argument instead of rejecting it", () => {
+    // Regression: without the dotAll flag the regex fails to match once the
+    // argument spans lines, so a valid command with a multi-line body parsed
+    // to an empty name and executeSlash reported "empty slash command".
+    expect(parseSlash("/remember line1\nline2")).toEqual({
+      name: "remember",
+      arg: "line1\nline2",
+    });
+  });
 });
 
 describe("executeSlash", () => {

--- a/src/renderer/src/screens/Chat/slashExec.ts
+++ b/src/renderer/src/screens/Chat/slashExec.ts
@@ -176,7 +176,12 @@ function handleCommandDispatch(
 
 /** Split "/name rest of args" into its name and trimmed argument string. */
 export function parseSlash(command: string): { name: string; arg: string } {
-  const m = command.replace(/^\/+/, "").match(/^(\S+)\s*(.*)$/);
+  // `s` (dotAll) flag so a multi-line argument is captured: without it `.`
+  // stops at the first newline and the whole match fails, so a valid command
+  // with a multi-line body (e.g. `/remember` a multi-line note) would parse to
+  // an empty name and be rejected as "empty slash command". Mirrors the sibling
+  // parser in slash/parseSlashCommand.ts, which already uses the flag.
+  const m = command.replace(/^\/+/, "").match(/^(\S+)\s*(.*)$/s);
   return m ? { name: m[1], arg: m[2].trim() } : { name: "", arg: "" };
 }
 


### PR DESCRIPTION
## Summary

Fixes #809 — a slash command whose argument spans multiple lines is rejected as `empty slash command` and never runs.

`parseSlash` split the input with `/^(\S+)\s*(.*)$/`. Without the `s` (dotAll) flag, `.` doesn't cross a newline and `$` (no multiline flag) only anchors the end of the string, so the **whole match fails** once the argument contains a newline. It then returned `{ name: "", arg: "" }`, and `executeSlash` rejected the empty name:

```ts
const { name, arg } = parseSlash(command);
if (!name) {
  return { kind: "error", message: "empty slash command" };
}
```

So a valid command with a multi-line body (e.g. a multi-line `/remember` note) could never run. The command reaches this path because the only gate before it is `text.startsWith("/")`, which a multi-line command satisfies.

## Fix

Add the `s` flag so the argument capture crosses newlines:

```ts
const m = command.replace(/^\/+/, "").match(/^(\S+)\s*(.*)$/s);
```

This mirrors the sibling parser `parseSlashCommand` (`slash/parseSlashCommand.ts`), which already uses `/^(\S+)(?:\s+(.*))?$/s` — strong evidence the two were meant to split identically.

## Verification

- Added a regression test in the existing `describe("parseSlash")` block. It **fails without this change** (`parseSlash("/remember line1\nline2")` → `{ name: "", arg: "" }`) and passes with it.
- `npm test` — full suite green except 3 pre-existing failures in `ConfigHealthBanner.test.tsx` (`localStorage.clear is not a function`, a jsdom mock issue on `main`), unrelated to this change.
- `npm run lint` — 0 errors; touched files are prettier- and eslint-clean.
- `npm run typecheck` — passes.
- Existing single-line behavior is unchanged (covered by the existing `parseSlash` test).

**Honesty note:** verified via the unit test that reproduces the exact parse/reject path. I did not drive it through the packaged Electron app against a live hermes-agent backend (no paired backend in my environment), so on-device confirmation would be welcome.

Fixes #809
