### PR TITLE
NOV-1177: Add Novita as an OpenAI-compatible provider option

### DIFF
--- a/src/main/installer.ts
+++ b/src/main/installer.ts
@@ -357,6 +357,7 @@ const URL_TO_ENV_KEY: Array<[RegExp, string]> = [
   [/api\.fireworks\.ai/i, "FIREWORKS_API_KEY"],
   [/api\.cerebras\.ai/i, "CEREBRAS_API_KEY"],
   [/atlascloud\.ai/i, "ATLASCLOUD_API_KEY"],
+  [/api\.novita\.ai/i, "NOVITA_API_KEY"],
   [/api\.mistral\.ai/i, "MISTRAL_API_KEY"],
   [/api\.perplexity\.ai/i, "PERPLEXITY_API_KEY"],
   [/api\.xiaomimimo\.com/i, "XIAOMI_API_KEY"],

--- a/src/main/provider-registry.ts
+++ b/src/main/provider-registry.ts
@@ -23,6 +23,7 @@ export const PROVIDER_BASE_URLS: Record<string, string> = {
   together: "https://api.together.xyz/v1",
   fireworks: "https://api.fireworks.ai/inference/v1",
   atlascloud: "https://api.atlascloud.ai/v1",
+  novita: "https://api.novita.ai/openai/v1",
   cerebras: "https://api.cerebras.ai/v1",
   perplexity: "https://api.perplexity.ai",
   huggingface: "https://router.huggingface.co/v1",

--- a/src/renderer/src/constants.ts
+++ b/src/renderer/src/constants.ts
@@ -89,6 +89,7 @@ export const PROVIDERS = {
   labels: {
     hermesone: "Hermes One",
     atlascloud: "AtlasCloud",
+    novita: "NovitaAI",
     openrouter: "constants.openrouterName",
     aimlapi: "constants.aimlapiName",
     anthropic: "constants.anthropicName",
@@ -386,6 +387,7 @@ export const OPENAI_COMPATIBLE_BASE_URLS: Record<string, string> = {
   fireworks: "https://api.fireworks.ai/inference/v1",
   cerebras: "https://api.cerebras.ai/v1",
   atlascloud: "https://api.atlascloud.ai/v1",
+  novita: "https://api.novita.ai/openai/v1",
   perplexity: "https://api.perplexity.ai",
   lmstudio: "http://localhost:1234/v1",
   atomicchat: "http://localhost:1337/v1",
@@ -497,6 +499,13 @@ export const LOCAL_PRESETS: LocalPreset[] = [
     baseUrl: "https://api.atlascloud.ai/v1",
     group: "remote",
     envKey: "ATLASCLOUD_API_KEY",
+  },
+  {
+    id: "novita",
+    name: "constants.novita",
+    baseUrl: "https://api.novita.ai/openai/v1",
+    group: "remote",
+    envKey: "NOVITA_API_KEY",
   },
   {
     id: "mistral",
@@ -865,6 +874,12 @@ export const SETTINGS_SECTIONS: SectionDef[] = [
         label: "constants.atlascloudApiKey",
         type: "password",
         hint: "constants.atlascloudHint",
+      },
+      {
+        key: "NOVITA_API_KEY",
+        label: "constants.novitaApiKey",
+        type: "password",
+        hint: "constants.novitaHint",
       },
       {
         key: "MISTRAL_API_KEY",

--- a/src/shared/i18n/locales/en/constants.ts
+++ b/src/shared/i18n/locales/en/constants.ts
@@ -41,6 +41,7 @@ export default {
   fireworks: "Fireworks",
   cerebras: "Cerebras",
   atlascloud: "AtlasCloud",
+  novita: "NovitaAI",
   mistral: "Mistral",
   // Theme
   themeSystem: "System",
@@ -100,6 +101,8 @@ export default {
   cerebrasHint: "Ultra-fast inference on Cerebras hardware",
   atlascloudApiKey: "AtlasCloud API Key",
   atlascloudHint: "Claude, GPT & open models via AtlasCloud",
+  novitaApiKey: "Novita API Key",
+  novitaHint: "90+ open and commercial models via Novita",
   mistralApiKey: "Mistral API Key",
   mistralHint: "Mistral and Codestral models",
   perplexityApiKey: "Perplexity API Key",

--- a/src/shared/i18n/locales/en/setup.ts
+++ b/src/shared/i18n/locales/en/setup.ts
@@ -23,6 +23,7 @@ export default {
     fireworks: "Fireworks",
     cerebras: "Cerebras",
     atlascloud: "AtlasCloud",
+    novita: "NovitaAI",
     mistral: "Mistral",
     aimlapi: "AIML API",
   },

--- a/src/shared/url-key-map.ts
+++ b/src/shared/url-key-map.ts
@@ -36,6 +36,7 @@ export const URL_KEY_MAP: ReadonlyArray<UrlKeyMapping> = [
   { pattern: /api\.fireworks\.ai/i, envKey: "FIREWORKS_API_KEY" },
   { pattern: /api\.cerebras\.ai/i, envKey: "CEREBRAS_API_KEY" },
   { pattern: /atlascloud\.ai/i, envKey: "ATLASCLOUD_API_KEY" },
+  { pattern: /api\.novita\.ai/i, envKey: "NOVITA_API_KEY" },
   { pattern: /api\.mistral\.ai/i, envKey: "MISTRAL_API_KEY" },
   { pattern: /api\.perplexity\.ai/i, envKey: "PERPLEXITY_API_KEY" },
   { pattern: /api\.xiaomimimo\.com/i, envKey: "XIAOMI_API_KEY" },
@@ -127,5 +128,6 @@ export const OPENAI_COMPAT_PROVIDERS: ReadonlySet<string> = new Set([
   "fireworks",
   "cerebras",
   "atlascloud",
+  "novita",
   "mistral",
 ]);

--- a/tests/url-key-map.test.ts
+++ b/tests/url-key-map.test.ts
@@ -34,6 +34,7 @@ describe("URL_KEY_MAP", () => {
       "https://api.mistral.ai/v1": "MISTRAL_API_KEY",
       "https://api.perplexity.ai": "PERPLEXITY_API_KEY",
       "https://api.atlascloud.ai/v1": "ATLASCLOUD_API_KEY",
+      "https://api.novita.ai/openai/v1": "NOVITA_API_KEY",
     };
     for (const [url, envKey] of Object.entries(expected)) {
       expect(expectedEnvKeyForUrl(url)).toBe(envKey);


### PR DESCRIPTION
Novita is now available through the remote provider preset and API-key settings. The desktop stores its OpenAI-compatible model using `https://api.novita.ai/openai/v1` and resolves `NOVITA_API_KEY` consistently in setup, provider selection, installer readiness, and runtime routing. These values match the sibling Hermes Agent implementation.

Validation: 98 focused provider/readiness tests pass; a full suite rerun passes 2,175 tests (3 skipped). The initial full run encountered unrelated worker-start and timing failures; the unchanged rerun passed. Typecheck, lint, and lat check pass. Current main is integrated, with readiness and provider tests rechecked after integration.
