### PR TITLE
fix: support system-trusted CAs for remote API URLs

### DIFF
--- a/lat.md/main-process.md
+++ b/lat.md/main-process.md
@@ -8,6 +8,26 @@ The Electron main process keeps the entrypoint small and separates app lifecycle
 
 [[src/main/index.ts]] applies GPU crash preferences, enables the optional CDP testing port, and calls [[src/main/app/start.ts#startMainProcess]]. This keeps one-off process boot concerns separate from windows, menus, updater wiring, and IPC.
 
+## System certificate trust
+
+Remote HTTPS clients retain Node's default roots and add operating-system trusted CAs before any connection starts.
+
+[[src/main/system-ca.ts#configureSystemCertificateTrust]] merges Node's existing default certificate list with its system certificate store. [[src/main/index.ts]] applies the merged list before app startup, covering Node HTTP, fetch, and WebSocket clients used by Remote mode.
+
+Certificate and hostname verification remain enabled: only CAs trusted by Node's defaults or the operating system are accepted. If the system store cannot be read, startup continues with the existing defaults and logs the failure.
+
+### Test specifications
+
+Focused tests protect both the trust-store composition and its startup ordering.
+
+#### Preserves default and system roots
+
+System CAs are appended without removing bundled or extra CAs already present in Node's default list.
+
+#### Runs before main startup
+
+The entrypoint configures TLS defaults before it starts the Electron lifecycle, so no cached connection can retain the old CA list.
+
 ## GPU Fallback
 
 Hardware acceleration is disabled and persisted after a GPU-process crash so machines without a usable GPU avoid an infinite crash → relaunch loop — but only temporarily, so a transient crash can't strand a working GPU on SwiftShader.

--- a/lat.md/remote-dashboard-oauth.md
+++ b/lat.md/remote-dashboard-oauth.md
@@ -8,6 +8,8 @@ The public dashboard status endpoint and raw-gateway health endpoint select toke
 
 [[src/main/remote-oauth.ts#probeRemoteAuthMode]] reads `/api/status`; `auth_required: true` selects OAuth. A `404` or `405` then probes `/health` with the supplied `API_SERVER_KEY`: a healthy response or an explicit `401`/`403` identifies the raw token gateway. Other probe failures remain errors rather than transport guesses.
 
+These probes and later Node-based Remote requests inherit [[main-process#System certificate trust]], allowing HTTPS gateways issued by an operating-system trusted CA without bypassing certificate verification.
+
 The first-run `connect-remote-gateway` operation in [[src/main/ipc/register.ts#registerIpcHandlers]] owns detection, authentication, validation, and configuration commit as one main-process transaction. OAuth opens the dedicated login window before saving; token mode verifies `/health`; either failure leaves the previous connection configuration untouched. [[src/renderer/src/screens/Welcome/Welcome.tsx#Welcome]] surfaces that single operation and explains that the remote key comes from `API_SERVER_KEY` in the remote `~/.hermes/.env`.
 
 The public startup probe uses `/api/status` without a stored token after OAuth is selected, avoiding the authenticated `/health` redirect and stale-token false negatives.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,12 +2,14 @@ import { app } from "electron";
 import { applyGpuPreferences, installGpuCrashGuard } from "./gpu-fallback";
 import { startMainProcess } from "./app/start";
 import { loadDotEnvForDev } from "./load-env";
+import { configureSystemCertificateTrust } from "./system-ca";
 
 // Dev only: make process.env reflect the project `.env` so runtime env reads
 // (e.g. the Hermes One API endpoint) pick up edits on relaunch without a
 // rebuild. Packaged builds carry their config baked in and ship no `.env`.
 if (!app.isPackaged) loadDotEnvForDev();
 
+configureSystemCertificateTrust();
 applyGpuPreferences();
 installGpuCrashGuard();
 

--- a/src/main/system-ca.ts
+++ b/src/main/system-ca.ts
@@ -1,0 +1,24 @@
+import { getCACertificates, setDefaultCACertificates } from "node:tls";
+
+/**
+ * Add operating-system trust decisions to Node's bundled CA roots.
+ *
+ * Electron's main-process HTTP, HTTPS, fetch, and WebSocket clients use Node's
+ * TLS defaults. Configure them before startup so a locally trusted CA works
+ * without weakening certificate or hostname verification.
+ */
+export function configureSystemCertificateTrust(): void {
+  try {
+    setDefaultCACertificates([
+      ...getCACertificates("default"),
+      ...getCACertificates("system"),
+    ]);
+  } catch (error) {
+    // Certificate-store access must not make the desktop unbootable. Standard
+    // bundled roots remain in effect when system roots cannot be loaded.
+    console.warn(
+      "[TLS] Could not load operating-system certificate authorities; using the existing trust store.",
+      error,
+    );
+  }
+}

--- a/tests/system-ca.test.ts
+++ b/tests/system-ca.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const tlsMocks = vi.hoisted(() => ({
+  getCACertificates: vi.fn(),
+  setDefaultCACertificates: vi.fn(),
+}));
+
+vi.mock("node:tls", () => ({ ...tlsMocks, default: tlsMocks }));
+
+import { configureSystemCertificateTrust } from "../src/main/system-ca";
+
+describe("system certificate trust", () => {
+  beforeEach(() => {
+    tlsMocks.getCACertificates.mockReset();
+    tlsMocks.setDefaultCACertificates.mockReset();
+  });
+
+  it("keeps default roots while adding operating-system roots", () => {
+    // @lat: [[main-process#System certificate trust#Test specifications#Preserves default and system roots]]
+    tlsMocks.getCACertificates.mockImplementation((type: string) =>
+      type === "system" ? ["system-ca"] : ["bundled-ca", "extra-ca"],
+    );
+
+    configureSystemCertificateTrust();
+
+    expect(tlsMocks.getCACertificates).toHaveBeenNthCalledWith(1, "default");
+    expect(tlsMocks.getCACertificates).toHaveBeenNthCalledWith(2, "system");
+    expect(tlsMocks.setDefaultCACertificates).toHaveBeenCalledWith([
+      "bundled-ca",
+      "extra-ca",
+      "system-ca",
+    ]);
+  });
+
+  it("configures trust before the Electron lifecycle starts", () => {
+    // @lat: [[main-process#System certificate trust#Test specifications#Runs before main startup]]
+    const source = readFileSync(
+      join(import.meta.dirname, "../src/main/index.ts"),
+      "utf8",
+    );
+    const trustSetup = source.indexOf("configureSystemCertificateTrust();");
+    const mainStartup = source.indexOf("startMainProcess();");
+
+    expect(trustSetup).toBeGreaterThan(-1);
+    expect(mainStartup).toBeGreaterThan(-1);
+    expect(trustSetup).toBeLessThan(mainStartup);
+  });
+
+  it("keeps startup available when the system store cannot be read", () => {
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    tlsMocks.getCACertificates.mockImplementation(() => {
+      throw new Error("store unavailable");
+    });
+
+    expect(() => configureSystemCertificateTrust()).not.toThrow();
+    expect(tlsMocks.setDefaultCACertificates).not.toHaveBeenCalled();
+    expect(warning).toHaveBeenCalledWith(
+      expect.stringContaining("existing trust store"),
+      expect.any(Error),
+    );
+
+    warning.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

- merge operating-system trusted CAs into Node's existing default certificate roots
- initialize the trust store before Electron starts any remote API, fetch, or WebSocket work
- keep certificate and hostname verification enabled
- add regression tests and `lat.md` architecture documentation

## Root cause

Remote gateway requests in the Electron main process use Node's TLS stack. Node's default CA set did not include locally trusted roots from the operating system, so a certificate issued by a self-signed CA marked **Always Trust** in macOS Keychain failed with `SELF_SIGNED_CERT_IN_CHAIN`.

## Impact

Remote HTTPS gateways issued by an OS-trusted private CA now work during onboarding, health/version checks, dashboard requests, and chat transports without an insecure certificate bypass.

Fixes #866

## Validation

- `npm test` — 188 files passed, 1,901 tests passed, 3 skipped
- `npm run build`
- focused ESLint on changed TypeScript files
- `lat check`
