### PR TITLE
fix: honor adopted home across inherited environment restart

### DIFF
--- a/lat.md/onboarding.md
+++ b/lat.md/onboarding.md
@@ -38,9 +38,9 @@ The progress view (`wide`) shows a step + percent header with a progress bar, th
 
 An adopted install wins over the exact inherited `HERMES_HOME` active during selection, preventing restart loops while preserving a different later environment override.
 
-[[src/main/installer.ts#setHermesHomeOverride]] records a one-way fingerprint of that shadowed environment value beside the selected home. On restart, a matching fingerprint activates the saved selection; absent, legacy, and later-different environment values keep the existing precedence.
+[[src/main/installer.ts#setHermesHomeOverride]] records a one-way fingerprint of that shadowed environment value beside the selected home. On restart, a matching fingerprint activates the saved selection only while it remains a desktop-compatible install; absent, legacy, incomplete, and later-different values keep the existing precedence.
 
-[[tests/installer-home-override.test.ts]] covers the same-environment handoff, launch-time capture, cleartext-path minimization, legacy precedence, absent environments, later-different environments, and stale selections.
+[[tests/installer-home-override.test.ts]] covers the same-environment handoff, launch-time capture, cleartext-path minimization, legacy precedence, absent environments, later-different environments, deleted selections, and incomplete installs.
 
 ### Single-run installation
 

--- a/lat.md/onboarding.md
+++ b/lat.md/onboarding.md
@@ -34,6 +34,14 @@ The confirm view (eyebrow "SETUP", title "Before installing") shows the target p
 
 The progress view (`wide`) shows a step + percent header with a progress bar, then a **fixed-size** terminal log window (`.onboard-terminal`): its body has a constant height and scrolls internally, so streaming log lines never reflow the surrounding layout. The log auto-scrolls to the newest line.
 
+### Existing-install environment handoff
+
+An adopted install wins over the exact inherited `HERMES_HOME` active during selection, preventing restart loops while preserving a different later environment override.
+
+[[src/main/installer.ts#setHermesHomeOverride]] records a one-way fingerprint of that shadowed environment value beside the selected home. On restart, a matching fingerprint activates the saved selection; absent, legacy, and later-different environment values keep the existing precedence.
+
+[[tests/installer-home-override.test.ts]] covers the same-environment handoff, launch-time capture, cleartext-path minimization, legacy precedence, absent environments, later-different environments, and stale selections.
+
 ### Single-run installation
 
 After confirmation, one mounted install screen starts exactly one installer run even if the active locale changes while that run is pending.

--- a/src/main/installer.ts
+++ b/src/main/installer.ts
@@ -122,8 +122,8 @@ function readHermesHomeOverride(): StoredHermesHomeOverride | null {
     };
     const hermesHome =
       typeof parsed.hermesHome === "string" ? parsed.hermesHome.trim() : "";
-    // Ignore a stale override whose directory no longer exists.
-    if (!hermesHome || !existsSync(hermesHome)) return null;
+    // Ignore an override whose desktop-compatible installation is stale or incomplete.
+    if (!hermesHome || !validateHermesHome(hermesHome)) return null;
     const shadowedHermesHomeHash =
       typeof parsed.shadowedHermesHomeHash === "string"
         ? parsed.shadowedHermesHomeHash.trim()

--- a/src/main/installer.ts
+++ b/src/main/installer.ts
@@ -9,7 +9,7 @@ import {
 } from "fs";
 import { join, delimiter, resolve } from "path";
 import { homedir, tmpdir } from "os";
-import { randomBytes } from "crypto";
+import { createHash, randomBytes } from "crypto";
 import { app, type BrowserWindow } from "electron";
 import {
   getConnectionConfig,
@@ -80,8 +80,10 @@ function defaultHermesHome(): string {
 // A Hermes home the user explicitly pointed the app at via the "use an
 // existing installation" flow (issue #272). Persisted in the desktop's own
 // userData dir — outside any Hermes home — so it can be read here, before
-// HERMES_HOME is resolved. Strictly additive: with no override file the
-// behaviour is identical to before.
+// HERMES_HOME is resolved. When the selection replaces an inherited
+// HERMES_HOME, remember a one-way fingerprint of that exact value so the same
+// launch environment cannot mask the user's choice again after restart. A
+// different later HERMES_HOME remains authoritative.
 function hermesHomeOverrideFile(): string {
   // `app` is undefined outside an Electron runtime (e.g. unit tests) —
   // optional-chain it so module load degrades to "no override" instead of
@@ -90,19 +92,50 @@ function hermesHomeOverrideFile(): string {
   return userData ? join(userData, "hermes-home.json") : "";
 }
 
-function readHermesHomeOverride(): string {
+const inheritedHermesHome = process.env.HERMES_HOME?.trim() || "";
+
+interface StoredHermesHomeOverride {
+  hermesHome: string;
+  shadowedHermesHomeHash?: string;
+}
+
+function normalizedHomePath(home: string): string {
+  const normalized = resolve(home);
+  return IS_WINDOWS ? normalized.toLowerCase() : normalized;
+}
+
+function sameHomePath(left: string, right: string): boolean {
+  return normalizedHomePath(left) === normalizedHomePath(right);
+}
+
+function homePathFingerprint(home: string): string {
+  return createHash("sha256").update(normalizedHomePath(home)).digest("hex");
+}
+
+function readHermesHomeOverride(): StoredHermesHomeOverride | null {
   try {
     const file = hermesHomeOverrideFile();
-    if (!file || !existsSync(file)) return "";
+    if (!file || !existsSync(file)) return null;
     const parsed = JSON.parse(readFileSync(file, "utf-8")) as {
       hermesHome?: unknown;
+      shadowedHermesHomeHash?: unknown;
     };
-    const p =
+    const hermesHome =
       typeof parsed.hermesHome === "string" ? parsed.hermesHome.trim() : "";
     // Ignore a stale override whose directory no longer exists.
-    return p && existsSync(p) ? p : "";
+    if (!hermesHome || !existsSync(hermesHome)) return null;
+    const shadowedHermesHomeHash =
+      typeof parsed.shadowedHermesHomeHash === "string"
+        ? parsed.shadowedHermesHomeHash.trim()
+        : "";
+    return {
+      hermesHome,
+      ...(/^[a-f0-9]{64}$/.test(shadowedHermesHomeHash)
+        ? { shadowedHermesHomeHash }
+        : {}),
+    };
   } catch {
-    return "";
+    return null;
   }
 }
 
@@ -111,23 +144,33 @@ export function setHermesHomeOverride(home: string): void {
   try {
     const file = hermesHomeOverrideFile();
     if (!file) return;
-    if (!home.trim()) {
+    const hermesHome = home.trim();
+    if (!hermesHome) {
       if (existsSync(file)) unlinkSync(file);
       return;
     }
-    writeFileSync(
-      file,
-      JSON.stringify({ hermesHome: home.trim() }, null, 2),
-      "utf-8",
-    );
+    const stored: StoredHermesHomeOverride = { hermesHome };
+    if (inheritedHermesHome && !sameHomePath(inheritedHermesHome, hermesHome)) {
+      stored.shadowedHermesHomeHash = homePathFingerprint(inheritedHermesHome);
+    }
+    writeFileSync(file, JSON.stringify(stored, null, 2), "utf-8");
   } catch {
     /* best effort — a failed write just means no override next launch */
   }
 }
 
+const storedHermesHome = readHermesHomeOverride();
+const storedHomeShadowsInherited = Boolean(
+  inheritedHermesHome &&
+  storedHermesHome?.shadowedHermesHomeHash &&
+  homePathFingerprint(inheritedHermesHome) ===
+    storedHermesHome.shadowedHermesHomeHash,
+);
+
 export const HERMES_HOME =
-  process.env.HERMES_HOME?.trim() ||
-  readHermesHomeOverride() ||
+  (storedHomeShadowsInherited ? storedHermesHome?.hermesHome : "") ||
+  inheritedHermesHome ||
+  storedHermesHome?.hermesHome ||
   defaultHermesHome();
 export const HERMES_REPO = join(HERMES_HOME, "hermes-agent");
 export const HERMES_VENV = join(HERMES_REPO, "venv");

--- a/tests/installer-home-override.test.ts
+++ b/tests/installer-home-override.test.ts
@@ -9,6 +9,23 @@ import {
 import { tmpdir } from "os";
 import { join } from "path";
 
+function createHermesInstall(home: string): void {
+  const repo = join(home, "hermes-agent");
+  const bin = join(
+    repo,
+    "venv",
+    process.platform === "win32" ? "Scripts" : "bin",
+  );
+  mkdirSync(bin, { recursive: true });
+  if (process.platform === "win32") {
+    writeFileSync(join(bin, "python.exe"), "");
+    writeFileSync(join(bin, "hermes.exe"), "");
+  } else {
+    writeFileSync(join(bin, "python"), "");
+    writeFileSync(join(repo, "hermes"), "");
+  }
+}
+
 describe("Hermes home adoption", () => {
   let testRoot: string;
   let desktopUserData: string;
@@ -24,8 +41,8 @@ describe("Hermes home adoption", () => {
     inheritedHome = join(testRoot, "inherited-home");
     selectedHome = join(testRoot, "selected-home");
     mkdirSync(desktopUserData, { recursive: true });
-    mkdirSync(inheritedHome, { recursive: true });
-    mkdirSync(selectedHome, { recursive: true });
+    createHermesInstall(inheritedHome);
+    createHermesInstall(selectedHome);
     process.env.HERMES_HOME = inheritedHome;
     vi.doMock("electron", () => ({
       app: {
@@ -118,6 +135,20 @@ describe("Hermes home adoption", () => {
     const firstLaunch = await import("../src/main/installer");
     firstLaunch.setHermesHomeOverride(selectedHome);
     rmSync(selectedHome, { recursive: true, force: true });
+
+    vi.resetModules();
+    const restarted = await import("../src/main/installer");
+
+    expect(restarted.HERMES_HOME).toBe(inheritedHome);
+  });
+
+  it("ignores an adopted home whose install becomes incomplete", async () => {
+    const firstLaunch = await import("../src/main/installer");
+    firstLaunch.setHermesHomeOverride(selectedHome);
+    rmSync(join(selectedHome, "hermes-agent", "venv"), {
+      recursive: true,
+      force: true,
+    });
 
     vi.resetModules();
     const restarted = await import("../src/main/installer");

--- a/tests/installer-home-override.test.ts
+++ b/tests/installer-home-override.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+describe("Hermes home adoption", () => {
+  let testRoot: string;
+  let desktopUserData: string;
+  let inheritedHome: string;
+  let selectedHome: string;
+  let previousHermesHome: string | undefined;
+
+  beforeEach(() => {
+    vi.resetModules();
+    previousHermesHome = process.env.HERMES_HOME;
+    testRoot = mkdtempSync(join(tmpdir(), "hermes-desktop-home-"));
+    desktopUserData = join(testRoot, "desktop-user-data");
+    inheritedHome = join(testRoot, "inherited-home");
+    selectedHome = join(testRoot, "selected-home");
+    mkdirSync(desktopUserData, { recursive: true });
+    mkdirSync(inheritedHome, { recursive: true });
+    mkdirSync(selectedHome, { recursive: true });
+    process.env.HERMES_HOME = inheritedHome;
+    vi.doMock("electron", () => ({
+      app: {
+        getPath: vi.fn(() => desktopUserData),
+        setPath: vi.fn(),
+      },
+    }));
+  });
+
+  afterEach(() => {
+    if (previousHermesHome === undefined) delete process.env.HERMES_HOME;
+    else process.env.HERMES_HOME = previousHermesHome;
+    vi.doUnmock("electron");
+    vi.resetModules();
+    rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  // @lat: [[onboarding#Install confirm + progress#Existing-install environment handoff]]
+  it("reuses the adopted home after a restart with the same inherited home", async () => {
+    const firstLaunch = await import("../src/main/installer");
+    firstLaunch.setHermesHomeOverride(selectedHome);
+
+    vi.resetModules();
+    const restarted = await import("../src/main/installer");
+
+    expect(restarted.HERMES_HOME).toBe(selectedHome);
+  });
+
+  it("does not persist the inherited home in cleartext", async () => {
+    const installer = await import("../src/main/installer");
+    installer.setHermesHomeOverride(selectedHome);
+
+    const stored = readFileSync(
+      join(desktopUserData, "hermes-home.json"),
+      "utf-8",
+    );
+
+    expect(stored).not.toContain(inheritedHome);
+  });
+
+  it("records the launch-time inherited home", async () => {
+    const firstLaunch = await import("../src/main/installer");
+    process.env.HERMES_HOME = join(testRoot, "runtime-mutated-home");
+    firstLaunch.setHermesHomeOverride(selectedHome);
+
+    process.env.HERMES_HOME = inheritedHome;
+    vi.resetModules();
+    const restarted = await import("../src/main/installer");
+
+    expect(restarted.HERMES_HOME).toBe(selectedHome);
+  });
+
+  it("honors a different inherited home on a later launch", async () => {
+    const firstLaunch = await import("../src/main/installer");
+    firstLaunch.setHermesHomeOverride(selectedHome);
+
+    const laterHome = join(testRoot, "later-home");
+    mkdirSync(laterHome, { recursive: true });
+    process.env.HERMES_HOME = laterHome;
+    vi.resetModules();
+    const laterLaunch = await import("../src/main/installer");
+
+    expect(laterLaunch.HERMES_HOME).toBe(laterHome);
+  });
+
+  it("keeps environment precedence for a legacy override file", async () => {
+    writeFileSync(
+      join(desktopUserData, "hermes-home.json"),
+      JSON.stringify({ hermesHome: selectedHome }),
+      "utf-8",
+    );
+
+    const installer = await import("../src/main/installer");
+
+    expect(installer.HERMES_HOME).toBe(inheritedHome);
+  });
+
+  it("uses the adopted home when the inherited environment is absent", async () => {
+    const firstLaunch = await import("../src/main/installer");
+    firstLaunch.setHermesHomeOverride(selectedHome);
+
+    delete process.env.HERMES_HOME;
+    vi.resetModules();
+    const laterLaunch = await import("../src/main/installer");
+
+    expect(laterLaunch.HERMES_HOME).toBe(selectedHome);
+  });
+
+  it("ignores a stale adopted home", async () => {
+    const firstLaunch = await import("../src/main/installer");
+    firstLaunch.setHermesHomeOverride(selectedHome);
+    rmSync(selectedHome, { recursive: true, force: true });
+
+    vi.resetModules();
+    const restarted = await import("../src/main/installer");
+
+    expect(restarted.HERMES_HOME).toBe(inheritedHome);
+  });
+});


### PR DESCRIPTION
## Summary

- remember the exact inherited `HERMES_HOME` replaced by the explicit “use existing installation” choice
- reuse the selected installation when that same inherited value is present after restart
- revalidate the persisted installation before it can shadow the inherited environment
- preserve normal environment precedence for legacy overrides and any different later `HERMES_HOME`

## Problem

When the desktop app is launched from a process that already defines `HERMES_HOME`, selecting a different existing installation persists the choice but the inherited environment value wins again after restart. The app returns to onboarding and the selection appears ineffective.

The override now records a one-way fingerprint of only the environment value it intentionally replaces. That exact value is shadowed on subsequent launches while the adopted installation remains complete; all other precedence behavior remains unchanged.

## Testing

- `npm test -- tests/installer-home-override.test.ts tests/installer-target.test.ts src/renderer/src/screens/Install/Install.test.tsx`
- `LC_ALL=C.UTF-8 LANG=C.UTF-8 npm test`
- `npm run typecheck`
- `npm run lint`
- `npx prettier --check src/main/installer.ts tests/installer-home-override.test.ts lat.md/onboarding.md`
- `npx --yes lat.md check`
- `npm run build`