### PR TITLE
fix(config-health): audit API_SERVER_KEY for non-ASCII characters

### DIFF
--- a/src/main/config-health.test.ts
+++ b/src/main/config-health.test.ts
@@ -168,6 +168,16 @@ describe("config-health audit - vault awareness", () => {
       const codes = report.issues.map((i) => i.code);
       expect(codes).not.toContain("MODEL_KEY_MISSING");
     });
+
+    it("flags a non-ASCII character in API_SERVER_KEY, not only *_API_KEY / *_TOKEN", () => {
+      // Regression: the audit regex could never match the literal
+      // API_SERVER_KEY, so a smart-quote pasted into the remote-mode bearer
+      // token went undetected while the upstream rejected auth.
+      mockedReadEnv.mockReturnValue({ API_SERVER_KEY: "secret”" });
+      const report = runConfigHealthCheck("default");
+      const codes = report.issues.map((i) => i.code);
+      expect(codes).toContain("NON_ASCII_CREDENTIAL");
+    });
   });
 
   describe("command provider - vault-only user", () => {

--- a/src/main/config-health.ts
+++ b/src/main/config-health.ts
@@ -389,7 +389,12 @@ function checkNonAsciiCredentials(profile?: string): ConfigHealthIssue[] {
   const env = readEnv(profile);
   const offenders: string[] = [];
   for (const [key, value] of Object.entries(env)) {
-    if (!/^[A-Z][A-Z0-9_]*(_API_KEY|_TOKEN|API_SERVER_KEY)$/.test(key)) {
+    // The `API_SERVER_KEY` alternative could never match: the leading
+    // `[A-Z][A-Z0-9_]*` requires at least one character before it, but the key
+    // *is* that literal with nothing preceding it. Anchor it as a whole-key
+    // alternative so the audit also covers the remote-mode bearer token —
+    // exactly the value a user pastes and where a stray smart-quote lands.
+    if (!/^([A-Z][A-Z0-9_]*(_API_KEY|_TOKEN)|API_SERVER_KEY)$/.test(key)) {
       continue;
     }
     if (!value) continue;


### PR DESCRIPTION
## Summary

Fixes #811 — the non-ASCII credential audit (`checkNonAsciiCredentials`) could never check `API_SERVER_KEY`.

The key filter `/^[A-Z][A-Z0-9_]*(_API_KEY|_TOKEN|API_SERVER_KEY)$/` intends to match `*_API_KEY`, `*_TOKEN`, and the literal `API_SERVER_KEY`. But the leading `[A-Z][A-Z0-9_]*` requires at least one character before the alternative, and `API_SERVER_KEY` *is* that literal with nothing preceding it — so it never matches:

```js
re.test("API_SERVER_KEY") // false (bug)
re.test("OPENAI_API_KEY") // true
```

`API_SERVER_KEY` is the remote-mode bearer token — exactly the value users paste, and where a stray smart-quote (e.g. `”`, U+201D) lands. The audit exists to catch precisely that (the upstream otherwise rejects auth with a confusing error), so this is a real gap.

## Fix

Anchor `API_SERVER_KEY` as a whole-key alternative:

```ts
if (!/^([A-Z][A-Z0-9_]*(_API_KEY|_TOKEN)|API_SERVER_KEY)$/.test(key)) {
  continue;
}
```

Deliberately surgical: this adds **only** the `API_SERVER_KEY` literal. `*_API_KEY` / `*_TOKEN` matching is byte-for-byte unchanged, and unrelated keys (`API_KEY`, `SOME_CACHE_KEY`, …) are not newly audited — so it fixes exactly the reported gap without broadening the audit's scope.

## Verification

- Added a regression test (a smart-quote in `API_SERVER_KEY` now raises `NON_ASCII_CREDENTIAL`). It **fails without this change** and passes with it, using the file's existing `readEnv`-mock harness.
- `npm test` — full suite green except 3 pre-existing failures in `ConfigHealthBanner.test.tsx` (`localStorage.clear is not a function`, a jsdom mock issue on `main`), unrelated to this change.
- `npm run lint` — 0 errors; touched files prettier- and eslint-clean.
- `npm run typecheck` — passes.

**Honesty note:** verified via the unit test exercising `runConfigHealthCheck` with a mocked `.env`. I did not reproduce end-to-end by pasting a smart-quote into a real `.env` and observing the banner in the packaged app.

Fixes #811
