### PR TITLE
fix: validate effective chat picker readiness

### DIFF
--- a/lat.md/model-selection.md
+++ b/lat.md/model-selection.md
@@ -22,6 +22,18 @@ The override is a `SessionModelOverride` (`{provider, model, baseUrl}`), not a b
 
 The picker builds it via [[src/renderer/src/screens/Chat/hooks/useModelConfig.ts#effectiveOverrideBaseUrl]], the same baseUrl rule `selectModel` applies (keep the URL only for `custom`/`ollama-cloud`; clear it for named providers that have a canonical base URL), so the session pick and a persisted save can't drift. It is threaded renderer → preload IPC → main `sendMessage` as `modelOverride`.
 
+## Readiness follows conversation model
+
+Pre-send readiness validates the current conversation's effective full routing identity, including session-only picker state, instead of rereading a stale global default.
+
+[[src/renderer/src/screens/Chat/Chat.tsx#Chat]] passes `{provider, model, baseUrl}` through preload IPC to [[src/main/validation.ts#validateChatReadiness]]. Main process remains responsible for provider policy and credential lookup.
+
+### Credential checks stay on owning host
+
+Desktop checks credential presence only in Local mode because Remote and SSH credentials belong to the other host and are not observable through local `.env` or `auth.json` files.
+
+[[src/main/ipc/register.ts#registerIpcHandlers]] derives credential scope from `ConnectionConfig.mode`. [[src/main/validation.ts#validateChatReadiness]] still rejects an empty effective model in every mode, then skips only local credential probes for Remote and SSH.
+
 ## Desktop-only persistence
 
 The selected model/provider is saved in a desktop-owned table keyed by session id, without storing API keys.

--- a/src/main/ipc/register.ts
+++ b/src/main/ipc/register.ts
@@ -895,9 +895,15 @@ export function registerIpcHandlers(context: IpcContext): void {
   // Pre-send chat readiness — answers "if Send is clicked right now,
   // will it work?". Fail-open semantics: any uncertain state returns
   // `ok: true`, so the renderer never false-blocks a Send.
-  ipcMain.handle("validate-chat-readiness", (_event, profile?: string) => {
-    return validateChatReadiness(profile);
-  });
+  ipcMain.handle(
+    "validate-chat-readiness",
+    (_event, profile?: string, modelOverride?: SessionModelOverride) => {
+      const connection = getConnectionConfig();
+      return validateChatReadiness(profile, modelOverride, {
+        checkCredentials: connection.mode === "local",
+      });
+    },
+  );
 
   // Config-health audit + per-issue auto-fix. The renderer renders a
   // dismissible banner above the chat input and a full report in the

--- a/src/main/validation.ts
+++ b/src/main/validation.ts
@@ -24,6 +24,7 @@ import {
 } from "./config";
 import { expectedEnvKeyForModel } from "./installer";
 import { isLocalBaseUrl } from "../shared/url-key-map";
+import type { SessionModelOverride } from "../shared/model-override";
 
 export type ChatReadinessCode =
   | "NO_ACTIVE_MODEL"
@@ -43,6 +44,11 @@ export interface ChatReadiness {
   fixLocation?: FixLocation;
   /** Env var name the user is expected to populate, if applicable. */
   expectedEnvKey?: string;
+}
+
+export interface ChatReadinessOptions {
+  /** Probe credentials only when they live in this Desktop's Hermes home. */
+  checkCredentials?: boolean;
 }
 
 const OK: ChatReadiness = { ok: true };
@@ -79,11 +85,16 @@ const NO_KEY_PROVIDERS = new Set(["auto"]);
  * Synchronous readiness check against the desktop's own config —
  * no network calls. Fast (single readEnv + getModelConfig).
  *
- * `profile` defaults to the active profile.
+ * `profile` defaults to the active profile. `modelOverride` is the effective
+ * routing identity selected for this conversation.
  */
-export function validateChatReadiness(profile?: string): ChatReadiness {
+export function validateChatReadiness(
+  profile?: string,
+  modelOverride?: SessionModelOverride,
+  options: ChatReadinessOptions = {},
+): ChatReadiness {
   try {
-    const mc = getModelConfig(profile);
+    const mc = modelOverride ?? getModelConfig(profile);
     const provider = (mc.provider || "").trim().toLowerCase();
     const model = (mc.model || "").trim();
     const baseUrl = (mc.baseUrl || "").trim();
@@ -101,6 +112,11 @@ export function validateChatReadiness(profile?: string): ChatReadiness {
         fixLocation: "models",
       };
     }
+
+    // Remote and SSH credentials live on the other host. Desktop cannot prove
+    // their absence, so retain model validation and fail open before probing
+    // local .env/auth.json state.
+    if (options.checkCredentials === false) return OK;
 
     if (OAUTH_PROVIDERS.has(provider) || NO_KEY_PROVIDERS.has(provider)) {
       // OAuth/no-key providers — skip the env-var check; the gateway's

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -289,7 +289,10 @@ interface HermesAPI {
   // Configuration (profile-aware)
   getEnv: (profile?: string) => Promise<Record<string, string>>;
   setEnv: (key: string, value: string, profile?: string) => Promise<boolean>;
-  validateChatReadiness: (profile?: string) => Promise<{
+  validateChatReadiness: (
+    profile?: string,
+    modelOverride?: SessionModelOverride,
+  ) => Promise<{
     ok: boolean;
     code?:
       | "NO_ACTIVE_MODEL"

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -241,6 +241,7 @@ const hermesAPI = {
 
   validateChatReadiness: (
     profile?: string,
+    modelOverride?: SessionModelOverride,
   ): Promise<{
     ok: boolean;
     code?:
@@ -252,7 +253,7 @@ const hermesAPI = {
     message?: string;
     fixLocation?: "providers" | "models" | "gateway" | "setup";
     expectedEnvKey?: string;
-  }> => ipcRenderer.invoke("validate-chat-readiness", profile),
+  }> => ipcRenderer.invoke("validate-chat-readiness", profile, modelOverride),
 
   getConfigHealth: (profile?: string): Promise<unknown> =>
     ipcRenderer.invoke("get-config-health", profile),

--- a/src/renderer/src/screens/Chat/Chat.tsx
+++ b/src/renderer/src/screens/Chat/Chat.tsx
@@ -394,7 +394,11 @@ function Chat({
     let cancelled = false;
     (async (): Promise<void> => {
       try {
-        const r = await window.hermesAPI.validateChatReadiness(profile);
+        const r = await window.hermesAPI.validateChatReadiness(profile, {
+          provider: chatCurrentProvider,
+          model: chatCurrentModel,
+          baseUrl: chatCurrentBaseUrl,
+        });
         if (!cancelled) setReadiness(r);
       } catch {
         // Fail open on IPC error — never block Send on validation failure

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -43,6 +43,79 @@ afterEach(() => {
 });
 
 describe("validateChatReadiness", () => {
+  it("uses the Chat session routing identity when the persisted model is empty", async () => {
+    writeConfig(
+      [
+        "model:",
+        "  provider: openrouter",
+        "  default: ''",
+        "  base_url: https://openrouter.ai/api/v1",
+        "",
+      ].join("\n"),
+    );
+    writeEnv("DEEPSEEK_API_KEY=sk-deepseek-test\n");
+    const { validateChatReadiness } = await freshValidation(TEST_DIR);
+
+    expect(
+      validateChatReadiness(undefined, {
+        provider: "deepseek",
+        model: "deepseek-chat",
+        baseUrl: "https://api.deepseek.com/v1",
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  it("skips Desktop credential probes when credentials belong to a remote host", async () => {
+    writeConfig(
+      [
+        "model:",
+        "  provider: ollama-cloud",
+        "  default: minimax-m3",
+        "  base_url: https://ollama.com/v1",
+        "",
+      ].join("\n"),
+    );
+    const { validateChatReadiness } = await freshValidation(TEST_DIR);
+
+    expect(
+      validateChatReadiness(
+        undefined,
+        {
+          provider: "ollama-cloud",
+          model: "minimax-m3",
+          baseUrl: "https://ollama.com/v1",
+        },
+        { checkCredentials: false },
+      ),
+    ).toEqual({ ok: true });
+  });
+
+  it("still rejects an empty effective model when credential probes are remote", async () => {
+    writeConfig(
+      [
+        "model:",
+        "  provider: openrouter",
+        "  default: openai/gpt-4o",
+        "  base_url: https://openrouter.ai/api/v1",
+        "",
+      ].join("\n"),
+    );
+    writeEnv("OPENROUTER_API_KEY=sk-openrouter-test\n");
+    const { validateChatReadiness } = await freshValidation(TEST_DIR);
+
+    const result = validateChatReadiness(
+      undefined,
+      {
+        provider: "custom",
+        model: "",
+        baseUrl: "https://example.test/v1",
+      },
+      { checkCredentials: false },
+    );
+
+    expect(result.code).toBe("NO_ACTIVE_MODEL");
+  });
+
   it("returns ok for auto provider (key check makes no sense)", async () => {
     writeConfig(["model:", "  provider: auto", "  default: ''", ""].join("\n"));
     const { validateChatReadiness } = await freshValidation(TEST_DIR);


### PR DESCRIPTION
## Summary

- validate pre-send readiness against the current Chat picker's full `{provider, model, baseUrl}` identity
- keep credential inspection in the main process
- skip Desktop-local `.env` and `auth.json` credential probes for Remote and SSH connections while preserving missing-model validation
- document the model and credential ownership boundaries in `lat.md`

## Why

Chat already reran readiness when picker state changed, but IPC validated only the persisted global model. That produced `NO_ACTIVE_MODEL` for valid session picks. Forwarding the picker identity exposes a second boundary: Remote and SSH credentials live on the other host, so Desktop cannot infer `MISSING_API_KEY` from local files.

This supersedes #839, credits its picker-override approach, and incorporates the Remote/SSH refinement reported in https://github.com/fathah/hermes-desktop/pull/839#issuecomment-4976280618.

## Verification

- RED: 3 focused regressions failed against current `main` with `NO_ACTIVE_MODEL`, `MISSING_API_KEY`, and missing model-detection mismatch
- GREEN: focused validation/preload/IPC-contract suite: 226 passed
- full suite: 1,747 passed, 3 skipped
- `npm run typecheck`: passed
- `npm run build`: passed
- changed-file ESLint: 0 errors
- Prettier, `git diff --check`, and `lat check`: passed

## Existing baseline

Full `npm run lint` remains nonzero because current `main` has 9 errors in unchanged `src/renderer/src/components/ProviderKeysSection.tsx`. This PR adds no lint errors.
