### PR TITLE
fix(chat): accept named provider vs normalized custom in model verification

### DIFF
--- a/src/renderer/src/screens/Chat/hooks/useDashboardChatTransport.test.tsx
+++ b/src/renderer/src/screens/Chat/hooks/useDashboardChatTransport.test.tsx
@@ -10,7 +10,10 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Mock } from "vitest";
 import type { DashboardRpcEvent } from "../dashboardGatewayClient";
-import { useDashboardChatTransport } from "./useDashboardChatTransport";
+import {
+  dashboardModelMatches,
+  useDashboardChatTransport,
+} from "./useDashboardChatTransport";
 import type { ActiveTurn, ChatMessage, UsageState } from "../types";
 
 type SetUsageMock = Mock<(value: SetStateAction<UsageState | null>) => void>;
@@ -731,5 +734,58 @@ describe("useDashboardChatTransport context gauge estimate (no usage payload)", 
     });
 
     expect(setUsage).not.toHaveBeenCalled();
+  });
+});
+
+describe("dashboardModelMatches named-custom provider equivalence (issue: omlx vs custom)", () => {
+  const MODEL = "Qwen3.8-Whittle-MoE-27B-MLX-4bit";
+  const live = {
+    model: MODEL,
+    provider: "custom",
+    providers: [
+      { slug: "omlx", models: [MODEL], base_url: "http://127.0.0.1:9999/v1" },
+      {
+        slug: "custom:lm",
+        models: ["other"],
+        base_url: "http://127.0.0.1:1234/v1",
+      },
+    ],
+  };
+
+  it("accepts a named provider the agent normalizes to bare custom", () => {
+    expect(dashboardModelMatches("omlx", MODEL, live)).toBe(true);
+  });
+
+  it("accepts custom:<slug> live spelling for the same named provider", () => {
+    expect(
+      dashboardModelMatches("lm", MODEL, {
+        ...live,
+        provider: "custom:lm",
+        providers: [
+          {
+            slug: "custom:lm",
+            models: [MODEL],
+            base_url: "http://127.0.0.1:1234/v1",
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("still rejects a genuinely different model", () => {
+    expect(dashboardModelMatches("omlx", "Some-Other-Model", live)).toBe(false);
+  });
+
+  it("still rejects a named provider absent from the live inventory", () => {
+    expect(dashboardModelMatches("other", MODEL, live)).toBe(false);
+  });
+
+  it("does not match a provider row that does not list the model", () => {
+    expect(
+      dashboardModelMatches("lm", MODEL, {
+        ...live,
+        providers: [{ slug: "lm", models: ["different"] }],
+      }),
+    ).toBe(false);
   });
 });

--- a/src/renderer/src/screens/Chat/hooks/useDashboardChatTransport.ts
+++ b/src/renderer/src/screens/Chat/hooks/useDashboardChatTransport.ts
@@ -575,7 +575,25 @@ export function dashboardModelMatches(
 
   // Named custom providers can be reported by Hermes Agent as custom:<slug>
   // while Hermes One's older model config still treats them as custom rows.
-  return provider === "custom" && liveProvider.startsWith("custom:");
+  if (provider === "custom" && liveProvider.startsWith("custom:")) return true;
+
+  // The reverse direction: Hermes Agent normalizes every named provider from
+  // config.yaml `providers:` (e.g. `omlx`, `lmstudio`) down to the bare
+  // billing namespace "custom" when it reports the live model, while the
+  // desktop requested the entry by its configured name. If the requested
+  // provider exists in the live inventory as a row that lists the requested
+  // model, the two identities describe the same endpoint and the string
+  // mismatch is a namespace artifact — not a failed switch. Without this,
+  // sending after a profile switch throws a false "did not switch" error.
+  const requestedRow =
+    liveProvider === "custom" || liveProvider.startsWith("custom:")
+      ? (live?.providers ?? []).find(
+          (row) =>
+            row.slug?.toLowerCase() === provider ||
+            row.slug?.toLowerCase() === `custom:${provider}`,
+        )
+      : undefined;
+  return !!requestedRow && modelIsListedByProvider(requestedRow, model);
 }
 
 function asRecord(value: unknown): Record<string, unknown> {


### PR DESCRIPTION
Fixes #925

## Problem
After switching to a profile that uses a named `providers:` entry (e.g. `omlx`, `lmstudio`), sending a message can throw a false error:

> Hermes dashboard did not switch to omlx/Qwen3.8-Whittle-MoE-27B-MLX-4bit; live model is custom/...

Hermes Agent normalizes every named custom provider down to the bare billing class `custom` in `model.options`, while Hermes One requests the model under its configured entry name. `dashboardModelMatches()` only tolerated the `custom → custom:<slug>` direction, so `omlx → custom` (same endpoint, same model) failed the string comparison and blocked the send — even though `/model` confirms the switch succeeded.

## Approach
Add the symmetric tolerance in `dashboardModelMatches()`: when the live provider is in the normalized `custom` namespace, accept the request if the requested provider appears in the live inventory (as `<provider>` or `custom:<provider>`) **and** that row lists the requested model. The model-name equality check still applies, so a genuinely wrong model or absent provider is still rejected.

## Tests
5 unit tests on `dashboardModelMatches` in `useDashboardChatTransport.test.tsx`: named→custom accepted, `custom:<slug>` spelling accepted, wrong model rejected, absent provider rejected, provider row not listing the model rejected. Verified they fail without the fix (sabotage run). Full file green (18 passed); `tsc --noEmit -p tsconfig.web.json` clean; eslint clean.

🤖 Generated with [Claude Code](https://claude.ai/code)