### PR TITLE
fix: keep chat popovers outside beam clipping

### DIFF
--- a/lat.md/chat-input.md
+++ b/lat.md/chat-input.md
@@ -6,12 +6,12 @@ The chat composer keeps message entry and its supporting controls inside one acc
 
 The composer uses a theme-aware decorative beam without changing its keyboard, attachment, voice, or submission behavior.
 
-[[src/renderer/src/screens/Chat/ChatInput.tsx#ChatInput]] wraps the complete `.chat-input-wrapper` with `border-beam` using the contained `pulse-inner` size, monochrome palette, and `0.7` strength. Theme colors follow the resolved Hermes theme appearance rather than the operating-system preference.
+[[src/renderer/src/screens/Chat/ChatInput.tsx#ChatInput]] places `border-beam` beside `.chat-input-wrapper` in a shared shell, using the contained `pulse-inner` size, monochrome palette, and `0.7` strength. Theme colors follow the resolved Hermes theme appearance rather than the operating-system preference.
 
-The beam is non-interactive and its generated CSS disables animation for `prefers-reduced-motion`. Because the contained pulse wrapper clips child overflow, the existing focus glow is drawn by `.chat-input-beam:focus-within` while the inner composer retains its focus border.
+The beam is an absolutely positioned, non-interactive decoration whose generated CSS disables animation for `prefers-reduced-motion`. Its internal clipping cannot clip toolbar popovers because the interactive composer is a sibling; the shared shell carries focus styling and keeps overflow visible.
 
 ### Uses the requested beam preset
 
-The ChatInput integration test verifies that the beam surrounds both the textarea and toolbar with the requested preset, strength, and theme.
+The ChatInput integration test verifies the requested preset, strength, and theme while ensuring the beam is decorative and not an overflow-clipping ancestor of the textarea or toolbar.
 
 [[src/renderer/src/screens/Chat/ChatInput.test.tsx]] protects the component boundary and configuration without coupling tests to the dependency's generated animation CSS.

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -5709,6 +5709,12 @@ body:has(.shell-vibrant),
   flex-shrink: 0;
 }
 
+.chat-input-shell {
+  position: relative;
+  width: 100%;
+  overflow: visible;
+}
+
 .chat-input-wrapper {
   display: flex;
   flex-direction: column;
@@ -5723,12 +5729,23 @@ body:has(.shell-vibrant),
     box-shadow var(--transition);
 }
 
-.chat-input-beam {
+.chat-input-shell > .chat-input-beam {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
   width: 100%;
+  pointer-events: none;
   transition: box-shadow var(--transition);
 }
 
-.chat-input-beam:focus-within {
+.chat-input-beam-surface {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: var(--radius-lg);
+}
+
+.chat-input-shell:focus-within > .chat-input-beam {
   box-shadow: 0 0 0 3px var(--accent-subtle);
 }
 

--- a/src/renderer/src/screens/Chat/ChatInput.test.tsx
+++ b/src/renderer/src/screens/Chat/ChatInput.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, cleanup } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { PropsWithChildren } from "react";
+import type { HTMLAttributes, PropsWithChildren } from "react";
 
 vi.mock("border-beam", () => ({
   BorderBeam: ({
@@ -10,14 +10,17 @@ vi.mock("border-beam", () => ({
     colorVariant,
     strength,
     theme,
+    ...htmlProps
   }: PropsWithChildren<{
     className?: string;
     size?: string;
     colorVariant?: string;
     strength?: number;
     theme?: string;
-  }>) => (
+  }> &
+    HTMLAttributes<HTMLDivElement>) => (
     <div
+      {...htmlProps}
       className={className}
       data-testid="chat-input-beam"
       data-size={size}
@@ -70,16 +73,20 @@ function renderInput(
 
 describe("ChatInput — border beam", () => {
   // @lat: [[chat-input#Animated composer border#Uses the requested beam preset]]
-  it("wraps the complete composer in the requested border beam", () => {
+  it("renders the requested border beam without clipping composer overlays", () => {
     const { textarea } = renderInput();
     const beam = screen.getByTestId("chat-input-beam");
+    const shell = beam.parentElement;
 
     expect(beam.dataset.size).toBe("pulse-inner");
     expect(beam.dataset.colorVariant).toBe("mono");
     expect(beam.dataset.strength).toBe("0.7");
     expect(beam.dataset.theme).toBe("dark");
-    expect(beam.contains(textarea)).toBe(true);
-    expect(beam.querySelector(".chat-input-toolbar")).not.toBeNull();
+    expect(beam).toHaveAttribute("aria-hidden", "true");
+    expect(beam.contains(textarea)).toBe(false);
+    expect(shell).toHaveClass("chat-input-shell");
+    expect(shell).toContainElement(textarea);
+    expect(shell?.querySelector(".chat-input-toolbar")).not.toBeNull();
   });
 });
 

--- a/src/renderer/src/screens/Chat/ChatInput.tsx
+++ b/src/renderer/src/screens/Chat/ChatInput.tsx
@@ -660,13 +660,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
             {voice.error}
           </div>
         )}
-        <BorderBeam
-          className="chat-input-beam"
-          size="pulse-inner"
-          colorVariant="mono"
-          strength={0.7}
-          theme={beamTheme}
-        >
+        <div className="chat-input-shell">
           <div className="chat-input-wrapper">
             <input
               ref={fileInputRef}
@@ -774,7 +768,17 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
               )}
             </div>
           </div>
-        </BorderBeam>
+          <BorderBeam
+            aria-hidden="true"
+            className="chat-input-beam"
+            size="pulse-inner"
+            colorVariant="mono"
+            strength={0.7}
+            theme={beamTheme}
+          >
+            <span className="chat-input-beam-surface" />
+          </BorderBeam>
+        </div>
       </>
     );
   },


### PR DESCRIPTION
Fixes the BorderBeam regression by rendering the pulse-inner beam as an inert decorative sibling of the composer instead of an overflow-clipping ancestor. Keeps the existing visual preset and focus treatment, restores model picker, reasoning, folder, and Fast Mode overlay overflow, adds a structural regression test, and updates lat.md. Verified with 1,934 passing tests, production build and typechecks, targeted lint and formatting, live Electron checks of the model picker and Fast Mode popover, and lat check.