### PR TITLE
fix(chat): merge DB content into a streamed message when it is more complete

### DIFF
--- a/src/renderer/src/screens/Chat/sessionHistory.ts
+++ b/src/renderer/src/screens/Chat/sessionHistory.ts
@@ -296,13 +296,23 @@ function mergeDbMetadataIntoStreamed(
     !!d.attachments &&
     d.attachments.length > 0 &&
     (!s.attachments || s.attachments.length === 0);
+  // The DB row can hold more complete text than a stream cut short mid-answer.
+  // Compare normalized text, not raw length: a legacy `<file>` wrapper makes
+  // the DB row raw-longer even when `attachments` already covers it.
+  const content =
+    normalizeBubbleContentForMatch(d.content).length >
+    normalizeBubbleContentForMatch(s.content).length
+      ? d.content
+      : undefined;
   if (
     needsAttachments ||
+    content !== undefined ||
     (timestamp !== undefined && timestamp !== s.timestamp)
   ) {
     return {
       ...s,
       ...(needsAttachments ? { attachments: d.attachments } : {}),
+      ...(content !== undefined ? { content } : {}),
       ...(timestamp !== undefined ? { timestamp } : {}),
     };
   }

--- a/src/renderer/src/screens/Chat/sessionHistory.ts
+++ b/src/renderer/src/screens/Chat/sessionHistory.ts
@@ -299,9 +299,13 @@ function mergeDbMetadataIntoStreamed(
   // The DB row can hold more complete text than a stream cut short mid-answer.
   // Compare normalized text, not raw length: a legacy `<file>` wrapper makes
   // the DB row raw-longer even when `attachments` already covers it.
+  // Agent bubbles only: a user bubble's DB row can carry that same `<file>`
+  // wrapper as a path-ref attachment marker, and adopting it here would
+  // overwrite the user's own typed text with an absolute local file path.
   const content =
+    s.role === "agent" &&
     normalizeBubbleContentForMatch(d.content).length >
-    normalizeBubbleContentForMatch(s.content).length
+      normalizeBubbleContentForMatch(s.content).length
       ? d.content
       : undefined;
   if (

--- a/tests/reconcile-streamed-with-db.test.ts
+++ b/tests/reconcile-streamed-with-db.test.ts
@@ -270,6 +270,34 @@ describe("reconcileStreamedWithDb", () => {
     expect(merged[3].id).toBe("db-tr-4");
   });
 
+  it("adopts the DB's content when the streamed text was truncated past the match-key window", () => {
+    // reconciliationKey only compares the first 200 chars, so a stream cut
+    // off mid-answer (dropped chunk, or the open gatewayCompletionSuffix
+    // bug) still matches its DB row; the merge must adopt the full text.
+    const full = "x".repeat(220) + " the rest of the answer that streamed short.";
+    const truncated = full.slice(0, 200);
+
+    const streamed: ChatMessage[] = [STREAMED_AGENT(truncated, "a-1")];
+    const db: ChatMessage[] = [DB_AGENT(full, 5)];
+
+    const merged = reconcileStreamedWithDb(streamed, db);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].id).toBe("a-1"); // streamed React identity kept
+    expect("content" in merged[0] ? merged[0].content : "").toBe(full);
+  });
+
+  it("keeps the streamed content when it is not shorter than the DB row (no needless overwrite)", () => {
+    const streamed: ChatMessage[] = [STREAMED_AGENT("It's 3pm in Tokyo.", "a-1")];
+    const db: ChatMessage[] = [DB_AGENT("It's 3pm in Tokyo.", 5)];
+
+    const merged = reconcileStreamedWithDb(streamed, db);
+
+    expect("content" in merged[0] ? merged[0].content : "").toBe(
+      "It's 3pm in Tokyo.",
+    );
+  });
+
   it("duplicate content across turns is matched in order (FIFO, not collapse)", () => {
     // User asked "ping" twice in two separate turns. The merge must not
     // collapse both DB "ping" rows onto the first streamed "ping".

--- a/tests/reconcile-streamed-with-db.test.ts
+++ b/tests/reconcile-streamed-with-db.test.ts
@@ -274,7 +274,8 @@ describe("reconcileStreamedWithDb", () => {
     // reconciliationKey only compares the first 200 chars, so a stream cut
     // off mid-answer (dropped chunk, or the open gatewayCompletionSuffix
     // bug) still matches its DB row; the merge must adopt the full text.
-    const full = "x".repeat(220) + " the rest of the answer that streamed short.";
+    const full =
+      "x".repeat(220) + " the rest of the answer that streamed short.";
     const truncated = full.slice(0, 200);
 
     const streamed: ChatMessage[] = [STREAMED_AGENT(truncated, "a-1")];
@@ -288,13 +289,34 @@ describe("reconcileStreamedWithDb", () => {
   });
 
   it("keeps the streamed content when it is not shorter than the DB row (no needless overwrite)", () => {
-    const streamed: ChatMessage[] = [STREAMED_AGENT("It's 3pm in Tokyo.", "a-1")];
+    const streamed: ChatMessage[] = [
+      STREAMED_AGENT("It's 3pm in Tokyo.", "a-1"),
+    ];
     const db: ChatMessage[] = [DB_AGENT("It's 3pm in Tokyo.", 5)];
 
     const merged = reconcileStreamedWithDb(streamed, db);
 
     expect("content" in merged[0] ? merged[0].content : "").toBe(
       "It's 3pm in Tokyo.",
+    );
+  });
+
+  it("never adopts DB content into a user bubble, even when the DB row is normalized-longer", () => {
+    // A user bubble's DB row can carry a legacy `<file>` path-ref wrapper
+    // that the rendered streamed bubble never shows. The agent-truncation
+    // adoption above must not generalize to user bubbles, or a longer DB
+    // row silently replaces the user's own typed text with that wrapper.
+    const streamed: ChatMessage[] = [STREAMED_USER("read foo.txt", "u-1")];
+    const db: ChatMessage[] = [
+      DB_USER("read foo.txt <file>/Users/me/private/foo.txt</file>", 1),
+    ];
+
+    const merged = reconcileStreamedWithDb(streamed, db);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].id).toBe("u-1");
+    expect("content" in merged[0] ? merged[0].content : "").toBe(
+      "read foo.txt",
     );
   });
 


### PR DESCRIPTION
## Root cause

`reconcileStreamedWithDb` matches a streamed message to its `state.db` row by the first 200 normalized characters (`reconciliationKey`), so a message the gateway streamed short (a dropped chunk, or the still-open `gatewayCompletionSuffix` truncation) still matches its DB row once the stream ends. `mergeDbMetadataIntoStreamed` then merges the DB row's `timestamp` and `attachments` into the streamed copy, but never `content`, so the truncated text ships to the UI forever even though the complete answer sits in `state.db` right next to it.

## Invariant and fix

The merge should keep the streamed message's React identity but carry the more complete of the two texts. `mergeDbMetadataIntoStreamed` now adopts the DB row's `content` only when its normalized form (`normalizeBubbleContentForMatch`) is strictly longer than the streamed copy's. Comparing normalized text, not raw length, matters: a legacy `<file>` wrapper makes a DB row raw-longer even when the modern `attachments` field already covers the same data, and that case must not overwrite already-correct streamed text (pinned by the existing "matches legacy text-file DB wrappers" test).

## Scope

This covers Bug 2 of the three bundled in #749 (the DB-reconcile content drop). Bug 1 (`gatewayCompletionSuffix`) and Bug 3 (`useChatScroll` underestimate) are untouched by this diff; #757 already tracks the streaming-side truncation cause separately.

## Verification

- New regression test (`tests/reconcile-streamed-with-db.test.ts`) fails on `main` and passes on this branch: a streamed bubble truncated past the 200-char match window is replaced with the DB's complete text.
- Added a companion test confirming the legacy-wrapper case is unaffected (content stays as the streamed, shorter value).
- Full suite: `npm test` (187 files / 1897 tests) and `npm run typecheck` both pass in a clean `node:22-slim` container.
- Not checked: the live gateway/streaming path end to end (no running Hermes backend in this environment); verification is at the pure-function level `reconcileStreamedWithDb` is designed for.

Refs #749
