### PR TITLE
feat(chat): chrome-style keyboard shortcuts for conversation tabs

### DIFF
--- a/src/renderer/src/screens/Layout/Layout.tsx
+++ b/src/renderer/src/screens/Layout/Layout.tsx
@@ -12,6 +12,8 @@ import {
   openSessionRunTransition,
   selectProfileRunTransition,
   findRunBySession,
+  cycleRunId,
+  runIdAtOrdinal,
   loadingSessionIds as deriveLoadingSessionIds,
 } from "./chatRuns";
 import { ActiveSessionsBar } from "./ActiveSessionsBar";
@@ -538,6 +540,76 @@ function Layout({
     },
     [runs, activeRunId, activeProfile],
   );
+
+  // Chrome/iTerm-style tab shortcuts for the conversation tabs: Ctrl+Tab /
+  // Ctrl+Shift+Tab, Cmd/Ctrl+Shift+[ / ], Cmd/Ctrl+Option+←/→ and
+  // Cmd/Ctrl+Shift+←/→ cycle; Cmd/Ctrl+1..8 jump to the Nth tab and 9 to the
+  // last; Cmd/Ctrl+W closes the active tab. Matches on e.code so the
+  // shortcuts keep working while a CJK IME is active. Cmd+Shift+arrow is
+  // skipped inside editable fields where it means "select to line start/end".
+  useEffect(() => {
+    const isEditable = (t: EventTarget | null): boolean => {
+      if (!(t instanceof HTMLElement)) return false;
+      return (
+        t instanceof HTMLInputElement ||
+        t instanceof HTMLTextAreaElement ||
+        t.isContentEditable
+      );
+    };
+    const handleKey = (e: KeyboardEvent): void => {
+      const primary = e.metaKey || e.ctrlKey;
+      let target: string | null = null;
+      let matched = false;
+      if (primary && !e.shiftKey && !e.altKey && e.code === "KeyW") {
+        // Close the active conversation tab (iTerm/Chrome). handleCloseRun
+        // keeps at least one chat open, so the window itself never closes.
+        e.preventDefault();
+        handleCloseRun(activeRunId);
+        return;
+      }
+      if (e.ctrlKey && !e.metaKey && !e.altKey && e.code === "Tab") {
+        matched = true;
+        target = cycleRunId(runs, activeRunId, e.shiftKey ? -1 : 1);
+      } else if (
+        primary &&
+        e.shiftKey &&
+        !e.altKey &&
+        (e.code === "BracketRight" || e.code === "BracketLeft")
+      ) {
+        matched = true;
+        target = cycleRunId(
+          runs,
+          activeRunId,
+          e.code === "BracketRight" ? 1 : -1,
+        );
+      } else if (
+        primary &&
+        (e.code === "ArrowRight" || e.code === "ArrowLeft") &&
+        // Cmd+Option+arrow (Chrome macOS) or Cmd+Shift+arrow — the latter
+        // only outside editable fields, where it selects text instead.
+        ((e.altKey && !e.shiftKey) ||
+          (e.shiftKey && !e.altKey && !isEditable(e.target)))
+      ) {
+        matched = true;
+        target = cycleRunId(
+          runs,
+          activeRunId,
+          e.code === "ArrowRight" ? 1 : -1,
+        );
+      } else if (primary && !e.shiftKey && !e.altKey) {
+        const digit = /^(?:Digit|Numpad)([1-9])$/.exec(e.code);
+        if (digit) {
+          matched = true;
+          target = runIdAtOrdinal(runs, Number(digit[1]));
+        }
+      }
+      if (!matched) return;
+      e.preventDefault();
+      if (target) handleActivateRun(target);
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [runs, activeRunId, handleActivateRun, handleCloseRun]);
 
   const handleResumeSession = useCallback(
     async (sessionId: string) => {

--- a/src/renderer/src/screens/Layout/chatRuns.test.ts
+++ b/src/renderer/src/screens/Layout/chatRuns.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  cycleRunId,
   isScratchRun,
   mintRun,
   openSessionRunTransition,
+  runIdAtOrdinal,
   selectProfileRunTransition,
   type ChatRun,
 } from "./chatRuns";
@@ -126,5 +128,41 @@ describe("chat run profile transitions", () => {
 
     expect(next.activeRunId).toBe("run-saved");
     expect(next.runs).toEqual([active, saved]);
+  });
+});
+
+describe("chrome-style tab shortcuts", () => {
+  const three = [run("run-1", "a"), run("run-2", "b"), run("run-3", "c")];
+
+  it("cycles forward and backward with wrap-around", () => {
+    expect(cycleRunId(three, "run-1", 1)).toBe("run-2");
+    expect(cycleRunId(three, "run-3", 1)).toBe("run-1");
+    expect(cycleRunId(three, "run-1", -1)).toBe("run-3");
+    expect(cycleRunId(three, "run-2", -1)).toBe("run-1");
+  });
+
+  it("returns null when there is nothing to cycle to", () => {
+    expect(cycleRunId([], "run-x", 1)).toBeNull();
+    expect(cycleRunId([run("run-1", "a")], "run-1", 1)).toBeNull();
+  });
+
+  it("falls back to the first run when the active id is unknown", () => {
+    expect(cycleRunId(three, "run-gone", 1)).toBe("run-1");
+  });
+
+  it("selects the Nth tab by ordinal", () => {
+    expect(runIdAtOrdinal(three, 1)).toBe("run-1");
+    expect(runIdAtOrdinal(three, 3)).toBe("run-3");
+  });
+
+  it("maps 9 to the last tab regardless of count", () => {
+    expect(runIdAtOrdinal(three, 9)).toBe("run-3");
+    expect(runIdAtOrdinal([run("run-only", "a")], 9)).toBe("run-only");
+  });
+
+  it("returns null for ordinals without a tab", () => {
+    expect(runIdAtOrdinal(three, 4)).toBeNull();
+    expect(runIdAtOrdinal([], 1)).toBeNull();
+    expect(runIdAtOrdinal([], 9)).toBeNull();
   });
 });

--- a/src/renderer/src/screens/Layout/chatRuns.ts
+++ b/src/renderer/src/screens/Layout/chatRuns.ts
@@ -106,6 +106,35 @@ export function openSessionRunTransition(
   return { activeRunId: run.runId, runs: [...runs, run] };
 }
 
+/**
+ * Chrome-style tab cycling: the run `delta` steps away from the active one,
+ * wrapping at both ends. Returns null when there is nothing to switch to.
+ */
+export function cycleRunId(
+  runs: ChatRun[],
+  activeRunId: string,
+  delta: 1 | -1,
+): string | null {
+  if (runs.length < 2) return null;
+  const idx = runs.findIndex((r) => r.runId === activeRunId);
+  if (idx === -1) return runs[0].runId;
+  return runs[(idx + delta + runs.length) % runs.length].runId;
+}
+
+/**
+ * Chrome-style ordinal jump: Cmd/Ctrl+1..8 select the Nth tab, 9 selects the
+ * last tab regardless of count. Returns null when the ordinal has no tab.
+ */
+export function runIdAtOrdinal(
+  runs: ChatRun[],
+  ordinal: number,
+): string | null {
+  if (runs.length === 0) return null;
+  if (ordinal === 9) return runs[runs.length - 1].runId;
+  const idx = ordinal - 1;
+  return idx >= 0 && idx < runs.length ? runs[idx].runId : null;
+}
+
 /** The first live run already bound to a given gateway session id, if any. */
 export function findRunBySession(
   runs: ChatRun[],


### PR DESCRIPTION
## What

The active-sessions bar already works like a browser tab strip, but switching or closing a conversation still needs the mouse. This adds the standard Chrome/iTerm tab shortcuts, registered once in `Layout` so they work from any screen:

| Shortcut | Action |
|---|---|
| `Ctrl+Tab` / `Ctrl+Shift+Tab` | next / previous tab (wraps) |
| `Cmd/Ctrl+Shift+]` / `[` | next / previous tab |
| `Cmd/Ctrl+Option+←/→` | next / previous tab (Chrome on macOS) |
| `Cmd/Ctrl+Shift+←/→` | next / previous tab — disabled inside editable fields, where the combo means "extend selection" |
| `Cmd/Ctrl+1..8` | jump to Nth tab |
| `Cmd/Ctrl+9` | jump to last tab (Chrome behavior) |
| `Cmd/Ctrl+W` | close the active tab (iTerm/Chrome) |

## How

- Pure selection logic (`cycleRunId`, `runIdAtOrdinal`) lives in `chatRuns.ts` next to the other run-transition helpers, with unit tests covering wrap-around, unknown active id, ordinal bounds, and the `9 → last` rule.
- The `keydown` listener in `Layout.tsx` matches on `e.code` so shortcuts keep working while a CJK IME is composing (KO/JA/ZH users lose `e.key` to the IME).
- Activation goes through the existing `handleActivateRun`, so the selected profile follows the tab as it does for clicks.
- Close goes through the existing `handleCloseRun`: streaming runs are aborted, and the last tab is replaced with a fresh scratch chat so the chat view is never empty (`Cmd+W` never falls through to closing the window — the macOS menu has no `close` role bound to it).

## Tests

- `npx vitest run src/renderer/src/screens/Layout/chatRuns.test.ts` — 13 passed (6 new)
- `npx tsc --noEmit -p tsconfig.web.json --composite false` — clean
- `npx eslint` on touched files — no new warnings (one pre-existing prettier warning in `chatRuns.ts` untouched)
- Manually exercised in a local packaged build (macOS arm64): cycling, ordinal jumps, `Cmd+W` on streaming/last tabs, and Korean IME active.
