### PR TITLE
fix(discover): use GitHub token auth for tree fetch + extend cache TTL

### DIFF
--- a/src/main/registry.ts
+++ b/src/main/registry.ts
@@ -87,8 +87,12 @@ const EMPTY_CATALOG: RegistryCatalog = {
 };
 
 // Short-lived cache so flipping between Discover sub-tabs doesn't refetch.
+// Covers the raw.githubusercontent fetches (index + models), which are
+// CDN-backed and not subject to the api.github.com rate limit — so this stays
+// short to keep the catalog/model list fresh. The rate-limited git-tree fetch
+// caches separately for far longer (see TREE_CACHE_TTL_MS).
 let cache: { at: number; data: RegistryCatalog } | null = null;
-const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour – was 5 min; reduces GitHub API rate-limit pressure
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 min
 
 function authorName(author: IndexEntry["author"]): string | undefined {
   if (!author) return undefined;
@@ -333,10 +337,14 @@ interface TreeBlob {
   type: string;
 }
 let treeCache: { at: number; blobs: TreeBlob[] } | null = null;
+// The recursive git tree is fetched from api.github.com, which rate-limits
+// anonymous callers at 60 req/h (token auth below raises that ceiling). Cache
+// it far longer than the CDN-backed raw fetches to keep that pressure low.
+const TREE_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
 /** All file paths under a folder, via the cached recursive git tree. */
 async function listFolderFiles(folder: string): Promise<string[]> {
-  if (!treeCache || Date.now() - treeCache.at >= CACHE_TTL_MS) {
+  if (!treeCache || Date.now() - treeCache.at >= TREE_CACHE_TTL_MS) {
     // Use GITHUB_TOKEN / GH_TOKEN when available to avoid anonymous
     // rate limits (60 req/h) on api.github.com.  Authenticated requests
     // get 5 000 req/h instead.

--- a/src/main/registry.ts
+++ b/src/main/registry.ts
@@ -88,7 +88,7 @@ const EMPTY_CATALOG: RegistryCatalog = {
 
 // Short-lived cache so flipping between Discover sub-tabs doesn't refetch.
 let cache: { at: number; data: RegistryCatalog } | null = null;
-const CACHE_TTL_MS = 5 * 60 * 1000;
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour – was 5 min; reduces GitHub API rate-limit pressure
 
 function authorName(author: IndexEntry["author"]): string | undefined {
   if (!author) return undefined;
@@ -337,9 +337,15 @@ let treeCache: { at: number; blobs: TreeBlob[] } | null = null;
 /** All file paths under a folder, via the cached recursive git tree. */
 async function listFolderFiles(folder: string): Promise<string[]> {
   if (!treeCache || Date.now() - treeCache.at >= CACHE_TTL_MS) {
-    const res = await fetch(TREE_URL, {
-      headers: { Accept: "application/vnd.github+json" },
-    });
+    // Use GITHUB_TOKEN / GH_TOKEN when available to avoid anonymous
+    // rate limits (60 req/h) on api.github.com.  Authenticated requests
+    // get 5 000 req/h instead.
+    const ghToken = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || "";
+    const headers: Record<string, string> = {
+      Accept: "application/vnd.github+json",
+    };
+    if (ghToken) headers.Authorization = `Bearer ${ghToken}`;
+    const res = await fetch(TREE_URL, { headers });
     if (!res.ok) throw new Error(`Tree fetch failed (${res.status})`);
     const json = (await res.json()) as { tree?: TreeBlob[] };
     treeCache = { at: Date.now(), blobs: json.tree ?? [] };


### PR DESCRIPTION
## Problem

The Discover page (registry browser) fails intermittently for users behind shared IPs — VPNs, NAT gateways, geographic regions like Vietnam — with errors like "Failed to load registry" and "Tree fetch failed (403)".

**Root cause:** `listFolderFiles()` hits `api.github.com/repos/fathah/hermes-registry/git/trees/main` for EVERY install/download action. Unauthenticated requests to the GitHub API are limited to 60 req/h per IP. On shared IPs this quota is exhausted quickly, causing 403 responses.

## Fix

Two changes in `src/main/registry.ts`:

1. **Extend cache TTL** — `CACHE_TTL_MS` from 5 min → 60 min (12× fewer API calls)
2. **Authenticate GitHub API requests** — read `GITHUB_TOKEN` / `GH_TOKEN` from environment and attach `Authorization: Bearer` header. Authenticated requests get 5 000 req/h instead of 60.

## Testing

- Verified registry browsing works (raw.githubusercontent.com, already CDN-backed)
- Verified install flow now uses authenticated API calls with token from env
- Verified backward-compatible: no token → same anonymous behavior as before
- Tested on Fedora 44 x86_64 with Hermes One Desktop v0.7.3

## Related

Ref: hermes-registry is fetched from https://github.com/fathah/hermes-registry