### PR TITLE
Sync Console

### DIFF
--- a/lat.md/agent-sync.md
+++ b/lat.md/agent-sync.md
@@ -8,6 +8,8 @@ Phase 1 covers the free parts from the backend's `docs/agent-sync.md`: color, pe
 
 [[src/main/agent-sync.ts#syncAgents]] runs one single-flight pass: link local profiles to cloud agents, reconcile each part, create missing counterparts on both sides, and unlink mappings whose cloud agent disappeared.
 
+The stored link (a profile's cloud `agentId`) is also read by [[wallet-token-balances#Wallet Sync]] via [[src/main/agent-sync.ts#getLinkedAgentId]], so backend-provisioned wallets can be fetched for the same agent.
+
 Requests are bearer-authenticated with the device-login token — the account is located app-wide by [[src/main/account-store.ts#findAccountProfile]] (the token is saved under whichever profile was active at sign-in). Linking keys on the cloud agent's stable `id`; names only match never-synced profiles to their cloud namesakes and are never used to rename.
 
 Per part, the pure [[src/main/agent-sync.ts#decidePartAction]] compares the last-sync base hash with both sides' current hashes: only one side moved → that side wins; both moved (or first sync) → last-writer-wins by timestamp (local file mtime vs the agent's `updatedAt`). Equal content is always a no-op.

--- a/lat.md/wallet-token-balances.md
+++ b/lat.md/wallet-token-balances.md
@@ -10,6 +10,16 @@ Profile wallets are stored per-profile in `wallets.json` alongside profile metad
 
 Wallet metadata types live in [[src/shared/wallets.ts]]: `ProfileWallet` (public shape), `WalletMutationResult` (one-time recovery phrase on create/import), and `ImportWalletInput`.
 
+Local **creation/import is being retired** in favour of backend-provisioned wallets (see [[wallet-token-balances#Wallet Sync]]). The store's `createWallet`/`importWallet` and their IPC channels are retained for now, but the wallet pane no longer exposes a create/import UI.
+
+## Wallet Sync
+
+Wallets provisioned by the Hermes One backend for a profile's linked cloud agent are fetched and shown read-only alongside local ones, so the desktop stops minting wallets itself.
+
+[[src/main/wallet-sync.ts#syncWalletsForProfile]] finds the signed-in account ([[src/main/account-store.ts#findAccountProfile]]), resolves the profile's cloud agent id via [[src/main/agent-sync.ts#getLinkedAgentId]] — auto-running [[src/main/agent-sync.ts#syncAgents]] once when the profile has never synced — then GETs `/api/wallets?agentId=…` (bearer + `x-api-key` via [[src/main/hermes-account.ts#apiHeaders]]). Rows are mapped by the pure [[src/main/wallet-sync.ts#mapCloudWallet]] into the shared `WalletView`; rows without an EVM address are dropped. No wallet secret ever reaches the device — these are receive/tracked addresses, matching the backend `docs/agent-sync.md` "Wallets per agent" intent.
+
+The `wallet-sync` IPC channel (registered in [[src/main/ipc/register.ts#registerIpcHandlers]]) exposes it as `syncWallets` on `window.hermesAPI`. [[src/renderer/src/components/profile/ProfileWalletPane.tsx]] renders local (`wallets.json`) and cloud wallets in one list, each tagged with a Local/Cloud badge; delete is offered only for local wallets, copy/balance for both. Signed-out or never-synced profiles show a hint instead of an error.
+
 ## Token Balances
 
 On-chain balance reads for Base mainnet ERC-20 tokens, fetched via ethers v6 `JsonRpcProvider`.
@@ -35,5 +45,6 @@ Balance data is cached at module level (keyed by wallet address) so it survives 
 Vitest test suites for wallet store and balance reads.
 
 - [[src/main/wallet-store.test.ts]] — wallet CRUD, rename/delete, encryption, dedup, caps, and import error distinction (invalid phrase vs. secure-storage failure)
+- [[src/main/wallet-sync.test.ts]] — `mapCloudWallet` mapping (default name, addressless drop) and `syncWalletsForProfile` paths: signed-out, linked-agent fetch, auto-sync-then-fetch when unlinked, and HTTP error
 - [[src/main/wallet-balances.test.ts]] — formatTokenBalance edge cases and big-balance precision, `withTimeout`, getTokenBalances with mocked RPC including timeout handling
 - [[src/renderer/src/components/profile/ProfileWalletPane.test.tsx]] — balance-chip rendering: one symbol label per token, icon only for known tokens

--- a/src/main/agent-sync.ts
+++ b/src/main/agent-sync.ts
@@ -213,6 +213,14 @@ function writeSyncState(profile: string, state: SyncState): void {
   safeWriteFile(statePath(profile), JSON.stringify(state, null, 2));
 }
 
+/**
+ * The cloud agent id a profile is linked to (from its cloud-sync.json), or null
+ * if it has never synced. Used by wallet sync to fetch the agent's wallets.
+ */
+export function getLinkedAgentId(profile: string): string | null {
+  return readSyncState(profile)?.agentId ?? null;
+}
+
 function clearSyncState(profile: string): void {
   try {
     unlinkSync(statePath(profile));

--- a/src/main/ipc/register.ts
+++ b/src/main/ipc/register.ts
@@ -241,6 +241,7 @@ import {
   listWallets,
   renameWallet,
 } from "../wallet-store";
+import { syncWalletsForProfile } from "../wallet-sync";
 import { getTokenBalances } from "../wallet-balances";
 import type { ImportWalletInput } from "../../shared/wallets";
 import {
@@ -1977,6 +1978,11 @@ export function registerIpcHandlers(context: IpcContext): void {
     "delete-wallet",
     (_event, profile: string | undefined, id: string) =>
       deleteWallet(profile, id),
+  );
+  // Cloud wallets provisioned by the backend for the profile's linked agent.
+  // Read-only here; the desktop no longer mints wallets locally.
+  ipcMain.handle("wallet-sync", (_event, profile?: string) =>
+    syncWalletsForProfile(profile),
   );
   ipcMain.handle("get-token-balances", (_event, address: string) =>
     getTokenBalances(address),

--- a/src/main/wallet-sync.test.ts
+++ b/src/main/wallet-sync.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CloudWalletRaw } from "../shared/wallets";
+
+// wallet-sync's deps are faked so the tests drive the fetch/link logic without
+// a real account, keychain, or network (pattern from agent-sync.test.ts).
+
+const mockState = vi.hoisted(() => ({
+  account: null as { apiUrl: string; token: string } | null,
+  linkedAgentId: null as string | null,
+  syncAgentsCalls: 0,
+  // A value the auto-sync "creates" — returned by getLinkedAgentId after sync.
+  linkAfterSync: null as string | null,
+}));
+
+vi.mock("./account-store", () => ({
+  findAccountProfile: () => (mockState.account ? "default" : null),
+  getAccount: () =>
+    mockState.account
+      ? {
+          apiUrl: mockState.account.apiUrl,
+          user: { id: "u1", email: null, name: null, avatarUrl: null },
+        }
+      : null,
+  getAccessToken: () => mockState.account?.token ?? null,
+}));
+
+vi.mock("./hermes-account", () => ({
+  apiHeaders: (json = true) =>
+    json ? { "content-type": "application/json" } : {},
+}));
+
+vi.mock("./agent-sync", () => ({
+  getLinkedAgentId: () => mockState.linkedAgentId,
+  syncAgents: vi.fn(async () => {
+    mockState.syncAgentsCalls++;
+    mockState.linkedAgentId = mockState.linkAfterSync;
+    return { status: "ok", outcomes: [], finishedAt: Date.now() };
+  }),
+}));
+
+function stubFetch(
+  wallets: CloudWalletRaw[],
+  ok = true,
+  status = 200,
+): string[] {
+  const calls: string[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string) => {
+      calls.push(url);
+      return { ok, status, json: async () => ({ wallets }) };
+    }),
+  );
+  return calls;
+}
+
+function rawWallet(overrides: Partial<CloudWalletRaw> = {}): CloudWalletRaw {
+  return {
+    id: "wal-1",
+    kind: "local",
+    label: "Treasury",
+    evmAddress: "0xabc",
+    receiveOnly: true,
+    canTransact: false,
+    createdAt: "2026-07-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+async function engine(): Promise<typeof import("./wallet-sync")> {
+  return import("./wallet-sync");
+}
+
+beforeEach(() => {
+  mockState.account = { apiUrl: "http://localhost:3002", token: "tok" };
+  mockState.linkedAgentId = null;
+  mockState.linkAfterSync = null;
+  mockState.syncAgentsCalls = 0;
+  vi.resetModules();
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("mapCloudWallet", () => {
+  it("maps a backend wallet row to the view model", async () => {
+    const { mapCloudWallet } = await engine();
+    expect(mapCloudWallet(rawWallet())).toEqual({
+      id: "wal-1",
+      name: "Treasury",
+      address: "0xabc",
+      network: "base",
+      source: "cloud",
+      createdAt: Date.parse("2026-07-01T00:00:00.000Z"),
+      kind: "local",
+      receiveOnly: true,
+      canTransact: false,
+    });
+  });
+
+  it("defaults the name when the label is null", async () => {
+    const { mapCloudWallet } = await engine();
+    expect(mapCloudWallet(rawWallet({ label: null }))?.name).toBe("Wallet");
+  });
+
+  it("drops rows without an EVM address", async () => {
+    const { mapCloudWallet } = await engine();
+    expect(mapCloudWallet(rawWallet({ evmAddress: null }))).toBeNull();
+  });
+});
+
+describe("syncWalletsForProfile", () => {
+  it("reports signed-out without hitting the network", async () => {
+    mockState.account = null;
+    const calls = stubFetch([]);
+    const { syncWalletsForProfile } = await engine();
+    const result = await syncWalletsForProfile("default");
+    expect(result.status).toBe("signed-out");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("fetches wallets for an already-linked agent", async () => {
+    mockState.linkedAgentId = "agent-1";
+    const calls = stubFetch([
+      rawWallet(),
+      rawWallet({ id: "wal-2", evmAddress: null }),
+    ]);
+    const { syncWalletsForProfile } = await engine();
+    const result = await syncWalletsForProfile("default");
+    expect(result.status).toBe("ok");
+    // The addressless row is dropped.
+    expect(result.wallets.map((w) => w.id)).toEqual(["wal-1"]);
+    expect(calls[0]).toContain("agentId=agent-1");
+    expect(mockState.syncAgentsCalls).toBe(0);
+  });
+
+  it("auto-syncs first when the profile has no linked agent", async () => {
+    mockState.linkedAgentId = null;
+    mockState.linkAfterSync = "agent-new";
+    const calls = stubFetch([rawWallet()]);
+    const { syncWalletsForProfile } = await engine();
+    const result = await syncWalletsForProfile("default");
+    expect(mockState.syncAgentsCalls).toBe(1);
+    expect(result.status).toBe("ok");
+    expect(calls[0]).toContain("agentId=agent-new");
+  });
+
+  it("stays unlinked when even a sync can't link the profile", async () => {
+    mockState.linkedAgentId = null;
+    mockState.linkAfterSync = null;
+    const calls = stubFetch([]);
+    const { syncWalletsForProfile } = await engine();
+    const result = await syncWalletsForProfile("default");
+    expect(mockState.syncAgentsCalls).toBe(1);
+    expect(result.status).toBe("unlinked");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("surfaces an HTTP error", async () => {
+    mockState.linkedAgentId = "agent-1";
+    stubFetch([], false, 401);
+    const { syncWalletsForProfile } = await engine();
+    const result = await syncWalletsForProfile("default");
+    expect(result.status).toBe("error");
+    expect(result.error).toContain("401");
+  });
+});

--- a/src/main/wallet-sync.ts
+++ b/src/main/wallet-sync.ts
@@ -1,0 +1,90 @@
+// @lat: [[wallet-token-balances#Wallet Sync]]
+import {
+  findAccountProfile,
+  getAccount,
+  getAccessToken,
+} from "./account-store";
+import { apiHeaders } from "./hermes-account";
+import { getLinkedAgentId, syncAgents } from "./agent-sync";
+import { BASE_NETWORK_ID } from "../shared/wallets";
+import type {
+  CloudWalletRaw,
+  WalletSyncResult,
+  WalletView,
+} from "../shared/wallets";
+
+// Fetches the wallets the backend has provisioned for a profile's linked cloud
+// agent (GET /api/wallets?agentId=…), so the desktop can show them read-only
+// instead of minting wallets locally. Wallets are attached to a cloud agent —
+// the same link agent-sync stores in cloud-sync.json — so a profile must be
+// synced first (we auto-sync when it isn't). No wallet secret ever reaches the
+// device; these are receive/tracked addresses.
+
+/**
+ * Map a backend wallet row to the pane's view model, or null when it has no
+ * EVM address to show (kept pure for unit tests, mirroring agent-sync.ts).
+ */
+export function mapCloudWallet(raw: CloudWalletRaw): WalletView | null {
+  if (!raw.evmAddress) return null;
+  return {
+    id: raw.id,
+    name: raw.label || "Wallet",
+    address: raw.evmAddress,
+    network: BASE_NETWORK_ID,
+    source: "cloud",
+    createdAt: Date.parse(raw.createdAt) || 0,
+    kind: raw.kind,
+    receiveOnly: raw.receiveOnly,
+    canTransact: raw.canTransact,
+  };
+}
+
+/**
+ * Cloud wallets for `profile`'s linked agent. Signed out → no wallets; a
+ * profile that has never synced triggers one agent sync first (so it gets an
+ * agent id), then the fetch. Errors (network/401) surface as `status: "error"`.
+ */
+export async function syncWalletsForProfile(
+  profile?: string,
+): Promise<WalletSyncResult> {
+  const name = profile || "default";
+  const accountProfile = findAccountProfile();
+  const account = accountProfile ? getAccount(accountProfile) : null;
+  const token = accountProfile ? getAccessToken(accountProfile) : null;
+  if (!account || !token) return { status: "signed-out", wallets: [] };
+
+  let agentId = getLinkedAgentId(name);
+  if (!agentId) {
+    // Never synced: create/link the cloud agent, then read its id.
+    await syncAgents();
+    agentId = getLinkedAgentId(name);
+  }
+  if (!agentId) return { status: "unlinked", wallets: [] };
+
+  try {
+    const res = await fetch(
+      `${account.apiUrl}/api/wallets?agentId=${encodeURIComponent(agentId)}`,
+      { headers: { ...apiHeaders(false), authorization: `Bearer ${token}` } },
+    );
+    if (!res.ok) {
+      return {
+        status: "error",
+        wallets: [],
+        error: `Cloud wallets unavailable (HTTP ${res.status}).`,
+      };
+    }
+    const data = (await res.json().catch(() => ({}))) as {
+      wallets?: CloudWalletRaw[];
+    };
+    const wallets = (data.wallets ?? [])
+      .map(mapCloudWallet)
+      .filter((w): w is WalletView => w !== null);
+    return { status: "ok", wallets };
+  } catch (err) {
+    return {
+      status: "error",
+      wallets: [],
+      error: `Couldn't reach ${account.apiUrl}: ${(err as Error).message}`,
+    };
+  }
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -7,6 +7,7 @@ import type {
   ImportWalletInput,
   ProfileWallet,
   WalletMutationResult,
+  WalletSyncResult,
 } from "../shared/wallets";
 import type { TokenBalancesResponse } from "../shared/tokens";
 import type {
@@ -650,6 +651,7 @@ interface HermesAPI {
     name: string,
   ) => Promise<{ success: boolean; error?: string }>;
   listWallets: (profile?: string) => Promise<ProfileWallet[]>;
+  syncWallets: (profile?: string) => Promise<WalletSyncResult>;
   createWallet: (
     profile?: string,
     name?: string,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -8,6 +8,7 @@ import type {
   ImportWalletInput,
   ProfileWallet,
   WalletMutationResult,
+  WalletSyncResult,
 } from "../shared/wallets";
 import type { TokenBalancesResponse } from "../shared/tokens";
 import type {
@@ -859,6 +860,10 @@ const hermesAPI = {
 
   listWallets: (profile?: string): Promise<ProfileWallet[]> =>
     ipcRenderer.invoke("list-wallets", profile),
+
+  // Cloud wallets from the backend for the profile's linked agent.
+  syncWallets: (profile?: string): Promise<WalletSyncResult> =>
+    ipcRenderer.invoke("wallet-sync", profile),
 
   createWallet: (
     profile?: string,

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -9436,6 +9436,39 @@ body {
   flex: 0 0 auto;
 }
 
+/* Origin badge: cloud (backend-managed) vs local (this device). */
+.profile-wallet-badge {
+  padding: 2px 7px;
+  border-radius: var(--radius-sm);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  flex: 0 0 auto;
+}
+
+.profile-wallet-badge-cloud {
+  background: var(--success-bg);
+  color: var(--success);
+}
+
+.profile-wallet-badge-local {
+  background: var(--bg-tertiary, var(--accent-subtle));
+  color: var(--text-muted);
+}
+
+.profile-wallet-empty-note,
+.profile-wallet-note {
+  color: var(--text-muted);
+  font-size: 12px;
+  text-align: center;
+  max-width: 340px;
+}
+
+.profile-wallet-note {
+  margin-top: 10px;
+}
+
 .profile-wallet-address {
   display: block;
   margin-top: 6px;

--- a/src/renderer/src/components/profile/ProfileWalletPane.test.tsx
+++ b/src/renderer/src/components/profile/ProfileWalletPane.test.tsx
@@ -67,6 +67,10 @@ function installApi(): void {
     configurable: true,
     value: {
       listWallets: vi.fn().mockResolvedValue([WALLET]),
+      // No linked cloud agent in this test — local wallets only.
+      syncWallets: vi
+        .fn()
+        .mockResolvedValue({ status: "unlinked", wallets: [] }),
       getTokenBalances: vi.fn().mockResolvedValue(BALANCES),
       copyToClipboard: vi.fn().mockResolvedValue(undefined),
     },

--- a/src/renderer/src/components/profile/ProfileWalletPane.tsx
+++ b/src/renderer/src/components/profile/ProfileWalletPane.tsx
@@ -56,6 +56,14 @@ export default function ProfileWalletPane({
   /** Ref that tracks wallet ID → address so fetchBalances can update the cache. */
   const walletIdToAddress = useRef<Map<string, string>>(new Map());
 
+  /**
+   * Generation counter for loadWallets. Each call bumps it and captures its
+   * value; after an await, a run whose id no longer matches has been
+   * superseded (profile change, refresh, or post-delete reload) and must not
+   * apply its now-stale results over the newer run's.
+   */
+  const loadRunRef = useRef(0);
+
   /** Hydrate balances from the module-level cache after wallets load. */
   function hydrateFromCache(walletList: WalletView[]): void {
     const map = new Map<string, TokenBalancesResponse>();
@@ -71,7 +79,10 @@ export default function ProfileWalletPane({
 
   async function fetchBalances(walletList: WalletView[]): Promise<void> {
     if (walletList.length === 0) return;
-    setBalancesLoading(new Set(walletList.map((w) => w.id)));
+    // Functional updates only touch this call's ids, so the two concurrent
+    // fetches (local + cloud) can't clobber each other's loading spinners.
+    const ids = new Set(walletList.map((w) => w.id));
+    setBalancesLoading((prev) => new Set([...prev, ...ids]));
     const results = await Promise.allSettled(
       walletList.map(async (w) => {
         const response = await window.hermesAPI.getTokenBalances(w.address);
@@ -89,7 +100,11 @@ export default function ProfileWalletPane({
       }
       return next;
     });
-    setBalancesLoading(new Set());
+    setBalancesLoading((prev) => {
+      const next = new Set(prev);
+      ids.forEach((id) => next.delete(id));
+      return next;
+    });
   }
 
   async function refreshSingleBalance(wallet: WalletView): Promise<void> {
@@ -114,6 +129,8 @@ export default function ProfileWalletPane({
   }
 
   const loadWallets = useCallback(async (): Promise<void> => {
+    const runId = ++loadRunRef.current;
+    const isStale = (): boolean => loadRunRef.current !== runId;
     setLoading(true);
     setError("");
     setCloudNote("");
@@ -123,8 +140,11 @@ export default function ProfileWalletPane({
     try {
       local = (await window.hermesAPI.listWallets(profile)).map(localToView);
     } catch {
-      setError(t("agents.walletLoadFailed"));
+      if (!isStale()) setError(t("agents.walletLoadFailed"));
     }
+    // A newer load (profile switch / refresh) has superseded this one; don't
+    // overwrite its state with this profile's data.
+    if (isStale()) return;
     setWallets(local);
     hydrateFromCache(local);
     void fetchBalances(local);
@@ -133,6 +153,7 @@ export default function ProfileWalletPane({
     setSyncing(true);
     try {
       const result = await window.hermesAPI.syncWallets(profile);
+      if (isStale()) return;
       if (result.status === "signed-out") {
         setCloudNote(t("agents.walletSignInHint"));
       } else if (result.status === "unlinked") {
@@ -147,9 +168,9 @@ export default function ProfileWalletPane({
         void fetchBalances(result.wallets);
       }
     } catch {
-      setCloudNote(t("agents.walletLoadFailed"));
+      if (!isStale()) setCloudNote(t("agents.walletLoadFailed"));
     } finally {
-      setSyncing(false);
+      if (!isStale()) setSyncing(false);
     }
   }, [profile, t]);
 
@@ -166,7 +187,9 @@ export default function ProfileWalletPane({
   }
 
   async function handleDelete(): Promise<void> {
-    if (!deleteTarget) return;
+    // Cloud wallets are backend-managed; only local ones have a deletable
+    // on-disk record (their delete button is the only way to open this modal).
+    if (!deleteTarget || deleteTarget.source !== "local") return;
     setError("");
     const result = await window.hermesAPI.deleteWallet(
       profile,

--- a/src/renderer/src/components/profile/ProfileWalletPane.tsx
+++ b/src/renderer/src/components/profile/ProfileWalletPane.tsx
@@ -1,20 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  Check,
-  Copy,
-  KeyRound,
-  Plus,
-  Refresh,
-  Trash,
-  Wallet,
-  X,
-} from "../../assets/icons";
+import { Check, Copy, Refresh, Trash, Wallet, X } from "../../assets/icons";
 import etheriumIcon from "../../assets/icons/etherium.webp";
 import hdTokenIcon from "../../assets/icons/hdtoken.webp";
-import type {
-  ProfileWallet,
-  WalletMutationResult,
-} from "../../../../shared/wallets";
+import type { ProfileWallet, WalletView } from "../../../../shared/wallets";
 import { BASE_NETWORK_LABEL } from "../../../../shared/wallets";
 import type { TokenBalancesResponse } from "../../../../shared/tokens";
 import { AppModal, AppModalTitle } from "../modal/AppModal";
@@ -37,27 +25,27 @@ interface ProfileWalletPaneProps {
   profile: string;
 }
 
-type WalletMode = "create" | "import";
-
 function formatAddress(address: string): string {
   return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}
+
+/** Present a local wallet as the shared view model. */
+function localToView(wallet: ProfileWallet): WalletView {
+  return { ...wallet, source: "local" };
 }
 
 export default function ProfileWalletPane({
   profile,
 }: ProfileWalletPaneProps): React.JSX.Element {
   const { t } = useI18n();
-  const [wallets, setWallets] = useState<ProfileWallet[]>([]);
+  const [wallets, setWallets] = useState<WalletView[]>([]);
   const [loading, setLoading] = useState(true);
+  const [syncing, setSyncing] = useState(false);
   const [error, setError] = useState("");
-  const [modalOpen, setModalOpen] = useState(false);
-  const [mode, setMode] = useState<WalletMode>("create");
-  const [name, setName] = useState("");
-  const [recoveryPhrase, setRecoveryPhrase] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-  const [created, setCreated] = useState<WalletMutationResult | null>(null);
+  // A non-fatal note about cloud wallets (signed out / not yet synced).
+  const [cloudNote, setCloudNote] = useState("");
   const [copied, setCopied] = useState<string | null>(null);
-  const [deleteTarget, setDeleteTarget] = useState<ProfileWallet | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<WalletView | null>(null);
   const [balances, setBalances] = useState<Map<string, TokenBalancesResponse>>(
     () => new Map(),
   );
@@ -69,7 +57,7 @@ export default function ProfileWalletPane({
   const walletIdToAddress = useRef<Map<string, string>>(new Map());
 
   /** Hydrate balances from the module-level cache after wallets load. */
-  function hydrateFromCache(walletList: ProfileWallet[]): void {
+  function hydrateFromCache(walletList: WalletView[]): void {
     const map = new Map<string, TokenBalancesResponse>();
     const addrMap = new Map<string, string>();
     for (const w of walletList) {
@@ -81,7 +69,8 @@ export default function ProfileWalletPane({
     setBalances(map);
   }
 
-  async function fetchBalances(walletList: ProfileWallet[]): Promise<void> {
+  async function fetchBalances(walletList: WalletView[]): Promise<void> {
+    if (walletList.length === 0) return;
     setBalancesLoading(new Set(walletList.map((w) => w.id)));
     const results = await Promise.allSettled(
       walletList.map(async (w) => {
@@ -89,19 +78,21 @@ export default function ProfileWalletPane({
         return { walletId: w.id, address: w.address, response };
       }),
     );
-    const next = new Map(balances);
-    for (const result of results) {
-      if (result.status === "fulfilled") {
-        const { walletId, address, response } = result.value;
-        next.set(walletId, response);
-        balanceCache.set(address, response);
+    setBalances((prev) => {
+      const next = new Map(prev);
+      for (const result of results) {
+        if (result.status === "fulfilled") {
+          const { walletId, address, response } = result.value;
+          next.set(walletId, response);
+          balanceCache.set(address, response);
+        }
       }
-    }
-    setBalances(next);
+      return next;
+    });
     setBalancesLoading(new Set());
   }
 
-  async function refreshSingleBalance(wallet: ProfileWallet): Promise<void> {
+  async function refreshSingleBalance(wallet: WalletView): Promise<void> {
     setBalancesLoading((prev) => new Set(prev).add(wallet.id));
     try {
       const response = await window.hermesAPI.getTokenBalances(wallet.address);
@@ -125,15 +116,40 @@ export default function ProfileWalletPane({
   const loadWallets = useCallback(async (): Promise<void> => {
     setLoading(true);
     setError("");
+    setCloudNote("");
+    // Local wallets are on disk and show immediately; cloud wallets come from
+    // the backend for the profile's linked agent and stream in after.
+    let local: WalletView[] = [];
     try {
-      const loaded = await window.hermesAPI.listWallets(profile);
-      setWallets(loaded);
-      hydrateFromCache(loaded);
-      fetchBalances(loaded);
+      local = (await window.hermesAPI.listWallets(profile)).map(localToView);
     } catch {
       setError(t("agents.walletLoadFailed"));
+    }
+    setWallets(local);
+    hydrateFromCache(local);
+    void fetchBalances(local);
+    setLoading(false);
+
+    setSyncing(true);
+    try {
+      const result = await window.hermesAPI.syncWallets(profile);
+      if (result.status === "signed-out") {
+        setCloudNote(t("agents.walletSignInHint"));
+      } else if (result.status === "unlinked") {
+        setCloudNote(t("agents.walletSyncedHint"));
+      } else if (result.status === "error") {
+        setCloudNote(result.error || t("agents.walletLoadFailed"));
+      } else if (result.wallets.length > 0) {
+        // Cloud ids are backend uuids; no collision with local ids.
+        const merged = [...local, ...result.wallets];
+        setWallets(merged);
+        hydrateFromCache(merged);
+        void fetchBalances(result.wallets);
+      }
+    } catch {
+      setCloudNote(t("agents.walletLoadFailed"));
     } finally {
-      setLoading(false);
+      setSyncing(false);
     }
   }, [profile, t]);
 
@@ -141,51 +157,12 @@ export default function ProfileWalletPane({
     void loadWallets();
   }, [loadWallets]);
 
-  function resetModal(): void {
-    setMode("create");
-    setName("");
-    setRecoveryPhrase("");
-    setSubmitting(false);
-    setCreated(null);
-    setError("");
-  }
-
-  function openCreateModal(): void {
-    resetModal();
-    setModalOpen(true);
-  }
-
   async function copyText(value: string, key: string): Promise<void> {
     await window.hermesAPI.copyToClipboard(value);
     setCopied(key);
     window.setTimeout(() => {
       setCopied((current) => (current === key ? null : current));
     }, 1600);
-  }
-
-  async function handleSubmit(): Promise<void> {
-    setSubmitting(true);
-    setError("");
-    try {
-      const result =
-        mode === "create"
-          ? await window.hermesAPI.createWallet(profile, name)
-          : await window.hermesAPI.importWallet({
-              profile,
-              name,
-              recoveryPhrase,
-            });
-      if (!result.success) {
-        setError(result.error || t("agents.walletCreateFailed"));
-        return;
-      }
-      setCreated(result);
-      await loadWallets();
-    } catch {
-      setError(t("agents.walletCreateFailed"));
-    } finally {
-      setSubmitting(false);
-    }
   }
 
   async function handleDelete(): Promise<void> {
@@ -215,9 +192,13 @@ export default function ProfileWalletPane({
             {t("agents.walletNetwork", { network: BASE_NETWORK_LABEL })}
           </div>
         </div>
-        <button className="btn btn-primary btn-sm" onClick={openCreateModal}>
-          <Plus size={15} />
-          {t("agents.walletCreate")}
+        <button
+          className="btn btn-secondary btn-sm"
+          onClick={() => void loadWallets()}
+          disabled={syncing}
+        >
+          <Refresh size={14} />
+          {syncing ? t("agents.walletSyncing") : t("agents.walletSync")}
         </button>
       </div>
 
@@ -228,14 +209,10 @@ export default function ProfileWalletPane({
       ) : wallets.length === 0 ? (
         <div className="profile-wallet-empty">
           <Wallet size={36} />
-          <span>{t("agents.walletEmpty")}</span>
-          <button
-            className="btn btn-secondary btn-sm"
-            onClick={openCreateModal}
-          >
-            <Plus size={15} />
-            {t("agents.walletCreate")}
-          </button>
+          <span>{t("agents.walletManagedEmpty")}</span>
+          {cloudNote && (
+            <span className="profile-wallet-empty-note">{cloudNote}</span>
+          )}
         </div>
       ) : (
         <div className="profile-wallet-list">
@@ -248,6 +225,13 @@ export default function ProfileWalletPane({
                 <div className="profile-wallet-meta">
                   <div className="profile-wallet-name-row">
                     <span className="profile-wallet-name">{wallet.name}</span>
+                    <span
+                      className={`profile-wallet-badge profile-wallet-badge-${wallet.source}`}
+                    >
+                      {wallet.source === "cloud"
+                        ? t("agents.walletSourceCloud")
+                        : t("agents.walletSourceLocal")}
+                    </span>
                     <span className="profile-wallet-network">
                       {BASE_NETWORK_LABEL}
                     </span>
@@ -313,149 +297,24 @@ export default function ProfileWalletPane({
                     ? t("agents.walletCopied")
                     : t("agents.walletCopyAddress")}
                 </button>
-                <button
-                  className="btn btn-danger-ghost btn-sm"
-                  onClick={() => setDeleteTarget(wallet)}
-                >
-                  <Trash size={14} />
-                </button>
+                {wallet.source === "local" && (
+                  <button
+                    className="btn btn-danger-ghost btn-sm"
+                    onClick={() => setDeleteTarget(wallet)}
+                  >
+                    <Trash size={14} />
+                  </button>
+                )}
               </div>
             </div>
           ))}
         </div>
       )}
 
+      {wallets.length > 0 && cloudNote && (
+        <div className="profile-wallet-note">{cloudNote}</div>
+      )}
       {error && <div className="agents-create-error">{error}</div>}
-
-      <AppModal
-        open={modalOpen}
-        onOpenChange={(open) => {
-          setModalOpen(open);
-          if (!open) resetModal();
-        }}
-        className="profile-wallet-modal"
-        overlayClassName="profile-wallet-modal-overlay"
-        labelledBy="profile-wallet-modal-title"
-      >
-        <div className="profile-wallet-modal-header">
-          <AppModalTitle
-            id="profile-wallet-modal-title"
-            className="profile-wallet-modal-title"
-          >
-            {created?.success
-              ? t("agents.walletRecoveryTitle")
-              : t("agents.walletCreateTitle")}
-          </AppModalTitle>
-          <button
-            className="profile-modal-close"
-            onClick={() => setModalOpen(false)}
-            aria-label={t("common.close")}
-          >
-            <X size={18} />
-          </button>
-        </div>
-
-        {created?.success && created.recoveryPhrase ? (
-          <div className="profile-wallet-modal-body">
-            <div className="profile-wallet-recovery">
-              <KeyRound size={22} />
-              <p>{t("agents.walletRecoveryInfo")}</p>
-              <div className="profile-wallet-phrase">
-                {created.recoveryPhrase.split(" ").map((word, index) => (
-                  <span key={`${word}-${index}`}>
-                    <strong>{index + 1}</strong>
-                    {word}
-                  </span>
-                ))}
-              </div>
-              <div className="profile-wallet-modal-actions">
-                <button
-                  className="btn btn-secondary"
-                  onClick={() =>
-                    copyText(created.recoveryPhrase || "", "recovery")
-                  }
-                >
-                  {copied === "recovery" ? (
-                    <Check size={16} />
-                  ) : (
-                    <Copy size={16} />
-                  )}
-                  {copied === "recovery"
-                    ? t("agents.walletCopied")
-                    : t("agents.walletCopyRecovery")}
-                </button>
-                <button
-                  className="btn btn-primary"
-                  onClick={() => setModalOpen(false)}
-                >
-                  {t("agents.walletDone")}
-                </button>
-              </div>
-            </div>
-          </div>
-        ) : (
-          <div className="profile-wallet-modal-body">
-            <div className="profile-wallet-mode">
-              <button
-                className={mode === "create" ? "active" : ""}
-                onClick={() => setMode("create")}
-              >
-                {t("agents.walletCreateNew")}
-              </button>
-              <button
-                className={mode === "import" ? "active" : ""}
-                onClick={() => setMode("import")}
-              >
-                {t("agents.walletImportExisting")}
-              </button>
-            </div>
-
-            <label className="profile-wallet-field">
-              <span>{t("agents.walletName")}</span>
-              <input
-                className="input"
-                value={name}
-                onChange={(event) => setName(event.target.value)}
-                placeholder={t("agents.walletNamePlaceholder")}
-              />
-            </label>
-
-            {mode === "import" && (
-              <label className="profile-wallet-field">
-                <span>{t("agents.walletRecoveryPhrase")}</span>
-                <textarea
-                  className="input profile-wallet-textarea"
-                  value={recoveryPhrase}
-                  onChange={(event) => setRecoveryPhrase(event.target.value)}
-                  placeholder={t("agents.walletRecoveryPlaceholder")}
-                />
-              </label>
-            )}
-
-            {error && <div className="agents-create-error">{error}</div>}
-
-            <div className="profile-wallet-modal-actions">
-              <button
-                className="btn btn-secondary"
-                onClick={() => setModalOpen(false)}
-              >
-                {t("common.cancel")}
-              </button>
-              <button
-                className="btn btn-primary"
-                onClick={handleSubmit}
-                disabled={
-                  submitting || (mode === "import" && !recoveryPhrase.trim())
-                }
-              >
-                {submitting
-                  ? t("agents.walletCreating")
-                  : t("agents.walletSave")}
-              </button>
-            </div>
-          </div>
-        )}
-      </AppModal>
 
       <AppModal
         open={deleteTarget !== null}

--- a/src/shared/i18n/locales/en/agents.ts
+++ b/src/shared/i18n/locales/en/agents.ts
@@ -95,4 +95,13 @@ export default {
   syncErrors: "Sync finished with {{count}} error(s)",
   syncUnauthorized: "Session expired — sign in again on the Providers page",
   syncFailed: "Sync failed",
+  walletSync: "Refresh",
+  walletSyncing: "Syncing…",
+  walletSourceLocal: "Local",
+  walletSourceCloud: "Cloud",
+  walletManagedEmpty: "No wallets yet",
+  walletSyncedHint:
+    "Wallets are managed in your Hermes One account and appear here once this agent syncs.",
+  walletSignInHint:
+    "Sign in to your Hermes One account on the Providers page to see this agent's wallets.",
 } as const;

--- a/src/shared/wallets.ts
+++ b/src/shared/wallets.ts
@@ -27,3 +27,44 @@ export interface WalletMutationResult {
   recoveryPhrase?: string;
   error?: string;
 }
+
+/**
+ * A wallet as the pane renders it, from either origin. Local wallets come from
+ * the per-profile `wallets.json`; cloud wallets are fetched live from the
+ * backend for the profile's linked agent and are never persisted locally.
+ */
+export interface WalletView {
+  id: string;
+  name: string;
+  address: string;
+  network: typeof BASE_NETWORK_ID;
+  source: "local" | "cloud";
+  createdAt: number;
+  /** Local only: whether the wallet was imported vs generated. */
+  imported?: boolean;
+  /** Cloud only: backend wallet kind ("bankr" | "local" | "external"). */
+  kind?: string;
+  /** Cloud only: address is receive-only (no custody on this device). */
+  receiveOnly?: boolean;
+  /** Cloud only: backend can move funds (has a stored transaction secret). */
+  canTransact?: boolean;
+}
+
+/** Result of fetching the linked agent's cloud wallets. */
+export interface WalletSyncResult {
+  status: "ok" | "signed-out" | "unlinked" | "error";
+  /** Cloud wallets only; the renderer merges local wallets in separately. */
+  wallets: WalletView[];
+  error?: string;
+}
+
+/** Backend `serializeWallet` shape (the fields the desktop consumes). */
+export interface CloudWalletRaw {
+  id: string;
+  kind: string;
+  label: string | null;
+  evmAddress: string | null;
+  receiveOnly: boolean;
+  canTransact: boolean;
+  createdAt: string;
+}


### PR DESCRIPTION
## Summary

Wallets are now **synced from the Hermes One backend** for a profile's linked cloud agent instead of being minted on the device. The local Create/Import UI is removed from the wallet pane; wallets already created locally continue to appear and stay fully usable. This aligns the desktop with the backend's wallet-provisioning model (`docs/agent-sync.md` → "Wallets per agent"), where wallets are attached to a cloud agent and no wallet secret ever leaves the device.

Builds on the existing agent-sync link: a synced profile stores its cloud `agentId` in `cloud-sync.json`, which wallet sync reuses to fetch that agent's wallets.

## What Changed

- **Removed local wallet creation from the UI** (`ProfileWalletPane.tsx`).
  - The "Create wallet" button, the empty-state create button, and the Create/Import modal are gone.
  - `createWallet` / `importWallet` remain in `wallet-store.ts` and their IPC channels for now (no UI path) — a deliberate "hide, don't delete yet" step for easy full removal later.
  - Delete/copy/balances/refresh are unchanged for local wallets.

- **New wallet sync engine** (`src/main/wallet-sync.ts`).
  - `syncWalletsForProfile(profile)` finds the signed-in account, resolves the profile's cloud `agentId` via `getLinkedAgentId` (new export on `agent-sync.ts`), and `GET`s `/api/wallets?agentId=…` with the bearer token + `x-api-key`.
  - A profile that has never synced triggers **one agent sync first** (to create/link its cloud agent), then fetches its wallets.
  - Pure `mapCloudWallet` maps the backend row → the shared `WalletView`; rows without an EVM address are dropped. No wallet secret is fetched or stored — these are receive/tracked addresses.

- **Merged, badged wallet list** (`ProfileWalletPane.tsx`, `main.css`).
  - Local wallets (`wallets.json`) render immediately with a **Local** badge; cloud wallets stream in after the sync with a **Cloud** badge.
  - Copy address + balances work for both; **delete is offered only for local wallets** (cloud wallets are backend-managed).
  - Signed-out or not-yet-synced profiles show a hint, not an error.

- **Types, IPC, and preload**.
  - `src/shared/wallets.ts`: `WalletView`, `WalletSyncResult`, `CloudWalletRaw`.
  - `wallet-sync` IPC channel (`ipc/register.ts`) → `window.hermesAPI.syncWallets(profile)` (preload + `.d.ts`).

- **Docs** (`lat.md/`).
  - New "Wallet Sync" section in `wallet-token-balances.md`; cross-linked from `agent-sync.md`; the retired local-creation path is noted in the Wallet Store section.

## Verification

- `npm test` — 152 files / 1666 tests passing (+8 new). New `wallet-sync.test.ts` covers `mapCloudWallet` (mapping, default name, addressless drop) and `syncWalletsForProfile` (signed-out, linked-agent fetch, auto-sync-then-fetch when unlinked, HTTP error). `ProfileWalletPane.test.tsx` updated for the removed create button.
- `npm run typecheck` — clean.
- `npx eslint` on changed files — clean.
- `lat check` — all wiki links and code refs pass.
- Manual (local backend at `HERMES_API_URL=http://localhost:3002`, signed in): open a profile's Wallets tab → existing local wallets show a "Local" badge with delete/copy intact; the linked agent's backend wallets show a "Cloud" badge with correct addresses/balances and no delete; an unsynced profile syncs first, then shows its cloud wallet; no Create/Import button anywhere.

## Notes / Follow-ups

- **No desktop wallet provisioning yet.** The pane reads backend wallets but can't create one — provisioning happens in the console (`POST /api/wallets`). Until an agent has wallets created there, only local wallets show. A future desktop "Provision wallet" action is the natural next step.
- The backend does not enforce `x-api-key` on these routes yet; the header is sent but ignored server-side.
