### PR TITLE
fix(ui): restore system theme and settings chrome

### DIFF
--- a/lat.md/lat.md
+++ b/lat.md/lat.md
@@ -11,6 +11,7 @@ This directory defines the high-level concepts, business logic, and architecture
 - [[code-blocks]] — collapsible long code blocks, and why expansion state is keyed on source position to survive react-markdown's streaming remounts.
 - [[loading-indicators]] — the thinking-orbs dotted-orb loaders behind every loading state, and the OrbLoader wrapper that pins dark/light from the Hermes theme registry instead of the library's auto-detection.
 - [[window-chrome]] — the browser-style title bar where open-conversation tabs sit on top of the window drag region, clickable while empty space still drags.
+- [[theme-selection]] — persisted palette selection, runtime System following, native Electron appearance synchronization, and modal chrome layering.
 - [[desktop-updates]] — GitHub release checks, startup upgrade button behavior, and the Settings auto-upgrade preference.
 - [[sidebar-navigation]] — the recent-sessions list under the Chat nav item, capped at five with a "Show more" button that opens the full session list in a modal.
 - [[context-folder]] — the per-session linked working folder, persisted in a desktop-owned state.db table so a re-opened conversation restores its folder.

--- a/lat.md/theme-selection.md
+++ b/lat.md/theme-selection.md
@@ -1,0 +1,39 @@
+# Theme selection
+
+Appearance settings preserve explicit palette ids and expose a System choice that resolves to the default Light or Dark palette without inventing a separate CSS palette.
+
+[[src/renderer/src/components/ThemeProvider.tsx#ThemeProvider]] accepts `system` plus every id in `THEMES`. Existing valid `hermes-theme` values remain unchanged; invalid values fall back to Dark, matching the pre-existing default.
+
+## Follow system behavior
+
+System mode listens to `prefers-color-scheme` and updates the resolved `data-theme` at runtime, while [[src/renderer/src/components/settings/AppearancePane.tsx#AppearancePane]] keeps System visibly selected and shows the currently resolved Light or Dark label.
+
+Preset cards remain explicit choices. Selecting one stops renderer updates from OS appearance changes and maps the preset's declared `appearance` to native window chrome.
+
+## Native window synchronization
+
+Renderer and Electron chrome share one appearance decision so macOS vibrancy and the hidden title bar never use the opposite tone from the active palette.
+
+[[src/renderer/src/components/ThemeProvider.tsx#ThemeProvider]] sends `system` for System mode and `light` or `dark` for explicit palettes through the existing `set-native-appearance` IPC. Electron applies it to `nativeTheme.themeSource`.
+
+## Modal chrome stacking
+
+The Settings modal stacks above the macOS drag strip and conversation title bar, ensuring its overlay dims and disables the whole top band without changing other modals' nested layering.
+
+The Settings surface and grouped preference rows use opaque theme surfaces. This prevents high-contrast content beneath the modal from ghosting through in Light mode while retaining the surrounding overlay separation.
+
+## Tests
+
+Focused renderer tests protect stored theme compatibility, runtime system changes, native appearance mapping, and the Settings entry point.
+
+### Stored system theme follows runtime changes
+
+A saved `system` value resolves from the current media query, reacts to later OS changes, keeps the stored selection, and leaves Electron's native appearance source on System.
+
+### Stored presets keep their appearance
+
+A saved custom palette remains selected and applies both its CSS theme id and declared native light/dark appearance without rewriting storage.
+
+### Appearance exposes the system choice
+
+Appearance marks System as an accessible pressed choice, reports the resolved Light or Dark mode, and sends `system` when selected.

--- a/lat.md/window-chrome.md
+++ b/lat.md/window-chrome.md
@@ -4,6 +4,8 @@ The top strip of the main window is a browser-style title bar: it is the window'
 
 On macOS the window is frameless (`titleBarStyle: "hiddenInset"`, traffic lights inset at x/y 16 — see [[src/main/app/start.ts#startMainProcess]]), and [[src/renderer/src/App.tsx]] renders a fixed full-width `.drag-region` (`-webkit-app-region: drag`, z-index 1000) so the whole top band — including over the sidebar/traffic-light area — drags the window. This strip is mac-only; other platforms keep the OS title bar.
 
+The Settings modal stacks above both the drag region and the z-index 1001 conversation tab bar. Its overlay therefore dims the complete title bar and prevents the invisible drag layer from intercepting modal interactions; see [[theme-selection#Modal chrome stacking]].
+
 `.app` fills the window (`height: 100vh`) so the chrome reaches every edge. The sidebar rounds only its **top-left** corner (`border-radius: 16px 0 0 0`); the full-width status strip owns the window's bottom edge and rounds both bottom corners (`0 0 16px 16px`), so the sidebar's bottom-left is square against it. A hairline seam (`.content` `border-inline-start`) separates the content pane from the sidebar.
 
 ## Translucent sidebar (macOS vibrancy)
@@ -16,9 +18,11 @@ For the material to paint, the renderer leaves surfaces transparent: [[src/rende
 
 ## Modal & popover glass is near-opaque (compositing-independent)
 
-Modals and pickers use a `--bg-secondary` tint plus `backdrop-filter: blur(30px) saturate(1.5)`, but the tint is **97% opaque** so legibility never depends on the blur actually painting.
+Frosted surfaces stay nearly opaque so legibility never depends on `backdrop-filter`; Settings is fully opaque in every theme.
 
-The blur is treated as pure enhancement, not a load-bearing layer. On the transparent vibrancy window above, `backdrop-filter` is unreliable in packaged macOS builds — it silently drops to a no-op even with hardware acceleration on — which left the earlier 85%-opaque panels showing sharp app content bleeding through (the "transparent modal" bug). Raising the tint to 97% in `main.css` makes every shared frosted surface — the settings/profile/models/schedules/gateway/profile-switch modals and the model/reasoning/fast-mode dropdowns — render near-identically for all users regardless of GPU or build type; where the blur *does* paint it adds a faint frost, but its absence is barely perceptible. Keep new glass surfaces at this opacity, not the old 85%, for the same reason.
+Modals and pickers use a 97%-opaque `--bg-secondary` tint plus `backdrop-filter: blur(30px) saturate(1.5)`. Settings uses a fully opaque `--bg-secondary` surface because its dense controls otherwise reveal high-contrast chat chrome in Light mode.
+
+The blur is treated as pure enhancement, not a load-bearing layer. On the transparent vibrancy window above, `backdrop-filter` is unreliable in packaged macOS builds — it silently drops to a no-op even with hardware acceleration on — which left the earlier 85%-opaque panels showing sharp app content bleeding through (the "transparent modal" bug). Raising the tint to 97% in `main.css` makes shared frosted surfaces — profile/models/schedules/gateway/profile-switch modals and the model/reasoning/fast-mode dropdowns — render near-identically for all users regardless of GPU or build type; where the blur *does* paint it adds a faint frost, but its absence is barely perceptible. Keep new glass surfaces at this opacity, not the old 85%, unless their content needs the fully opaque Settings treatment.
 
 ## Bottom status strip
 

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -10160,16 +10160,43 @@ body:has(.shell-vibrant),
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+  width: 100%;
   padding: 12px;
   margin-bottom: 12px;
   background: var(--bg-primary);
   border: 1.5px solid var(--border);
   border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-family: var(--font-sans);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background var(--transition),
+    border-color var(--transition),
+    color var(--transition);
+}
+
+.settings-theme-system:hover {
+  border-color: var(--border-bright);
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.settings-theme-system:focus-visible {
+  outline: 2px solid var(--border-focus);
+  outline-offset: 2px;
 }
 
 .settings-theme-system.active {
   border-color: var(--accent);
   background: var(--accent-subtle);
+}
+
+.settings-theme-system-copy {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
 }
 
 .settings-theme-system-label {
@@ -10179,6 +10206,7 @@ body:has(.shell-vibrant),
 }
 
 .settings-theme-system-hint {
+  display: block;
   font-size: 12px;
   color: var(--text-muted);
   margin-top: 2px;
@@ -10187,7 +10215,9 @@ body:has(.shell-vibrant),
 /* Grouped preferences — one quiet card, hairline row dividers, macOS-style. */
 .settings-group {
   border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--text-primary) 4%, transparent);
+  /* Keep preference copy opaque in light themes: translucent rows let the
+     high-contrast chat toolbar beneath the modal ghost through. */
+  background: var(--bg-tertiary);
   overflow: hidden;
 }
 .settings-row {
@@ -10917,6 +10947,9 @@ body:has(.shell-vibrant),
   padding: 24px;
   /* Lighter scrim so the frosted glass reads as translucent. */
   background: rgba(0, 0, 0, 0.4);
+  /* Above the macOS drag strip (1000) and browser-style tab bar (1001), so
+     Settings dims and disables the entire title-bar band. */
+  z-index: 1200;
 }
 
 .settings-modal {
@@ -10926,8 +10959,10 @@ body:has(.shell-vibrant),
   height: 80vh;
   max-width: 1000px;
   max-height: 780px;
-  /* Frosted glass — same material as the pickers/profile modal. */
-  background: color-mix(in srgb, var(--bg-secondary) 97%, transparent);
+  z-index: 1201;
+  /* Settings carries dense labels and controls, so use an opaque themed
+     surface; the backdrop still provides the glass separation. */
+  background: var(--bg-secondary);
   backdrop-filter: blur(30px) saturate(1.5);
   -webkit-backdrop-filter: blur(30px) saturate(1.5);
   border: 0.5px solid var(--border);

--- a/src/renderer/src/components/ThemeProvider.test.tsx
+++ b/src/renderer/src/components/ThemeProvider.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { THEMES, THEME_STORAGE_KEY } from "../constants";
+import { ThemeProvider, useTheme } from "./ThemeProvider";
+
+type ColorSchemeListener = (event: MediaQueryListEvent) => void;
+
+function installMatchMedia(initiallyDark: boolean): {
+  setDark: (dark: boolean) => void;
+} {
+  let matches = initiallyDark;
+  const listeners = new Set<ColorSchemeListener>();
+  const mediaQuery = {
+    get matches() {
+      return matches;
+    },
+    media: "(prefers-color-scheme: dark)",
+    onchange: null,
+    addEventListener: (_type: string, listener: ColorSchemeListener) => {
+      listeners.add(listener);
+    },
+    removeEventListener: (_type: string, listener: ColorSchemeListener) => {
+      listeners.delete(listener);
+    },
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  } as MediaQueryList;
+
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: vi.fn(() => mediaQuery),
+  });
+
+  return {
+    setDark(dark: boolean) {
+      matches = dark;
+      const event = {
+        matches: dark,
+        media: mediaQuery.media,
+      } as MediaQueryListEvent;
+      listeners.forEach((listener) => listener(event));
+    },
+  };
+}
+
+function ThemeProbe(): React.JSX.Element {
+  const { theme, resolved } = useTheme();
+  return <div>{`${theme}:${resolved}`}</div>;
+}
+
+describe("ThemeProvider", () => {
+  const setNativeAppearance = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute("data-theme");
+    document.documentElement.removeAttribute("data-radius");
+    setNativeAppearance.mockClear();
+    Object.defineProperty(window, "hermesAPI", {
+      configurable: true,
+      value: { setNativeAppearance },
+    });
+  });
+
+  it("keeps a stored system choice and follows runtime OS changes", async () => {
+    // @lat: [[theme-selection#Tests#Stored system theme follows runtime changes]]
+    const colorScheme = installMatchMedia(true);
+    localStorage.setItem(THEME_STORAGE_KEY, "system");
+
+    render(
+      <ThemeProvider>
+        <ThemeProbe />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByText("system:dark")).toBeTruthy();
+    await waitFor(() => {
+      expect(document.documentElement).toHaveAttribute("data-theme", "dark");
+      expect(setNativeAppearance).toHaveBeenLastCalledWith("system");
+    });
+
+    colorScheme.setDark(false);
+
+    await waitFor(() => {
+      expect(screen.getByText("system:light")).toBeTruthy();
+      expect(document.documentElement).toHaveAttribute("data-theme", "light");
+      expect(setNativeAppearance).toHaveBeenLastCalledWith("system");
+    });
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("system");
+  });
+
+  it.each(THEMES)(
+    "preserves stored preset $id and pins its native appearance",
+    async ({ id, appearance }) => {
+      // @lat: [[theme-selection#Tests#Stored presets keep their appearance]]
+      installMatchMedia(true);
+      localStorage.setItem(THEME_STORAGE_KEY, id);
+
+      render(
+        <ThemeProvider>
+          <ThemeProbe />
+        </ThemeProvider>,
+      );
+
+      expect(screen.getByText(`${id}:${id}`)).toBeTruthy();
+      await waitFor(() => {
+        expect(document.documentElement).toHaveAttribute("data-theme", id);
+        expect(setNativeAppearance).toHaveBeenLastCalledWith(appearance);
+      });
+      expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe(id);
+    },
+  );
+});

--- a/src/renderer/src/components/settings/AppearancePane.test.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import AppearancePane from "./AppearancePane";
+
+const theme = vi.hoisted(() => ({
+  theme: "system",
+  resolved: "light",
+  setTheme: vi.fn(),
+  rounded: true,
+  setRounded: vi.fn(),
+}));
+
+vi.mock("../ThemeProvider", () => ({ useTheme: () => theme }));
+vi.mock("../FontProvider", () => ({
+  useFont: () => ({ font: "manrope", setFont: vi.fn() }),
+}));
+vi.mock("../useI18n", () => ({ useI18n: () => ({ t: (key: string) => key }) }));
+
+describe("AppearancePane themes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    theme.theme = "system";
+    theme.resolved = "light";
+    Object.defineProperty(window, "hermesAPI", {
+      configurable: true,
+      value: {
+        getGpuStatus: vi.fn().mockRejectedValue(new Error("unavailable")),
+      },
+    });
+  });
+
+  it("shows the active system choice and lets users select it", () => {
+    // @lat: [[theme-selection#Tests#Appearance exposes the system choice]]
+    const { rerender } = render(<AppearancePane />);
+    const systemChoice = screen.getByRole("button", {
+      name: /settings\.theme\.system/,
+    });
+
+    expect(systemChoice).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByText("settings.theme.light")).toBeTruthy();
+
+    theme.theme = "dark";
+    rerender(<AppearancePane />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /settings\.theme\.system/ }),
+    );
+
+    expect(theme.setTheme).toHaveBeenCalledWith("system");
+  });
+});

--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Check } from "lucide-react";
+import { Check, Monitor } from "lucide-react";
 import { useTheme } from "../ThemeProvider";
 import { useFont } from "../FontProvider";
 import { THEMES, FONT_OPTIONS } from "../../constants";
@@ -14,7 +14,7 @@ const THEME_PREVIEW_COUNT = 7;
 /** Theme, rounded corners, interface font, and hardware acceleration. */
 export default function AppearancePane(): React.JSX.Element {
   const { t } = useI18n();
-  const { theme, setTheme, rounded, setRounded } = useTheme();
+  const { theme, resolved, setTheme, rounded, setRounded } = useTheme();
   const { font, setFont } = useFont();
   const [showAllThemes, setShowAllThemes] = useState(false);
   // Hardware acceleration is fixed pre-ready, so a changed preference only
@@ -64,6 +64,35 @@ export default function AppearancePane(): React.JSX.Element {
         <label className="settings-field-label">
           {t("settings.theme.label")}
         </label>
+        <button
+          type="button"
+          className={`settings-theme-system ${theme === "system" ? "active" : ""}`}
+          aria-pressed={theme === "system"}
+          onClick={() => setTheme("system")}
+        >
+          <span className="settings-theme-system-copy">
+            <Monitor size={18} aria-hidden="true" />
+            <span>
+              <span className="settings-theme-system-label">
+                {t("settings.theme.system")}
+              </span>
+              {theme === "system" && (
+                <span className="settings-theme-system-hint">
+                  {t(
+                    resolved === "light"
+                      ? "settings.theme.light"
+                      : "settings.theme.dark",
+                  )}
+                </span>
+              )}
+            </span>
+          </span>
+          {theme === "system" && (
+            <span className="settings-theme-card-check" aria-hidden="true">
+              <Check size={14} />
+            </span>
+          )}
+        </button>
         <div className="settings-theme-grid">
           {visibleThemes.map((th) => {
             const active = theme === th.id;
@@ -72,6 +101,7 @@ export default function AppearancePane(): React.JSX.Element {
                 key={th.id}
                 type="button"
                 className={`settings-theme-card ${active ? "active" : ""}`}
+                aria-pressed={active}
                 onClick={() => setTheme(th.id)}
               >
                 <div className="settings-theme-preview" data-theme={th.id}>


### PR DESCRIPTION
## What

- Restore a visible, accessible **System** option in Settings → Appearance while retaining every existing explicit theme preset.
- Keep System mode responsive to runtime OS light/dark changes and synchronize Electron's native window appearance with the resolved renderer theme.
- Place the Settings overlay above the macOS drag region and conversation title bar, and use opaque themed surfaces to prevent Light-mode content bleed-through.
- Add focused theme-provider and appearance-picker tests, plus corresponding `lat.md` architecture documentation.

## Why

The theme provider still understood the persisted `system` value and already had the native-appearance IPC path, but the multi-theme picker no longer exposed System. Existing users with that stored choice had no selected control, and new users could not enable it.

Separately, the Settings modal used lower stacking levels than the macOS drag region and browser-style conversation bar. Its translucent Light surfaces also allowed high-contrast content beneath the modal to remain visible.

## User impact

Users can choose System again, existing saved themes remain compatible, and System follows OS appearance changes without restarting. The Settings modal now covers the complete window chrome and remains readable in Light mode.

## Automated checks

- Focused theme tests: 14 passed
- Full test suite: 1,864 passed, 3 skipped
- `npm run typecheck`
- `npm run build`
- `npm run lint`: 0 errors, 21 baseline warnings
- `npx lat.md check`
- `git diff --check`

## Manual QA limitation

The standalone renderer remained on onboarding without the Electron bridge, so full in-app Electron visual QA of Settings could not be completed without starting the installation flow.
