### PR TITLE
fix: scope session browsing and polish chat settings UI

### DIFF
--- a/docs/superpowers/plans/2026-08-23-hermes-agent-enhanced-desktop-roadmap.md
+++ b/docs/superpowers/plans/2026-08-23-hermes-agent-enhanced-desktop-roadmap.md
@@ -145,7 +145,7 @@ R1 creates the identities and extension seams required by every later feature.
 - [ ] Add connection create, edit, test, reconnect, remove, and select workflows. Create, edit, test, remove, and select are complete; isolated reconnect remains.
 - [ ] Add a fleet overview with connection-specific update actions.
 
-Progress (2026-08-24): Settings now manages redacted named records through main-process CRUD IPC and exposes manual per-record health, latency, authentication, version, and capability snapshots. Dashboard and legacy Local/direct-Remote chats now keep an immutable saved connection while other records are selected, including URL, authentication, capability probes, fallbacks, cancellation, resumed transcript reads, live transcript reconciliation, and chat deletion. Local transcript operations also retain their profile, while inactive SSH operations do not retarget the global tunnel. Remaining session browsing, desktop metadata, model/command routing, and isolated reconnect are pending before simultaneous-connection support is complete.
+Progress (2026-09-02): Settings now manages redacted named records through main-process CRUD IPC and exposes manual per-record health, latency, authentication, version, and capability snapshots. Dashboard and legacy Local/direct-Remote chats keep an immutable saved connection while other records are selected, including URL, authentication, capability probes, fallbacks, cancellation, resumed transcript reads, and live transcript reconciliation. Sidebar and full-list browsing now route list, cache sync, pagination, search, rename, single delete, and bulk delete through the selected connection and profile; Local cache and database access retain that explicit profile, while inactive SSH operations cannot retarget the global tunnel. Remaining desktop metadata, attachments, model/command routing, isolated reconnect, and true simultaneous connection lifecycles are pending.
 
 #### Verification
 
@@ -165,6 +165,7 @@ Progress (2026-08-24): Settings now manages redacted named records through main-
 - PR/commit: branch `codex/hermes-enhanced-desktop-roadmap`; M1 registry foundation in progress.
 - Decisions: version 1 lives inside the existing `desktop.json`; current callers keep using `getConnectionConfig()` as an active-record adapter. Session locations use a credential-free global desktop metadata file instead of the active profile's Agent database, so background runs cannot persist under the wrong profile. Status refresh is initial/manual rather than polling so saved SSH targets do not spawn recurring background probes.
 - Verified 2026-08-24: `npm test -- --reporter=json --maxWorkers=2` (191 files, 1,921 passed, 3 skipped), `npm run typecheck`, focused ESLint, and `npm run build`. Full multi-connection routing remains pending.
+- Verified 2026-09-02: connection-explicit session browsing passed 192 focused tests across renderer, cache, database deletion, and preload contracts; focused ESLint and the production build also pass.
 
 ### M2 — Internal contribution framework
 

--- a/lat.md/chat-input.md
+++ b/lat.md/chat-input.md
@@ -1,0 +1,17 @@
+# Chat Input
+
+The chat composer keeps message entry and its supporting controls inside one accessible, visually unified surface.
+
+## Animated composer border
+
+The composer uses a theme-aware decorative beam without changing its keyboard, attachment, voice, or submission behavior.
+
+[[src/renderer/src/screens/Chat/ChatInput.tsx#ChatInput]] wraps the complete `.chat-input-wrapper` with `border-beam` using the `line` size, `colorful` palette, and `0.7` strength. Theme colors follow the resolved Hermes theme appearance rather than the operating-system preference.
+
+The beam is non-interactive and its generated CSS disables animation for `prefers-reduced-motion`. Because the line wrapper clips child overflow, the existing focus glow is drawn by `.chat-input-beam:focus-within` while the inner composer retains its focus border.
+
+### Uses the requested beam preset
+
+The ChatInput integration test verifies that the beam surrounds both the textarea and toolbar with the requested preset, strength, and theme.
+
+[[src/renderer/src/screens/Chat/ChatInput.test.tsx]] protects the component boundary and configuration without coupling tests to the dependency's generated animation CSS.

--- a/lat.md/chat-input.md
+++ b/lat.md/chat-input.md
@@ -6,9 +6,9 @@ The chat composer keeps message entry and its supporting controls inside one acc
 
 The composer uses a theme-aware decorative beam without changing its keyboard, attachment, voice, or submission behavior.
 
-[[src/renderer/src/screens/Chat/ChatInput.tsx#ChatInput]] wraps the complete `.chat-input-wrapper` with `border-beam` using the `line` size, `colorful` palette, and `0.7` strength. Theme colors follow the resolved Hermes theme appearance rather than the operating-system preference.
+[[src/renderer/src/screens/Chat/ChatInput.tsx#ChatInput]] wraps the complete `.chat-input-wrapper` with `border-beam` using the contained `pulse-inner` size, monochrome palette, and `0.7` strength. Theme colors follow the resolved Hermes theme appearance rather than the operating-system preference.
 
-The beam is non-interactive and its generated CSS disables animation for `prefers-reduced-motion`. Because the line wrapper clips child overflow, the existing focus glow is drawn by `.chat-input-beam:focus-within` while the inner composer retains its focus border.
+The beam is non-interactive and its generated CSS disables animation for `prefers-reduced-motion`. Because the contained pulse wrapper clips child overflow, the existing focus glow is drawn by `.chat-input-beam:focus-within` while the inner composer retains its focus border.
 
 ### Uses the requested beam preset
 

--- a/lat.md/connections.md
+++ b/lat.md/connections.md
@@ -55,6 +55,12 @@ Legacy `send-message` IPC scopes its abort handle by connection plus renderer ru
 
 Resumed-chat reads, live transcript reconciliation, and chat deletion carry the same immutable connection and profile through preload IPC. Direct Remote requests therefore retain their endpoint and authentication, Local reads open the requested profile database, and inactive SSH reads fail without retargeting the shared tunnel.
 
+Sidebar and full-list session browsing carry the selected connection and profile through [[src/preload/index.ts]] to [[src/main/ipc/register.ts#registerIpcHandlers]] for list, cache sync, pagination, search, rename, single delete, and bulk delete. Each handler resolves the saved connection record named by that stable ID instead of consulting a later UI selection.
+
+Direct Remote requests build a profile-scoped session configuration. SSH dashboard and CLI fallbacks retain the requested profile, and [[src/main/ssh-remote.ts#sshListCachedSessions]] forwards the requested cache offset instead of restarting pagination at zero.
+
+Local [[src/main/session-cache.ts#syncSessionCache]], [[src/main/session-cache.ts#listCachedSessions]], [[src/main/sessions.ts#listSessions]], [[src/main/sessions.ts#searchSessions]], title mutation, deletion cleanup, and batched context-folder reads resolve `state.db` and `sessions.json` from the explicit profile. Omitted IDs retain the active connection/profile fallback for legacy callers.
+
 ### Connection-explicit dashboard transport
 
 Dashboard startup and WebSocket refresh resolve the chat's stable connection ID instead of consulting whichever record is currently selected.
@@ -102,6 +108,10 @@ Simultaneous legacy sends to distinct direct-Remote records retain separate endp
 ### Connection-explicit transcript routing
 
 Transcript reconciliation forwards the chat's saved connection and profile rather than reading from whichever connection or profile is currently selected.
+
+### Connection-explicit session browsing
+
+Sidebar and Sessions-screen list, sync, search, rename, single-delete, and bulk-delete requests retain the selected connection and profile, including Local cache/database routing and SSH pagination.
 
 ### Non-destructive registry recovery
 

--- a/lat.md/connections.md
+++ b/lat.md/connections.md
@@ -113,6 +113,18 @@ Transcript reconciliation forwards the chat's saved connection and profile rathe
 
 Sidebar and Sessions-screen list, sync, search, rename, single-delete, and bulk-delete requests retain the selected connection and profile, including Local cache/database routing and SSH pagination.
 
+#### Routes renderer operations
+
+The Sessions-screen integration test verifies that sync, search, and rename calls carry the selected connection ID and profile through the preload boundary.
+
+#### Scopes Remote list requests
+
+Remote profile-list requests send the selected profile to the Agent dashboard instead of silently requesting the cross-profile `all` aggregate.
+
+#### Keeps Local profile caches isolated
+
+Local cache synchronization reads the selected profile database, writes that profile's desktop cache, and cannot leak the default profile's sessions into the result.
+
 ### Non-destructive registry recovery
 
 Malformed, duplicate-identity, and newer-version registries are rejected without changing `desktop.json`, so recovery cannot erase credentials or unrelated preferences.

--- a/lat.md/lat.md
+++ b/lat.md/lat.md
@@ -3,6 +3,7 @@ This directory defines the high-level concepts, business logic, and architecture
 > **Hermes One** is a community-maintained project. This desktop app is a wrapper around **Hermes Agent** — it is **not affiliated with, endorsed by, or supported by Nous Research**. "Hermes One" is the name of this community project; "Hermes"/"Hermes Agent" refer to the upstream agent it builds on.
 
 - [[chat-commands]] — how typed slash commands are routed through the gateway's `slash.exec`/`command.dispatch` pipeline instead of being sent as prompt text.
+- [[chat-input]] — the unified chat composer surface and its theme-aware animated border treatment.
 - [[chat-performance]] — how chat rendering stays responsive through contained transcript rows, batched textarea resizing, and fixed-row slash-command virtualization.
 - [[chat-experience-preferences]] — user-message Markdown plus persisted completion-sound and native multi-language spell-check preferences.
 - [[model-context]] — the per-model context-window override that drives the context gauge and the agent's auto-compaction.

--- a/lat.md/sidebar-navigation.md
+++ b/lat.md/sidebar-navigation.md
@@ -4,6 +4,8 @@ The sidebar starts with New Chat, keeps app destinations pinned, then gives conv
 
 [[src/renderer/src/screens/Layout/Layout.tsx#Layout]] renders a New Chat action before Discover, Office, Kanban, and Schedules from `PINNED_NAV_ITEMS`, then renders [[src/renderer/src/screens/Layout/SidebarRecentSessions.tsx]] inside a flexible `.sidebar-chat-section`. New Chat is active when the visible Chat view has no session id yet. The standalone `sessions` view is still absent from the `View` union; the full list opens from the Cmd/Ctrl+K menu action.
 
+Layout passes the selected connection ID and profile into both session surfaces. Cache reads, sync, pagination, search, rename, and deletion therefore remain on that machine/profile instead of consulting a later global selection; see [[connections#Session locations]].
+
 ## Collapse toggle brand mark
 
 The sidebar header's collapse control doubles as the brand mark: collapsed it shows a circular dot that swaps to the expand icon on hover; expanded it is just the collapse icon, parked top-right for a clean, logo-free header.

--- a/lat.md/sidebar-navigation.md
+++ b/lat.md/sidebar-navigation.md
@@ -156,6 +156,12 @@ The Appearance preference markup and stylesheet must retain a shared responsive 
 
 Appearance rows must use logical spacing and separators for RTL mirroring, while the narrow-container rule changes the shared grid to a stacked row and aligns controls at the logical start.
 
+### Shared animated toggle
+
+Settings boolean preferences use one accessible controlled switch with consistent motion, sizing, disabled behavior, and switch semantics.
+
+[[src/renderer/src/components/common/Toggle.tsx#Toggle]] exposes `role="switch"` and `aria-checked`, gates the bounce until interaction so initial hydration stays still, and disables keyframes for reduced-motion users. Settings panes pass their existing localized labels and state mutations through `onCheckedChange`.
+
 ## Provisional fresh sessions
 
 Fresh chat session ids are provisional until a turn produces output or completes successfully, so provider errors do not create visible recent-session rows.

--- a/lat.md/window-chrome.md
+++ b/lat.md/window-chrome.md
@@ -20,6 +20,12 @@ Modals and pickers use a `--bg-secondary` tint plus `backdrop-filter: blur(30px)
 
 The blur is treated as pure enhancement, not a load-bearing layer. On the transparent vibrancy window above, `backdrop-filter` is unreliable in packaged macOS builds — it silently drops to a no-op even with hardware acceleration on — which left the earlier 85%-opaque panels showing sharp app content bleeding through (the "transparent modal" bug). Raising the tint to 97% in `main.css` makes every shared frosted surface — the settings/profile/models/schedules/gateway/profile-switch modals and the model/reasoning/fast-mode dropdowns — render near-identically for all users regardless of GPU or build type; where the blur *does* paint it adds a faint frost, but its absence is barely perceptible. Keep new glass surfaces at this opacity, not the old 85%, for the same reason.
 
+### Fast-mode icon alignment
+
+The Fast Mode status badge keeps its Zap glyph optically centered without allowing shared popover typography to override the icon's flex alignment.
+
+In `src/renderer/src/assets/main.css`, `.chat-fast-popover-icon` owns flex centering while the description typography selector targets only the popover's direct child `span`. [[tests/chat-fast-popover-css.test.ts]] protects that cascade boundary.
+
 ## Bottom status strip
 
 A native system strip pinned full-width beneath the sidebar+content row surfaces live state that was otherwise hidden: gateway/connection, active model, and skill count, plus real keyboard hints.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/react-syntax-highlighter": "^15.5.13",
         "@wesbos/code-icons": "^1.2.4",
         "better-sqlite3": "^12.8.0",
+        "border-beam": "^1.3.0",
         "date-fns": "^4.4.0",
         "electron-updater": "^6.3.9",
         "ethers": "^6.17.0",
@@ -1071,13 +1072,6 @@
       "engines": {
         "node": ">= 10.0.0"
       }
-    },
-    "node_modules/@emotion/memoize": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
-      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
@@ -6174,6 +6168,16 @@
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/border-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/border-beam/-/border-beam-1.3.0.tgz",
+      "integrity": "sha512-oZSISp3aQau4ASTmzm5pzxeBinO6Fh2HW0gyEixJgtpUZvRiU0vNpP+IwGRrNpIyqPjA7Rf5EBnVqDSJ49cm5w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "5.0.5",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/react-syntax-highlighter": "^15.5.13",
     "@wesbos/code-icons": "^1.2.4",
     "better-sqlite3": "^12.8.0",
+    "border-beam": "^1.3.0",
     "date-fns": "^4.4.0",
     "electron-updater": "^6.3.9",
     "ethers": "^6.17.0",

--- a/src/main/ipc/register.ts
+++ b/src/main/ipc/register.ts
@@ -2242,18 +2242,33 @@ export function registerIpcHandlers(context: IpcContext): void {
   );
 
   // Sessions
-  ipcMain.handle("list-sessions", (_event, limit?: number, offset?: number) => {
-    const conn = getConnectionConfig();
-    if (conn.mode === "remote") return remoteListSessions(conn, limit, offset);
-    if (conn.mode === "ssh" && conn.ssh)
-      return withSshDashboardSessions(
-        conn,
-        (config) => remoteListSessions(config, limit, offset),
-        () => sshListSessions(conn.ssh, limit, offset),
-        activeSshProfile(),
-      );
-    return listSessions(limit, offset);
-  });
+  ipcMain.handle(
+    "list-sessions",
+    (
+      _event,
+      limit?: number,
+      offset?: number,
+      connectionId?: string,
+      profile?: string,
+    ) => {
+      const conn = sessionConnection(connectionId);
+      const scopedProfile = activeSshProfile(profile);
+      if (conn.mode === "remote")
+        return remoteListSessions(
+          scopedRemoteSessionConfig(conn, scopedProfile),
+          limit,
+          offset,
+        );
+      if (conn.mode === "ssh" && conn.ssh)
+        return withSshDashboardSessions(
+          conn,
+          (config) => remoteListSessions(config, limit, offset),
+          () => sshListSessions(conn.ssh!, limit, offset, scopedProfile),
+          scopedProfile,
+        );
+      return listSessions(limit, offset, scopedProfile);
+    },
+  );
 
   ipcMain.handle(
     "get-session-messages",
@@ -2380,19 +2395,27 @@ export function registerIpcHandlers(context: IpcContext): void {
     },
   );
 
-  ipcMain.handle("delete-sessions", (_event, sessionIds: string[]) => {
-    const ids = Array.isArray(sessionIds) ? sessionIds : [];
-    const conn = getConnectionConfig();
-    if (conn.mode === "remote") return remoteDeleteSessions(conn, ids);
-    if (conn.mode === "ssh" && conn.ssh)
-      return withSshDashboardSessions(
-        conn,
-        (config) => remoteDeleteSessions(config, ids),
-        undefined,
-        activeSshProfile(),
-      );
-    return deleteSessions(ids);
-  });
+  ipcMain.handle(
+    "delete-sessions",
+    (_event, sessionIds: string[], connectionId?: string, profile?: string) => {
+      const ids = Array.isArray(sessionIds) ? sessionIds : [];
+      const conn = sessionConnection(connectionId);
+      const scopedProfile = activeSshProfile(profile);
+      if (conn.mode === "remote")
+        return remoteDeleteSessions(
+          scopedRemoteSessionConfig(conn, scopedProfile),
+          ids,
+        );
+      if (conn.mode === "ssh" && conn.ssh)
+        return withSshDashboardSessions(
+          conn,
+          (config) => remoteDeleteSessions(config, ids),
+          undefined,
+          scopedProfile,
+        );
+      return deleteSessions(ids, scopedProfile);
+    },
+  );
 
   // Profiles
   ipcMain.handle("list-profiles", async () => {
@@ -2673,67 +2696,112 @@ export function registerIpcHandlers(context: IpcContext): void {
   // Session cache (fast local cache with generated titles)
   ipcMain.handle(
     "list-cached-sessions",
-    (_event, limit?: number, offset?: number) => {
-      const conn = getConnectionConfig();
+    (
+      _event,
+      limit?: number,
+      offset?: number,
+      connectionId?: string,
+      profile?: string,
+    ) => {
+      const conn = sessionConnection(connectionId);
+      const scopedProfile = activeSshProfile(profile);
       if (conn.mode === "remote")
-        return remoteListCachedSessions(conn, limit, offset);
+        return remoteListCachedSessions(
+          scopedRemoteSessionConfig(conn, scopedProfile),
+          limit,
+          offset,
+        );
       if (conn.mode === "ssh" && conn.ssh)
         return withSshDashboardSessions(
           conn,
           (config) => remoteListCachedSessions(config, limit, offset),
-          () => sshListCachedSessions(conn.ssh, limit, offset),
-          activeSshProfile(),
+          () => sshListCachedSessions(conn.ssh!, limit, offset, scopedProfile),
+          scopedProfile,
         );
-      return listCachedSessions(limit, offset);
+      return listCachedSessions(limit, offset, scopedProfile);
     },
   );
-  ipcMain.handle("sync-session-cache", () => {
-    const conn = getConnectionConfig();
-    if (conn.mode === "remote") return remoteListCachedSessions(conn, 50);
-    if (conn.mode === "ssh" && conn.ssh)
-      return withSshDashboardSessions(
-        conn,
-        (config) => remoteListCachedSessions(config, 50),
-        () => sshListCachedSessions(conn.ssh, 50),
-        activeSshProfile(),
-      );
-    try {
-      return syncSessionCache();
-    } catch (error) {
-      console.error("sync-session-cache failed; using local cache", error);
-      return listCachedSessions(50);
-    }
-  });
+  ipcMain.handle(
+    "sync-session-cache",
+    (_event, connectionId?: string, profile?: string) => {
+      const conn = sessionConnection(connectionId);
+      const scopedProfile = activeSshProfile(profile);
+      if (conn.mode === "remote")
+        return remoteListCachedSessions(
+          scopedRemoteSessionConfig(conn, scopedProfile),
+          50,
+        );
+      if (conn.mode === "ssh" && conn.ssh)
+        return withSshDashboardSessions(
+          conn,
+          (config) => remoteListCachedSessions(config, 50),
+          () => sshListCachedSessions(conn.ssh!, 50, 0, scopedProfile),
+          scopedProfile,
+        );
+      try {
+        return syncSessionCache(scopedProfile);
+      } catch (error) {
+        console.error("sync-session-cache failed; using local cache", error);
+        return listCachedSessions(50, 0, scopedProfile);
+      }
+    },
+  );
   ipcMain.handle(
     "update-session-title",
-    (_event, sessionId: string, title: string) => {
-      const conn = getConnectionConfig();
+    (
+      _event,
+      sessionId: string,
+      title: string,
+      connectionId?: string,
+      profile?: string,
+    ) => {
+      const conn = sessionConnection(connectionId);
+      const scopedProfile = activeSshProfile(profile);
       if (conn.mode === "remote")
-        return remoteUpdateSessionTitle(conn, sessionId, title);
+        return remoteUpdateSessionTitle(
+          scopedRemoteSessionConfig(conn, scopedProfile),
+          sessionId,
+          title,
+        );
       if (conn.mode === "ssh" && conn.ssh)
         return withSshDashboardSessions(
           conn,
           (config) => remoteUpdateSessionTitle(config, sessionId, title),
           undefined,
-          activeSshProfile(),
+          scopedProfile,
         );
-      return updateSessionTitle(sessionId, title);
+      return updateSessionTitle(sessionId, title, scopedProfile);
     },
   );
 
   // Session search
-  ipcMain.handle("search-sessions", (_event, query: string, limit?: number) => {
-    const conn = getConnectionConfig();
-    if (conn.mode === "remote") return remoteSearchSessions(conn, query, limit);
-    if (conn.mode === "ssh" && conn.ssh)
-      return withSshDashboardSessions(
-        conn,
-        (config) => remoteSearchSessions(config, query, limit),
-        () => sshSearchSessions(conn.ssh, query, limit),
-        activeSshProfile(),
-      );
-    return searchSessions(query, limit);
-  });
+  ipcMain.handle(
+    "search-sessions",
+    (
+      _event,
+      query: string,
+      limit?: number,
+      connectionId?: string,
+      profile?: string,
+    ) => {
+      const conn = sessionConnection(connectionId);
+      const scopedProfile = activeSshProfile(profile);
+      if (conn.mode === "remote")
+        return remoteSearchSessions(
+          scopedRemoteSessionConfig(conn, scopedProfile),
+          query,
+          limit,
+        );
+      if (conn.mode === "ssh" && conn.ssh)
+        return withSshDashboardSessions(
+          conn,
+          (config) => remoteSearchSessions(config, query, limit),
+          () => sshSearchSessions(conn.ssh!, query, limit, scopedProfile),
+          scopedProfile,
+        );
+      return searchSessions(query, limit, scopedProfile);
+    },
+  );
 
   // Credential Pool — profile-aware. When `profile` is omitted, the
   // credential pool helpers default to the currently active profile's

--- a/src/main/remote-sessions.ts
+++ b/src/main/remote-sessions.ts
@@ -285,9 +285,10 @@ async function remoteSessionListPage(
   limit: number,
   offset: number,
 ): Promise<unknown> {
+  const profile = config.profile?.trim() || "all";
   const profileEndpoint =
     `/api/profiles/sessions?limit=${limit}&offset=${offset}` +
-    "&min_messages=0&archived=exclude&order=recent&profile=all";
+    `&min_messages=0&archived=exclude&order=recent&profile=${encodeURIComponent(profile)}`;
 
   try {
     return await remoteRequestJson(config, profileEndpoint);

--- a/src/main/session-cache.ts
+++ b/src/main/session-cache.ts
@@ -18,12 +18,12 @@ import { getSessionContextFolders } from "./session-context-folder-store";
  * ~/.hermes/desktop/sessions.json; named profiles use
  * ~/.hermes/profiles/<name>/desktop/sessions.json (issue #311).
  */
-function cacheFilePath(): string {
-  return join(
-    profileHome(getActiveProfileNameSync()),
-    "desktop",
-    "sessions.json",
-  );
+function cacheFilePath(profile?: unknown): string {
+  const selectedProfile =
+    profile === undefined || profile === ""
+      ? getActiveProfileNameSync()
+      : profile;
+  return join(profileHome(selectedProfile), "desktop", "sessions.json");
 }
 
 export interface CachedSession {
@@ -72,8 +72,8 @@ function generateTitle(message: string): string {
   return title || text.slice(0, 45) + "...";
 }
 
-function readCache(): CacheData {
-  const file = cacheFilePath();
+function readCache(profile?: unknown): CacheData {
+  const file = cacheFilePath(profile);
   try {
     if (!existsSync(file)) return { sessions: [], lastSync: 0 };
     const parsed = JSON.parse(readFileSync(file, "utf-8")) as CacheData;
@@ -92,24 +92,30 @@ function readCache(): CacheData {
   }
 }
 
-function writeCache(data: CacheData): void {
+function writeCache(data: CacheData, profile?: unknown): void {
   try {
-    safeWriteFile(cacheFilePath(), JSON.stringify(data));
+    safeWriteFile(cacheFilePath(profile), JSON.stringify(data));
   } catch {
     // non-fatal
   }
 }
 
-function getDb(): Database.Database | null {
-  return getDbConnection(true);
+function getDb(profile?: unknown): Database.Database | null {
+  return getDbConnection(true, profile);
 }
 
 // Attach each session's linked folder in a single batched store read, so a
 // full sync stays a couple of queries rather than two per row. The result is
 // written into the JSON cache by `syncSessionCache`, which lets the renderer's
 // fast read path (`listCachedSessions`) stay DB-free.
-function attachContextFolders(sessions: CachedSession[]): CachedSession[] {
-  const folders = getSessionContextFolders(sessions.map((s) => s.id));
+function attachContextFolders(
+  sessions: CachedSession[],
+  profile?: unknown,
+): CachedSession[] {
+  const folders = getSessionContextFolders(
+    sessions.map((s) => s.id),
+    profile,
+  );
   return sessions.map((session) => ({
     ...session,
     contextFolder: folders.get(session.id) ?? null,
@@ -117,9 +123,9 @@ function attachContextFolders(sessions: CachedSession[]): CachedSession[] {
 }
 
 // Sync from hermes DB to local cache — only fetches new/updated sessions
-export function syncSessionCache(): CachedSession[] {
-  const cache = readCache();
-  const db = getDb();
+export function syncSessionCache(profile?: unknown): CachedSession[] {
+  const cache = readCache(profile);
+  const db = getDb(profile);
   if (!db) return cache.sessions;
 
   try {
@@ -235,14 +241,17 @@ export function syncSessionCache(): CachedSession[] {
     const merged = new Map<string, CachedSession>();
     for (const s of cache.sessions) merged.set(s.id, s);
     for (const s of newSessions) merged.set(s.id, s);
-    const allSessions = attachContextFolders(Array.from(merged.values()));
+    const allSessions = attachContextFolders(
+      Array.from(merged.values()),
+      profile,
+    );
     allSessions.sort((a, b) => b.startedAt - a.startedAt);
 
     const updated: CacheData = {
       sessions: allSessions,
       lastSync: Math.floor(Date.now() / 1000),
     };
-    writeCache(updated);
+    writeCache(updated, profile);
     return updated.sessions;
   } catch {
     return cache.sessions;
@@ -253,22 +262,30 @@ export function syncSessionCache(): CachedSession[] {
 // the cache by `syncSessionCache`, and folder changes trigger a re-sync (the
 // renderer fires `hermes-session-context-folder-changed`), so the cached value
 // stays current without this path touching the DB.
-export function listCachedSessions(limit = 50, offset = 0): CachedSession[] {
-  const cache = readCache();
+export function listCachedSessions(
+  limit = 50,
+  offset = 0,
+  profile?: unknown,
+): CachedSession[] {
+  const cache = readCache(profile);
   return cache.sessions.slice(offset, offset + limit);
 }
 
 // Update title for a specific session
-export function updateSessionTitle(sessionId: string, title: string): void {
-  const cache = readCache();
+export function updateSessionTitle(
+  sessionId: string,
+  title: string,
+  profile?: unknown,
+): void {
+  const cache = readCache(profile);
   const idx = cache.sessions.findIndex((s) => s.id === sessionId);
   if (idx >= 0) {
     cache.sessions[idx].title = title;
-    writeCache(cache);
+    writeCache(cache, profile);
   }
   // Also persist in state.db so the rename survives cache rebuilds
   try {
-    const dbPath = activeStateDbPath();
+    const dbPath = activeStateDbPath(profile);
     if (existsSync(dbPath)) {
       const db = new Database(dbPath);
       try {
@@ -288,11 +305,14 @@ export function updateSessionTitle(sessionId: string, title: string): void {
 // Remove a session entry from the local cache. Called after the underlying
 // row in state.db is deleted so the renderer's fast-path cache doesn't keep
 // surfacing a session that no longer exists.
-export function removeSessionFromCache(sessionId: string): void {
-  const cache = readCache();
+export function removeSessionFromCache(
+  sessionId: string,
+  profile?: unknown,
+): void {
+  const cache = readCache(profile);
   const next = cache.sessions.filter((s) => s.id !== sessionId);
   if (next.length !== cache.sessions.length) {
     cache.sessions = next;
-    writeCache(cache);
+    writeCache(cache, profile);
   }
 }

--- a/src/main/session-context-folder-store.ts
+++ b/src/main/session-context-folder-store.ts
@@ -77,10 +77,11 @@ export function getSessionContextFolder(sessionId: string): string | null {
  */
 export function getSessionContextFolders(
   sessionIds: string[],
+  profile?: unknown,
 ): Map<string, string> {
   const result = new Map<string, string>();
   if (sessionIds.length === 0) return result;
-  const db = getDbConnection(true);
+  const db = getDbConnection(true, profile);
   if (!db || !tableExists(db)) return result;
 
   // Chunk well under SQLITE_MAX_VARIABLE_NUMBER for portability, matching the

--- a/src/main/sessions.ts
+++ b/src/main/sessions.ts
@@ -260,8 +260,12 @@ function getDb(readonly = true, profile?: unknown): Database.Database | null {
   return getDbConnection(readonly, profile);
 }
 
-export function listSessions(limit = 30, offset = 0): SessionSummary[] {
-  const db = getDb();
+export function listSessions(
+  limit = 30,
+  offset = 0,
+  profile?: unknown,
+): SessionSummary[] {
+  const db = getDb(true, profile);
   if (!db) return [];
 
   // Simple query without correlated subquery — titles come from session cache
@@ -301,8 +305,12 @@ export function listSessions(limit = 30, offset = 0): SessionSummary[] {
   }));
 }
 
-export function searchSessions(query: string, limit = 20): SearchResult[] {
-  const db = getDb();
+export function searchSessions(
+  query: string,
+  limit = 20,
+  profile?: unknown,
+): SearchResult[] {
+  const db = getDb(true, profile);
   if (!db) return [];
 
   try {
@@ -770,9 +778,9 @@ function deleteSessionRows(db: Database.Database, sessionId: string): number {
   return result.changes;
 }
 
-function cleanupDeletedSession(sessionId: string): void {
+function cleanupDeletedSession(sessionId: string, profile?: unknown): void {
   clearStagedAttachments(sessionId);
-  removeSessionFromCache(sessionId);
+  removeSessionFromCache(sessionId, profile);
 }
 
 export function deleteSession(sessionId: string, profile?: unknown): void {
@@ -788,7 +796,7 @@ export function deleteSession(sessionId: string, profile?: unknown): void {
     tx(id);
   }
 
-  cleanupDeletedSession(id);
+  cleanupDeletedSession(id, profile);
 }
 
 export function deleteSessions(
@@ -810,7 +818,7 @@ export function deleteSessions(
   }
 
   for (const id of ids) {
-    cleanupDeletedSession(id);
+    cleanupDeletedSession(id, profile);
   }
 
   return { requested: ids.length, deleted };

--- a/src/main/ssh-remote.ts
+++ b/src/main/ssh-remote.ts
@@ -3320,9 +3320,9 @@ export async function sshListCachedSessions(
   config: SshConfig,
   limit = 50,
   offset = 0,
+  profile?: string,
 ): Promise<CachedSession[]> {
-  void offset;
-  const sessions = await sshListSessions(config, limit, 0);
+  const sessions = await sshListSessions(config, limit, offset, profile);
   return sessions.map((s) => ({
     id: s.id,
     title: s.title || s.id,

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -615,6 +615,8 @@ interface HermesAPI {
   listSessions: (
     limit?: number,
     offset?: number,
+    connectionId?: string,
+    profile?: string,
   ) => Promise<
     Array<{
       id: string;
@@ -842,6 +844,8 @@ interface HermesAPI {
   listCachedSessions: (
     limit?: number,
     offset?: number,
+    connectionId?: string,
+    profile?: string,
   ) => Promise<
     Array<{
       id: string;
@@ -853,7 +857,10 @@ interface HermesAPI {
       contextFolder: string | null;
     }>
   >;
-  syncSessionCache: () => Promise<
+  syncSessionCache: (
+    connectionId?: string,
+    profile?: string,
+  ) => Promise<
     Array<{
       id: string;
       title: string;
@@ -864,7 +871,12 @@ interface HermesAPI {
       contextFolder: string | null;
     }>
   >;
-  updateSessionTitle: (sessionId: string, title: string) => Promise<void>;
+  updateSessionTitle: (
+    sessionId: string,
+    title: string,
+    connectionId?: string,
+    profile?: string,
+  ) => Promise<void>;
   deleteSession: (
     sessionId: string,
     connectionId?: string,
@@ -872,12 +884,16 @@ interface HermesAPI {
   ) => Promise<void>;
   deleteSessions: (
     sessionIds: string[],
+    connectionId?: string,
+    profile?: string,
   ) => Promise<{ requested: number; deleted: number }>;
 
   // Session search
   searchSessions: (
     query: string,
     limit?: number,
+    connectionId?: string,
+    profile?: string,
   ) => Promise<
     Array<{
       sessionId: string;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -882,6 +882,8 @@ const hermesAPI = {
   listSessions: (
     limit?: number,
     offset?: number,
+    connectionId?: string,
+    profile?: string,
   ): Promise<
     Array<{
       id: string;
@@ -893,7 +895,8 @@ const hermesAPI = {
       title: string | null;
       preview: string;
     }>
-  > => ipcRenderer.invoke("list-sessions", limit, offset),
+  > =>
+    ipcRenderer.invoke("list-sessions", limit, offset, connectionId, profile),
 
   getSessionMessages: (
     sessionId: string,
@@ -1144,6 +1147,8 @@ const hermesAPI = {
   listCachedSessions: (
     limit?: number,
     offset?: number,
+    connectionId?: string,
+    profile?: string,
   ): Promise<
     Array<{
       id: string;
@@ -1154,9 +1159,19 @@ const hermesAPI = {
       model: string;
       contextFolder: string | null;
     }>
-  > => ipcRenderer.invoke("list-cached-sessions", limit, offset),
+  > =>
+    ipcRenderer.invoke(
+      "list-cached-sessions",
+      limit,
+      offset,
+      connectionId,
+      profile,
+    ),
 
-  syncSessionCache: (): Promise<
+  syncSessionCache: (
+    connectionId?: string,
+    profile?: string,
+  ): Promise<
     Array<{
       id: string;
       title: string;
@@ -1166,10 +1181,21 @@ const hermesAPI = {
       model: string;
       contextFolder: string | null;
     }>
-  > => ipcRenderer.invoke("sync-session-cache"),
+  > => ipcRenderer.invoke("sync-session-cache", connectionId, profile),
 
-  updateSessionTitle: (sessionId: string, title: string): Promise<void> =>
-    ipcRenderer.invoke("update-session-title", sessionId, title),
+  updateSessionTitle: (
+    sessionId: string,
+    title: string,
+    connectionId?: string,
+    profile?: string,
+  ): Promise<void> =>
+    ipcRenderer.invoke(
+      "update-session-title",
+      sessionId,
+      title,
+      connectionId,
+      profile,
+    ),
   deleteSession: (
     sessionId: string,
     connectionId?: string,
@@ -1178,13 +1204,17 @@ const hermesAPI = {
     ipcRenderer.invoke("delete-session", sessionId, connectionId, profile),
   deleteSessions: (
     sessionIds: string[],
+    connectionId?: string,
+    profile?: string,
   ): Promise<{ requested: number; deleted: number }> =>
-    ipcRenderer.invoke("delete-sessions", sessionIds),
+    ipcRenderer.invoke("delete-sessions", sessionIds, connectionId, profile),
 
   // Session search
   searchSessions: (
     query: string,
     limit?: number,
+    connectionId?: string,
+    profile?: string,
   ): Promise<
     Array<{
       sessionId: string;
@@ -1195,7 +1225,8 @@ const hermesAPI = {
       model: string;
       snippet: string;
     }>
-  > => ipcRenderer.invoke("search-sessions", query, limit),
+  > =>
+    ipcRenderer.invoke("search-sessions", query, limit, connectionId, profile),
 
   // Credential Pool (profile-aware: reads/writes the named profile's
   // auth.json; defaults to the currently active profile when omitted)

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -4763,7 +4763,7 @@ body:has(.shell-vibrant),
   color: var(--text-primary);
 }
 
-.chat-fast-popover span {
+.chat-fast-popover > span {
   display: block;
   font-size: 11px;
   line-height: 1.5;
@@ -5723,10 +5723,19 @@ body:has(.shell-vibrant),
     box-shadow var(--transition);
 }
 
+.chat-input-beam {
+  width: 100%;
+  transition: box-shadow var(--transition);
+}
+
+.chat-input-beam:focus-within {
+  box-shadow: 0 0 0 3px var(--accent-subtle);
+}
+
 .chat-input-wrapper:focus-within {
   /* Soft accent glow on focus instead of a saturated electric-blue stroke. */
   border-color: color-mix(in srgb, var(--accent) 45%, var(--border-bright));
-  box-shadow: 0 0 0 3px var(--accent-subtle);
+  box-shadow: none;
 }
 
 .chat-input {
@@ -15088,7 +15097,105 @@ body:has(.shell-vibrant),
   }
 }
 
-/* Toggle switch */
+/* Shared settings toggle — adapted from Transitions.dev. The interaction gate
+   prevents the off animation from playing during initial settings hydration. */
+.app-toggle {
+  --toggle-duration: 350ms;
+  --toggle-travel: 18px;
+  --toggle-overshoot: 1px;
+  --toggle-settle: 0px;
+  --toggle-track-duration: 0ms;
+  --toggle-ease: cubic-bezier(0.34, 1.35, 0.64, 1);
+  appearance: none;
+  position: relative;
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  width: 40px;
+  height: 22px;
+  padding: 3px;
+  border: 0;
+  border-radius: 999px;
+  color: var(--text-muted);
+  background: color-mix(in srgb, var(--text-primary) 16%, transparent);
+  cursor: pointer;
+  transition: background var(--toggle-track-duration) var(--toggle-ease);
+}
+
+.app-toggle:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--text-primary) 24%, transparent);
+}
+
+.app-toggle:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.app-toggle-thumb {
+  display: block;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: currentColor;
+  translate: 0 0;
+  will-change: translate;
+}
+
+.app-toggle[data-on="true"] {
+  color: #fff;
+  background: var(--accent);
+}
+
+.app-toggle[data-on="true"] .app-toggle-thumb {
+  translate: var(--toggle-travel) 0;
+}
+
+.app-toggle.is-init[data-on="true"] .app-toggle-thumb {
+  animation: app-toggle-on var(--toggle-duration) var(--toggle-ease) both;
+}
+
+.app-toggle.is-init[data-on="false"] .app-toggle-thumb {
+  animation: app-toggle-off var(--toggle-duration) var(--toggle-ease) both;
+}
+
+@keyframes app-toggle-on {
+  0% {
+    translate: 0 0;
+  }
+  55% {
+    translate: calc(var(--toggle-travel) + var(--toggle-overshoot)) 0;
+  }
+  80% {
+    translate: calc(var(--toggle-travel) - var(--toggle-settle)) 0;
+  }
+  100% {
+    translate: var(--toggle-travel) 0;
+  }
+}
+
+@keyframes app-toggle-off {
+  0% {
+    translate: var(--toggle-travel) 0;
+  }
+  55% {
+    translate: calc(0px - var(--toggle-overshoot)) 0;
+  }
+  80% {
+    translate: var(--toggle-settle) 0;
+  }
+  100% {
+    translate: 0 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .app-toggle-thumb {
+    animation: none !important;
+    will-change: auto;
+  }
+}
+
+/* Legacy switch markup used outside the Settings modal. */
 .tools-toggle {
   position: relative;
   display: inline-flex;

--- a/src/renderer/src/components/ChatPreferencesProvider.test.tsx
+++ b/src/renderer/src/components/ChatPreferencesProvider.test.tsx
@@ -52,7 +52,7 @@ describe("chat preferences", () => {
       </Wrapper>,
     );
 
-    const toggle = screen.getByRole("checkbox", {
+    const toggle = screen.getByRole("switch", {
       name: "Play a sound when a response finishes",
     });
     expect(toggle).toBeChecked();
@@ -88,9 +88,7 @@ describe("chat preferences", () => {
     );
     expect(screen.getByRole("status")).toHaveTextContent("en-US,nl-NL");
 
-    fireEvent.click(
-      screen.getByRole("checkbox", { name: "Enable spellcheck" }),
-    );
+    fireEvent.click(screen.getByRole("switch", { name: "Enable spellcheck" }));
     await waitFor(() =>
       expect(setSpellCheckerLanguages).toHaveBeenLastCalledWith([]),
     );

--- a/src/renderer/src/components/common/Toggle.test.tsx
+++ b/src/renderer/src/components/common/Toggle.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { Toggle } from "./Toggle";
+
+function ToggleHarness(): React.JSX.Element {
+  const [checked, setChecked] = useState(false);
+  return (
+    <Toggle
+      checked={checked}
+      label="Enable priority processing"
+      onCheckedChange={setChecked}
+    />
+  );
+}
+
+describe("Toggle", () => {
+  // @lat: [[sidebar-navigation#Sidebar recent sessions#Settings modal#Shared animated toggle]]
+  it("exposes switch semantics and gates movement until interaction", () => {
+    render(<ToggleHarness />);
+    const toggle = screen.getByRole("switch", {
+      name: "Enable priority processing",
+    });
+
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+    expect(toggle).toHaveAttribute("data-on", "false");
+    expect(toggle).not.toHaveClass("is-init");
+
+    fireEvent.click(toggle);
+
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+    expect(toggle).toHaveAttribute("data-on", "true");
+    expect(toggle).toHaveClass("is-init");
+  });
+
+  it("does not invoke changes while disabled", () => {
+    const onCheckedChange = vi.fn();
+    render(
+      <Toggle
+        checked={false}
+        label="Unavailable setting"
+        disabled
+        onCheckedChange={onCheckedChange}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Unavailable setting" }),
+    );
+    expect(onCheckedChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/src/components/common/Toggle.tsx
+++ b/src/renderer/src/components/common/Toggle.tsx
@@ -1,0 +1,43 @@
+import { useState, type ButtonHTMLAttributes } from "react";
+
+type NativeButtonProps = Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  "aria-checked" | "onChange" | "onClick" | "role" | "type"
+>;
+
+export interface ToggleProps extends NativeButtonProps {
+  checked: boolean;
+  label: string;
+  onCheckedChange: (checked: boolean) => void | Promise<void>;
+}
+
+/** Accessible controlled switch with an interaction-gated bounce animation. */
+export function Toggle({
+  checked,
+  label,
+  onCheckedChange,
+  className,
+  disabled,
+  ...buttonProps
+}: ToggleProps): React.JSX.Element {
+  const [hasInteracted, setHasInteracted] = useState(false);
+
+  return (
+    <button
+      {...buttonProps}
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      data-on={checked ? "true" : "false"}
+      className={`app-toggle${hasInteracted ? " is-init" : ""}${className ? ` ${className}` : ""}`}
+      disabled={disabled}
+      onClick={() => {
+        setHasInteracted(true);
+        void onCheckedChange(!checked);
+      }}
+    >
+      <span className="app-toggle-thumb" aria-hidden="true" />
+    </button>
+  );
+}

--- a/src/renderer/src/components/settings/AboutPane.tsx
+++ b/src/renderer/src/components/settings/AboutPane.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { useI18n } from "../useI18n";
 import BrandLogo from "../common/BrandLogo";
+import { Toggle } from "../common/Toggle";
 import hermesIcon from "../../assets/hermes-icon.svg";
 import pythonLogo from "../../assets/logos/python.svg";
 import openaiLogo from "../../assets/logos/openai.svg";
@@ -292,14 +293,11 @@ export default function AboutPane(): React.JSX.Element {
                 {t("settings.autoUpgradeDesktopHint")}
               </div>
             </div>
-            <label className="tools-toggle">
-              <input
-                type="checkbox"
-                checked={autoUpgradeEnabled}
-                onChange={(e) => void handleAutoUpgradeChange(e.target.checked)}
-              />
-              <span className="tools-toggle-track" />
-            </label>
+            <Toggle
+              checked={autoUpgradeEnabled}
+              label={t("settings.autoUpgradeDesktop")}
+              onCheckedChange={handleAutoUpgradeChange}
+            />
           </div>
         </div>
       </section>

--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Check } from "lucide-react";
+import { Toggle } from "../common/Toggle";
 import { useTheme } from "../ThemeProvider";
 import { useFont } from "../FontProvider";
 import { THEMES, FONT_OPTIONS } from "../../constants";
@@ -117,17 +118,11 @@ export default function AppearancePane(): React.JSX.Element {
             </div>
           </div>
           <div className="settings-row-control">
-            <label
-              className="tools-toggle"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <input
-                type="checkbox"
-                checked={rounded}
-                onChange={() => setRounded(!rounded)}
-              />
-              <span className="tools-toggle-track" />
-            </label>
+            <Toggle
+              checked={rounded}
+              label={t("settings.roundedCorners.label")}
+              onCheckedChange={setRounded}
+            />
           </div>
         </div>
 

--- a/src/renderer/src/components/settings/ConnectionPane.tsx
+++ b/src/renderer/src/components/settings/ConnectionPane.tsx
@@ -1,4 +1,5 @@
 import { Laptop, Server, Terminal, Wifi } from "lucide-react";
+import { Toggle } from "../common/Toggle";
 import { useI18n } from "../useI18n";
 import { useSettings } from "./SettingsDataContext";
 import { CHAT_TRANSPORT_OPTIONS } from "./settingsHelpers";
@@ -551,34 +552,29 @@ export default function ConnectionPane(): React.JSX.Element {
             <span className="settings-saved">{t("settings.saved")}</span>
           )}
         </div>
-        <div className="settings-field">
-          <label className="settings-field-label">
-            {t("settings.forceIpv4")}
-            <label
-              className="tools-toggle"
-              style={{ marginLeft: 12, verticalAlign: "middle" }}
-            >
-              <input
-                type="checkbox"
-                checked={forceIpv4}
-                onChange={async (e) => {
-                  const val = e.target.checked;
-                  setForceIpv4(val);
-                  await window.hermesAPI.setConfig(
-                    "network.force_ipv4",
-                    val ? "true" : "false",
-                    profile,
-                  );
-                  setNetworkSaved(true);
-                  setTimeout(() => setNetworkSaved(false), 2000);
-                }}
-              />
-              <span className="tools-toggle-track" />
-            </label>
-          </label>
-          <div className="settings-field-hint">
-            {t("settings.forceIpv4Hint")}
+        <div className="settings-field settings-toggle-row">
+          <div className="settings-toggle-text">
+            <div className="settings-toggle-title">
+              {t("settings.forceIpv4")}
+            </div>
+            <div className="settings-field-hint">
+              {t("settings.forceIpv4Hint")}
+            </div>
           </div>
+          <Toggle
+            checked={forceIpv4}
+            label={t("settings.forceIpv4")}
+            onCheckedChange={async (enabled) => {
+              setForceIpv4(enabled);
+              await window.hermesAPI.setConfig(
+                "network.force_ipv4",
+                enabled ? "true" : "false",
+                profile,
+              );
+              setNetworkSaved(true);
+              setTimeout(() => setNetworkSaved(false), 2000);
+            }}
+          />
         </div>
         <div className="settings-field">
           <label className="settings-field-label">

--- a/src/renderer/src/components/settings/LanguagePane.tsx
+++ b/src/renderer/src/components/settings/LanguagePane.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Check, ChevronDown } from "lucide-react";
+import { Toggle } from "../common/Toggle";
 import { useI18n } from "../useI18n";
 import { APP_LOCALES, type AppLocale } from "../../../../shared/i18n";
 import { LANGUAGE_NATIVE_NAMES } from "./settingsHelpers";
@@ -49,15 +50,11 @@ export default function LanguagePane(): React.JSX.Element {
             {t("settings.spellcheck.enableHint")}
           </div>
         </div>
-        <label className="tools-toggle">
-          <input
-            type="checkbox"
-            aria-label={t("settings.spellcheck.enable")}
-            checked={spellcheckEnabled}
-            onChange={(event) => setSpellcheckEnabled(event.target.checked)}
-          />
-          <span className="tools-toggle-track" />
-        </label>
+        <Toggle
+          checked={spellcheckEnabled}
+          label={t("settings.spellcheck.enable")}
+          onCheckedChange={setSpellcheckEnabled}
+        />
       </div>
 
       {spellcheckEnabled && (

--- a/src/renderer/src/components/settings/NotificationsPane.tsx
+++ b/src/renderer/src/components/settings/NotificationsPane.tsx
@@ -1,4 +1,5 @@
 import { useChatPreferences } from "../ChatPreferencesProvider";
+import { Toggle } from "../common/Toggle";
 import { useI18n } from "../useI18n";
 
 /** Desktop response notification preferences. */
@@ -18,17 +19,11 @@ export default function NotificationsPane(): React.JSX.Element {
             {t("settings.notifications.completionSoundHint")}
           </div>
         </div>
-        <label className="tools-toggle">
-          <input
-            type="checkbox"
-            aria-label={t("settings.notifications.completionSound")}
-            checked={completionSoundEnabled}
-            onChange={(event) =>
-              setCompletionSoundEnabled(event.target.checked)
-            }
-          />
-          <span className="tools-toggle-track" />
-        </label>
+        <Toggle
+          checked={completionSoundEnabled}
+          label={t("settings.notifications.completionSound")}
+          onCheckedChange={setCompletionSoundEnabled}
+        />
       </div>
     </div>
   );

--- a/src/renderer/src/components/settings/PrivacyPane.tsx
+++ b/src/renderer/src/components/settings/PrivacyPane.tsx
@@ -1,5 +1,6 @@
 import { useI18n } from "../useI18n";
 import { setAnalyticsConsent } from "../../utils/analytics";
+import { Toggle } from "../common/Toggle";
 import { useSettings } from "./SettingsDataContext";
 
 /** Anonymous usage analytics consent. */
@@ -9,28 +10,23 @@ export default function PrivacyPane(): React.JSX.Element {
 
   return (
     <div className="settings-modal-pane">
-      <div className="settings-field">
-        <label className="settings-field-label">
-          {t("settings.analytics.label")}
-          <label
-            className="tools-toggle"
-            style={{ marginLeft: 12, verticalAlign: "middle" }}
-          >
-            <input
-              type="checkbox"
-              checked={analyticsEnabled}
-              onChange={(e) => {
-                const enabled = e.target.checked;
-                setAnalyticsEnabled(enabled);
-                setAnalyticsConsent(enabled);
-              }}
-            />
-            <span className="tools-toggle-track" />
-          </label>
-        </label>
-        <div className="settings-field-hint">
-          {t("settings.analytics.hint")}
+      <div className="settings-field settings-toggle-row">
+        <div className="settings-toggle-text">
+          <div className="settings-toggle-title">
+            {t("settings.analytics.label")}
+          </div>
+          <div className="settings-field-hint">
+            {t("settings.analytics.hint")}
+          </div>
         </div>
+        <Toggle
+          checked={analyticsEnabled}
+          label={t("settings.analytics.label")}
+          onCheckedChange={(enabled) => {
+            setAnalyticsEnabled(enabled);
+            setAnalyticsConsent(enabled);
+          }}
+        />
       </div>
     </div>
   );

--- a/src/renderer/src/screens/Chat/ChatInput.test.tsx
+++ b/src/renderer/src/screens/Chat/ChatInput.test.tsx
@@ -1,5 +1,34 @@
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PropsWithChildren } from "react";
+
+vi.mock("border-beam", () => ({
+  BorderBeam: ({
+    children,
+    className,
+    size,
+    colorVariant,
+    strength,
+    theme,
+  }: PropsWithChildren<{
+    className?: string;
+    size?: string;
+    colorVariant?: string;
+    strength?: number;
+    theme?: string;
+  }>) => (
+    <div
+      className={className}
+      data-testid="chat-input-beam"
+      data-size={size}
+      data-color-variant={colorVariant}
+      data-strength={strength}
+      data-theme={theme}
+    >
+      {children}
+    </div>
+  ),
+}));
 
 // ChatInput pulls translations through useI18n (which requires the i18next
 // provider). Stub it so the component can render in isolation; the keys are
@@ -38,6 +67,21 @@ function renderInput(
   ) as HTMLTextAreaElement;
   return { onSubmit, textarea };
 }
+
+describe("ChatInput — border beam", () => {
+  // @lat: [[chat-input#Animated composer border#Uses the requested beam preset]]
+  it("wraps the complete composer in the requested border beam", () => {
+    const { textarea } = renderInput();
+    const beam = screen.getByTestId("chat-input-beam");
+
+    expect(beam.dataset.size).toBe("line");
+    expect(beam.dataset.colorVariant).toBe("colorful");
+    expect(beam.dataset.strength).toBe("0.7");
+    expect(beam.dataset.theme).toBe("dark");
+    expect(beam.contains(textarea)).toBe(true);
+    expect(beam.querySelector(".chat-input-toolbar")).not.toBeNull();
+  });
+});
 
 describe("ChatInput — CJK IME Enter handling", () => {
   // Repro: typing Korean (or any CJK IME), the final syllable stays in

--- a/src/renderer/src/screens/Chat/ChatInput.test.tsx
+++ b/src/renderer/src/screens/Chat/ChatInput.test.tsx
@@ -74,8 +74,8 @@ describe("ChatInput — border beam", () => {
     const { textarea } = renderInput();
     const beam = screen.getByTestId("chat-input-beam");
 
-    expect(beam.dataset.size).toBe("line");
-    expect(beam.dataset.colorVariant).toBe("colorful");
+    expect(beam.dataset.size).toBe("pulse-inner");
+    expect(beam.dataset.colorVariant).toBe("mono");
     expect(beam.dataset.strength).toBe("0.7");
     expect(beam.dataset.theme).toBe("dark");
     expect(beam.contains(textarea)).toBe(true);

--- a/src/renderer/src/screens/Chat/ChatInput.tsx
+++ b/src/renderer/src/screens/Chat/ChatInput.tsx
@@ -9,9 +9,12 @@ import {
   useImperativeHandle,
 } from "react";
 import { Square as Stop, Search, Paperclip, Mic, ArrowUp } from "lucide-react";
+import { BorderBeam } from "border-beam";
 import { isImeComposing } from "./keyboard";
 import { useI18n } from "../../components/useI18n";
 import { useChatPreferences } from "../../components/ChatPreferencesProvider";
+import { useTheme } from "../../components/ThemeProvider";
+import { THEMES } from "../../constants";
 import { SLASH_COMMANDS, type SlashCommand } from "./slashCommands";
 import { SlashCommandIcon } from "./slash/SlashCommandIcon";
 import {
@@ -30,6 +33,10 @@ import {
 import { AttachmentChip } from "../../components/AttachmentChip";
 import { ContextGauge, type ContextUsage } from "./ContextGauge";
 import type { Attachment } from "../../../../shared/attachments";
+
+const THEME_APPEARANCE = new Map(
+  THEMES.map((theme) => [theme.id, theme.appearance]),
+);
 
 export interface ChatInputHandle {
   setText(text: string): void;
@@ -89,6 +96,8 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
   ): React.JSX.Element {
     const { t } = useI18n();
     const { spellcheckEnabled } = useChatPreferences();
+    const { resolved: resolvedTheme } = useTheme();
+    const beamTheme = THEME_APPEARANCE.get(resolvedTheme) ?? "dark";
     const [input, setInput] = useState("");
     const [slashMenuOpen, setSlashMenuOpen] = useState(false);
     const [slashFilter, setSlashFilter] = useState("");
@@ -651,113 +660,121 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
             {voice.error}
           </div>
         )}
-        <div className="chat-input-wrapper">
-          <input
-            ref={fileInputRef}
-            type="file"
-            multiple
-            style={{ display: "none" }}
-            onChange={handleFileInputChange}
-          />
-          <textarea
-            ref={inputRef}
-            className="chat-input"
-            placeholder={t("chat.typeMessage")}
-            value={input}
-            onChange={handleInputChange}
-            onKeyDown={handleKeyDown}
-            onCompositionStart={() => {
-              composingRef.current = true;
-            }}
-            onCompositionEnd={() => {
-              composingRef.current = false;
-            }}
-            onPaste={handlePaste}
-            rows={1}
-            spellCheck={spellcheckEnabled}
-            autoFocus
-          />
-          <div className="chat-input-toolbar">
-            <button
-              className="chat-attach-btn"
-              onClick={() => fileInputRef.current?.click()}
-              disabled={isLoading}
-              title={t("chat.attach")}
-              aria-label={t("chat.attach")}
-              type="button"
-            >
-              <Paperclip size={16} />
-            </button>
-            {voice.supported && (
+        <BorderBeam
+          className="chat-input-beam"
+          size="pulse-inner"
+          colorVariant="mono"
+          strength={0.7}
+          theme={beamTheme}
+        >
+          <div className="chat-input-wrapper">
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              style={{ display: "none" }}
+              onChange={handleFileInputChange}
+            />
+            <textarea
+              ref={inputRef}
+              className="chat-input"
+              placeholder={t("chat.typeMessage")}
+              value={input}
+              onChange={handleInputChange}
+              onKeyDown={handleKeyDown}
+              onCompositionStart={() => {
+                composingRef.current = true;
+              }}
+              onCompositionEnd={() => {
+                composingRef.current = false;
+              }}
+              onPaste={handlePaste}
+              rows={1}
+              spellCheck={spellcheckEnabled}
+              autoFocus
+            />
+            <div className="chat-input-toolbar">
               <button
-                className={`chat-mic-btn${
-                  voice.recording ? " chat-mic-btn--recording" : ""
-                }`}
-                onClick={() => {
-                  // Snapshot the current text so live results append to it.
-                  if (!voice.recording && !voice.transcribing) {
-                    voiceBaseRef.current = input;
-                  }
-                  voice.toggle();
-                }}
-                disabled={voice.transcribing}
-                title={
-                  voice.transcribing
-                    ? t("chat.voiceTranscribing")
-                    : voice.recording
-                      ? t("chat.voiceStop")
-                      : t("chat.voiceInput")
-                }
-                aria-label={
-                  voice.recording ? t("chat.voiceStop") : t("chat.voiceInput")
-                }
-                aria-pressed={voice.recording}
+                className="chat-attach-btn"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={isLoading}
+                title={t("chat.attach")}
+                aria-label={t("chat.attach")}
                 type="button"
               >
-                <Mic size={16} />
+                <Paperclip size={16} />
               </button>
-            )}
-            {toolbarExtras && (
-              <>
-                <span className="chat-input-toolbar-divider" aria-hidden />
-                {toolbarExtras}
-              </>
-            )}
-            <div className="chat-input-toolbar-spacer" />
-            {contextUsage && contextUsage.used > 0 && (
-              <ContextGauge {...contextUsage} />
-            )}
-            {isLoading ? (
-              <button
-                className="chat-send-btn chat-stop-btn"
-                onClick={onAbort}
-                title={t("common.stop")}
-              >
-                <Stop size={14} />
-              </button>
-            ) : (
-              <>
-                {input.trim() && hasSession && (
-                  <button
-                    className="chat-btw-btn"
-                    onClick={handleQuickAsk}
-                    title={t("chat.quickAskTitle")}
-                  >
-                    💭
-                  </button>
-                )}
+              {voice.supported && (
                 <button
-                  className="chat-send-btn"
-                  onClick={handleSend}
-                  disabled={!canSend}
-                  title={t("chat.send")}
+                  className={`chat-mic-btn${
+                    voice.recording ? " chat-mic-btn--recording" : ""
+                  }`}
+                  onClick={() => {
+                    // Snapshot the current text so live results append to it.
+                    if (!voice.recording && !voice.transcribing) {
+                      voiceBaseRef.current = input;
+                    }
+                    voice.toggle();
+                  }}
+                  disabled={voice.transcribing}
+                  title={
+                    voice.transcribing
+                      ? t("chat.voiceTranscribing")
+                      : voice.recording
+                        ? t("chat.voiceStop")
+                        : t("chat.voiceInput")
+                  }
+                  aria-label={
+                    voice.recording ? t("chat.voiceStop") : t("chat.voiceInput")
+                  }
+                  aria-pressed={voice.recording}
+                  type="button"
                 >
-                  <ArrowUp size={20} />
+                  <Mic size={16} />
                 </button>
-              </>
-            )}
+              )}
+              {toolbarExtras && (
+                <>
+                  <span className="chat-input-toolbar-divider" aria-hidden />
+                  {toolbarExtras}
+                </>
+              )}
+              <div className="chat-input-toolbar-spacer" />
+              {contextUsage && contextUsage.used > 0 && (
+                <ContextGauge {...contextUsage} />
+              )}
+              {isLoading ? (
+                <button
+                  className="chat-send-btn chat-stop-btn"
+                  onClick={onAbort}
+                  title={t("common.stop")}
+                >
+                  <Stop size={14} />
+                </button>
+              ) : (
+                <>
+                  {input.trim() && hasSession && (
+                    <button
+                      className="chat-btw-btn"
+                      onClick={handleQuickAsk}
+                      title={t("chat.quickAskTitle")}
+                    >
+                      💭
+                    </button>
+                  )}
+                  <button
+                    className="chat-send-btn"
+                    onClick={handleSend}
+                    disabled={!canSend}
+                    title={t("chat.send")}
+                  >
+                    <ArrowUp size={20} />
+                  </button>
+                </>
+              )}
+            </div>
           </div>
-        </div>
+        </BorderBeam>
       </>
     );
   },

--- a/src/renderer/src/screens/Layout/Layout.tsx
+++ b/src/renderer/src/screens/Layout/Layout.tsx
@@ -748,6 +748,7 @@ function Layout({
               <div className="sidebar-chat-scroll" ref={sidebarChatScrollRef}>
                 <SidebarRecentSessions
                   open={!sidebarCollapsed}
+                  connectionId={connectionId}
                   activeProfile={activeProfile}
                   currentSessionId={currentSessionId}
                   loadingSessionIds={loadingSessionIds}
@@ -910,6 +911,8 @@ function Layout({
                 onClick={(e) => e.stopPropagation()}
               >
                 <Sessions
+                  connectionId={connectionId}
+                  profile={activeProfile}
                   onResumeSession={(id) => {
                     setSessionsModalOpen(false);
                     void handleResumeSession(id);

--- a/src/renderer/src/screens/Layout/SidebarRecentSessions.tsx
+++ b/src/renderer/src/screens/Layout/SidebarRecentSessions.tsx
@@ -159,6 +159,7 @@ function groupSessionsByWorkspace(sessions: RecentSession[]): {
  */
 const SidebarRecentSessions = memo(function SidebarRecentSessions({
   open,
+  connectionId,
   activeProfile,
   currentSessionId,
   loadingSessionIds,
@@ -168,6 +169,8 @@ const SidebarRecentSessions = memo(function SidebarRecentSessions({
   scrollRootRef,
 }: {
   open: boolean;
+  /** Stable connection registry id used to route every session operation. */
+  connectionId: string;
   /** Active profile — the list is per-profile, so switching forces a reload. */
   activeProfile: string;
   currentSessionId: string | null;
@@ -314,13 +317,16 @@ const SidebarRecentSessions = memo(function SidebarRecentSessions({
       if (!force && now - lastRefreshRef.current < REFRESH_THROTTLE_MS) return;
       lastRefreshRef.current = now;
       try {
-        const synced = await window.hermesAPI.syncSessionCache();
+        const synced = await window.hermesAPI.syncSessionCache(
+          connectionId,
+          activeProfile,
+        );
         applyLoadedWindow(synced);
       } catch {
         // keep whatever we had — the list is best-effort UI sugar
       }
     },
-    [applyLoadedWindow],
+    [activeProfile, applyLoadedWindow, connectionId],
   );
 
   const loadNextPage = useCallback(async (): Promise<void> => {
@@ -331,6 +337,8 @@ const SidebarRecentSessions = memo(function SidebarRecentSessions({
       const nextPage = await window.hermesAPI.listCachedSessions(
         RECENT_SESSIONS_PAGE_SIZE + 1,
         sessionsRef.current.length,
+        connectionId,
+        activeProfile,
       );
       appendPage(nextPage);
     } catch {
@@ -339,7 +347,7 @@ const SidebarRecentSessions = memo(function SidebarRecentSessions({
       loadingMoreRef.current = false;
       setLoadingMore(false);
     }
-  }, [appendPage, open]);
+  }, [activeProfile, appendPage, connectionId, open]);
 
   const maybeLoadNextPage = useCallback((): void => {
     const root = scrollRootRef.current;
@@ -362,6 +370,9 @@ const SidebarRecentSessions = memo(function SidebarRecentSessions({
           // One over the page size so the cache read alone can decide whether
           // another page exists without a separate count query.
           RECENT_SESSIONS_PAGE_SIZE + 1,
+          0,
+          connectionId,
+          activeProfile,
         );
         if (!cancelled) applyFirstPage(cached);
       } catch {
@@ -369,7 +380,10 @@ const SidebarRecentSessions = memo(function SidebarRecentSessions({
       }
       lastRefreshRef.current = Date.now();
       try {
-        const synced = await window.hermesAPI.syncSessionCache();
+        const synced = await window.hermesAPI.syncSessionCache(
+          connectionId,
+          activeProfile,
+        );
         if (!cancelled) applyFirstPage(synced);
       } catch {
         // cache read above already painted something
@@ -378,7 +392,7 @@ const SidebarRecentSessions = memo(function SidebarRecentSessions({
     return () => {
       cancelled = true;
     };
-  }, [open, activeProfile, applyFirstPage]);
+  }, [open, connectionId, activeProfile, applyFirstPage]);
 
   // While open: pick up background sessions (gateway, cron, other devices)
   // on focus and on a slow timer. No listeners or timers at all when closed.
@@ -522,7 +536,12 @@ const SidebarRecentSessions = memo(function SidebarRecentSessions({
       );
       if (editingIdRef.current === id) cancelRename();
       try {
-        await window.hermesAPI.updateSessionTitle(id, trimmed);
+        await window.hermesAPI.updateSessionTitle(
+          id,
+          trimmed,
+          connectionId,
+          activeProfile,
+        );
       } catch (err) {
         console.error("Failed to rename session", id, err);
         setSessions((prev) =>
@@ -530,7 +549,7 @@ const SidebarRecentSessions = memo(function SidebarRecentSessions({
         );
       }
     },
-    [cancelRename],
+    [activeProfile, cancelRename, connectionId],
   );
 
   const handleMoveToProject = useCallback(
@@ -586,7 +605,7 @@ const SidebarRecentSessions = memo(function SidebarRecentSessions({
         return next;
       });
       try {
-        await window.hermesAPI.deleteSession(id);
+        await window.hermesAPI.deleteSession(id, connectionId, activeProfile);
         onSessionDeleted?.(id);
       } catch (err) {
         console.error("Failed to delete session", id, err);
@@ -596,7 +615,7 @@ const SidebarRecentSessions = memo(function SidebarRecentSessions({
         void refresh(true);
       }
     },
-    [onSessionDeleted, refresh],
+    [activeProfile, connectionId, onSessionDeleted, refresh],
   );
 
   const openMenuForSession = useCallback(

--- a/src/renderer/src/screens/Sessions/Sessions.test.tsx
+++ b/src/renderer/src/screens/Sessions/Sessions.test.tsx
@@ -23,12 +23,15 @@ const baseProps = {
   onResumeSession: (): void => {},
   onNewChat: (): void => {},
   currentSessionId: null,
+  connectionId: "connection-one",
+  profile: "work",
 };
 
 function installHermesAPI(initialSessions: unknown[] = []): {
   listCachedSessions: ReturnType<typeof vi.fn>;
   syncSessionCache: ReturnType<typeof vi.fn>;
   searchSessions: ReturnType<typeof vi.fn>;
+  updateSessionTitle: ReturnType<typeof vi.fn>;
   deleteSession: ReturnType<typeof vi.fn>;
   deleteSessions: ReturnType<typeof vi.fn>;
   emitConnectionConfigChanged: () => void;
@@ -38,6 +41,7 @@ function installHermesAPI(initialSessions: unknown[] = []): {
     listCachedSessions: vi.fn().mockResolvedValue(initialSessions),
     syncSessionCache: vi.fn().mockResolvedValue(initialSessions),
     searchSessions: vi.fn().mockResolvedValue([]),
+    updateSessionTitle: vi.fn().mockResolvedValue(undefined),
     deleteSession: vi.fn().mockResolvedValue(undefined),
     deleteSessions: vi.fn().mockResolvedValue({ requested: 0, deleted: 0 }),
     onConnectionConfigChanged: vi.fn((callback: () => void) => {
@@ -97,6 +101,55 @@ describe("Sessions tab live refresh (#322)", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  // @lat: [[connections#Test specifications#Connection-explicit session browsing]]
+  it("routes browsing and rename operations through the selected connection and profile", async () => {
+    vi.useRealTimers();
+    const api = installHermesAPI([
+      {
+        id: "routed-session",
+        title: "Routed chat",
+        startedAt: Math.floor(Date.now() / 1000),
+        source: "desktop",
+        messageCount: 2,
+        model: "gpt-5.5",
+      },
+    ]);
+
+    render(<Sessions {...baseProps} visible={true} />);
+    await waitFor(() => {
+      expect(api.syncSessionCache).toHaveBeenCalledWith(
+        "connection-one",
+        "work",
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "sessions.rename" }));
+    const renameInput = screen.getAllByRole("textbox")[1];
+    fireEvent.change(renameInput, { target: { value: "Renamed route" } });
+    fireEvent.keyDown(renameInput, { key: "Enter" });
+    await waitFor(() => {
+      expect(api.updateSessionTitle).toHaveBeenCalledWith(
+        "routed-session",
+        "Renamed route",
+        "connection-one",
+        "work",
+      );
+    });
+
+    fireEvent.change(
+      screen.getByPlaceholderText("sessions.searchPlaceholder"),
+      { target: { value: "route" } },
+    );
+    await waitFor(() => {
+      expect(api.searchSessions).toHaveBeenCalledWith(
+        "route",
+        undefined,
+        "connection-one",
+        "work",
+      );
+    });
   });
 
   it("re-syncs from state.db on an interval while the tab is visible", async () => {
@@ -423,7 +476,11 @@ describe("Sessions tab — delete affordance (#408)", () => {
       );
     });
 
-    expect(api.deleteSession).toHaveBeenCalledWith("sess-abc-123");
+    expect(api.deleteSession).toHaveBeenCalledWith(
+      "sess-abc-123",
+      "connection-one",
+      "work",
+    );
   });
 
   it("does NOT call deleteSession when the confirm is cancelled", async () => {
@@ -562,7 +619,11 @@ describe("Sessions tab — bulk delete selection (#490)", () => {
     });
 
     await waitFor(() => {
-      expect(api.deleteSessions).toHaveBeenCalledWith(["sess-one", "sess-two"]);
+      expect(api.deleteSessions).toHaveBeenCalledWith(
+        ["sess-one", "sess-two"],
+        "connection-one",
+        "work",
+      );
     });
     expect(api.deleteSession).not.toHaveBeenCalled();
   });
@@ -616,10 +677,11 @@ describe("Sessions tab — bulk delete selection (#490)", () => {
     });
 
     await waitFor(() => {
-      expect(api.deleteSessions).toHaveBeenCalledWith([
-        "search-one",
-        "search-two",
-      ]);
+      expect(api.deleteSessions).toHaveBeenCalledWith(
+        ["search-one", "search-two"],
+        "connection-one",
+        "work",
+      );
     });
     expect(api.deleteSessions).not.toHaveBeenCalledWith(["main-session"]);
   });

--- a/src/renderer/src/screens/Sessions/Sessions.test.tsx
+++ b/src/renderer/src/screens/Sessions/Sessions.test.tsx
@@ -103,7 +103,7 @@ describe("Sessions tab live refresh (#322)", () => {
     vi.useRealTimers();
   });
 
-  // @lat: [[connections#Test specifications#Connection-explicit session browsing]]
+  // @lat: [[connections#Test specifications#Connection-explicit session browsing#Routes renderer operations]]
   it("routes browsing and rename operations through the selected connection and profile", async () => {
     vi.useRealTimers();
     const api = installHermesAPI([

--- a/src/renderer/src/screens/Sessions/Sessions.tsx
+++ b/src/renderer/src/screens/Sessions/Sessions.tsx
@@ -87,6 +87,8 @@ interface SessionsProps {
   onNewChat: () => void;
   currentSessionId: string | null;
   visible: boolean;
+  connectionId: string;
+  profile: string;
 }
 
 function formatTime(ts: number): string {
@@ -353,6 +355,8 @@ function Sessions({
   onNewChat,
   currentSessionId,
   visible,
+  connectionId,
+  profile,
 }: SessionsProps): React.JSX.Element {
   const { t } = useI18n();
   const [sessions, setSessions] = useState<CachedSession[]>([]);
@@ -417,7 +421,10 @@ function Sessions({
   // loading state, so it can run on a timer or on focus with no spinner flash.
   const refreshSessions = useCallback(async (): Promise<void> => {
     const requestId = ++loadRequestId.current;
-    const synced = await window.hermesAPI.syncSessionCache();
+    const synced = await window.hermesAPI.syncSessionCache(
+      connectionId,
+      profile,
+    );
     if (loadRequestId.current !== requestId) return;
     setSessions((prev) => {
       if (synced.length === 0 && prev.length > 0) {
@@ -425,19 +432,27 @@ function Sessions({
       }
       return synced.slice(0, 50);
     });
-  }, []);
+  }, [connectionId, profile]);
 
   const loadSessions = useCallback(async (): Promise<void> => {
     const requestId = ++loadRequestId.current;
     setLoading(true);
     try {
-      const synced = await window.hermesAPI.syncSessionCache();
+      const synced = await window.hermesAPI.syncSessionCache(
+        connectionId,
+        profile,
+      );
       if (loadRequestId.current !== requestId) return;
       setSessions(synced.slice(0, 50));
     } catch (error) {
       console.error("Failed to load sessions", error);
       try {
-        const cached = await window.hermesAPI.listCachedSessions(50);
+        const cached = await window.hermesAPI.listCachedSessions(
+          50,
+          0,
+          connectionId,
+          profile,
+        );
         if (loadRequestId.current === requestId) {
           setSessions(cached);
         }
@@ -449,7 +464,7 @@ function Sessions({
         setLoading(false);
       }
     }
-  }, []);
+  }, [connectionId, profile]);
 
   useEffect(() => {
     loadSessions();
@@ -502,7 +517,12 @@ function Sessions({
         );
       });
       try {
-        await window.hermesAPI.updateSessionTitle(sessionId, trimmed);
+        await window.hermesAPI.updateSessionTitle(
+          sessionId,
+          trimmed,
+          connectionId,
+          profile,
+        );
       } catch (err) {
         console.error("Failed to rename session", sessionId, err);
         // Rollback optimistic update
@@ -526,7 +546,7 @@ function Sessions({
         setEditingTitle("");
       }
     },
-    [cancelRename],
+    [cancelRename, connectionId, profile],
   );
 
   const cancelDelete = useCallback((): void => {
@@ -545,7 +565,7 @@ function Sessions({
       setSessions((prev) => prev.filter((s) => s.id !== sessionId));
       setSearchResults((prev) => prev.filter((r) => r.sessionId !== sessionId));
       try {
-        await window.hermesAPI.deleteSession(sessionId);
+        await window.hermesAPI.deleteSession(sessionId, connectionId, profile);
       } catch (err) {
         console.error("Failed to delete session", sessionId, err);
       } finally {
@@ -554,7 +574,7 @@ function Sessions({
         setPendingDeleteSessionId(null);
       }
     },
-    [refreshSessions],
+    [connectionId, profile, refreshSessions],
   );
 
   const toggleSelectionMode = useCallback((): void => {
@@ -598,7 +618,7 @@ function Sessions({
       setSessions((prev) => prev.filter((s) => !idSet.has(s.id)));
       setSearchResults((prev) => prev.filter((r) => !idSet.has(r.sessionId)));
       try {
-        await window.hermesAPI.deleteSessions(ids);
+        await window.hermesAPI.deleteSessions(ids, connectionId, profile);
       } catch (err) {
         console.error("Failed to delete selected sessions", ids, err);
       } finally {
@@ -609,7 +629,7 @@ function Sessions({
         setIsSelectionMode(false);
       }
     },
-    [refreshSessions],
+    [connectionId, profile, refreshSessions],
   );
 
   useEffect(() => {
@@ -691,9 +711,16 @@ function Sessions({
     setIsSearching(true);
     searchTimer.current = setTimeout(async () => {
       try {
-        await window.hermesAPI.syncSessionCache().catch(() => []);
+        await window.hermesAPI
+          .syncSessionCache(connectionId, profile)
+          .catch(() => []);
         if (searchRequestId.current !== requestId) return;
-        const results = await window.hermesAPI.searchSessions(query);
+        const results = await window.hermesAPI.searchSessions(
+          query,
+          undefined,
+          connectionId,
+          profile,
+        );
         if (searchRequestId.current !== requestId) return;
         setSearchResults(results);
       } finally {
@@ -705,7 +732,7 @@ function Sessions({
     return () => {
       if (searchTimer.current) clearTimeout(searchTimer.current);
     };
-  }, [searchQuery]);
+  }, [connectionId, profile, searchQuery]);
 
   const isShowingSearch = searchQuery.trim().length > 0;
   const sourceOptions = useMemo(

--- a/tests/chat-fast-popover-css.test.ts
+++ b/tests/chat-fast-popover-css.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import { describe, expect, it } from "vitest";
+
+const CSS = readFileSync(
+  join(import.meta.dirname, "../src/renderer/src/assets/main.css"),
+  "utf-8",
+);
+
+describe("Fast Mode popover icon alignment", () => {
+  // @lat: [[window-chrome#Modal & popover glass is near-opaque (compositing-independent)#Fast-mode icon alignment]]
+  it("keeps description typography from overriding the icon flex container", () => {
+    const iconRule = CSS.match(
+      /\.chat-fast-popover-icon\s*\{(?<body>[\s\S]*?)\n\}/,
+    )?.groups?.body;
+
+    expect(iconRule).toContain("display: inline-flex");
+    expect(iconRule).toContain("align-items: center");
+    expect(iconRule).toContain("justify-content: center");
+    expect(CSS).not.toMatch(/\.chat-fast-popover\s+span\s*\{/);
+    expect(CSS).toMatch(/\.chat-fast-popover\s*>\s*span\s*\{/);
+  });
+});

--- a/tests/remote-sessions.test.ts
+++ b/tests/remote-sessions.test.ts
@@ -375,18 +375,20 @@ describe("remote session REST bridge", () => {
     ]);
   });
 
-  it("uses the persistent OAuth session for direct Remote session lists", async () => {
+  // @lat: [[connections#Test specifications#Connection-explicit session browsing#Scopes Remote list requests]]
+  it("uses the persistent OAuth session and selected profile for direct Remote session lists", async () => {
     const connection = {
       mode: "remote",
       remoteUrl: "https://remote.example",
       apiKey: "",
       remoteAuthMode: "oauth",
+      profile: "work profile",
     } as ConnectionConfig;
     requestRemoteOAuthJson.mockResolvedValue({ sessions: [] });
 
     await expect(remoteListCachedSessions(connection)).resolves.toEqual([]);
     expect(requestRemoteOAuthJson).toHaveBeenCalledWith(
-      "https://remote.example/api/profiles/sessions?limit=50&offset=0&min_messages=0&archived=exclude&order=recent&profile=all",
+      "https://remote.example/api/profiles/sessions?limit=50&offset=0&min_messages=0&archived=exclude&order=recent&profile=work%20profile",
       {},
     );
     expect(requests).toEqual([]);

--- a/tests/session-cache-sync.test.ts
+++ b/tests/session-cache-sync.test.ts
@@ -26,12 +26,22 @@ vi.mock("../src/main/installer", () => ({
 }));
 
 vi.mock("../src/main/utils", () => ({
-  activeStateDbPath: () => {
+  activeStateDbPath: (profile?: unknown) => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const path = require("path");
-    return path.join(TEST_HOME, "state.db");
+    const home =
+      profile && profile !== "default"
+        ? path.join(TEST_HOME, "profiles", String(profile))
+        : TEST_HOME;
+    return path.join(home, "state.db");
   },
-  profileHome: () => TEST_HOME,
+  profileHome: (profile?: unknown) => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const path = require("path");
+    return profile && profile !== "default"
+      ? path.join(TEST_HOME, "profiles", String(profile))
+      : TEST_HOME;
+  },
   getActiveProfileNameSync: () => "default",
   safeWriteFile: (path: string, data: string) => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -233,7 +243,12 @@ import { syncSessionCache } from "../src/main/session-cache";
 import { closeDbConnection } from "../src/main/db";
 
 const CACHE_FILE = join(TEST_HOME, "desktop", "sessions.json");
-const DB_PATH = join(TEST_HOME, "state.db");
+
+function testProfileHome(profile = "default"): string {
+  return profile === "default"
+    ? TEST_HOME
+    : join(TEST_HOME, "profiles", profile);
+}
 
 function seedDb(
   sessions: Array<{
@@ -245,8 +260,9 @@ function seedDb(
     title?: string | null;
     firstUserMessage?: string;
   }>,
+  profile = "default",
 ): void {
-  const db = new Database(DB_PATH);
+  const db = new Database(join(testProfileHome(profile), "state.db"));
   db.exec(`
     CREATE TABLE IF NOT EXISTS sessions (
       id TEXT PRIMARY KEY,
@@ -329,6 +345,38 @@ describe("syncSessionCache", () => {
     expect(result[0].title).toContain("RAII");
     expect(result[1].title).toContain("Python decorator");
     expect(existsSync(CACHE_FILE)).toBe(true);
+  });
+
+  // @lat: [[connections#Test specifications#Connection-explicit session browsing#Keeps Local profile caches isolated]]
+  it("reads and writes only the explicitly selected Local profile", () => {
+    const now = Math.floor(Date.now() / 1000);
+    seedDb([
+      {
+        id: "default-session",
+        started_at: now,
+        firstUserMessage: "Default profile",
+      },
+    ]);
+    seedDb(
+      [
+        {
+          id: "work-session",
+          started_at: now + 1,
+          firstUserMessage: "Work profile",
+        },
+      ],
+      "work",
+    );
+
+    expect(syncSessionCache("work").map((session) => session.id)).toEqual([
+      "work-session",
+    ]);
+    expect(
+      existsSync(join(testProfileHome("work"), "desktop", "sessions.json")),
+    ).toBe(true);
+    expect(syncSessionCache().map((session) => session.id)).toEqual([
+      "default-session",
+    ]);
   });
 
   it("treats an empty cache with a stale lastSync as a cold cache", () => {


### PR DESCRIPTION
## Summary
- Route sidebar and Sessions browsing, cache sync, search, rename, and deletion through the selected connection and profile; preserve Local profile isolation and SSH pagination.
- Scope Remote profile-list requests to the selected Hermes Agent profile instead of the cross-profile aggregate.
- Add the shared accessible animated settings toggle, the chat composer border pulse, and the Fast Mode icon alignment fix.
- Keep architecture and test specifications synchronized in lat.md.

## Verification
- npm run lint (0 errors; 21 pre-existing warnings)
- npm run build
- npm test (1934 passed, 3 skipped)
- lat check