### PR TITLE
fix(security): escape OpenClaw path in migration banner to prevent XSS (#913)

### DIFF
--- a/src/renderer/src/components/settings/DataPane.test.tsx
+++ b/src/renderer/src/components/settings/DataPane.test.tsx
@@ -1,0 +1,70 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import DataPane from "./DataPane";
+
+// Mimic i18next configured with escapeValue: false (see src/shared/i18n/index.ts):
+// interpolated values land in the returned string raw, so any runtime value a
+// pane passes through t() ends up unescaped in markup rendered via
+// dangerouslySetInnerHTML.
+const rawTemplate =
+  "Found OpenClaw at <code>{{path}}</code>. You can migrate your configuration.";
+
+vi.mock("../useI18n", () => ({
+  useI18n: () => ({
+    t: (key: string, opts?: Record<string, string>) =>
+      key === "settings.migrationDesc"
+        ? rawTemplate.replace("{{path}}", opts?.path ?? "")
+        : key,
+  }),
+}));
+
+const settings = vi.hoisted(() => ({ openclawPath: "" }));
+
+vi.mock("./SettingsDataContext", () => ({
+  useSettings: () => ({
+    backingUp: false,
+    backupResult: null,
+    importing: false,
+    importResult: null,
+    handleBackup: vi.fn(),
+    handleImport: vi.fn(),
+    openclawFound: true,
+    openclawPath: settings.openclawPath,
+    migrationDismissed: false,
+    migrating: false,
+    migrationLog: null,
+    migrationResult: null,
+    migrationResultType: null,
+    migrationLogRef: { current: null },
+    handleMigrate: vi.fn(),
+    handleDismissMigration: vi.fn(),
+  }),
+}));
+
+describe("DataPane migration banner", () => {
+  beforeEach(() => {
+    settings.openclawPath = "";
+  });
+
+  it("renders a normal path inside the trusted <code> wrapper", () => {
+    settings.openclawPath = "C:\\Users\\dev\\.openclaw";
+    const { container } = render(<DataPane />);
+    const desc = container.querySelector(".settings-migration-desc");
+    expect(desc).not.toBeNull();
+    expect(desc!.querySelector("code")?.textContent).toBe(
+      "C:\\Users\\dev\\.openclaw",
+    );
+  });
+
+  it("never injects HTML from the discovered OpenClaw path (#913)", () => {
+    settings.openclawPath = 'C:\\Users\\<img src=x onerror=alert(1)>\\.openclaw';
+    const { container } = render(<DataPane />);
+    const desc = container.querySelector(".settings-migration-desc");
+    expect(desc).not.toBeNull();
+    // The malicious payload must survive as inert text, not become a live tag.
+    expect(desc!.innerHTML).not.toContain("<img");
+    expect(desc!.innerHTML).toContain("&lt;img src=x");
+    // The trusted translation markup is still real HTML.
+    expect(desc!.querySelector("code")).not.toBeNull();
+  });
+});

--- a/src/renderer/src/components/settings/DataPane.tsx
+++ b/src/renderer/src/components/settings/DataPane.tsx
@@ -2,6 +2,19 @@ import { Download, Upload } from "lucide-react";
 import { useI18n } from "../useI18n";
 import { useSettings } from "./SettingsDataContext";
 
+// Escape a runtime value before interpolating it into a translation string
+// that is rendered via dangerouslySetInnerHTML (i18next runs with
+// escapeValue: false, so nothing escapes it for us). The translation markup
+// itself (<code>) is trusted; only the runtime path must be escaped.
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 /**
  * Export / import a full Hermes backup archive, plus the OpenClaw → Hermes
  * migration (which imports config, keys, sessions, and skills — a data import,
@@ -81,7 +94,7 @@ export default function DataPane(): React.JSX.Element {
                 className="settings-migration-desc"
                 dangerouslySetInnerHTML={{
                   __html: t("settings.migrationDesc", {
-                    path: openclawPath || "",
+                    path: escapeHtml(openclawPath || ""),
                   }),
                 }}
               />


### PR DESCRIPTION
## What changed

Escape the runtime `openclawPath` value before it is interpolated into the `settings.migrationDesc` translation string and rendered via `dangerouslySetInnerHTML` in `DataPane`.

The translation markup itself (`<code>{{path}}</code>`) is trusted; only the filesystem path — which comes from disk — must be escaped.

## Why

`i18next` is configured globally with `escapeValue: false` (`src/shared/i18n/index.ts:602`), meaning interpolated values land in the returned string raw. Because `DataPane` renders this string via `dangerouslySetInnerHTML`, an attacker who can influence the discovered OpenClaw path (e.g. a directory named `<img src=x onerror=alert(1)>`) gets arbitrary HTML injected into the Electron renderer process.

## Root cause

No escaping is applied to the runtime `openclawPath` value before it reaches `dangerouslySetInnerHTML` via the i18next interpolation pipeline.

## User impact

Medium-severity stored XSS in the Electron renderer: a malicious directory name on disk becomes executable HTML the next time the user opens Settings → Data. Because the renderer runs in an Electron context with `nodeIntegration` capabilities, this is higher-impact than a typical browser XSS.

## Validation

- `npm run typecheck` — clean (both `typecheck:node` and `typecheck:web`)
- `npx vitest run DataPane.test.tsx` — 2/2 pass:
  - renders a normal path inside the trusted `<code>` wrapper
  - never injects HTML from the discovered OpenClaw path (verifies `innerHTML` contains `&lt;img` not `<img`, and the `<code>` wrapper survives as real DOM)
- **Fail-without-fix proof:** reverting only the interpolation line causes the "never injects HTML" test to fail (exit 1), confirming the test locks the vulnerability.

## Follow-up

Open PR #909 fixes the same pattern in `MemoryProviders.tsx`. This PR scopes exclusively to `DataPane.tsx` per the small/focused contribution policy. Once both land, the `escapeHtml` helper could be extracted to a shared utility — but that is a maintainer decision.
