### PR TITLE
Require manual approval for dangerous desktop commands

### DIFF
--- a/lat.md/chat-commands.md
+++ b/lat.md/chat-commands.md
@@ -30,7 +30,6 @@ Because no global loading state is set, the slash branch shows its own feedback:
 
 ## Transport connection lifecycle
 
-
 Every dashboard turn first connects a JSON-RPC WebSocket to the gateway; that handshake must be time-bounded or a stalled socket wedges the whole transport with no error and no fallback (issue #718).
 
 [[src/renderer/src/screens/Chat/dashboardGatewayClient.ts#DashboardGatewayClient#connect]] resolves on `open`, rejects on `error` or an early `close`, **and** rejects on a connect-timeout (default 10s). A WebSocket stuck in `CONNECTING` — TCP accepted but the upgrade never completing, e.g. when a busy renderer starves the handshake — fires none of those events on its own, so without the timer the connect promise never settles. When it never settles, `ensureClient` in [[src/renderer/src/screens/Chat/hooks/useDashboardChatTransport.ts#useDashboardChatTransport]] never resolves, its cached `connectingRef` promise poisons every later send, `setIsLoading(false)` never runs, and the user sees a permanent loading spinner. The timeout makes the promise reject so auto mode falls back to the legacy HTTP transport (and explicit-dashboard mode surfaces a real error) instead of hanging. Per-request calls are separately bounded by their own 30s timeout.
@@ -91,7 +90,15 @@ The canonical time comes from state.db: [[src/renderer/src/screens/Chat/sessionH
 
 A few non-local commands have dedicated desktop handling and must NOT be diverted to the gateway slash pipeline, or they'd lose their behaviour.
 
-The approval responses `/approve` and `/deny` (the `RENDERER_NATIVE_SLASH` set) are excluded from the pipeline and sent as prompt-level input, matching their dedicated button handlers — `slash.exec` rejects pending-input commands anyway.
+The legacy approval responses `/approve` and `/deny` (the `RENDERER_NATIVE_SLASH` set) are excluded from the pipeline and sent as prompt-level input. They remain a compatibility path for text-only backends; structured gateway approvals use the flow below.
+
+## Structured command approvals
+
+Dangerous commands pause the current turn until the user explicitly allows or denies them; the desktop never auto-approves or replays a prompt after an approval request.
+
+[[src/shared/chat-approval.ts#normalizeApprovalRequest]] validates the gateway's offered `once`, `session`, `always`, and `deny` choices and always preserves a deny path. Dashboard chat (local, direct Remote, and SSH) renders [[src/renderer/src/screens/Chat/ApprovalCard.tsx#ApprovalCard]] from `approval.request` and sends `approval.respond` on the same runtime session through [[src/renderer/src/screens/Chat/hooks/useDashboardChatTransport.ts#useDashboardChatTransport]]. Because upstream responses are session-scoped FIFO rather than request-addressed, cards queue in arrival order and only the queue head is actionable; an in-flight guard prevents duplicate clicks from resolving the next command. A card resolves only when the gateway reports a positive resolved count. RPC rejection remains retryable, while connection/session loss marks pending cards unavailable and stops the active turn.
+
+Gateway-only chat uses the run-scoped preload bridge from [[src/main/ipc/register.ts#registerIpcHandlers]]. The TUI WebSocket and `/v1/runs` transports register an opaque pending request through [[src/main/hermes.ts#registerPendingApproval]], bind it to the originating renderer and chat run, then await the renderer's choice before responding upstream. Those queues also resolve in FIFO order. Pending requests are cleared on completion, cancellation, or renderer destruction, and transport failure after a request surfaces an error instead of falling back and potentially repeating earlier tool effects. A caller without an interactive approval UI fails closed. `Always allow` requires a second confirmation in the card because the gateway persists that choice beyond the current session.
 
 ## Side questions (`/btw`)
 

--- a/src/main/hermes.test.ts
+++ b/src/main/hermes.test.ts
@@ -60,12 +60,17 @@ import type { ConnectionConfig } from "./config";
 import { providerListSafe } from "./secrets";
 import {
   getRemoteAuthHeader,
+  bindPendingApproval,
+  clearAllPendingApprovals,
+  registerPendingApproval,
+  resolvePendingApproval,
   sendMessage,
   shouldForceCliForSessionOverride,
   stopHealthPolling,
   transcribeAudio,
 } from "./hermes";
 import type { ChatCallbacks } from "./hermes";
+import { normalizeApprovalRequest } from "../shared/chat-approval";
 
 const mockedGetModelConfig = vi.mocked(getModelConfig);
 const mockedGetApiServerKey = vi.mocked(getApiServerKey);
@@ -73,6 +78,119 @@ const mockedGetConnectionConfig = vi.mocked(getConnectionConfig);
 const mockedReadEnv = vi.mocked(readEnv);
 const mockedProviderListSafe = vi.mocked(providerListSafe);
 const mockedSpawn = vi.mocked(spawn);
+
+describe("chat approval normalization", () => {
+  it("preserves an explicit safe choice subset and always includes deny", () => {
+    expect(
+      normalizeApprovalRequest(
+        {
+          command: "rm -rf build",
+          reason: "recursive delete",
+          choices: ["session", "bogus", "session"],
+        },
+        "opaque-id",
+      ),
+    ).toEqual({
+      requestId: "opaque-id",
+      command: "rm -rf build",
+      description: "recursive delete",
+      choices: ["session", "deny"],
+    });
+  });
+
+  it("does not expose permanent approval when the payload forbids it", () => {
+    expect(
+      normalizeApprovalRequest(
+        {
+          cmd: "chmod 777 file",
+          choices: ["once", "always"],
+          allow_permanent: false,
+        },
+        "opaque-id",
+      ).choices,
+    ).toEqual(["once", "deny"]);
+  });
+});
+
+describe("pending chat approvals", () => {
+  afterEach(() => clearAllPendingApprovals());
+
+  it("validates offered choices and removes only an acknowledged response", async () => {
+    const responder = vi
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const requestId = registerPendingApproval(["once", "deny"], responder);
+
+    await expect(resolvePendingApproval(requestId, "always")).resolves.toBe(
+      false,
+    );
+    await expect(resolvePendingApproval(requestId, "once")).resolves.toBe(
+      false,
+    );
+    await expect(resolvePendingApproval(requestId, "deny")).resolves.toBe(true);
+    await expect(resolvePendingApproval(requestId, "deny")).resolves.toBe(
+      false,
+    );
+    expect(responder).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects a duplicate response while acknowledgement is in flight", async () => {
+    let acknowledge!: (value: boolean) => void;
+    const responder = vi.fn(
+      () => new Promise<boolean>((resolve) => (acknowledge = resolve)),
+    );
+    const requestId = registerPendingApproval(["once"], responder);
+    const first = resolvePendingApproval(requestId, "once");
+
+    await expect(resolvePendingApproval(requestId, "once")).resolves.toBe(
+      false,
+    );
+    acknowledge(true);
+    await expect(first).resolves.toBe(true);
+    expect(responder).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not report success after a pending request is cleared", async () => {
+    let acknowledge!: (value: boolean) => void;
+    const requestId = registerPendingApproval(
+      ["once"],
+      () => new Promise<boolean>((resolve) => (acknowledge = resolve)),
+    );
+    const response = resolvePendingApproval(requestId, "once");
+
+    clearAllPendingApprovals();
+    acknowledge(true);
+    await expect(response).resolves.toBe(false);
+  });
+
+  it("scopes an approval response to its renderer and run", async () => {
+    const responder = vi.fn().mockResolvedValue(true);
+    const requestId = registerPendingApproval(["deny"], responder);
+    expect(bindPendingApproval(requestId, { ownerId: 7, runId: "run-1" })).toBe(
+      true,
+    );
+
+    await expect(
+      resolvePendingApproval(requestId, "deny", {
+        ownerId: 8,
+        runId: "run-1",
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      resolvePendingApproval(requestId, "deny", {
+        ownerId: 7,
+        runId: "run-2",
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      resolvePendingApproval(requestId, "deny", {
+        ownerId: 7,
+        runId: "run-1",
+      }),
+    ).resolves.toBe(true);
+  });
+});
 
 function testConnection(
   fields: Partial<ConnectionConfig> = {},

--- a/src/main/hermes.ts
+++ b/src/main/hermes.ts
@@ -55,6 +55,11 @@ import { HIDDEN_SUBPROCESS_OPTIONS } from "./process-options";
 import { type Attachment, escapeXmlAttr } from "../shared/attachments";
 import { type SessionModelOverride } from "../shared/model-override";
 import {
+  normalizeApprovalRequest,
+  type ApprovalChoice,
+  type ChatApprovalRequest,
+} from "../shared/chat-approval";
+import {
   OPENAI_COMPAT_PROVIDERS,
   customProviderEnvKey,
 } from "../shared/url-key-map";
@@ -1066,6 +1071,87 @@ export function clearPendingClarify(requestId: string): void {
   pendingClarify.delete(requestId);
 }
 
+interface PendingApproval {
+  choices: ReadonlySet<ApprovalChoice>;
+  ownerId?: number;
+  responding: boolean;
+  responder: (choice: ApprovalChoice) => Promise<boolean>;
+  runId?: string;
+}
+
+const pendingApprovals = new Map<string, PendingApproval>();
+
+export function registerPendingApproval(
+  choices: readonly ApprovalChoice[],
+  responder: (choice: ApprovalChoice) => Promise<boolean>,
+): string {
+  const requestId = `approval-${randomUUID()}`;
+  pendingApprovals.set(requestId, {
+    choices: new Set(choices),
+    responding: false,
+    responder,
+  });
+  return requestId;
+}
+
+export function bindPendingApproval(
+  requestId: string,
+  owner: { ownerId: number; runId: string },
+): boolean {
+  const pending = pendingApprovals.get(requestId);
+  if (
+    !pending ||
+    pending.ownerId !== undefined ||
+    pending.runId !== undefined
+  ) {
+    return false;
+  }
+  pending.ownerId = owner.ownerId;
+  pending.runId = owner.runId;
+  return true;
+}
+
+export async function resolvePendingApproval(
+  requestId: string,
+  choice: unknown,
+  owner?: { ownerId: number; runId: string },
+): Promise<boolean> {
+  const pending = pendingApprovals.get(requestId);
+  if (
+    !pending ||
+    (pending.ownerId !== undefined && pending.ownerId !== owner?.ownerId) ||
+    (pending.runId !== undefined && pending.runId !== owner?.runId) ||
+    typeof choice !== "string" ||
+    !pending.choices.has(choice as ApprovalChoice) ||
+    pending.responding
+  ) {
+    return false;
+  }
+
+  pending.responding = true;
+  try {
+    const acknowledged = await pending.responder(choice as ApprovalChoice);
+    if (!acknowledged || pendingApprovals.get(requestId) !== pending)
+      return false;
+    pendingApprovals.delete(requestId);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (pendingApprovals.get(requestId) === pending) {
+      pending.responding = false;
+    }
+  }
+}
+
+export function clearPendingApproval(requestId: string): void {
+  pendingApprovals.delete(requestId);
+}
+
+export function clearAllPendingApprovals(): void {
+  pendingApprovals.clear();
+}
+
 export interface ChatCallbacks {
   onChunk: (text: string) => void;
   /** Streaming reasoning / thinking tokens, when the provider emits them
@@ -1099,6 +1185,7 @@ export interface ChatCallbacks {
     question: string;
     choices: string[];
   }) => void;
+  onApproval?: (req: ChatApprovalRequest) => boolean | void;
 }
 
 type ChatContent =
@@ -1612,6 +1699,30 @@ function postRunStop(
   req.end();
 }
 
+async function postRunApproval(
+  apiUrl: string,
+  profile: string | undefined,
+  runId: string,
+  choice: ApprovalChoice,
+): Promise<boolean> {
+  const response = await fetch(
+    `${apiUrl}/v1/runs/${encodeURIComponent(runId)}/approval`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...getApiAuthHeaders(profile),
+      },
+      body: JSON.stringify({ choice, all: false }),
+    },
+  );
+  if (!response.ok) return false;
+  const result = (await response.json().catch(() => null)) as {
+    resolved?: unknown;
+  } | null;
+  return typeof result?.resolved === "number" && result.resolved > 0;
+}
+
 function sendMessageViaRuns(
   message: string,
   cb: ChatCallbacks,
@@ -1662,12 +1773,24 @@ function sendMessageViaRuns(
   let startReq: http.ClientRequest | null = null;
   let eventsReq: http.ClientRequest | null = null;
   let fallbackHandle: ChatHandle | null = null;
+  let approvalInteraction = false;
+  const pendingApprovalIds = new Set<string>();
+
+  function clearApprovals(): void {
+    for (const requestId of pendingApprovalIds) {
+      clearPendingApproval(requestId);
+    }
+    pendingApprovalIds.clear();
+  }
 
   function finish(error?: string): void {
     if (finished || fallbackStarted) return;
     finished = true;
+    clearApprovals();
     if (error) {
-      cb.onError(error);
+      cb.onError(
+        approvalInteraction ? `Approval flow failed: ${error}` : error,
+      );
     } else {
       cb.onDone(sessionId || undefined);
     }
@@ -1675,6 +1798,12 @@ function sendMessageViaRuns(
 
   function fallbackToChatCompletions(): void {
     if (finished || fallbackStarted) return;
+    if (approvalInteraction) {
+      finish(
+        "Hermes lost the run after requesting approval. The prompt was not replayed.",
+      );
+      return;
+    }
     fallbackStarted = true;
     fallbackHandle = sendMessageViaApi(
       message,
@@ -1757,11 +1886,41 @@ function sendMessageViaRuns(
     }
 
     if (eventName === "approval.request") {
-      // The current renderer's approval controls are wired to the legacy chat
-      // flow and only appear after a response finishes. A run pauses before it
-      // can finish, so fall back to the existing path instead of deadlocking
-      // the user on a hidden approval request.
-      stopRunAndFallback();
+      approvalInteraction = true;
+      let requestId = "";
+      const normalized = normalizeApprovalRequest(raw, "");
+      requestId = registerPendingApproval(
+        normalized.choices,
+        async (choice) => {
+          if (pendingApprovalIds.values().next().value !== requestId) {
+            return false;
+          }
+          const acknowledged = await postRunApproval(
+            apiUrl,
+            profile,
+            runId,
+            choice,
+          );
+          if (acknowledged) pendingApprovalIds.delete(requestId);
+          return acknowledged;
+        },
+      );
+      pendingApprovalIds.add(requestId);
+      const request = { ...normalized, requestId };
+      let delivered = false;
+      try {
+        delivered = cb.onApproval?.(request) !== false && !!cb.onApproval;
+      } catch {
+        delivered = false;
+      }
+      if (!delivered) {
+        clearPendingApproval(requestId);
+        pendingApprovalIds.delete(requestId);
+        if (runId) postRunStop(apiUrl, profile, runId);
+        finish(
+          "Hermes requested approval, but no approval listener is available. The run was stopped without approving.",
+        );
+      }
     }
   }
 
@@ -1813,7 +1972,14 @@ function sendMessageViaRuns(
               }
             }
           }
-          if (!finished) finish();
+          if (!finished && approvalInteraction) {
+            if (runId) postRunStop(apiUrl, profile, runId);
+            finish(
+              "Run event stream ended while approval was pending. The run was stopped without approving.",
+            );
+          } else if (!finished) {
+            finish();
+          }
         });
       },
     );
@@ -1884,6 +2050,7 @@ function sendMessageViaRuns(
   return {
     abort: () => {
       if (finished && !fallbackStarted) return;
+      clearApprovals();
       controller.abort();
       startReq?.destroy();
       eventsReq?.destroy();
@@ -1912,10 +2079,19 @@ async function sendMessageViaTuiGateway(
   let fallbackHandle: ChatHandle | null = null;
   let fallbackStarted = false;
   let promptSubmitted = false;
+  let approvalInteraction = false;
   let cleanup = (): void => undefined;
   // request_id of an in-flight clarify question, if the agent is awaiting an
   // answer. Cleared on turn end so an abandoned turn leaks no stale resolver.
   let pendingClarifyId: string | null = null;
+  const pendingApprovalIds = new Set<string>();
+
+  function clearApprovals(): void {
+    for (const requestId of pendingApprovalIds) {
+      clearPendingApproval(requestId);
+    }
+    pendingApprovalIds.clear();
+  }
 
   function finish(error?: string): void {
     if (finished) return;
@@ -1924,9 +2100,12 @@ async function sendMessageViaTuiGateway(
       clearPendingClarify(pendingClarifyId);
       pendingClarifyId = null;
     }
+    clearApprovals();
     cleanup();
     if (error) {
-      cb.onError(error);
+      cb.onError(
+        approvalInteraction ? `Approval flow failed: ${error}` : error,
+      );
     } else {
       cb.onDone(storedSessionId || undefined);
     }
@@ -1939,11 +2118,18 @@ async function sendMessageViaTuiGateway(
       clearPendingClarify(pendingClarifyId);
       pendingClarifyId = null;
     }
+    clearApprovals();
     cleanup();
   }
 
   function startApiFallback(reason: string): void {
     if (finished || fallbackStarted) return;
+    if (approvalInteraction) {
+      finish(
+        `${reason} The prompt was not replayed after the approval request.`,
+      );
+      return;
+    }
     fallbackStarted = true;
     cleanup();
     client.stop();
@@ -2026,28 +2212,48 @@ async function sendMessageViaTuiGateway(
     }
 
     if (event.type === "approval.request") {
-      // Match the existing local chat posture: Hermes One does not expose a
-      // mid-stream approval dialog, so answer the dashboard protocol once and
-      // keep the transcript focused on the resulting tool call/result events.
-      void client
-        .request(
-          "approval.respond",
-          {
-            session_id: activeSessionId,
-            choice: "once",
-            all: false,
-          },
-          30_000,
-        )
-        .catch((error) => {
-          const message =
-            error instanceof Error ? error.message : String(error);
-          if (!hasGatewayOutput) {
-            startApiFallback(message);
-            return;
+      approvalInteraction = true;
+      let requestId = "";
+      const normalized = normalizeApprovalRequest(event.payload, "");
+      requestId = registerPendingApproval(
+        normalized.choices,
+        async (choice) => {
+          if (pendingApprovalIds.values().next().value !== requestId) {
+            return false;
           }
-          finish(message);
-        });
+          const result = await client.request<{ resolved?: unknown }>(
+            "approval.respond",
+            {
+              session_id: activeSessionId,
+              choice,
+              all: false,
+            },
+            30_000,
+          );
+          const acknowledged =
+            typeof result?.resolved === "number" && result.resolved > 0;
+          if (acknowledged) pendingApprovalIds.delete(requestId);
+          return acknowledged;
+        },
+      );
+      pendingApprovalIds.add(requestId);
+      const request = { ...normalized, requestId };
+      let delivered = false;
+      try {
+        delivered = cb.onApproval?.(request) !== false && !!cb.onApproval;
+      } catch {
+        delivered = false;
+      }
+      if (!delivered) {
+        clearPendingApproval(requestId);
+        pendingApprovalIds.delete(requestId);
+        void client
+          .request("session.interrupt", { session_id: activeSessionId }, 5_000)
+          .catch(() => undefined);
+        finish(
+          "Hermes requested approval, but no approval listener is available. The turn was stopped without approving.",
+        );
+      }
       return;
     }
 

--- a/src/main/ipc/register.ts
+++ b/src/main/ipc/register.ts
@@ -122,7 +122,9 @@ import {
   restartGateway,
   notifyProfileSwitched,
   setSshRemoteApiKey,
+  bindPendingApproval,
   resolvePendingClarify,
+  resolvePendingApproval,
 } from "../hermes";
 import {
   freshDashboardWebSocketUrl,
@@ -1574,7 +1576,7 @@ export function registerIpcHandlers(context: IpcContext): void {
       let fullResponse = "";
       const chatStartTime = Date.now();
       let resolveChat: (v: { response: string; sessionId?: string }) => void;
-      let rejectChat: (reason?: unknown) => void;
+      let rejectChat!: (reason?: unknown) => void;
       const promise = new Promise<{ response: string; sessionId?: string }>(
         (res, rej) => {
           resolveChat = res;
@@ -1601,92 +1603,134 @@ export function registerIpcHandlers(context: IpcContext): void {
       const abortThisRun = (): void => {
         activeRuns.get(chatRunId)?.();
       };
+      const senderId = event.sender.id;
+      let senderDestroyed = false;
+      const handleSenderDestroyed = (): void => {
+        senderDestroyed = true;
+        abortThisRun();
+      };
+      event.sender.once("destroyed", handleSenderDestroyed);
+      const cleanupSender = (): void => {
+        if (!event.sender.isDestroyed()) {
+          event.sender.removeListener("destroyed", handleSenderDestroyed);
+        }
+      };
 
-      const handle = await sendMessage(
-        message,
-        {
-          onChunk: (chunk) => {
-            fullResponse += chunk;
-            if (!safeSend("chat-chunk", chunk)) {
-              // Renderer is gone — stop generating and resolve with what we
-              // have so the awaiting promise doesn't leak.
-              abortThisRun();
-            }
+      let handle;
+      try {
+        handle = await sendMessage(
+          message,
+          {
+            onChunk: (chunk) => {
+              fullResponse += chunk;
+              if (!safeSend("chat-chunk", chunk)) {
+                // Renderer is gone — stop generating and resolve with what we
+                // have so the awaiting promise doesn't leak.
+                abortThisRun();
+              }
+            },
+            onReasoningChunk: (chunk) => {
+              // Forward reasoning/thinking tokens on a dedicated channel so
+              // the renderer can render the thinking bubble live during the
+              // stream rather than waiting for a focus-change refresh (#352).
+              // Same renderer-gone abort guard as the content channel.
+              if (!safeSend("chat-reasoning-chunk", chunk)) {
+                abortThisRun();
+              }
+            },
+            onDone: (sessionId) => {
+              cleanupSender();
+              activeRuns.delete(chatRunId);
+              try {
+                persistPromptImageAttachments(sessionId, message, attachments);
+              } catch (err) {
+                console.warn(
+                  "[sessions] Failed to persist prompt image attachments:",
+                  err,
+                );
+              }
+              safeSend("chat-done", sessionId || "");
+              resolveChat({ response: fullResponse, sessionId });
+              // Desktop notification when window is not focused and response took >10s
+              if (
+                mainWindow &&
+                !mainWindow.isFocused() &&
+                Date.now() - chatStartTime > 10000
+              ) {
+                const preview = fullResponse
+                  .replace(/[#*_`~\n]+/g, " ")
+                  .trim()
+                  .slice(0, 80);
+                new Notification({
+                  title: APP_NAME,
+                  body: preview || "Response ready",
+                }).show();
+              }
+            },
+            onSessionStarted: (sessionId) => {
+              safeSend("chat-session-started", sessionId);
+            },
+            onError: (error) => {
+              cleanupSender();
+              activeRuns.delete(chatRunId);
+              safeSend("chat-error", error);
+              rejectChat(new Error(error));
+              // Notify on error too if window not focused
+              if (mainWindow && !mainWindow.isFocused()) {
+                new Notification({
+                  title: `${APP_NAME} — Error`,
+                  body: error.slice(0, 100),
+                }).show();
+              }
+            },
+            onToolProgress: (tool) => {
+              safeSend("chat-tool-progress", tool);
+            },
+            onToolEvent: (toolEvent) => {
+              safeSend("chat-tool-event", toolEvent);
+            },
+            onUsage: (usage) => {
+              safeSend("chat-usage", usage);
+            },
+            onClarify: (req) => {
+              safeSend("chat-clarify-request", req);
+            },
+            onApproval: (req) => {
+              // Office one-chat omits runId and has no approval UI.
+              if (!runId) return false;
+              if (
+                !bindPendingApproval(req.requestId, {
+                  ownerId: senderId,
+                  runId: chatRunId,
+                })
+              ) {
+                return false;
+              }
+              return safeSend("chat-approval-request", req);
+            },
           },
-          onReasoningChunk: (chunk) => {
-            // Forward reasoning/thinking tokens on a dedicated channel so
-            // the renderer can render the thinking bubble live during the
-            // stream rather than waiting for a focus-change refresh (#352).
-            // Same renderer-gone abort guard as the content channel.
-            if (!safeSend("chat-reasoning-chunk", chunk)) {
-              abortThisRun();
-            }
-          },
-          onDone: (sessionId) => {
-            activeRuns.delete(chatRunId);
-            try {
-              persistPromptImageAttachments(sessionId, message, attachments);
-            } catch (err) {
-              console.warn(
-                "[sessions] Failed to persist prompt image attachments:",
-                err,
-              );
-            }
-            safeSend("chat-done", sessionId || "");
-            resolveChat({ response: fullResponse, sessionId });
-            // Desktop notification when window is not focused and response took >10s
-            if (
-              mainWindow &&
-              !mainWindow.isFocused() &&
-              Date.now() - chatStartTime > 10000
-            ) {
-              const preview = fullResponse
-                .replace(/[#*_`~\n]+/g, " ")
-                .trim()
-                .slice(0, 80);
-              new Notification({
-                title: APP_NAME,
-                body: preview || "Response ready",
-              }).show();
-            }
-          },
-          onSessionStarted: (sessionId) => {
-            safeSend("chat-session-started", sessionId);
-          },
-          onError: (error) => {
-            activeRuns.delete(chatRunId);
-            safeSend("chat-error", error);
-            rejectChat(new Error(error));
-            // Notify on error too if window not focused
-            if (mainWindow && !mainWindow.isFocused()) {
-              new Notification({
-                title: `${APP_NAME} — Error`,
-                body: error.slice(0, 100),
-              }).show();
-            }
-          },
-          onToolProgress: (tool) => {
-            safeSend("chat-tool-progress", tool);
-          },
-          onToolEvent: (toolEvent) => {
-            safeSend("chat-tool-event", toolEvent);
-          },
-          onUsage: (usage) => {
-            safeSend("chat-usage", usage);
-          },
-          onClarify: (req) => {
-            safeSend("chat-clarify-request", req);
-          },
-        },
-        profile,
-        resumeSessionId,
-        history,
-        attachments,
-        contextFolder,
-        modelOverride,
-      );
+          profile,
+          resumeSessionId,
+          history,
+          attachments,
+          contextFolder,
+          modelOverride,
+        );
+      } catch (error) {
+        cleanupSender();
+        throw error;
+      }
 
-      activeRuns.set(chatRunId, handle.abort);
+      const abortRun = (): void => {
+        cleanupSender();
+        handle.abort();
+      };
+      if (senderDestroyed) {
+        abortRun();
+        rejectChat(new Error("Chat renderer closed before the run started."));
+        return promise;
+      }
+      activeRuns.set(chatRunId, abortRun);
       return promise;
     },
   );
@@ -1710,6 +1754,25 @@ export function registerIpcHandlers(context: IpcContext): void {
       return resolvePendingClarify(
         payload?.requestId ?? "",
         payload?.answer ?? "",
+      );
+    },
+  );
+
+  ipcMain.handle(
+    "approval-respond",
+    async (
+      _event,
+      payload:
+        | { requestId?: unknown; choice?: unknown; runId?: unknown }
+        | undefined,
+    ) => {
+      return resolvePendingApproval(
+        typeof payload?.requestId === "string" ? payload.requestId : "",
+        payload?.choice,
+        {
+          ownerId: _event.sender.id,
+          runId: typeof payload?.runId === "string" ? payload.runId : "",
+        },
       );
     },
   );

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -34,6 +34,10 @@ import type {
   MessagingPlatformUpdate,
 } from "../shared/messaging-platforms";
 import type { ChatToolEvent } from "../shared/chat-stream";
+import type {
+  ApprovalChoice,
+  ChatApprovalRequest,
+} from "../shared/chat-approval";
 import type { GpuPreferenceMode, GpuStatus } from "../shared/gpu";
 
 interface ElectronAPI {
@@ -544,6 +548,14 @@ interface HermesAPI {
     ) => void,
   ) => () => void;
   respondClarify: (requestId: string, answer: string) => Promise<boolean>;
+  onApprovalRequest: (
+    callback: (runId: string, req: ChatApprovalRequest) => void,
+  ) => () => void;
+  respondApproval: (
+    requestId: string,
+    choice: ApprovalChoice,
+    runId: string,
+  ) => Promise<boolean>;
 
   // Gateway
   startGateway: () => Promise<GatewayStartResult>;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -21,6 +21,10 @@ import type {
 } from "../shared/messaging-platforms";
 import type { ChatToolEvent } from "../shared/chat-stream";
 import type {
+  ApprovalChoice,
+  ChatApprovalRequest,
+} from "../shared/chat-approval";
+import type {
   DeviceCodeInfo,
   EnsureHermesOneKeyResult,
   HermesAccount,
@@ -793,6 +797,25 @@ const hermesAPI = {
    *  autonomously (the gateway treats it as "you decide"). */
   respondClarify: (requestId: string, answer: string): Promise<boolean> =>
     ipcRenderer.invoke("clarify-respond", { requestId, answer }),
+
+  onApprovalRequest: (
+    callback: (runId: string, req: ChatApprovalRequest) => void,
+  ): (() => void) => {
+    const handler = (
+      _event: Electron.IpcRendererEvent,
+      runId: string,
+      req: ChatApprovalRequest,
+    ): void => callback(runId, req);
+    ipcRenderer.on("chat-approval-request", handler);
+    return () => ipcRenderer.removeListener("chat-approval-request", handler);
+  },
+
+  respondApproval: (
+    requestId: string,
+    choice: ApprovalChoice,
+    runId: string,
+  ): Promise<boolean> =>
+    ipcRenderer.invoke("approval-respond", { requestId, choice, runId }),
 
   // Gateway
   startGateway: (): Promise<GatewayStartResult> =>

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -5459,6 +5459,70 @@ body:has(.shell-vibrant),
   margin-top: 2px;
 }
 
+.chat-approval-card {
+  border-left-color: var(--warning, #d97706);
+}
+
+.chat-approval-heading {
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.chat-approval-command {
+  max-height: 180px;
+  margin: 0;
+  padding: 10px 12px;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-base);
+  color: var(--text-primary);
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.chat-approval-choice--deny {
+  color: var(--danger, #ef4444);
+}
+
+.chat-approval-confirm {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--warning, #d97706);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.chat-approval-confirm-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.chat-approval-confirm-actions .chat-clarify-choice,
+.chat-approval-confirm-actions .chat-clarify-send {
+  width: auto;
+  align-self: auto;
+  text-align: center;
+}
+
+@media (max-width: 720px) {
+  .chat-approval-card {
+    margin-left: 0;
+  }
+}
+
 /* Override Tailwind preflight spacing inside agent bubbles */
 .chat-bubble-agent p {
   margin: 0 0 0.85em !important;

--- a/src/renderer/src/screens/Chat/ApprovalCard.test.tsx
+++ b/src/renderer/src/screens/Chat/ApprovalCard.test.tsx
@@ -1,0 +1,128 @@
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { I18nProvider } from "../../components/I18nProvider";
+import { ApprovalCard } from "./ApprovalCard";
+import type { ApprovalMessage } from "./types";
+
+afterEach(cleanup);
+
+function message(overrides: Partial<ApprovalMessage> = {}): ApprovalMessage {
+  return {
+    id: "approval-r1",
+    kind: "approval",
+    role: "agent",
+    requestId: "r1",
+    responsePath: "ipc",
+    command: "rm -rf ./build",
+    description: "Remove generated output",
+    choices: ["once", "session", "always", "deny"],
+    ...overrides,
+  };
+}
+
+function renderCard(
+  msg: ApprovalMessage,
+  onRespond = vi.fn(),
+  onResolved = vi.fn(),
+  isActive = true,
+): ReturnType<typeof render> {
+  return render(
+    <I18nProvider>
+      <ApprovalCard
+        msg={msg}
+        isActive={isActive}
+        onRespond={onRespond}
+        onResolved={onResolved}
+      />
+    </I18nProvider>,
+  );
+}
+
+describe("ApprovalCard", () => {
+  it("renders only offered choices and safely renders command text", () => {
+    renderCard(
+      message({
+        command: '<img src=x onerror="alert(1)">',
+        choices: ["once", "deny"],
+      }),
+    );
+
+    expect(screen.getByText('<img src=x onerror="alert(1)">')).toBeTruthy();
+    expect(screen.getByText("Allow once")).toBeTruthy();
+    expect(screen.getByText("Deny")).toBeTruthy();
+    expect(screen.queryByText("Allow for session")).toBeNull();
+    expect(document.querySelector("img")).toBeNull();
+  });
+
+  it("requires a second explicit confirmation for always", async () => {
+    const onRespond = vi.fn().mockResolvedValue(true);
+    const onResolved = vi.fn();
+    renderCard(message(), onRespond, onResolved);
+
+    fireEvent.click(screen.getByText("Always allow"));
+    expect(onRespond).not.toHaveBeenCalled();
+    await act(async () => {
+      fireEvent.click(screen.getByText("Confirm always allow"));
+    });
+
+    await vi.waitFor(() =>
+      expect(onRespond).toHaveBeenCalledWith(message(), "always"),
+    );
+    expect(onResolved).toHaveBeenCalledWith(message(), "always");
+  });
+
+  it.each([
+    ["returns false", vi.fn().mockResolvedValue(false)],
+    ["rejects", vi.fn().mockRejectedValue(new Error("offline"))],
+  ])(
+    "stays retryable and alerts when response %s",
+    async (_case, onRespond) => {
+      const onResolved = vi.fn();
+      renderCard(message({ choices: ["once"] }), onRespond, onResolved);
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Allow once"));
+      });
+      await vi.waitFor(() => expect(screen.getByRole("alert")).toBeTruthy());
+      expect(onResolved).not.toHaveBeenCalled();
+      expect(
+        (screen.getByText("Allow once") as HTMLButtonElement).disabled,
+      ).toBe(false);
+    },
+  );
+
+  it("renders a resolved card as read-only", () => {
+    const onRespond = vi.fn();
+    renderCard(message({ resolved: true, choice: "deny" }), onRespond);
+
+    expect(screen.getByText("Deny")).toBeTruthy();
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(onRespond).not.toHaveBeenCalled();
+  });
+
+  it("renders an unavailable card without actions", () => {
+    renderCard(message({ unavailable: true }));
+
+    expect(screen.getByRole("alert")).toBeTruthy();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("disables a queued approval until earlier requests resolve", () => {
+    renderCard(message(), vi.fn(), vi.fn(), false);
+
+    expect(
+      screen.getByText("Resolve the earlier approval request first."),
+    ).toBeTruthy();
+    expect(
+      screen
+        .getAllByRole("button")
+        .every((button) => (button as HTMLButtonElement).disabled),
+    ).toBe(true);
+  });
+});

--- a/src/renderer/src/screens/Chat/ApprovalCard.tsx
+++ b/src/renderer/src/screens/Chat/ApprovalCard.tsx
@@ -1,0 +1,137 @@
+import { memo, useState } from "react";
+import {
+  APPROVAL_CHOICES,
+  type ApprovalChoice,
+} from "../../../../shared/chat-approval";
+import { useI18n } from "../../components/useI18n";
+import type { ApprovalMessage } from "./types";
+
+interface ApprovalCardProps {
+  msg: ApprovalMessage;
+  isActive?: boolean;
+  onRespond: (msg: ApprovalMessage, choice: ApprovalChoice) => Promise<boolean>;
+  onResolved: (msg: ApprovalMessage, choice: ApprovalChoice) => void;
+}
+
+export const ApprovalCard = memo(function ApprovalCard({
+  msg,
+  isActive = true,
+  onRespond,
+  onResolved,
+}: ApprovalCardProps): React.JSX.Element {
+  const { t } = useI18n();
+  const [submitting, setSubmitting] = useState(false);
+  const [confirmAlways, setConfirmAlways] = useState(false);
+  const [error, setError] = useState(false);
+  const resolved = !!msg.resolved;
+  const unavailable = !!msg.unavailable;
+  const choices = APPROVAL_CHOICES.filter((choice) =>
+    msg.choices.includes(choice),
+  );
+  const choiceLabel = (choice: ApprovalChoice): string =>
+    t(`chat.approval.${choice}`);
+
+  const submit = async (choice: ApprovalChoice): Promise<void> => {
+    if (resolved || submitting || !isActive || !choices.includes(choice))
+      return;
+    setSubmitting(true);
+    setError(false);
+    try {
+      const ok = await onRespond(msg, choice);
+      if (!ok) {
+        setError(true);
+        return;
+      }
+      setConfirmAlways(false);
+      onResolved(msg, choice);
+    } catch {
+      setError(true);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className={`chat-clarify chat-approval-card${
+        resolved ? " chat-clarify--resolved" : ""
+      }`}
+    >
+      <div className="chat-approval-heading">{t("chat.approval.title")}</div>
+      <div className="chat-clarify-question">{msg.description}</div>
+      <pre className="chat-approval-command">
+        <code>{msg.command}</code>
+      </pre>
+
+      {unavailable ? (
+        <div className="chat-clarify-error" role="alert">
+          {t("chat.approval.unavailable")}
+        </div>
+      ) : resolved ? (
+        <div className="chat-clarify-answer">
+          {msg.choice ? choiceLabel(msg.choice) : t("chat.approval.responded")}
+        </div>
+      ) : (
+        <>
+          <div className="chat-clarify-choices chat-approval-choices">
+            {choices.map((choice) => (
+              <button
+                key={choice}
+                type="button"
+                className={`chat-clarify-choice chat-approval-choice--${choice}`}
+                disabled={submitting || !isActive}
+                onClick={() => {
+                  if (choice === "always") {
+                    setError(false);
+                    setConfirmAlways(true);
+                    return;
+                  }
+                  setConfirmAlways(false);
+                  void submit(choice);
+                }}
+              >
+                {choiceLabel(choice)}
+              </button>
+            ))}
+          </div>
+
+          {!isActive && (
+            <div className="chat-clarify-answer">
+              {t("chat.approval.queued")}
+            </div>
+          )}
+
+          {confirmAlways && (
+            <div className="chat-approval-confirm">
+              <span>{t("chat.approval.confirm")}</span>
+              <div className="chat-approval-confirm-actions">
+                <button
+                  type="button"
+                  className="chat-clarify-choice"
+                  disabled={submitting}
+                  onClick={() => setConfirmAlways(false)}
+                >
+                  {t("chat.approval.cancel")}
+                </button>
+                <button
+                  type="button"
+                  className="chat-clarify-send"
+                  disabled={submitting}
+                  onClick={() => void submit("always")}
+                >
+                  {t("chat.approval.confirmAlways")}
+                </button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      {error && (
+        <div className="chat-clarify-error" role="alert">
+          {t("chat.approval.error")}
+        </div>
+      )}
+    </div>
+  );
+});

--- a/src/renderer/src/screens/Chat/Chat.tsx
+++ b/src/renderer/src/screens/Chat/Chat.tsx
@@ -30,8 +30,14 @@ import { buildChatTranscript } from "./transcriptUtils";
 import { ConfigHealthBanner } from "../../components/ConfigHealthBanner";
 import FollowUsModal from "../../components/FollowUsModal";
 import type { Attachment } from "../../../../shared/attachments";
+import type { ApprovalChoice } from "../../../../shared/chat-approval";
 import type { SessionModelOverride } from "../../../../shared/model-override";
-import type { ActiveTurn, ChatMessage, UsageState } from "./types";
+import type {
+  ActiveTurn,
+  ApprovalMessage,
+  ChatMessage,
+  UsageState,
+} from "./types";
 import type { ContextUsage } from "./ContextGauge";
 import { contextWindowForModel } from "./contextWindows";
 import { QueuedMessages } from "./QueuedMessages";
@@ -629,6 +635,31 @@ function Chat({
     onDashboardUnavailable: handleDashboardUnavailable,
   });
 
+  const handleApprovalRespond = useCallback(
+    (msg: ApprovalMessage, choice: ApprovalChoice): Promise<boolean> =>
+      msg.responsePath === "dashboard"
+        ? dashboardTransport.respondApproval(msg.requestId, choice)
+        : window.hermesAPI.respondApproval(
+            msg.requestId,
+            choice,
+            msg.runId || "",
+          ),
+    [dashboardTransport.respondApproval],
+  );
+
+  const handleApprovalResolved = useCallback(
+    (msg: ApprovalMessage, choice: ApprovalChoice) => {
+      setMessages((prev) =>
+        prev.map((candidate) =>
+          candidate.kind === "approval" && candidate.id === msg.id
+            ? { ...candidate, choice, resolved: true }
+            : candidate,
+        ),
+      );
+    },
+    [setMessages],
+  );
+
   const [agentCommandCatalog, setAgentCommandCatalog] =
     useState<AgentCommandsCatalogResponse | null>(null);
   const getCommandCatalog = dashboardTransport.getCommandCatalog;
@@ -942,6 +973,8 @@ function Chat({
               onApprove={actions.handleApprove}
               onDeny={actions.handleDeny}
               onClarifyResolved={handleClarifyResolved}
+              onApprovalRespond={handleApprovalRespond}
+              onApprovalResolved={handleApprovalResolved}
               agentAvatar={agentAvatar}
             />
           )}

--- a/src/renderer/src/screens/Chat/MessageList.tsx
+++ b/src/renderer/src/screens/Chat/MessageList.tsx
@@ -3,7 +3,10 @@ import { HermesAvatar, MessageRow } from "./MessageRow";
 import type { AgentAvatarInfo } from "./MessageRow";
 import { ReasoningRow, ToolActivityGroup } from "./HistoryRow";
 import { ClarifyCard } from "./ClarifyCard";
+import { ApprovalCard } from "./ApprovalCard";
+import type { ApprovalChoice } from "../../../../shared/chat-approval";
 import type {
+  ApprovalMessage,
   ChatMessage,
   ClarifyMessage,
   ToolCallMessage,
@@ -23,6 +26,11 @@ interface MessageListProps {
   onDeny: () => void;
   /** Mark an inline clarify card resolved once the user answers/skips. */
   onClarifyResolved: (requestId: string, answer: string) => void;
+  onApprovalRespond: (
+    msg: ApprovalMessage,
+    choice: ApprovalChoice,
+  ) => Promise<boolean>;
+  onApprovalResolved: (msg: ApprovalMessage, choice: ApprovalChoice) => void;
   /** Appearance of the agent this conversation is with, so idle avatars show
    *  the agent's profile picture instead of the loading gif. */
   agentAvatar?: AgentAvatarInfo;
@@ -72,6 +80,8 @@ export const MessageList = memo(function MessageList({
   onApprove,
   onDeny,
   onClarifyResolved,
+  onApprovalRespond,
+  onApprovalResolved,
   agentAvatar,
 }: MessageListProps): React.JSX.Element {
   // Bubbles with empty content are still hidden (live-stream placeholders).
@@ -87,6 +97,13 @@ export const MessageList = memo(function MessageList({
 
   const lastBubble = [...messages].reverse().find(isBubble);
   const lastMessageIsAgent = !!lastBubble && lastBubble.role === "agent";
+  const awaitingApproval = messages.some(
+    (message) => message.kind === "approval" && !message.resolved,
+  );
+  const activeApprovalId = messages.find(
+    (message) =>
+      message.kind === "approval" && !message.resolved && !message.unavailable,
+  )?.id;
 
   // Render plan: bubble/reasoning rows pass through one-to-one, but a
   // contiguous run of tool_call/tool_result rows folds into a single
@@ -153,6 +170,19 @@ export const MessageList = memo(function MessageList({
       continue;
     }
 
+    if (k === "approval") {
+      rows.push(
+        <ApprovalCard
+          key={msg.id}
+          msg={msg as ApprovalMessage}
+          isActive={msg.id === activeApprovalId}
+          onRespond={onApprovalRespond}
+          onResolved={onApprovalResolved}
+        />,
+      );
+      continue;
+    }
+
     const bubble = msg as Extract<ChatMessage, { role: "user" | "agent" }>;
     rows.push(
       <MessageRow
@@ -172,7 +202,7 @@ export const MessageList = memo(function MessageList({
     <>
       {rows}
 
-      {isLoading && !lastMessageIsAgent && (
+      {isLoading && !lastMessageIsAgent && !awaitingApproval && (
         <TypingIndicator
           toolProgress={toolProgress}
           agentAvatar={agentAvatar}

--- a/src/renderer/src/screens/Chat/dashboardEventAdapter.test.ts
+++ b/src/renderer/src/screens/Chat/dashboardEventAdapter.test.ts
@@ -209,3 +209,76 @@ describe("applyDashboardStreamEvent — message.complete text reconciliation", (
     expect((bubble as { content: string }).content).toBe("Remote answer");
   });
 });
+
+describe("applyDashboardStreamEvent approval requests", () => {
+  it("projects a structured dashboard approval and dedupes repeated events", () => {
+    const state: DashboardEventState = {
+      messages: [],
+      reasoningSegmentClosed: false,
+    };
+    const event = {
+      type: "approval.request",
+      session_id: "session-1",
+      payload: {
+        request_id: "request-1",
+        command: "npm publish",
+        description: "Publish this package",
+        choices: ["once", "always", "bogus"],
+      },
+    };
+
+    const first = applyDashboardStreamEvent(state, event);
+    const second = applyDashboardStreamEvent(first, event);
+
+    expect(first.reasoningSegmentClosed).toBe(true);
+    expect(first.messages).toEqual([
+      {
+        id: "approval-dashboard-request-1",
+        kind: "approval",
+        role: "agent",
+        responsePath: "dashboard",
+        requestId: "request-1",
+        command: "npm publish",
+        description: "Publish this package",
+        choices: ["once", "always", "deny"],
+      },
+    ]);
+    expect(second.messages).toHaveLength(1);
+  });
+
+  it("creates a session/time-scoped identity when the gateway omits one", () => {
+    const next = applyDashboardStreamEvent(
+      { messages: [], reasoningSegmentClosed: false },
+      {
+        type: "approval.request",
+        session_id: "session-2",
+        payload: { command: "echo hello" },
+      },
+      { now: 1234 },
+    );
+
+    expect(next.messages[0]).toMatchObject({
+      requestId: "dashboard-approval-session-2-1234",
+      responsePath: "dashboard",
+    });
+  });
+
+  it("keeps distinct gateway request IDs even when request content matches", () => {
+    const first = applyDashboardStreamEvent(
+      { messages: [], reasoningSegmentClosed: false },
+      {
+        type: "approval.request",
+        payload: { request_id: "one", command: "echo hello" },
+      },
+    );
+    const second = applyDashboardStreamEvent(first, {
+      type: "approval.request",
+      payload: { request_id: "two", command: "echo hello" },
+    });
+
+    expect(second.messages.map((message) => message.id)).toEqual([
+      "approval-dashboard-one",
+      "approval-dashboard-two",
+    ]);
+  });
+});

--- a/src/renderer/src/screens/Chat/dashboardEventAdapter.ts
+++ b/src/renderer/src/screens/Chat/dashboardEventAdapter.ts
@@ -1,4 +1,5 @@
 import type { ChatToolEvent } from "../../../../shared/chat-stream";
+import { normalizeApprovalRequest } from "../../../../shared/chat-approval";
 import { isLossyChunkCopy } from "./lossyText";
 import type { ActiveTurn, ChatBubbleMessage, ChatMessage } from "./types";
 
@@ -15,8 +16,57 @@ export interface DashboardEventState {
 
 interface ApplyDashboardEventOptions {
   activeTurn?: ActiveTurn | null;
+  approvalRequestId?: string;
   now?: number;
   renderAssistantDeltas?: boolean;
+}
+
+export function dashboardApprovalRequestId(
+  event: DashboardStreamEvent,
+  now = Date.now(),
+  fallbackNonce?: number,
+): string {
+  const payload = isRecord(event.payload) ? event.payload : {};
+  const supplied = textFromPayload(payload, "request_id", "id").trim();
+  if (supplied) return supplied;
+  const payloadTime = textFromPayload(
+    payload,
+    "timestamp",
+    "time",
+    "created_at",
+  );
+  if (payloadTime) {
+    return `dashboard-approval-${event.session_id || "session"}-${payloadTime}`;
+  }
+  return `dashboard-approval-${event.session_id || "session"}-${now}${
+    fallbackNonce === undefined ? "" : `-${fallbackNonce}`
+  }`;
+}
+
+function appendApprovalRequest(
+  messages: ReadonlyArray<ChatMessage>,
+  payload: unknown,
+  requestId: string,
+): ChatMessage[] {
+  if (
+    messages.some(
+      (message) =>
+        message.kind === "approval" && message.requestId === requestId,
+    )
+  ) {
+    return [...messages];
+  }
+  const request = normalizeApprovalRequest(payload, requestId);
+  return [
+    ...messages,
+    {
+      id: `approval-dashboard-${requestId}`,
+      kind: "approval",
+      role: "agent",
+      responsePath: "dashboard",
+      ...request,
+    },
+  ];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -704,6 +754,18 @@ export function applyDashboardStreamEvent(
         messages: appendClarifyRequest(state.messages, event.payload, now),
         reasoningSegmentClosed: true,
       };
+    case "approval.request": {
+      const requestId =
+        options.approvalRequestId ?? dashboardApprovalRequestId(event, now);
+      return {
+        messages: appendApprovalRequest(
+          state.messages,
+          event.payload,
+          requestId,
+        ),
+        reasoningSegmentClosed: true,
+      };
+    }
     case "message.complete": {
       const finalText = textFromPayload(event.payload, "text", "rendered");
       const finalReasoning = thinkingTextFromPayload(

--- a/src/renderer/src/screens/Chat/hooks/useChatActions.ts
+++ b/src/renderer/src/screens/Chat/hooks/useChatActions.ts
@@ -403,9 +403,25 @@ export function useChatActions({
     abortDashboard?.();
     window.hermesAPI.abortChat(runId);
     activeTurnRef.current = null;
+    setMessages((current) =>
+      current.map((message) =>
+        message.kind === "approval" &&
+        message.responsePath === "ipc" &&
+        !message.resolved
+          ? { ...message, unavailable: true }
+          : message,
+      ),
+    );
     setIsLoading(false);
     setTimeout(() => chatInputRef.current?.focus(), 50);
-  }, [abortDashboard, runId, activeTurnRef, chatInputRef, setIsLoading]);
+  }, [
+    abortDashboard,
+    runId,
+    activeTurnRef,
+    chatInputRef,
+    setIsLoading,
+    setMessages,
+  ]);
 
   const handleApprove = useCallback(() => {
     chatInputRef.current?.clear();

--- a/src/renderer/src/screens/Chat/hooks/useChatIPC.test.tsx
+++ b/src/renderer/src/screens/Chat/hooks/useChatIPC.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { useRef, useState } from "react";
 import { useChatIPC } from "./useChatIPC";
 import type { ActiveTurn, ChatMessage, UsageState } from "../types";
+import type { ChatApprovalRequest } from "../../../../../shared/chat-approval";
 
 type Callback<T extends unknown[]> = (...args: T) => void;
 
@@ -12,6 +13,7 @@ interface ChatIpcCallbacks {
   reasoning?: Callback<[string, string]>;
   done?: Callback<[string, string]>;
   error?: Callback<[string, string]>;
+  approval?: Callback<[string, ChatApprovalRequest]>;
   toolProgress?: Callback<[string, string]>;
   toolEvent?: Callback<[string, unknown]>;
   usage?: Callback<[string, UsageState]>;
@@ -63,6 +65,10 @@ function installHermesApi(callbacks: ChatIpcCallbacks): {
         return vi.fn();
       },
       onClarifyRequest: vi.fn(() => vi.fn()),
+      onApprovalRequest: (cb: Callback<[string, ChatApprovalRequest]>) => {
+        callbacks.approval = cb;
+        return vi.fn();
+      },
       onChatUsage: (cb: Callback<[string, UsageState]>) => {
         callbacks.usage = cb;
         return vi.fn();
@@ -136,6 +142,30 @@ describe("useChatIPC session scoping", () => {
     expect(api.getSessionMessages).toHaveBeenCalledWith("old-session");
     expect(screen.getByTestId("ids")).toHaveTextContent(
       JSON.stringify(["db-1", "db-2"]),
+    );
+  });
+});
+
+describe("useChatIPC approval requests", () => {
+  it("run-scopes, structures, and dedupes approval cards while loading", async () => {
+    const callbacks: ChatIpcCallbacks = {};
+    installHermesApi(callbacks);
+    render(<Harness sessionScopeId={null} />);
+    const request: ChatApprovalRequest = {
+      requestId: "approval-1",
+      command: "rm temp.txt",
+      description: "Remove a temporary file",
+      choices: ["once", "deny"],
+    };
+
+    await act(async () => {
+      callbacks.approval?.("other-run", request);
+      callbacks.approval?.("run-1", request);
+      callbacks.approval?.("run-1", request);
+    });
+
+    expect(screen.getByTestId("ids")).toHaveTextContent(
+      JSON.stringify(["approval-ipc-approval-1"]),
     );
   });
 });

--- a/src/renderer/src/screens/Chat/hooks/useChatIPC.ts
+++ b/src/renderer/src/screens/Chat/hooks/useChatIPC.ts
@@ -227,9 +227,16 @@ export function useChatIPC({
       reasoningSegmentClosedRef.current = false;
       stopDbPolling();
       const activeTurn = activeTurnRef.current;
-      if (!activeTurn) return;
-      activeTurn.status = "failed";
-      setMessages((prev) => markActiveTurnFailed(prev, error, activeTurn));
+      if (activeTurn) activeTurn.status = "failed";
+      setMessages((prev) =>
+        markActiveTurnFailed(prev, error, activeTurn).map((message) =>
+          message.kind === "approval" &&
+          message.responsePath === "ipc" &&
+          !message.resolved
+            ? { ...message, unavailable: true }
+            : message,
+        ),
+      );
       setToolProgress(null);
       setIsLoading(false);
     });
@@ -257,6 +264,38 @@ export function useChatIPC({
               requestId: req.requestId,
               question: req.question,
               choices: Array.isArray(req.choices) ? req.choices : [],
+            },
+          ];
+        });
+      },
+    );
+
+    const cleanupApproval = window.hermesAPI.onApprovalRequest(
+      (eventRunId, req) => {
+        if (!eventMatchesRun(eventRunId, runId)) return;
+        reasoningSegmentClosedRef.current = true;
+        setToolProgress(null);
+        setIsLoading(true);
+        setMessages((prev) => {
+          if (
+            prev.some(
+              (message) =>
+                message.kind === "approval" &&
+                message.responsePath === "ipc" &&
+                message.requestId === req.requestId,
+            )
+          ) {
+            return prev;
+          }
+          return [
+            ...prev,
+            {
+              id: `approval-ipc-${req.requestId}`,
+              kind: "approval",
+              role: "agent",
+              responsePath: "ipc",
+              runId,
+              ...req,
             },
           ];
         });
@@ -353,6 +392,7 @@ export function useChatIPC({
       cleanupDone();
       cleanupError();
       cleanupClarify();
+      cleanupApproval();
       cleanupToolProgress();
       cleanupToolEvent();
       cleanupUsage();

--- a/src/renderer/src/screens/Chat/hooks/useDashboardChatTransport.test.tsx
+++ b/src/renderer/src/screens/Chat/hooks/useDashboardChatTransport.test.tsx
@@ -46,7 +46,11 @@ vi.mock("../dashboardGatewayClient", () => ({
 
 interface HarnessApi {
   activeTurnRef?: MutableRefObject<ActiveTurn | null>;
+  abort?: () => void;
   messages?: ChatMessage[];
+  respondApproval?: ReturnType<
+    typeof useDashboardChatTransport
+  >["respondApproval"];
   send?: (text: string) => Promise<boolean>;
   setConnectionMode?: Dispatch<SetStateAction<"local" | "remote" | "ssh">>;
   setMessages?: Dispatch<SetStateAction<ChatMessage[]>>;
@@ -120,7 +124,9 @@ function Harness({
     // holds) without per-prop assignment, which the immutability rule rejects.
     Object.assign(api, {
       activeTurnRef,
+      abort: transport.abort,
       messages,
+      respondApproval: transport.respondApproval,
       send: transport.sendMessage,
       setConnectionMode,
       setMessages,
@@ -134,6 +140,8 @@ function Harness({
     setConnectionMode,
     setMessages,
     transport.sendMessage,
+    transport.respondApproval,
+    transport.abort,
   ]);
 
   return null;
@@ -443,6 +451,174 @@ describe("useDashboardChatTransport recovery", () => {
     expect(requests.map((request) => request.method)).toContain(
       "prompt.submit",
     );
+  });
+});
+
+describe("useDashboardChatTransport approvals", () => {
+  beforeEach(() => {
+    dashboardMock.close.mockClear();
+    dashboardMock.connect.mockClear();
+    dashboardMock.instances.length = 0;
+    dashboardMock.onEvent = null;
+    dashboardMock.request.mockReset();
+    dashboardMock.request.mockImplementation(async (method: string) => {
+      if (method === "session.create") {
+        return { session_id: "live-1", stored_session_id: "stored-1" };
+      }
+      if (method === "approval.respond") return { resolved: 1 };
+      return {};
+    });
+    Object.defineProperty(window, "hermesAPI", {
+      configurable: true,
+      value: {
+        recordSessionContinuation: vi.fn(async () => true),
+        recordSessionLocalError: vi.fn(async () => true),
+        startDashboard: vi.fn(async () => ({
+          connection: { wsUrl: "ws://127.0.0.1:12345" },
+          running: true,
+        })),
+      },
+    });
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  it("responds only to the pending offered choice and clears after ack", async () => {
+    const api: HarnessApi = {};
+    render(<Harness api={api} />);
+    await act(async () => {
+      await api.send?.("hello");
+      dashboardMock.onEvent?.({
+        type: "approval.request",
+        session_id: "live-1",
+        payload: {
+          request_id: "approval-1",
+          command: "npm publish",
+          choices: ["once"],
+        },
+      });
+    });
+
+    await expect(api.respondApproval?.("approval-1", "always")).resolves.toBe(
+      false,
+    );
+    await expect(api.respondApproval?.("approval-1", "once")).resolves.toBe(
+      true,
+    );
+    expect(dashboardMock.request).toHaveBeenCalledWith("approval.respond", {
+      session_id: "live-1",
+      choice: "once",
+      all: false,
+    });
+    await expect(api.respondApproval?.("approval-1", "once")).resolves.toBe(
+      false,
+    );
+  });
+
+  it("keeps a failed response pending for retry", async () => {
+    const api: HarnessApi = {};
+    render(<Harness api={api} />);
+    await act(async () => {
+      await api.send?.("hello");
+      dashboardMock.onEvent?.({
+        type: "approval.request",
+        session_id: "live-1",
+        payload: { request_id: "approval-2", choices: ["deny"] },
+      });
+    });
+    dashboardMock.request.mockRejectedValueOnce(new Error("offline"));
+
+    await expect(api.respondApproval?.("approval-2", "deny")).resolves.toBe(
+      false,
+    );
+    dashboardMock.request.mockResolvedValueOnce({ resolved: 1 });
+    await expect(api.respondApproval?.("approval-2", "deny")).resolves.toBe(
+      true,
+    );
+  });
+
+  it("keeps an unresolved response pending for retry", async () => {
+    const api: HarnessApi = {};
+    render(<Harness api={api} />);
+    await act(async () => {
+      await api.send?.("hello");
+      dashboardMock.onEvent?.({
+        type: "approval.request",
+        session_id: "live-1",
+        payload: { request_id: "approval-unresolved", choices: ["deny"] },
+      });
+    });
+    dashboardMock.request.mockResolvedValueOnce({ resolved: 0 });
+
+    await expect(
+      api.respondApproval?.("approval-unresolved", "deny"),
+    ).resolves.toBe(false);
+    dashboardMock.request.mockResolvedValueOnce({ resolved: 1 });
+    await expect(
+      api.respondApproval?.("approval-unresolved", "deny"),
+    ).resolves.toBe(true);
+  });
+
+  it("clears pending approval on completion and abort", async () => {
+    const api: HarnessApi = {};
+    render(<Harness api={api} />);
+    await act(async () => {
+      await api.send?.("hello");
+      dashboardMock.onEvent?.({
+        type: "approval.request",
+        session_id: "live-1",
+        payload: { request_id: "approval-3", choices: ["once"] },
+      });
+      dashboardMock.onEvent?.({
+        type: "message.complete",
+        session_id: "live-1",
+        payload: { text: "complete" },
+      });
+    });
+
+    await expect(api.respondApproval?.("approval-3", "once")).resolves.toBe(
+      false,
+    );
+
+    await act(async () => {
+      dashboardMock.onEvent?.({
+        type: "approval.request",
+        session_id: "live-1",
+        payload: { request_id: "approval-4", choices: ["once"] },
+      });
+      api.abort?.();
+    });
+    await expect(api.respondApproval?.("approval-4", "once")).resolves.toBe(
+      false,
+    );
+  });
+
+  it("answers queued approvals in gateway FIFO order", async () => {
+    const api: HarnessApi = {};
+    render(<Harness api={api} />);
+    await act(async () => {
+      await api.send?.("hello");
+      dashboardMock.onEvent?.({
+        type: "approval.request",
+        session_id: "live-1",
+        payload: { request_id: "approval-first", choices: ["deny"] },
+      });
+      dashboardMock.onEvent?.({
+        type: "approval.request",
+        session_id: "live-1",
+        payload: { request_id: "approval-second", choices: ["once"] },
+      });
+    });
+
+    await expect(
+      api.respondApproval?.("approval-second", "once"),
+    ).resolves.toBe(false);
+    await expect(api.respondApproval?.("approval-first", "deny")).resolves.toBe(
+      true,
+    );
+    await expect(
+      api.respondApproval?.("approval-second", "once"),
+    ).resolves.toBe(true);
   });
 });
 

--- a/src/renderer/src/screens/Chat/hooks/useDashboardChatTransport.ts
+++ b/src/renderer/src/screens/Chat/hooks/useDashboardChatTransport.ts
@@ -7,6 +7,7 @@ import {
 } from "../chatMessages";
 import {
   applyDashboardStreamEvent,
+  dashboardApprovalRequestId,
   type DashboardStreamEvent,
 } from "../dashboardEventAdapter";
 import { DashboardGatewayClient } from "../dashboardGatewayClient";
@@ -14,6 +15,10 @@ import { executeSlash, type SlashExecOutcome } from "../slashExec";
 import type { AgentCommandsCatalogResponse } from "../slash/types";
 import type { ActiveTurn, Attachment, ChatMessage, UsageState } from "../types";
 import type { DesktopSessionContinuationItem } from "../../../../../shared/session-continuation";
+import {
+  normalizeApprovalRequest,
+  type ApprovalChoice,
+} from "../../../../../shared/chat-approval";
 
 interface SessionResponse {
   info?: unknown;
@@ -104,6 +109,10 @@ interface UseDashboardChatTransportArgs {
 interface UseDashboardChatTransportResult {
   abort: () => void;
   enabled: boolean;
+  respondApproval: (
+    requestId: string,
+    choice: ApprovalChoice,
+  ) => Promise<boolean>;
   sendMessage: (text: string, attachments?: Attachment[]) => Promise<boolean>;
   /**
    * Run a slash command through the gateway's `slash.exec` pipeline instead of
@@ -123,6 +132,13 @@ interface UseDashboardChatTransportResult {
    * a `background.complete` event rendered into the transcript.
    */
   runBackground: (text: string) => Promise<{ taskId?: string; error?: string }>;
+}
+
+interface PendingDashboardApproval {
+  choices: ApprovalChoice[];
+  requestId: string;
+  responding: boolean;
+  sessionId: string;
 }
 
 interface DashboardSeedMessage {
@@ -692,6 +708,8 @@ function messageChars(message: ChatMessage): number {
       return message.name.length + message.args.length;
     case "clarify":
       return message.question.length;
+    case "approval":
+      return message.description.length + message.command.length;
     default:
       return 0;
   }
@@ -927,10 +945,41 @@ export function useDashboardChatTransport({
   const recreateRuntimeSessionRef = useRef(false);
   const lastRuntimeSessionWasCreatedRef = useRef(false);
   const pendingClarifyRequestIdRef = useRef<string | null>(null);
+  const pendingApprovalsRef = useRef<PendingDashboardApproval[]>([]);
+  const approvalNonceRef = useRef(0);
   const pendingRecoveredContinuationRef = useRef<
     DesktopSessionContinuationItem[]
   >([]);
   const lastSyncedCwdRef = useRef<string | null>(null);
+
+  const expirePendingApprovalsRef = useRef<(failActiveTurn?: boolean) => void>(
+    () => undefined,
+  );
+  expirePendingApprovalsRef.current = (failActiveTurn = false): void => {
+    if (pendingApprovalsRef.current.length === 0) return;
+    const pendingIds = new Set(
+      pendingApprovalsRef.current.map(({ requestId }) => requestId),
+    );
+    pendingApprovalsRef.current = [];
+    setMessages((current) => {
+      const unavailable = current.map((message) =>
+        message.kind === "approval" &&
+        pendingIds.has(message.requestId) &&
+        !message.resolved
+          ? { ...message, unavailable: true }
+          : message,
+      );
+      messagesRef.current = unavailable;
+      return unavailable;
+    });
+    if (failActiveTurn) {
+      const activeTurn = activeTurnRef.current;
+      if (activeTurn) activeTurn.status = "failed";
+      activeTurnRef.current = null;
+      setToolProgress(null);
+      setIsLoading(false);
+    }
+  };
 
   useEffect(() => {
     // `messagesRef` is the synchronous source of truth for `handleGatewayEvent`:
@@ -947,10 +996,12 @@ export function useDashboardChatTransport({
     if (messages !== messagesRef.current) {
       messagesRef.current = messages;
     }
+    if (messages.length === 0) pendingApprovalsRef.current = [];
   }, [messages]);
 
   useEffect(() => {
     if (hermesSessionId === storedSessionIdRef.current) return;
+    expirePendingApprovalsRef.current();
     storedSessionIdRef.current = hermesSessionId;
     runtimeSessionIdRef.current = null;
     reasoningSegmentClosedRef.current = false;
@@ -968,6 +1019,7 @@ export function useDashboardChatTransport({
   useEffect(() => {
     clientGenerationRef.current += 1;
     dashboardUnavailableRef.current = false;
+    expirePendingApprovalsRef.current(true);
     clientRef.current?.close();
     clientRef.current = null;
     connectingRef.current = null;
@@ -1020,6 +1072,37 @@ export function useDashboardChatTransport({
 
       const failed =
         event.type === "message.complete" && completionFailed(event.payload);
+      const approvalRequestId =
+        event.type === "approval.request"
+          ? dashboardApprovalRequestId(
+              event,
+              Date.now(),
+              ++approvalNonceRef.current,
+            )
+          : undefined;
+      if (approvalRequestId) {
+        const sessionId = event.session_id || runtimeSessionId;
+        if (sessionId) {
+          if (
+            !pendingApprovalsRef.current.some(
+              (pending) => pending.requestId === approvalRequestId,
+            )
+          ) {
+            pendingApprovalsRef.current = [
+              ...pendingApprovalsRef.current,
+              {
+                requestId: approvalRequestId,
+                responding: false,
+                sessionId,
+                choices: normalizeApprovalRequest(
+                  event.payload,
+                  approvalRequestId,
+                ).choices,
+              },
+            ];
+          }
+        }
+      }
       const next = applyDashboardStreamEvent(
         {
           messages: messagesRef.current,
@@ -1028,6 +1111,7 @@ export function useDashboardChatTransport({
         event,
         {
           activeTurn: activeTurnRef.current,
+          approvalRequestId,
           renderAssistantDeltas: connectionMode === "local",
         },
       );
@@ -1043,6 +1127,7 @@ export function useDashboardChatTransport({
       setMessages(nextMessages);
 
       if (event.type === "message.complete") {
+        pendingApprovalsRef.current = [];
         if (failed) {
           appliedModelRef.current = null;
           recreateRuntimeSessionRef.current = true;
@@ -1179,6 +1264,7 @@ export function useDashboardChatTransport({
             onEvent: handleGatewayEvent,
             onClose: () => {
               if (clientRef.current === client) {
+                expirePendingApprovalsRef.current(true);
                 clientRef.current = null;
               }
             },
@@ -1319,6 +1405,7 @@ export function useDashboardChatTransport({
           .request("session.close", { session_id: targetSessionId })
           .catch(() => undefined);
         runtimeSessionIdRef.current = null;
+        pendingApprovalsRef.current = [];
         storedSessionIdRef.current = storedSessionId;
         reasoningSegmentClosedRef.current = false;
         appliedModelRef.current = null;
@@ -1580,6 +1667,7 @@ export function useDashboardChatTransport({
               .catch(() => undefined);
           }
           runtimeSessionIdRef.current = null;
+          pendingApprovalsRef.current = [];
           reasoningSegmentClosedRef.current = false;
           appliedModelRef.current = null;
         }
@@ -1649,6 +1737,50 @@ export function useDashboardChatTransport({
     ],
   );
 
+  const respondApproval = useCallback(
+    async (requestId: string, choice: ApprovalChoice): Promise<boolean> => {
+      const pending = pendingApprovalsRef.current[0];
+      const runtimeSessionId = runtimeSessionIdRef.current;
+      if (
+        !enabled ||
+        !pending ||
+        pending.responding ||
+        pending.requestId !== requestId ||
+        pending.sessionId !== runtimeSessionId ||
+        !pending.choices.includes(choice)
+      ) {
+        return false;
+      }
+
+      const client = clientRef.current;
+      if (!client?.connected) return false;
+      pending.responding = true;
+      try {
+        const result = await client.request<{ resolved?: unknown }>(
+          "approval.respond",
+          {
+            session_id: pending.sessionId,
+            choice,
+            all: false,
+          },
+        );
+        if (typeof result?.resolved !== "number" || result.resolved < 1) {
+          return false;
+        }
+        if (pendingApprovalsRef.current[0] !== pending) return false;
+        pendingApprovalsRef.current = pendingApprovalsRef.current.slice(1);
+        return true;
+      } catch {
+        return false;
+      } finally {
+        if (pendingApprovalsRef.current[0] === pending) {
+          pending.responding = false;
+        }
+      }
+    },
+    [enabled],
+  );
+
   const execSlash = useCallback(
     async (
       command: string,
@@ -1715,6 +1847,7 @@ export function useDashboardChatTransport({
   );
 
   const abort = useCallback(() => {
+    expirePendingApprovalsRef.current();
     const client = clientRef.current;
     const sessionId = runtimeSessionIdRef.current;
     if (!enabled || !client || !sessionId) return;
@@ -1727,6 +1860,7 @@ export function useDashboardChatTransport({
 
   useEffect(
     () => () => {
+      expirePendingApprovalsRef.current();
       clientRef.current?.close();
       clientRef.current = null;
     },
@@ -1736,6 +1870,7 @@ export function useDashboardChatTransport({
   return {
     abort,
     enabled,
+    respondApproval,
     sendMessage,
     execSlash,
     getCommandCatalog,

--- a/src/renderer/src/screens/Chat/sessionHistory.ts
+++ b/src/renderer/src/screens/Chat/sessionHistory.ts
@@ -881,7 +881,7 @@ export function reconcileStreamedWithDb(
   // landing *below* any agent content the gateway streamed after the user
   // answered (the reverse of what the user saw live). Re-anchor each card
   // immediately after the streamed message that preceded it.
-  return repositionClarifyCards(
+  return repositionInteractiveCards(
     dropLossyStreamedReasoning(dedupeMessageIds(merged)),
     streamed,
   );
@@ -951,32 +951,32 @@ function dropLossyStreamedReasoning(
 }
 
 /**
- * Move `kind === "clarify"` cards from wherever the reconcile placed them back
+ * Move interactive cards from wherever the reconcile placed them back
  * to their streamed position: directly after the message that immediately
  * preceded them in `streamed`. Pure, order-preserving for all other rows.
  */
-function repositionClarifyCards(
+function repositionInteractiveCards(
   merged: ChatMessage[],
   streamed: ReadonlyArray<ChatMessage>,
 ): ChatMessage[] {
-  const isClarify = (m: ChatMessage): boolean =>
-    "kind" in m && m.kind === "clarify";
-  if (!streamed.some(isClarify)) return merged;
+  const isInteractive = (m: ChatMessage): boolean =>
+    "kind" in m && (m.kind === "clarify" || m.kind === "approval");
+  if (!streamed.some(isInteractive)) return merged;
 
-  // Pull clarify cards out of the merged list; remember each card's streamed
+  // Pull interactive cards out of the merged list; remember each card's streamed
   // predecessor id so we can re-anchor it.
-  const cards = merged.filter(isClarify);
+  const cards = merged.filter(isInteractive);
   if (cards.length === 0) return merged;
-  const without = merged.filter((m) => !isClarify(m));
+  const without = merged.filter((m) => !isInteractive(m));
 
   const predecessorIdByCardId = new Map<string, string | null>();
   for (let i = 0; i < streamed.length; i++) {
     const m = streamed[i];
-    if (!isClarify(m)) continue;
-    // Nearest preceding non-clarify message in the streamed order.
+    if (!isInteractive(m)) continue;
+    // Nearest preceding non-card message in the streamed order.
     let predId: string | null = null;
     for (let j = i - 1; j >= 0; j--) {
-      if (!isClarify(streamed[j])) {
+      if (!isInteractive(streamed[j])) {
         predId = streamed[j].id;
         break;
       }

--- a/src/renderer/src/screens/Chat/types.ts
+++ b/src/renderer/src/screens/Chat/types.ts
@@ -4,6 +4,7 @@ export type {
 } from "../../../../shared/attachments";
 
 import type { Attachment } from "../../../../shared/attachments";
+import type { ApprovalChoice } from "../../../../shared/chat-approval";
 
 /**
  * Visible chat bubble (user or assistant). Used for live streaming and as
@@ -80,12 +81,28 @@ export interface ClarifyMessage {
   resolved?: boolean;
 }
 
+export interface ApprovalMessage {
+  id: string;
+  kind: "approval";
+  role: "agent";
+  requestId: string;
+  responsePath: "dashboard" | "ipc";
+  runId?: string;
+  command: string;
+  description: string;
+  choices: ApprovalChoice[];
+  choice?: ApprovalChoice;
+  resolved?: boolean;
+  unavailable?: boolean;
+}
+
 export type ChatMessage =
   | ChatBubbleMessage
   | ReasoningMessage
   | ToolCallMessage
   | ToolResultMessage
-  | ClarifyMessage;
+  | ClarifyMessage
+  | ApprovalMessage;
 
 export interface ActiveTurn {
   turnId: string;

--- a/src/renderer/src/screens/Office/OneChatModal.tsx
+++ b/src/renderer/src/screens/Office/OneChatModal.tsx
@@ -190,6 +190,7 @@ export default function OneChatModal({
         [selectedAgentId]: toChatMessages(items),
       }));
     } catch (err) {
+      const errorText = `Error: ${(err as Error).message}`;
       // The response may have been persisted even though the promise rejected.
       // Try to reload from the database before showing a raw error.
       try {
@@ -205,7 +206,17 @@ export default function OneChatModal({
         if (loaded.length > 0) {
           setMessages((prev) => ({
             ...prev,
-            [selectedAgentId]: loaded,
+            [selectedAgentId]: (err as Error).message.includes("Approval flow")
+              ? [
+                  ...loaded,
+                  {
+                    id: `err-${Date.now()}`,
+                    role: "agent",
+                    text: errorText,
+                    timestamp: Date.now(),
+                  },
+                ]
+              : loaded,
           }));
           return;
         }
@@ -222,7 +233,7 @@ export default function OneChatModal({
             {
               id: `err-${Date.now()}`,
               role: "agent",
-              text: `Error: ${(err as Error).message}`,
+              text: errorText,
               timestamp: Date.now(),
             },
           ],

--- a/src/shared/chat-approval.ts
+++ b/src/shared/chat-approval.ts
@@ -1,0 +1,107 @@
+export const APPROVAL_CHOICES = ["once", "session", "always", "deny"] as const;
+
+export type ApprovalChoice = (typeof APPROVAL_CHOICES)[number];
+
+export interface ChatApprovalRequest {
+  requestId: string;
+  command: string;
+  description: string;
+  choices: ApprovalChoice[];
+}
+
+const VALID_CHOICES = new Set<string>(APPROVAL_CHOICES);
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function cleanText(value: unknown, maxLength: number): string {
+  if (typeof value !== "string") return "";
+  return Array.from(value)
+    .filter((character) => {
+      const code = character.charCodeAt(0);
+      return code === 9 || code === 10 || code === 13 || code >= 32;
+    })
+    .join("")
+    .trim()
+    .slice(0, maxLength);
+}
+
+function firstText(
+  sources: Array<Record<string, unknown> | null>,
+  fields: string[],
+  maxLength: number,
+): string {
+  for (const source of sources) {
+    if (!source) continue;
+    for (const field of fields) {
+      const value = cleanText(source[field], maxLength);
+      if (value) return value;
+    }
+  }
+  return "";
+}
+
+export function normalizeApprovalRequest(
+  payload: unknown,
+  requestId: string,
+): ChatApprovalRequest {
+  const root = record(payload);
+  const nested = [
+    record(root?.approval),
+    record(root?.request),
+    record(root?.tool_call),
+    record(root?.tool),
+  ];
+  const sources = [root, ...nested];
+  const rawChoices = root?.choices;
+  const hasExplicitChoices = Array.isArray(rawChoices);
+  const choices: ApprovalChoice[] = [];
+
+  if (hasExplicitChoices) {
+    for (const rawChoice of rawChoices) {
+      if (typeof rawChoice !== "string") continue;
+      const choice = rawChoice.trim().toLowerCase();
+      if (!VALID_CHOICES.has(choice)) continue;
+      if (choice === "always" && root?.allow_permanent === false) continue;
+      if (!choices.includes(choice as ApprovalChoice)) {
+        choices.push(choice as ApprovalChoice);
+      }
+    }
+  } else if (root?.smart_denied === true) {
+    choices.push("once");
+  } else {
+    choices.push("once");
+    if (typeof root?.allow_permanent === "boolean") choices.push("session");
+    if (root?.allow_permanent === true) choices.push("always");
+  }
+
+  if (!choices.includes("deny")) choices.push("deny");
+
+  return {
+    requestId,
+    command:
+      firstText(
+        sources,
+        ["command", "cmd", "command_line", "input", "args", "action"],
+        8192,
+      ) || "Command details unavailable",
+    description:
+      firstText(
+        sources,
+        [
+          "description",
+          "reason",
+          "message",
+          "prompt",
+          "summary",
+          "pattern_description",
+          "warning",
+        ],
+        2048,
+      ) || "Hermes requires approval before continuing.",
+    choices,
+  };
+}

--- a/src/shared/i18n/locales/en/chat.ts
+++ b/src/shared/i18n/locales/en/chat.ts
@@ -52,6 +52,22 @@ export default {
     skipped: "Skipped — Hermes decided",
     error: "Couldn't deliver your answer — the turn may have ended. Try again.",
   },
+  approval: {
+    title: "Command approval required",
+    once: "Allow once",
+    session: "Allow for session",
+    always: "Always allow",
+    deny: "Deny",
+    responded: "Responded",
+    unavailable:
+      "Approval is no longer available because the connection closed.",
+    queued: "Resolve the earlier approval request first.",
+    confirm:
+      "Always allow this command in future sessions? This permission persists until revoked.",
+    cancel: "Cancel",
+    confirmAlways: "Confirm always allow",
+    error: "Couldn't send the approval response. Try again.",
+  },
   thinking: "Thinking…",
   thought: "Thought",
   toolCall: "Tool call",

--- a/tests/preload-api-surface.test.ts
+++ b/tests/preload-api-surface.test.ts
@@ -66,6 +66,12 @@ describe("Preload API Surface", () => {
 // ─── New APIs exist ─────────────────────────────────────
 
 describe("New APIs from v0.8/v0.9 features", () => {
+  it("has chat approval APIs", () => {
+    expect(preloadMethods).toContain("onApprovalRequest");
+    expect(typeMethods).toContain("onApprovalRequest");
+    expect(preloadMethods).toContain("respondApproval");
+    expect(typeMethods).toContain("respondApproval");
+  });
   it("has backup/import APIs", () => {
     expect(preloadMethods).toContain("runHermesBackup");
     expect(preloadMethods).toContain("runHermesImport");

--- a/tests/reconcile-streamed-with-db.test.ts
+++ b/tests/reconcile-streamed-with-db.test.ts
@@ -979,6 +979,34 @@ describe("reconcileStreamedWithDb", () => {
     expect(merged.map((m) => m.id)).toEqual(["clarify-r1", "a-1"]);
   });
 
+  it("keeps a resolved approval card before the resulting agent output", () => {
+    const approval: ChatMessage = {
+      id: "approval-r1",
+      kind: "approval",
+      role: "agent",
+      requestId: "r1",
+      responsePath: "dashboard",
+      command: "npm publish",
+      description: "Publish the package",
+      choices: ["once", "deny"],
+      resolved: true,
+      choice: "once",
+    };
+    const streamed: ChatMessage[] = [
+      STREAMED_USER("publish it", "u-1"),
+      approval,
+      STREAMED_AGENT("Published.", "a-1"),
+    ];
+    const db: ChatMessage[] = [
+      DB_USER("publish it", 1),
+      DB_AGENT("Published.", 2),
+    ];
+
+    const merged = reconcileStreamedWithDb(streamed, db);
+
+    expect(merged.map((m) => m.id)).toEqual(["u-1", "approval-r1", "a-1"]);
+  });
+
   it("keeps a continued restored image prompt before its answer when the DB snapshot briefly misses that user row", () => {
     const answer =
       "It's a cute yellow toy duck in a bathtub filled with blue bathwater.";


### PR DESCRIPTION
Dangerous commands now pause for an explicit decision in Dashboard and local gateway WebSocket chat. The approval card shows the command, offers the gateway's allowed choices, and requires a second confirmation before granting permanent permission.

Responses target the gateway's request ID and runtime session. The main-process bridge also binds each opaque UI request to its renderer and chat run. Expired requests, lost acknowledgments, duplicate clicks, disconnects, and cancellation cannot approve another queued command or replay the original prompt. Pending cards become unavailable when their turn ends.

The current Hermes Agent Runs approval endpoint ignores request IDs and resolves the queue head. Runs that request approval therefore stop safely with the original connection's credentials and direct users to Dashboard chat; ordinary Runs streaming remains supported. Manual Runs approval support needs an upstream request-addressed contract first.

Validated against the sibling Hermes Agent source at 503d863fcd2cbfc0be5a6d6c536fae2e98aa4204. Updated against current main while preserving connection-scoped run routing.

Validation: 2,150 tests passed, 3 skipped; TypeScript checks, ESLint, and `lat check` passed. Added transport-level regressions for request correlation, stale requests, missing IDs, disconnects, prompt acknowledgment failure, and unsupported Runs approvals.
